### PR TITLE
Fix: add AUTH_URL for NextAuth callback behind reverse proxy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           AUTH_ZITADEL_ID=${{ secrets.AUTH_ZITADEL_ID }}
           AUTH_ZITADEL_ISSUER=${{ secrets.AUTH_ZITADEL_ISSUER }}
           AUTH_TRUST_HOST=true
+          AUTH_URL=https://beacon.altermundi.net
           LIVEKIT_API_KEY=${{ secrets.LIVEKIT_API_KEY }}
           LIVEKIT_API_SECRET=${{ secrets.LIVEKIT_API_SECRET }}
           LIVEKIT_ROOM_NAME=beacon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - AUTH_ZITADEL_ID=${AUTH_ZITADEL_ID}
       - AUTH_ZITADEL_ISSUER=${AUTH_ZITADEL_ISSUER:-https://auth.altermundi.net}
       - AUTH_TRUST_HOST=true
+      - AUTH_URL=${AUTH_URL:-https://beacon.altermundi.net}
       - LIVEKIT_API_KEY=${LIVEKIT_API_KEY}
       - LIVEKIT_API_SECRET=${LIVEKIT_API_SECRET}
       - LIVEKIT_ROOM_NAME=${LIVEKIT_ROOM_NAME:-beacon}


### PR DESCRIPTION
## Summary
- Add `AUTH_URL=https://beacon.altermundi.net` to docker-compose.yml and deploy.yml
- Auth.js v5 beta ignores `AUTH_TRUST_HOST` and falls back to `HOSTNAME` env var (`0.0.0.0`) for callback URL construction, causing login to fail

## Test plan
- [ ] `curl https://beacon.altermundi.net/api/auth/providers` returns `callbackUrl` with `beacon.altermundi.net` instead of `0.0.0.0:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)