### PR TITLE
docs: pre-public-release audit of the product & policy documentation

### DIFF
--- a/docs/audit/LEGAL_AUDIT.md
+++ b/docs/audit/LEGAL_AUDIT.md
@@ -1,0 +1,148 @@
+# Legal Audit — Product & Policy Documentation
+
+*Audit date: 2026-06-09 · Scope: the `docs/` policy corpus + `BUSINESS_RULES.md` + root `README.md` claims · See [README.md](./README.md) for methodology and severity scale.*
+
+Each finding states: where it is (file:line), what it says, why it is a problem, and a recommended action. Line numbers refer to repo state at commit `b72b279`. Findings are ordered by severity, then by document.
+
+---
+
+## BLOCKER
+
+### L1 — No license; "All rights reserved" on a repo being prepared for public release
+
+- **Where**: `README.md:95` ("© 2026 AlterMundi. All rights reserved. Content and code ownership details are maintained in separate legal agreements"); no `LICENSE` file anywhere in the repo; `package.json` has `"private": true` and **no `license` field**.
+- **Problem**: Publishing a repository with no license is not a neutral default — it leaves every visitor with zero rights to use, copy, or run the code, while the README's reference to "separate legal agreements" (which are not in the repo and are not identified) creates ambiguity about who owns what. If the intent is open source, a license must be chosen; if the intent is source-available/proprietary, that must be stated explicitly (`LICENSE` file with proprietary terms, `"license": "UNLICENSED"` in `package.json`).
+- **Action**: Counsel + AlterMundi decide the licensing posture **before** visibility flips. Add `LICENSE`, set `package.json` license field, and make `README.md:95` consistent with the decision. Note that AlterMundi's existing public projects may set a precedent worth matching.
+
+### L2 — Guaranteed data rights (export, deletion) that the system cannot deliver
+
+- **Where**:
+  - `BUSINESS_RULES.md:31` — Listener guarantee: "One-click account export; one-click account deletion."
+  - `BUSINESS_RULES.md:279` — "a Listener may download, via `/api/users/me/export`, their profile, listening history, favourites, research participations and responses, patronage status, and journal entries."
+  - `BUSINESS_RULES.md:280` — "a Listener may delete their account at any time via `/api/users/me`. Deletion purges identifiable data within 30 days."
+- **Problem**: Neither endpoint exists (`src/app/api/users/me/route.ts` implements GET only; verified 2026-06-09). These are written as present-tense product guarantees naming specific API routes. If published, they are representations about data-subject rights (GDPR Arts. 15/17/20 territory, and Argentina's Ley 25.326 equivalents) that the platform cannot honor. A regulator or journalist testing the claim would falsify it in minutes.
+- **Action**: Either implement export + deletion before release, or rewrite §1.1 and §9.1 as commitments with a phase marker. Do not publish a named endpoint that returns 404/405.
+
+### L3 — GDPR 72-hour rule misstated (wrong addressee)
+
+- **Where**: `docs/TRUST_AND_SAFETY.md:137` — Data-exposure playbook: "**Notify** — affected users notified within the timeframe required by the applicable data-protection law (72 hours for GDPR)."
+- **Problem**: GDPR's 72-hour deadline (Art. 33) applies to notifying the **supervisory authority**. Notification of affected data subjects (Art. 34) is "without undue delay" when the breach is high-risk — a different obligation with a different trigger. As written, the playbook misstates the law in a document intended for public release, and an incident team following it literally would conflate the two duties.
+- **Action**: Correct the playbook to distinguish Art. 33 (authority, 72h) from Art. 34 (users, without undue delay, high-risk threshold). Add the applicable Argentine framework (Ley 25.326 / AAIP guidance) since the operating entity and hosting are in Argentina, and identify which law applies when.
+
+### L4 — Session recording based on implied consent
+
+- **Where**: `docs/TRUST_AND_SAFETY.md:54` — "Recordings are disclosed to participants before joining. **Participation implies consent to recording.**" Related: `BUSINESS_RULES.md:106` ("Recording is disclosed in-UI to participants before they join").
+- **Problem**: "Participation implies consent" is precisely the consent model GDPR rejects (consent must be unambiguous, and recording of voice in a contemplative/wellness session context can capture special-category data — see L13). It also contradicts the platform's own research-consent posture (`docs/RESEARCH_PROTOCOL.md` §2.2: "Informed consent for every instrument, before collection"). The product is one consent standard; the sessions are another.
+- **Action**: Replace with an affirmative pre-join consent step ("this session is recorded — Join and accept / Decline"), or rely on a lawful basis other than consent with counsel's sign-off, and align the wording across both docs.
+
+### L5 — The live marketing site claims research activity that does not exist
+
+- **Where**: `docs/RESEARCH_PROTOCOL.md:13-17` — "The public site makes three research-related claims: 1. We administer 'already standardized surveys within the psychological research field'… 2. We are 'developing a battery of tests…'". Also `docs/VISION.md:50` ("our own uptime, our own aggregate listener metrics, our own provider count — these are public" — they are not), and `BUSINESS_RULES.md` §6 written in operative present tense.
+- **Problem**: Per the roadmap itself, **no research data collection exists until Phase 3**, and no consent/survey models exist in the schema (verified). The protocol doc candidly records that harmonicbeacon.com *already* makes present-tense claims of administering surveys. `RESEARCH_PROTOCOL.md:194` itself names the failure mode: "a skeptical journalist or a regulator finds that we collect data under vague consent, never publish anything, and use the research frame as marketing." Right now the exposure is the inverse but equally damaging: claiming research that is not occurring — consumer-protection (deceptive practice) territory, and brand-fatal for a "decentralized science" positioning.
+- **Action**: Audit harmonicbeacon.com copy now (do not wait for Phase 1): re-tense research claims to "we are building / will administer." Re-tense `BUSINESS_RULES.md` §6 and `VISION.md` promise 6 to future commitments. This is the single highest-credibility-risk item in the corpus.
+
+---
+
+## HIGH
+
+### L6 — Safety and compliance controls asserted in the present tense that do not exist
+
+- **Where** (selection; full technical inventory in [TECH_AUDIT.md](./TECH_AUDIT.md)):
+  - `BUSINESS_RULES.md:62` "Every administrative action is written to the audit log" — no audit log exists.
+  - `BUSINESS_RULES.md:302-304` "Every scheduled session has an Admin-accessible kill-switch… Every content surface… has a report button. Reports are acknowledged within 24 hours" — none implemented.
+  - `docs/TRUST_AND_SAFETY.md:32-36` CAPTCHA, email verification before first listen, per-IP signup rate limit — none implemented.
+  - `docs/TRUST_AND_SAFETY.md:65-66` "At-rest encryption on Postgres. PII in logs is mechanically filtered" — neither is true; the app logs user emails in plaintext (`src/lib/auth-config.ts:89`).
+  - `docs/TRUST_AND_SAFETY.md:199-208` public `/trust` page, status page — do not exist.
+- **Problem**: For a wellness-adjacent platform inviting vulnerable users, publicly asserting safety controls that don't exist is worse than not having them: it is a misrepresentation that aggravates liability in any later incident ("you told users reports were acknowledged within 24 hours"). SLA promises (24h acknowledgement, 5-business-day review, postmortems within 14 days) are quasi-contractual once published.
+- **Action**: A single decision applies to the whole class: every control statement gets either (a) implemented, or (b) re-tensed and phase-tagged. Legal should specifically review the SLA numbers before they are ever published, because they become the standard the platform is judged against.
+
+### L7 — README presents draft policies as "enforceable" commitments
+
+- **Where**: `README.md:81` — "The product makes public commitments that are **documented and enforceable**," followed by links to the five policy docs — every one of which is marked "Draft · pending validation."
+- **Problem**: "Enforceable" invites a contractual reading of documents the team itself has not ratified, and which (per this audit) the system does not implement. It is the single word in the corpus most likely to be quoted back in a dispute.
+- **Action**: Replace with accurate framing, e.g. "documented; they will bind us as they are ratified and shipped." Keep the doc-status banners prominent.
+
+### L8 — Contradiction: provider recording/content license — perpetual or revocable?
+
+- **Where**:
+  - `BUSINESS_RULES.md:108` — "the platform retains a **perpetual, royalty-free license** to serve it [the session recording]."
+  - `BUSINESS_RULES.md:286-287` — "the platform's license to serve them is **revoked on removal** unless otherwise agreed."
+  - `docs/CONTENT_POLICY.md:194` — "License **terminates on content removal**, subject to cached-delivery technical tail of up to 30 days."
+  - `docs/CONTENT_POLICY.md:198` — "Term: **perpetual** license for content the Provider chose to publish, **terminable by removal**."
+- **Problem**: "Perpetual" and "terminates on removal" are different deal terms stated as the same policy in two canonical documents. The Provider Content Agreement (maintained outside the repo per CONTENT_POLICY §7) will have to pick one; until then, the published summary contradicts itself — a dispute magnet with the exact audience (Providers) these docs are meant to reassure. Note "perpetual, terminable" is also internally confused drafting: the intended term is likely "non-exclusive license for the duration of publication, plus a 30-day technical tail."
+- **Action**: Counsel fixes the term once, in the Content Agreement, and all three doc locations are rewritten from it.
+
+### L9 — Contradiction: two different provider revenue-share models, both called "50%"
+
+- **Where**:
+  - `BUSINESS_RULES.md:202` — "a defined share (**default 50%, configurable per-provider**) of *attributable patronage revenue* is paid monthly."
+  - `docs/MONETIZATION.md:121` — "Attributable revenue share **pool = 50% of net patronage revenue (after payment processing fees and Harmonic Beacon's operating cut** — published quarterly)," distributed pro-rata by listening time.
+- **Problem**: These are materially different economics: (a) a per-provider 50% share of revenue attributable to that provider vs. (b) a common pool of 50% of *net-of-operating-cut* platform revenue split pro-rata. Under (b), "50%" of "net after our cut" can be an arbitrarily small fraction of gross — describing it with the same headline number as (a) is the kind of statement a payments regulator or a provider dispute would characterize as misleading. The canonical doc and its detail doc must not disagree on money.
+- **Action**: Pick one model; define "net" exhaustively (what the "operating cut" is, who sets it, where it is published); rewrite both docs from the single definition. Until the formula is fixed, do not publish a percentage.
+
+### L10 — Tax-deductibility implication for patronage payments
+
+- **Where**: `docs/MONETIZATION.md:175` — "Annual patrons receive a year-end summary **for deductibility where applicable**"; `docs/phases/PHASE_2_PARTICIPATION.md:43` — "Annual year-end summary email with total patronage contribution (**for tax-deductibility where applicable**)."
+- **Problem**: Patronage payments to a non-charitable entity are generally not tax-deductible in any of the named launch geographies. "Where applicable" hedges, but the sentence exists to suggest deductibility. Unless the receiving AlterMundi entity has charitable status in the patron's jurisdiction, this invites patrons to take deductions the platform implied were available.
+- **Action**: Remove the deductibility framing, or condition it explicitly on the entity's verified status per jurisdiction ("a summary of your contributions; consult your tax advisor — patronage is not a charitable donation unless stated"). Tie to the "tax advisor engagement" open thread (`docs/README.md:67`).
+
+### L11 — DMCA framework assumed for an Argentina-operated platform
+
+- **Where**: `BUSINESS_RULES.md:161` — "copyright complaint (**DMCA path**)"; `docs/CONTENT_POLICY.md:168,177` and `docs/TRUST_AND_SAFETY.md:151-158` use the better-hedged "DMCA-style notice or equivalent under applicable law."
+- **Problem**: DMCA safe-harbor protection requires, among other things, a registered agent with the US Copyright Office and is US law; the platform is operated from Argentina on Argentine infrastructure with an international audience. Naming "DMCA" as *the* path overstates available protection and understates obligations under other regimes (e.g., EU DSA notice-and-action if EU users are in scope — and EU pricing/VAT plans say they are).
+- **Action**: Counsel defines the actual notice-and-takedown framework (jurisdiction, agent registration if DMCA protection is wanted, DSA exposure assessment) and the docs adopt one consistent, hedged formulation.
+
+### L12 — Health-benefit claim leaks past the platform's own language rules
+
+- **Where**: `docs/PRODUCT_PRINCIPLES.md:83` — "The populations that **most benefit from the beacon** include neurodiverse, disabled, elderly, and non-technical users."
+- **Problem**: The corpus's own rule (`PRODUCT_PRINCIPLES.md:45-46`) bans unhedged clinical-adjacent claims; "populations that most benefit" is an unhedged efficacy claim about clinically defined populations, in the very document that defines the rule. Singly it is small; in a regulator's or journalist's hands it is the example that shows the discipline is cosmetic. Same pattern risk: `docs/VISION.md:7` "help a human being remember a state of spiritual homeostasis" is fine under the rules (spiritual frame), but the boundary must be policed exactly because the frame walks the line.
+- **Action**: Rewrite to accessibility framing without the efficacy claim ("The populations the beacon must not exclude include…"). Add this audit's finding as a test case for the planned language linter (`PRODUCT_PRINCIPLES.md:50`).
+
+### L13 — GDPR special-category data (mental health) not addressed anywhere
+
+- **Where**: `docs/RESEARCH_PROTOCOL.md` §3 (instruments: POMS-SF, STAI-6, PANAS, WHO-5 — mood and anxiety scales), §4 (data handling), §4.3 ("Pseudonymized data: retained **indefinitely**").
+- **Problem**: Mood/anxiety/well-being survey responses are health data — special-category under GDPR Art. 9 — and the protocol never performs that classification, names a lawful basis, or addresses Art. 9(2) conditions. Two specific frictions: (a) pseudonymized data **is still personal data** under GDPR; "retained indefinitely" needs a justification and conflicts with the doc's own erasure framing; (b) the EU is plainly in scope (EUR/GBP pricing in `MONETIZATION.md:77`, EU VAT in `PHASE_2:31`). Argentina's Ley 25.326 has an analogous sensitive-data category. The protocol's ethics posture is genuinely good — this is a legal-basis gap, not an ethics gap.
+- **Action**: Add a data-protection section to RESEARCH_PROTOCOL.md (classification: Art. 9 health data; lawful basis: explicit consent; pseudonymization ≠ anonymization; retention justification; cross-border transfer analysis for the AR/EU pair). This belongs to the "Counsel engagement" open thread and should gate Phase 3, as the doc already implies.
+
+### L14 — Third-party processor claim is false-by-roadmap
+
+- **Where**: `docs/RESEARCH_PROTOCOL.md:118` — "**no third-party processor touches identifiable data except Stripe (billing) and our email provider (transactional)**."
+- **Problem**: Stated in the present tense when neither Stripe nor an email provider is integrated; more importantly, the roadmap then adds processors the sentence excludes: Sentry with "release tracking" (`PHASE_1:59`), Resend/Postmark (`PHASE_2:101`), **Firebase Crashlytics** (`PHASE_3:70` — Google as processor, with its own data-sharing posture), Stripe Connect KYC, push-notification services. The absolute claim will be falsified by the platform's own plan.
+- **Action**: Convert to a maintained, dated processor list ("current processors: …; we update this list before adding any") — which is also what GDPR Art. 28/30 record-keeping will need anyway.
+
+### L15 — Names of third parties imply associations that do not exist
+
+- **Where**: `docs/MONETIZATION.md:151-156` (Mind & Life, Fetzer, John Templeton, Sloan, Ford, Mozilla, IDB as "candidate funders"); `docs/RESEARCH_PROTOCOL.md:85` (Apple Health, Google Fit, Oura, Muse, Whoop as "candidate integrations"); `docs/RESEARCH_PROTOCOL.md:184` (CONICET, Mind & Life as partner candidates).
+- **Problem**: In an internal doc these are work lists; published, they read as an ecosystem the product participates in. None of these organizations has any stated relationship with the project. Foundations in particular are sensitive to being named in fundraising-adjacent material.
+- **Action**: Low-cost: a one-line disclaimer where lists appear ("named organizations are candidates we may approach; no affiliation or endorsement is implied"), or move candidate lists out of the public corpus into the issue tracker (which `docs/README.md:71` already says is where open threads belong).
+
+### L16 — Psychometric instruments named without licensing clearance
+
+- **Where**: `docs/RESEARCH_PROTOCOL.md` §3.2–3.4 (POMS-SF, STAI-6, PANAS, WHO-5, FFMQ-SF), §8.3 ("Some validated scales (e.g. PSS, PANAS) are free; others may have fees or use restrictions. A scale-licensing audit is Phase 2 work").
+- **Problem**: The doc partially self-flags, but understates it: **POMS-SF is a commercially licensed instrument (MHS)** and **STAI (including short forms) is licensed via Mind Garden with per-administration fees** — the two scales the protocol names as the likely pre/post pair (`PHASE_3:97-98`: "likely POMS-SF + STAI-6"). Administering them in-product without a license is a copyright problem inside the research surface, which is the platform's most scrutinized surface.
+- **Action**: Do the licensing audit **before** instruments are named in any public doc; prefer genuinely free/open scales where equivalent (e.g., WHO-5 is free with attribution; I-PANAS-SF and PSS have permissive research-use terms). Re-mark §3 lists as "subject to licensing audit."
+
+---
+
+## MEDIUM
+
+### L17 — "The beacon never goes dark" as an absolute public promise
+
+- **Where**: `docs/VISION.md:45`, `BUSINESS_RULES.md:258`, `docs/SLO.md` §1, `README.md:83` ("the beacon never goes dark").
+- **Problem**: The SLO doc itself targets 99.5% audibility — i.e., up to ~3.6 dark hours/month inside target. The covenant framing is good brand writing, and SLO §4 defines "dark" carefully; the risk is the absolute sentence traveling without its definition (press quotes, app-store copy) and ending up in a deceptive-practice or warranty argument.
+- **Action**: Keep the covenant; ensure Terms of Service expressly disclaim availability warranties and define outage remedies; in marketing surfaces, pair the sentence with the audibility metric ("our target and track record: status page").
+
+### L18 — Minor consistency and drafting items for the legal pass
+
+1. **S1 communication timing conflict**: `TRUST_AND_SAFETY.md:86` (table: "public/user comms within **6h**") vs `TRUST_AND_SAFETY.md:129` (playbook: acknowledgement email "within **24h**"). Pick one per artifact type.
+2. **Garbled data-rights parenthetical**: `BUSINESS_RULES.md:279` — "(JSON for data; original audio not included for journal-attached recordings that don't exist yet)" — un-parseable in a rights statement; rewrite.
+3. **Probation review tier referenced but undefined in lifecycle**: `CONTENT_POLICY.md:101` defines a "Providers on probation" review tier and `:153` a path into probation, but `BUSINESS_RULES.md` §3.3 offboarding categories never define probation as a state. Define it once.
+4. **"Severe breach… public disclosure where legally permissible"** (`BUSINESS_RULES.md:148`): naming an offboarded provider publicly has defamation exposure; require counsel sign-off per instance, and say so.
+5. **Recording ownership vs. research data ownership boundary**: `BUSINESS_RULES.md:108` (provider owns recordings) vs Listener participants' voices inside those recordings — the Content Agreement should address participant rights in recorded sessions, not only provider rights.
+6. **Age gating is policy-only**: `PHASE_1:38` ("Age gate at signup: affirmation of 18+") does not exist in code, and `RESEARCH_PROTOCOL.md:43` relies on it for the minors exclusion. When re-tensing (L6), note the research-consent dependency explicitly.
+
+---
+
+## Closing note for counsel
+
+The corpus's biggest structural virtue is also the audit's main lever: it already contains the honesty standard it needs (`VISION.md` promise 7: *"'We believe' and 'we hope to prove' are never replaced with 'we have proven' without evidence"*). Almost every BLOCKER and HIGH above is resolved by applying that standard reflexively — to the docs themselves, not only to product copy. The recommended global mechanic is in [README.md §Recommended release path](./README.md): re-tense, phase-tag, banner the draft status, and let the genuinely strong policy thinking stand on accurate ground.

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -1,0 +1,57 @@
+# Pre-Public-Release Audit of the Product & Policy Documentation
+
+*Audit date: 2026-06-09 · Auditor: automated full-corpus review (Claude Code) · Status: findings recorded, remediation pending*
+
+## What this is
+
+A complete, claim-by-claim audit of the **product and policy documentation set** — the structure of the wellness-adjacent app — performed in preparation for public release. Every factual assertion in these docs was checked against the actual codebase, git history, and deploy configuration; every legally significant statement was reviewed for accuracy, internal consistency, and exposure.
+
+**Verdict: the doc set is NOT ready to be published as-is.** It is well-written and internally principled, but it systematically describes an aspirational product in the present tense: a substantial number of the controls, endpoints, and guarantees it asserts do not exist in code, several statements are legally inaccurate, and the policy docs contradict each other on material terms (provider license, revenue share, content states). Each finding is itemized, cited to file and line, and assigned a severity.
+
+## Corpus audited
+
+The policy/product spine, as defined by `docs/README.md`:
+
+```
+docs/VISION.md                  docs/CONTENT_POLICY.md
+docs/PRODUCT_PRINCIPLES.md      docs/TRUST_AND_SAFETY.md
+BUSINESS_RULES.md (root)        docs/SLO.md
+docs/MONETIZATION.md            docs/ROADMAP.md
+docs/RESEARCH_PROTOCOL.md       docs/phases/PHASE_1..PHASE_4 (all four)
+docs/README.md
+```
+
+The root `README.md` §"Operational commitments" and §"License & ownership" are included because they republish claims from this corpus. The developer/infra readmes (`deploy/`, `go2rtc/`, `TESTING.md`, `public/*`) were also read; their minor findings are confined to an appendix of TECH_AUDIT.md.
+
+Verification sources: `prisma/schema.prisma`, all `src/app/api/` routes, `src/lib/auth-config.ts`, `src/context/AudioContext.tsx`, `services/playlist-bot/`, `docker-compose.yml`, `.github/workflows/deploy.yml`, full git history (branch list, secret scan, env-file scan). Repo state: commit `b72b279`.
+
+## Documents in this audit
+
+| File | Audience | Contents |
+|---|---|---|
+| [LEGAL_AUDIT.md](./LEGAL_AUDIT.md) | Legal team / counsel | 18 findings: licensing, health-claims exposure, GDPR, consent, IP, monetization representations, contradictions between policy docs |
+| [TECH_AUDIT.md](./TECH_AUDIT.md) | Tech team | 20 findings: claims the docs make about the system that the code does not support, each with file:line evidence and a recommended fix path (build it vs. re-tense the doc) |
+
+## Severity scale
+
+- **BLOCKER** — must be resolved before the docs or the repo become public.
+- **HIGH** — significant legal or credibility exposure; resolve before launch or explicitly accept in writing.
+- **MEDIUM** — inconsistency or inaccuracy that will mislead a reader; fix before release.
+- **LOW** — editorial or hygiene item.
+
+## Headline findings
+
+1. **No license decision has been made** (BLOCKER). No `LICENSE` file, no `license` field in `package.json`, and `README.md:95` says "All rights reserved" while preparing a public release. → [LEGAL_AUDIT.md §L1](./LEGAL_AUDIT.md)
+2. **The policy docs guarantee data rights the system cannot deliver** (BLOCKER). `BUSINESS_RULES.md` §1.1 and §9.1 promise one-click export and deletion via named endpoints; neither endpoint exists. → [LEGAL_AUDIT.md §L2](./LEGAL_AUDIT.md), [TECH_AUDIT.md §T1](./TECH_AUDIT.md)
+3. **Documented safety/compliance controls do not exist** (BLOCKER while stated in the present tense): audit log, session kill switch, report buttons, CAPTCHA, email verification, age gate, Postgres encryption at rest, PII log filtering, and every public policy page (`/privacy`, `/terms`, `/research`, `/trust`, `/incidents`). The code in fact logs user email addresses to console, directly contradicting two docs. → [TECH_AUDIT.md §T2–T6](./TECH_AUDIT.md)
+4. **Two legally wrong statements on GDPR and consent** (HIGH): the 72-hour breach window misattributed to user notification, and session recording justified by "participation implies consent." → [LEGAL_AUDIT.md §L3, §L4](./LEGAL_AUDIT.md)
+5. **The wellness-claims discipline leaks** (HIGH): the corpus bans therapeutic claims, yet `PRODUCT_PRINCIPLES.md` asserts which "populations most benefit from the beacon," and `RESEARCH_PROTOCOL.md` records that the live marketing site already claims, in the present tense, research activity that does not exist. → [LEGAL_AUDIT.md §L5, §L12](./LEGAL_AUDIT.md)
+6. **Material contradictions between policy docs** (HIGH): recording license (perpetual vs. revoked-on-removal), provider revenue share (two different 50% models), the "Hidden" content-state flags. → [LEGAL_AUDIT.md §L8, §L9](./LEGAL_AUDIT.md), [TECH_AUDIT.md §T8](./TECH_AUDIT.md)
+7. **Good news**: no secrets or real env files anywhere in git history (all commits scanned); the Prisma schema, role enums, content-state flags, LiveKit/go2rtc topology, and the repo-layout claims in the docs are accurate; the docs' own "Draft · pending validation" discipline is consistently applied and is the cheapest global mitigation available.
+
+## Recommended release path
+
+1. Legal works through LEGAL_AUDIT.md top-down; every BLOCKER/HIGH gets a written decision in the PR that closes it.
+2. Tech works through TECH_AUDIT.md; for each docs-vs-code gap, either build the control or re-tense the claim ("will", "Phase N") — each finding states which fix is realistic.
+3. Global mitigation, cheap and honest: promote the existing "Draft · pending validation" marker into an unmissable status banner in each doc and in the root README, and convert all present-tense claims about unbuilt systems into explicitly-marked roadmap commitments. The corpus already contains the right vocabulary for this (`VISION.md` promise 7: *"We are honest about what we don't yet know"*) — the fix is to apply it to the docs themselves.
+4. Re-run this audit's claim list before flipping repo visibility.

--- a/docs/audit/TECH_AUDIT.md
+++ b/docs/audit/TECH_AUDIT.md
@@ -1,0 +1,144 @@
+# Tech Audit — Claims in the Product & Policy Docs vs. the Codebase
+
+*Audit date: 2026-06-09 · Scope: the `docs/` policy corpus + `BUSINESS_RULES.md`; infra readmes in Appendix A · Repo state: commit `b72b279` · See [README.md](./README.md) for methodology and severity scale.*
+
+Every present-tense system claim in the policy docs was checked against the code. Each finding gives the doc claim, the code evidence, and a recommended fix: **BUILD** (implement before release), **RE-TENSE** (rewrite the doc as a phase-tagged commitment), or **CORRECT** (the doc is simply wrong about the code).
+
+What checked out — for the record, these doc claims are **accurate**: `UserRole`/`ModerationStatus`/`TagCategory` enums, `isPublished`/`isFeatured`/`isHidden`/`defaultMix`/`originalPath` fields (`prisma/schema.prisma:16-105`); `ListeningSession`, `ScheduledSession`, `SessionRecording`, `SessionInvite`, `Favorite` models (`schema.prisma:151-267`); LiveKit topology `wss://live.altermundi.net` / room `beacon` / identity `beacon01` (`src/context/AudioContext.tsx:7,78`, `src/app/api/livekit/token/route.ts`); go2rtc on-demand stream creation with `#audio=opus` (`src/app/api/meditations/route.ts:160-206`); playlist-bot fallback publisher exists and reacts to `beacon01` presence (`services/playlist-bot/src/index.ts:240-288`); nginx rate limiting (`deploy/nginx-harmonic-beacon.conf:27-29`); repo-layout section of root README; no secrets in git history (full scan, all commits).
+
+---
+
+## BLOCKER — guaranteed user-facing mechanisms that do not exist
+
+### T1 — Data export and account deletion endpoints
+
+- **Claim**: `BUSINESS_RULES.md:31,279-281` — one-click export via `/api/users/me/export`; deletion via `DELETE /api/users/me` purging identifiable data within 30 days.
+- **Code**: `src/app/api/users/me/route.ts` exports **GET only** (59 lines). No export route, no DELETE handler, no purge job anywhere.
+- **Fix**: **BUILD** — this is the one gap that should be closed in code rather than in prose: both endpoints are small (the export is a few Prisma queries serialized to JSON; deletion is a cascade the schema mostly already supports), and they underwrite the corpus's central data-rights promises. Until merged, RE-TENSE the two doc lines.
+
+### T2 — Audit log
+
+- **Claim**: `BUSINESS_RULES.md:62` "Every administrative action is written to the audit log"; relied on throughout (`TRUST_AND_SAFETY.md:41-43` role-change events, `PHASE_2:133` financial events).
+- **Code**: No `AuditLog` model in `prisma/schema.prisma` (ends at line 285); zero hits for any audit mechanism in `src/`.
+- **Fix**: **BUILD** (append-only table + a `logAdminAction()` helper called from the existing admin routes is a day of work and is listed as a Phase 1 deliverable anyway, `PHASE_1:63`) or RE-TENSE every present-tense reference.
+
+### T3 — Report system and session kill switch
+
+- **Claim**: `BUSINESS_RULES.md:302-304` "Every scheduled session has an Admin-accessible kill-switch. Every content surface… has a report button. Reports are acknowledged within 24 hours"; full kill-switch spec in `TRUST_AND_SAFETY.md` §4; report capture spec in §2.5.
+- **Code**: No `Report` model, no report endpoints, no report UI. No admin room-termination endpoint — the only session-end path is the Provider ending **their own** session (`src/app/api/provider/sessions/[id]/route.ts:125-181`).
+- **Fix**: **RE-TENSE now; BUILD before any open signup.** These are the safety affordances the T&S doc stakes the brand on; flipping the repo public with the spec visible and the buttons absent is the worst of both.
+
+### T4 — Signup/identity controls: CAPTCHA, email verification, rate limit, age gate
+
+- **Claim**: `TRUST_AND_SAFETY.md:32-36` (CAPTCHA, email verification before first listen, per-IP signup rate limit, disposable-email scoring); `PHASE_1:38` + `RESEARCH_PROTOCOL.md:43` (18+ age gate, minors blocked from research).
+- **Code**: None of it. Auth is Zitadel OIDC (`src/lib/auth-config.ts`); the app applies no gates of its own. Some controls may legitimately live in Zitadel — but nothing verifies or documents that configuration, and the docs claim them as platform properties.
+- **Fix**: **CORRECT + RE-TENSE** — restate which controls are delegated to Zitadel (and verify them there, recording the config), which are app-level and unbuilt (age gate, listen-gating), and phase-tag the latter.
+
+### T5 — "PII in logs is mechanically filtered" — the code does the opposite
+
+- **Claim**: `TRUST_AND_SAFETY.md:66`; `PRODUCT_PRINCIPLES.md:58` "No logging PII to anywhere we can't purge."
+- **Code**: `src/lib/auth-config.ts:89` — `` console.log(`[auth] jwt sync: sub=${token.sub} email=${token.email} role=${dbRole}`) `` logs subject ID + email on every JWT sync; `:57` logs the full roles claim. Container stdout ends up in Docker logs on the host — unpurgeable in practice.
+- **Fix**: **BUILD (trivial)** — strip/mask the email from both log lines this week, regardless of release timing. Then RE-TENSE the "mechanically filtered" claim until structured logging (Phase 1 deliverable) exists.
+
+### T6 — Public policy/transparency pages
+
+- **Claim**: routes referenced as live surfaces — `/privacy`, `/terms` (`PHASE_1:32-33`), `/research` (`RESEARCH_PROTOCOL.md:149`), `/policy/content` (`CONTENT_POLICY.md:239`), `/trust` (`TRUST_AND_SAFETY.md:201`), `/incidents` (`TRUST_AND_SAFETY.md:92`), `/hearth` (`PHASE_2:42`), status page (`SLO.md` §7).
+- **Code**: None exist. `src/app/` contains only: `admin`, `api`, `join`, `live`, `login`, `meditation`, `playback`, `profile`, `provider`, `session`, `sessions`, `settings`.
+- **Fix**: **RE-TENSE** (most are explicitly Phase 1–2 deliverables; the furcio is the docs that cite them as present locations, e.g. CONTENT_POLICY §9 "We publish, at `/policy/content`").
+
+---
+
+## HIGH — policy logic the code does not enforce
+
+### T7 — Business rules stated as system behavior with no enforcement
+
+| Rule as documented | Where | Code reality |
+|---|---|---|
+| `completed` = durationSeconds ≥ 0.85 × duration (MEDITATION) / ≥60s (LIVE); finalized on 30-min inactivity | `BUSINESS_RULES.md:114-115` | Client sets `completed` arbitrarily; server applies `body.completed ?? true` with no validation (`src/app/api/sessions/[id]/route.ts:125`). No inactivity finalizer exists. |
+| SCHEDULED→LIVE only within −10/+60 min of `scheduledAt` without admin override | `BUSINESS_RULES.md:104` | Start action checks only `status !== 'SCHEDULED'` (`src/app/api/provider/sessions/[id]/route.ts:111-123`). |
+| Session exceeding declared duration by 100% auto-flagged | `BUSINESS_RULES.md:107` | No such mechanism. |
+| LANGUAGE tag + one of MOOD/TECHNIQUE/DURATION required at publication | `BUSINESS_RULES.md:96-97`, `CONTENT_POLICY.md:36-38` | Admin approval endpoint performs no tag validation (`src/app/api/admin/meditations/[id]/route.ts:54-86`). |
+| Two-reviewer approval for first-submission providers | `BUSINESS_RULES.md:159`, `CONTENT_POLICY.md:99` | Single-approver UI only (`src/app/admin/moderation/page.tsx`). |
+
+- **Fix**: Each row: **BUILD** if the rule should bind at launch, otherwise **RE-TENSE**. Recommended minimum builds: the server-side `completed` computation (research integrity and future revshare attribution both depend on `ListeningSession` being trustworthy — `MONETIZATION.md:130` calls it "auditable from the ListeningSession ledger", which it currently is not) and the tag check at approval (one query in the approval handler).
+
+### T8 — The "Hidden" content state is defined two contradictory ways
+
+- **Claim**: `BUSINESS_RULES.md:93` (lifecycle table): Hidden = `ModerationStatus: APPROVED`, `isPublished: true`, `isHidden: true`. But `CONTENT_POLICY.md:174` (takedown workflow): "Admin moves content to `isHidden=true`, **`isPublished=false`**."
+- **Problem**: The canonical table and the operational workflow disagree on the flag combination. Whichever the code eventually enforces, queries written from the other doc will leak or lose hidden content (e.g., a "visible = published && !hidden" filter behaves differently under each definition).
+- **Fix**: **CORRECT** — pick one (the table's version preserves the pre-takedown publication state, which is more informative; the workflow's version is safer-by-default). Document the chosen invariant next to the schema.
+
+### T9 — Continuity claims: standby, transition UI, client contract
+
+- **Claims vs code**:
+  - "warm-standby upstream" listed in the *current* source hierarchy (`BUSINESS_RULES.md:262`) — `beacon02` exists nowhere in code (only as Phase 1 *plan* in `SLO.md` §3 and `PHASE_1:68`). The BUSINESS_RULES phrasing presents it as already part of the documented hierarchy.
+  - "fallback… surfaced to the listener as a 'Beacon in transit' state" (`BUSINESS_RULES.md:235`); "the UI tells the truth about it" (`SLO.md` §1) — **no source-state UI exists**. The client silently mutes/unmutes fallback audio on `beacon01` presence (`src/context/AudioContext.tsx:104-144,185`). Today a listener hearing the fallback has no indication it is not live — the exact situation `SLO.md:20` calls deception and `TRUST_AND_SAFETY.md:216` says "we do not" do.
+  - Client contract `SLO.md` §8 ("These are **enforced in code review**"): exponential backoff to 15 min — not present; 30-second local audio cache — not present; transparent token refresh — only whatever the LiveKit SDK does by default.
+  - "playlist-fallback switchover (already implemented) … < 10-second handover" (`SLO.md:87`) — the bot publishes on disconnect events with no measured/tuned handover bound (`services/playlist-bot/src/index.ts:240-288`); "10 seconds" appears nowhere in code.
+- **Fix**: **BUILD the source-state UI first** — it is the smallest piece (the client already knows `beacon01` presence; render it) and it converts the continuity story from misleading to honest even while standby/backoff remain roadmap. RE-TENSE beacon02, the client contract, and the 10-second figure (or measure and then claim it).
+
+### T10 — Research, monetization, and community schema described in operative detail with zero schema presence
+
+- **Claim**: operative references to `ConsentRecord`, `ResearchParticipant`, `SurveyInstrument`, `SurveyResponse`, `rpid` (`PHASE_1:86-88`, `RESEARCH_PROTOCOL.md` §4), `Patronage` (`PHASE_2:33`), `JournalEntry`, `Sitting`, `ProviderApplication`, `PayoutStatement` (`PHASE_2`), pseudonymization pipeline diagram (`RESEARCH_PROTOCOL.md:103-116`).
+- **Code**: none of these models exist (`prisma/schema.prisma` ends at `SessionParticipant`, line 285).
+- **Assessment**: Mostly **correctly tensed** — the phase docs label these as deliverables. The furcios are the places that slip into present tense: `BUSINESS_RULES.md` §6 (research rules as operative), `RESEARCH_PROTOCOL.md:118` (processor claim, see LEGAL L14), `RESEARCH_PROTOCOL.md:99` (classification "is" three levels). **RE-TENSE** those specific spots.
+
+### T11 — Role mapping diverges from the documented model
+
+- **Claim**: `BUSINESS_RULES.md:13` — roles "synchronized via Zitadel (`BEAC_ADMIN`, `BEAC_PROVIDER`, `BEAC_LISTENER`)".
+- **Code**: `src/lib/auth-config.ts:59-63` — checks `BEAC_ADMIN`, `BEAC_PROVIDER`, **and a legacy undocumented `certified_provider` claim**; `BEAC_LISTENER` is never read (absence of the other two → default). Internal role type uses `'USER'` as the default string, mapped to `LISTENER` only at DB sync (`auth-config.ts:87`).
+- **Fix**: **CORRECT** the doc (listener-by-default, no claim required) and **decide** whether `certified_provider` is still a valid grant path — an undocumented role-granting claim is exactly what `TRUST_AND_SAFETY.md` §2.2's "role changes logged" posture should not tolerate.
+
+### T12 — Observability stack claimed/relied on, none present
+
+- **Claim**: `SLO.md` §9 (structured logs, metrics, traces, Sentry, external uptime monitor, alerts); `TRUST_AND_SAFETY.md:71-74` (healthchecks ✓ exist, external monitor ✗, WAF ✗ — plain nginx rate-limit only).
+- **Code**: zero hits for Sentry or any structured-logging/metrics library; only ad-hoc `console.log`. Container healthchecks do exist (`docker-compose.yml:45-114`).
+- **Fix**: **RE-TENSE** (Phase 1 already owns this work, `PHASE_1:57-65`); keep §9 as the target spec, but the SLO doc's measurement table (`SLO.md` §2 "How measured") should say "to be measured by", because today none of the listed measurement mechanisms exist — publishing SLO targets with no measurement apparatus invites the "show me the number" question with no answer.
+
+---
+
+## MEDIUM
+
+### T13 — Resonance Journal encryption design is impossible under the current auth architecture
+
+- **Claim**: `PHASE_2:93-94` — journal body "encrypted at rest with a key derived from the user's secret (so even Admin cannot read it)"; risk table `PHASE_2:159` — "Key derived from **user's password** with recovery-phrase option."
+- **Problem**: Authentication is Zitadel OIDC with PKCE; **the application never possesses a user password** to derive a key from. As designed, the feature cannot be built. Additionally `BUSINESS_RULES.md:244` says the research layer can (with consent) read journal fields — contradicting "only the Listener can read" unless the design separates encrypted body from plaintext structured fields (which `PHASE_2:95` does say — the contradiction is in `BUSINESS_RULES.md:244`'s phrasing "only the Listener (and… the research layer) can read **them**" applying to entries wholesale).
+- **Fix**: **CORRECT** the design before Phase 2: client-held key material (WebCrypto + recovery phrase), or app-managed encryption with an honest "Admin-resistant, not Admin-proof" claim. Align `BUSINESS_RULES.md` §7.3 wording with the body-vs-fields split.
+
+### T14 — Commons commitment has no mechanism
+
+- **Claim**: `BUSINESS_RULES.md:177` — Commons of "minimum 15 [published meditations] at any time across the top tag categories"; `MONETIZATION.md:67` "15 published meditations rotating monthly."
+- **Code**: no rotation mechanism, no count guard, and (pre-monetization) no free/patron distinction at all — currently everything published is available to everyone, which exceeds the commitment but means the "minimum 15" floor exists nowhere.
+- **Fix**: **RE-TENSE**; when patronage ships, the floor needs an actual guard (an admin dashboard warning is enough) or the commitment becomes silently breachable.
+
+### T15 — Doc-internal numeric/SLA inconsistencies
+
+1. S1 comms: 6h (`TRUST_AND_SAFETY.md:86`) vs 24h (`:129`) — see LEGAL L18.1.
+2. Kindred private sittings "up to 6 co-listeners" (`MONETIZATION.md:33`) vs sittings capacity caps "e.g. 50" (`PHASE_2:157`) — different surfaces, but a reader can't tell; clarify.
+3. `SLO.md:33` publishes a **mobile crash-free SLO** at launch tier when no mobile app exists (and the `feat/flutter-migration` branch named in `PHASE_2:185`/`PHASE_3:28` **does not exist** — branches are `main` and `release` only; no Flutter or Expo code anywhere in history). The mobile premise of Phase 3 currently has no code substrate; re-tag the branch reference to "to be created" or restore the missing branch from wherever it lives.
+4. `docs/README.md:43` instructs editors to preserve the draft-status line — good; but `README.md:81` then markets those drafts as "enforceable" (LEGAL L7). The two should be reconciled in the same PR.
+
+### T16 — i18n status
+
+- **Claim**: EN/ES parity is consistently and honestly marked as Phase 1 work (`PHASE_1:102-105`). Accurate.
+- **Code reality worth noting**: today's "language support" is a settings dropdown writing `app_language` to localStorage with no message catalogs (`src/app/settings/page.tsx:8-30`) — i.e., a control that visibly does nothing. Minor, but it's user-visible vaporware of the same species this audit exists to catch.
+- **Fix**: hide the dropdown until next-intl lands, or label it.
+
+---
+
+## Appendix A — infra/dev readmes (outside the policy corpus; for completeness)
+
+1. **`deploy/README.md:67`** — wrong env var name and wrong path: documents `MEDITATIONS_PATH=/mnt/raid1/harmonic-beacon/meditations`; the code reads **`MEDITATIONS_STORAGE_PATH`** and production mounts **`/mnt/n8n-data/harmonic-beacon/meditations`** (`docker-compose.yml:32,37`; the readme's own troubleshooting section at `:113` uses the correct path). Following the config section as written breaks the deploy. **CORRECT.**
+2. **`deploy/README.md:61`** — "Create `.env` at project root" contradicts both `.env.example:5` ("no .env files on server") and the actual mechanism: CI writes `/etc/sai-harmonic-beacon/production.env` (`.github/workflows/deploy.yml:36-50`), which `TRUST_AND_SAFETY.md:67` gets right. Three docs, three stories; one is true. **CORRECT** the readme and the `.env.example` comment (it predates commit `6b5918e`).
+3. **Operational exposure decision**: `deploy/README.md` publishes the production IP (`131.72.205.6`, `:68,104`), runner home path (`:46`), internal ports and storage paths. None are secrets, but together they are a tidy reconnaissance page. Decide deliberately whether `deploy/` stays in the public repo, gets genericized, or moves to a private ops repo. (Git history is clean: full-history scan found no committed secrets; only `.env.example` files were ever added.)
+4. **`deploy/README.md` "Prisma migrations run automatically"** — true via CI on the host before containers start (`deploy.yml:25-28`), not inside the compose lifecycle; fine, but clarify for whoever does a manual deploy (the manual-deploy section omits the migrate step entirely — a real foot-gun). **CORRECT.**
+5. **`TESTING.md`, `go2rtc/README.md`, `public/*/README.md`** — verified accurate (console strings exist at `src/context/AudioContext.tsx:316-349`; POST `/api/meditations` does create streams as described; `/data/meditations` is the in-container path, accurate in context).
+
+---
+
+## Suggested execution order (tech team)
+
+1. **This week, regardless of release date**: T5 (strip email from logs — two lines), T11 decision on `certified_provider`.
+2. **Before repo goes public**: T1 (export + delete endpoints), T8 (pick the Hidden invariant), Appendix A.1/A.2 (deploy doc corrections), A.3 (deploy-dir exposure decision), and the global re-tense pass over BUSINESS_RULES/T&S/SLO present-tense claims (T2, T3, T4, T6, T9, T10, T12).
+3. **Before open signup**: T3 (reports + kill switch), T4 (age gate), T7 minimum builds (`completed` server-side, tag check), T9 source-state UI.
+4. **Phase-gated as already planned**: everything else, with the docs now telling the truth about the gate.


### PR DESCRIPTION
## Summary

Complete claim-by-claim audit of the `docs/` policy corpus (+ `BUSINESS_RULES.md`) against the codebase, git history, and deploy configuration, in preparation for public release.

- **`docs/audit/README.md`** — scope, methodology, severity scale, headline verdict
- **`docs/audit/LEGAL_AUDIT.md`** — 18 findings for counsel: licensing posture (no LICENSE file), GDPR misstatements (72h rule, implied recording consent, Art. 9 special-category data), cross-doc contradictions (provider license terms, revenue-share models), claims exposure (marketing-site research claims, health-benefit slip, psychometric instrument licensing)
- **`docs/audit/TECH_AUDIT.md`** — 20 findings for the tech team: every present-tense system claim in the docs checked against code, with file:line evidence and a recommended fix path (build vs. re-tense vs. correct), plus a prioritized execution order

**Verdict: the doc set is not publishable as-is** — it describes an aspirational product in the present tense (data-rights endpoints, audit log, kill switch, report system, policy pages, and encryption claims have no code substrate; PII is actually logged in plaintext). Remediation paths are included per finding.

## Review notes

- Legal team: work LEGAL_AUDIT.md top-down; each BLOCKER/HIGH needs a written decision.
- Tech team: TECH_AUDIT.md §Suggested execution order; item T5 (PII in auth logs) is a two-line fix worth doing immediately regardless of release timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)