### PR TITLE
feat(ws6-02): link canonical terms + document the ticket purchase URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,11 @@ SESSION_COOKIE_TTL_SECONDS=604800
 # request into one shared bucket.
 TRUSTED_PROXY_HOPS=1
 
-# External ticketing platform purchase link. Unset until WS6-01 proves the
-# payout rail; the landing page then says sales open shortly instead of linking.
-TICKET_PURCHASE_URL=
+# Where the landing's "Buy a ticket" link points. This is the registration entry
+# point on the marketing site, which then routes to Ticket Tailor for payment:
+#   harmonicbeacon.com/inscripcion -> Ticket Tailor -> payment -> /confirmacion
+# Leave unset to keep the landing on "sales open shortly"; set it to open sales.
+TICKET_PURCHASE_URL=https://harmonicbeacon.com/inscripcion/
 
 # Password digests use: scrypt$<salt-base64url>$<digest-base64url>.
 # These placeholders are deliberately invalid; supply unique production digests.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,7 +154,15 @@ export default async function LandingPage({
                 <LoginClient next={next} />
             </section>
 
-            <footer className="mt-auto text-xs text-[var(--text-secondary)]">
+            <footer className="mt-auto flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--text-secondary)]">
+                <a
+                    href="https://harmonicbeacon.com/politica/"
+                    className="underline"
+                    rel="noreferrer noopener"
+                    target="_blank"
+                >
+                    Terms &amp; privacy <span>/ Términos y privacidad</span>
+                </a>
                 <Link href="/staff/login" className="underline">
                     Staff sign-in <span>/ Ingreso del equipo</span>
                 </Link>


### PR DESCRIPTION
App-side of WS6-02:
- Landing footer links to the canonical attendee terms (https://harmonicbeacon.com/politica/) instead of an in-app copy that would drift.
- .env.example documents TICKET_PURCHASE_URL = https://harmonicbeacon.com/inscripcion/ (the registration entry that routes to Ticket Tailor -> payment -> /confirmacion). The landing already renders "Buy a ticket" when it's set and "sales open shortly" when not; setting the value in prod is an ops/WS6-03 step.

Rebased on current main. Advances #26; the platform / tier / code-loading / email parts remain ops/external and stay open on the card.