### PR TITLE
Feat/harmonic projection visual system

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -58,8 +58,8 @@ describe('landing page', () => {
         mountDb(vi.fn().mockResolvedValue([SATURDAY, SESSION_2]));
         await renderPage();
 
-        expect(screen.getByText('In English')).toBeInTheDocument();
-        expect(screen.getByText('En español')).toBeInTheDocument();
+        expect(screen.getByText('English')).toBeInTheDocument();
+        expect(screen.getByText('Español')).toBeInTheDocument();
 
         // The event's advertised Costa Rica time comes first, with operator and
         // universal references explicitly labelled below it.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,92 +1,108 @@
 @import "tailwindcss";
 
 /* ============================================
-   HARMONIC BEACON - Design System
+   HARMONIC PROJECTION — Design System
+   Event visual language: warm-black / ink / gold
+   Based on harmonicbeacon.com/inscripcion/confirmacion
    ============================================ */
 
 :root {
-  /* Primary - Deep calming purples/blues */
-  --primary-50: #f0f0ff;
-  --primary-100: #e4e4ff;
-  --primary-200: #cccbff;
-  --primary-300: #a9a4ff;
-  --primary-400: #8274ff;
-  --primary-500: #6346ff;
-  --primary-600: #5423f7;
-  --primary-700: #4614e3;
-  --primary-800: #3a12be;
-  --primary-900: #30119b;
-  --primary-950: #1c0869;
+  /* ---- Core palette ---- */
+  --ink: #080B16;
+  --deep: #071419;
+  --deep-2: #0B1720;
+  --cream: #FFF6DF;
+  --paper: #DCE6DF;
+  --muted: #91A2A2;
 
-  /* Accent - Warm amber for highlights */
-  --accent-400: #fbbf24;
-  --accent-500: #f59e0b;
-  --accent-600: #d97706;
+  /* ---- Accent palette ---- */
+  --gold: #FFD36D;
+  --cyan: #63EDFF;
+  --pink: #FF71BD;
+  --lime: #B6FF71;
+  --violet: #9E72FF;
 
-  /* Background gradient */
-  --bg-dark: #0a0a1a;
-  --bg-dark-secondary: #12122a;
-  --bg-card: rgba(255, 255, 255, 0.03);
-  --bg-card-hover: rgba(255, 255, 255, 0.06);
-  
-  /* Text colors */
-  --text-primary: #ffffff;
-  --text-secondary: rgba(255, 255, 255, 0.7);
-  --text-muted: rgba(255, 255, 255, 0.4);
-  
-  /* Border colors */
+  /* ---- Semantic tokens ---- */
+  --bg-page: var(--ink);
+  --bg-elevated: rgba(255, 255, 255, 0.03);
+  --bg-elevated-hover: rgba(255, 255, 255, 0.06);
+  --bg-operator: rgba(8, 11, 22, 0.92);
+  --bg-card: rgba(255, 255, 255, 0.02);
+  --bg-card-hover: rgba(255, 255, 255, 0.04);
+
+  --text-primary: var(--cream);
+  --text-secondary: rgba(255, 246, 223, 0.7);
+  --text-muted: rgba(255, 246, 223, 0.45);
+  --text-inverse: var(--ink);
+
   --border-subtle: rgba(255, 255, 255, 0.08);
-  --border-active: rgba(99, 70, 255, 0.5);
-  
-  /* Shadows */
-  --shadow-glow: 0 0 60px rgba(99, 70, 255, 0.15);
-  --shadow-card: 0 4px 20px rgba(0, 0, 0, 0.3);
-  
-  /* Safe areas for mobile */
+  --border-active: rgba(99, 237, 255, 0.4);
+  --border-gold: rgba(255, 211, 109, 0.25);
+
+  /* ---- Status tokens ---- */
+  --brand: var(--gold);
+  --live: var(--cyan);
+  --request: var(--pink);
+  --success: var(--lime);
+  --warning: #f59e0b;
+  --danger: #ef4444;
+
+  /* ---- Focus ---- */
+  --focus-ring: var(--gold);
+
+  /* ---- Shadows ---- */
+  --shadow-card: 0 4px 20px rgba(0, 0, 0, 0.35);
+  --shadow-glow: 0 0 40px rgba(255, 211, 109, 0.08);
+
+  /* ---- Safe areas ---- */
   --safe-top: env(safe-area-inset-top);
   --safe-bottom: env(safe-area-inset-bottom);
 }
 
 @theme inline {
-  --color-background: var(--bg-dark);
+  --color-background: var(--bg-page);
   --color-foreground: var(--text-primary);
-  --font-sans: system-ui;
-  --font-mono: ui-monospace;
+  --font-sans: var(--font-syne), system-ui, -apple-system, sans-serif;
+  --font-serif: var(--font-cormorant), Georgia, serif;
+  --font-mono: var(--font-space-mono), ui-monospace, monospace;
 }
 
-/* Global styles */
+/* ============================================
+   BASE
+   ============================================ */
+
 * {
   box-sizing: border-box;
 }
 
 html {
   scroll-behavior: smooth;
+  background: var(--ink);
 }
 
 body {
-  background: linear-gradient(180deg, var(--bg-dark) 0%, var(--bg-dark-secondary) 100%);
+  background: var(--ink);
   color: var(--text-primary);
-  font-family: var(--font-sans), system-ui, -apple-system, sans-serif;
+  font-family: var(--font-syne), system-ui, -apple-system, sans-serif;
   min-height: 100vh;
   overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-/* Scrollbar styling */
+/* Scrollbar */
 ::-webkit-scrollbar {
-  width: 8px;
+  width: 6px;
 }
-
 ::-webkit-scrollbar-track {
-  background: var(--bg-dark);
+  background: var(--ink);
 }
-
 ::-webkit-scrollbar-thumb {
-  background: var(--primary-700);
-  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 3px;
 }
-
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--primary-600);
+  background: rgba(255, 255, 255, 0.2);
 }
 
 /* ============================================
@@ -94,471 +110,539 @@ body {
    ============================================ */
 
 @keyframes pulse-glow {
-  0%, 100% {
-    box-shadow: 0 0 20px rgba(99, 70, 255, 0.3);
-  }
-  50% {
-    box-shadow: 0 0 40px rgba(99, 70, 255, 0.6);
-  }
-}
-
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-10px);
-  }
-}
-
-@keyframes wave {
-  0% {
-    transform: scaleY(1);
-  }
-  50% {
-    transform: scaleY(0.5);
-  }
-  100% {
-    transform: scaleY(1);
-  }
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes slide-up {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  0%, 100% { box-shadow: 0 0 12px rgba(255, 211, 109, 0.2); }
+  50% { box-shadow: 0 0 24px rgba(255, 211, 109, 0.4); }
 }
 
 @keyframes breathe {
-  0%, 100% {
-    transform: scale(1);
-    opacity: 0.6;
-  }
-  50% {
-    transform: scale(1.1);
-    opacity: 1;
-  }
+  0%, 100% { transform: scale(1); opacity: 0.7; }
+  50% { transform: scale(1.15); opacity: 1; }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes live-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(99, 237, 255, 0.5); }
+  70% { box-shadow: 0 0 0 8px rgba(99, 237, 255, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(99, 237, 255, 0); }
 }
 
 .animate-pulse-glow {
   animation: pulse-glow 3s ease-in-out infinite;
 }
 
-.animate-float {
-  animation: float 4s ease-in-out infinite;
+.animate-breathe {
+  animation: breathe 2.4s ease-in-out infinite;
 }
 
 .animate-fade-in {
-  animation: fade-in 0.5s ease-out forwards;
+  animation: fade-in 0.4s ease-out forwards;
 }
 
 .animate-slide-up {
-  animation: slide-up 0.6s ease-out forwards;
+  animation: slide-up 0.5s ease-out forwards;
 }
 
-.animate-breathe {
-  animation: breathe 4s ease-in-out infinite;
+.animate-live-pulse {
+  animation: live-pulse 2.4s infinite;
 }
 
-/* Staggered animations */
-.stagger-1 { animation-delay: 0.1s; }
-.stagger-2 { animation-delay: 0.2s; }
-.stagger-3 { animation-delay: 0.3s; }
-.stagger-4 { animation-delay: 0.4s; }
-.stagger-5 { animation-delay: 0.5s; }
+/* Staggered */
+.stagger-1 { animation-delay: 0.08s; }
+.stagger-2 { animation-delay: 0.16s; }
+.stagger-3 { animation-delay: 0.24s; }
+.stagger-4 { animation-delay: 0.32s; }
 
 /* ============================================
-   COMPONENT STYLES
+   EVENT SHELL
    ============================================ */
 
-/* Glass card effect */
-.glass-card {
-  background: rgba(255, 255, 255, 0.02); /* More translucent */
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 20px; /* Softer corners */
-  transition: background-color 0.3s ease, border-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.glass-card:hover {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.1);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-}
-
-/* Page Gradient Overlay - Simulates the Live page depth */
-.page-gradient {
-  position: fixed;
-  inset: 0;
-  background: radial-gradient(circle at 50% 0%, rgba(99, 70, 255, 0.15), transparent 70%),
-              linear-gradient(180deg, rgba(10, 10, 26, 0.8) 0%, var(--bg-dark) 100%);
-  pointer-events: none;
-  z-index: 0;
-}
-
-/* Primary button */
-.btn-primary {
-  background: linear-gradient(135deg, var(--primary-600) 0%, var(--primary-700) 100%);
-  color: white;
-  padding: 12px 24px;
-  border-radius: 12px;
-  font-weight: 600;
-  font-size: 0.95rem;
-  border: none;
-  cursor: pointer;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-  position: relative;
-  overflow: hidden;
-}
-
-.btn-primary:focus-visible {
-  outline: 2px solid var(--primary-400);
-  outline-offset: 2px;
-}
-
-.btn-primary::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(99, 70, 255, 0.4);
-}
-
-.btn-primary:hover::before {
-  opacity: 1;
-}
-
-.btn-primary:active {
-  transform: translateY(0);
-}
-
-.btn-primary span {
-  position: relative;
-  z-index: 1;
-}
-
-/* Secondary button */
-.btn-secondary {
-  background: transparent;
-  color: var(--text-primary);
-  padding: 12px 24px;
-  border-radius: 12px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  border: 1px solid var(--border-subtle);
-  cursor: pointer;
-  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
-}
-
-.btn-secondary:focus-visible {
-  outline: 2px solid var(--primary-400);
-  outline-offset: 2px;
-}
-
-.btn-secondary:hover {
-  background: var(--bg-card-hover);
-  border-color: var(--primary-500);
-  color: var(--primary-400);
-}
-
-/* Input styles */
-.input-field {
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid var(--border-subtle);
-  border-radius: 12px;
-  padding: 14px 16px;
-  color: var(--text-primary);
-  font-size: 1rem;
-  width: 100%;
-  transition: border-color 0.3s ease, box-shadow 0.3s ease;
-}
-
-/* Focus ring utility */
-.focus-ring {
-  outline: none;
-}
-.focus-ring:focus-visible {
-  outline: 2px solid var(--primary-500);
-  outline-offset: 2px;
-}
-
-.input-field::placeholder {
-  color: var(--text-muted);
-}
-
-.input-field:focus {
-  outline: none;
-  border-color: var(--primary-500);
-  box-shadow: 0 0 0 3px rgba(99, 70, 255, 0.1);
-}
-
-/* Tab navigation */
-.tab-nav {
-  display: flex;
-  justify-content: center;
-  gap: 4px;
-  padding: 4px;
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 16px;
-  border: 1px solid var(--border-subtle);
-}
-
-.tab-item {
-  flex: 1;
+.event-shell {
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: var(--ink);
+  position: relative;
+}
+
+.event-shell::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 15% 10%, rgba(158, 114, 255, 0.06) 0%, transparent 50%),
+    radial-gradient(ellipse at 85% 80%, rgba(99, 237, 255, 0.04) 0%, transparent 50%);
+}
+
+/* ============================================
+   BRAND LOCKUP
+   ============================================ */
+
+.brand-lockup {
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 12px 8px;
-  border-radius: 12px;
-  color: var(--text-muted);
-  font-size: 0.75rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
+  gap: 10px;
+  color: var(--cream);
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 0.19em;
+  text-transform: uppercase;
+  line-height: 1.15;
   text-decoration: none;
 }
 
-.tab-item:hover {
-  color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.tab-item:focus-visible {
-  outline: 2px solid var(--primary-500);
-  outline-offset: -2px;
-}
-
-.tab-item.active {
-  color: var(--text-primary);
-  background: var(--primary-700);
-}
-
-.tab-item svg {
-  width: 24px;
-  height: 24px;
-}
-
-/* Audio visualizer bars */
-.audio-bars {
-  display: flex;
-  align-items: flex-end;
-  gap: 3px;
-  height: 40px;
-}
-
-.audio-bar {
-  width: 4px;
-  background: linear-gradient(to top, var(--primary-600), var(--primary-400));
-  border-radius: 2px;
-  animation: wave 1s ease-in-out infinite;
-}
-
-.audio-bar:nth-child(1) { height: 60%; animation-delay: 0s; }
-.audio-bar:nth-child(2) { height: 100%; animation-delay: 0.1s; }
-.audio-bar:nth-child(3) { height: 75%; animation-delay: 0.2s; }
-.audio-bar:nth-child(4) { height: 90%; animation-delay: 0.3s; }
-.audio-bar:nth-child(5) { height: 50%; animation-delay: 0.4s; }
-
-/* Live indicator */
-.live-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: #ef4444;
-  border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.live-badge::before {
-  content: '';
-  width: 8px;
-  height: 8px;
-  background: white;
+.brand-lockup__mark {
+  display: grid;
+  place-items: center;
+  width: 29px;
+  height: 29px;
+  border: 1px solid var(--gold);
   border-radius: 50%;
-  animation: breathe 1.5s ease-in-out infinite;
+  color: var(--gold);
+  font-size: 14px;
+  flex-shrink: 0;
+  box-shadow: 0 0 18px rgba(255, 211, 109, 0.2);
 }
 
-/* Progress ring for sessions */
-.progress-ring {
-  position: relative;
-  width: 200px;
-  height: 200px;
+.brand-lockup__accent {
+  color: var(--cyan);
+  font-style: normal;
 }
 
-.progress-ring-circle {
-  fill: none;
-  stroke-width: 8;
-  stroke-linecap: round;
-  transform: rotate(-90deg);
-  transform-origin: center;
-}
+/* ============================================
+   CARDS
+   ============================================ */
 
-.progress-ring-bg {
-  stroke: var(--border-subtle);
-}
-
-.progress-ring-fg {
-  stroke: url(#gradient);
-  transition: stroke-dashoffset 0.5s ease;
-}
-
-/* Meditation card */
-.meditation-card {
-  position: relative;
-  overflow: hidden;
-  border-radius: 20px;
-  background: linear-gradient(135deg, rgba(99, 70, 255, 0.2), rgba(99, 70, 255, 0.05));
-  border: 1px solid var(--border-subtle);
-  padding: 20px;
-  cursor: pointer;
-  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
-}
-
-.meditation-card:focus-visible {
-  outline: 2px solid var(--primary-500);
-  outline-offset: 2px;
-}
-
-.meditation-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, var(--primary-600), var(--primary-800));
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.meditation-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 40px rgba(99, 70, 255, 0.2);
-}
-
-.meditation-card:hover::before {
-  opacity: 0.1;
-}
-
-/* Session stat cards */
-.stat-card {
+.event-card {
   background: var(--bg-card);
   border: 1px solid var(--border-subtle);
   border-radius: 16px;
   padding: 20px;
-  text-align: center;
+  transition: border-color 0.3s ease, background-color 0.3s ease, transform 0.3s ease;
 }
 
-.stat-value {
-  font-size: 2rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, var(--primary-400), var(--accent-400));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+.event-card:hover {
+  background: var(--bg-card-hover);
+  border-color: rgba(255, 255, 255, 0.12);
+  transform: translateY(-2px);
 }
 
-.stat-label {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  margin-top: 4px;
-}
+/* ============================================
+   BUTTONS
+   ============================================ */
 
-/* Health connection badge */
-.health-badge {
+.event-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
-  padding: 8px 16px;
-  background: rgba(34, 197, 94, 0.1);
-  border: 1px solid rgba(34, 197, 94, 0.3);
-  border-radius: 20px;
-  color: #22c55e;
-  font-size: 0.85rem;
-  font-weight: 500;
+  min-height: 48px;
+  padding: 0 24px;
+  border-radius: 999px;
+  font-family: var(--font-space-mono), monospace;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background-color 0.3s ease;
+  border: 1px solid transparent;
+  position: relative;
+  overflow: hidden;
 }
 
-.health-badge.disconnected {
-  background: rgba(239, 68, 68, 0.1);
+.event-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.event-button--primary {
+  color: var(--ink);
+  background: linear-gradient(105deg, var(--gold), var(--lime) 56%, var(--cyan));
+  box-shadow: 0 8px 28px rgba(99, 237, 255, 0.12), 0 0 20px rgba(255, 211, 109, 0.15);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.event-button--primary:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 12px 36px rgba(99, 237, 255, 0.18), 0 0 28px rgba(255, 211, 109, 0.22);
+}
+
+.event-button--primary:active {
+  transform: translateY(0) scale(0.99);
+}
+
+.event-button--secondary {
+  color: var(--cream);
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--border-subtle);
+}
+
+.event-button--secondary:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.event-button--danger {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.08);
   border-color: rgba(239, 68, 68, 0.3);
-  color: #ef4444;
 }
 
-/* Floating orb background effect */
-.bg-orb {
-  position: absolute;
+.event-button--danger:hover {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+.event-button--ghost {
+  color: var(--text-secondary);
+  background: transparent;
+  border-color: transparent;
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.event-button--ghost:hover {
+  color: var(--cream);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.event-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none !important;
+}
+
+/* ============================================
+   FORM FIELDS
+   ============================================ */
+
+.event-field {
+  width: 100%;
+  height: 48px;
+  padding: 0 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--cream);
+  font-size: 15px;
+  font-family: var(--font-syne), system-ui, sans-serif;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.event-field::placeholder {
+  color: var(--text-muted);
+}
+
+.event-field:focus {
+  outline: none;
+  border-color: var(--pink);
+  box-shadow: 0 0 0 3px rgba(255, 113, 189, 0.1), 0 0 16px rgba(255, 113, 189, 0.08);
+}
+
+.event-field:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ============================================
+   STATUS PILLS
+   ============================================ */
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-family: var(--font-space-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+
+.status-pill--live {
+  color: var(--cyan);
+  background: rgba(99, 237, 255, 0.08);
+  border-color: rgba(99, 237, 255, 0.25);
+}
+
+.status-pill--success {
+  color: var(--lime);
+  background: rgba(182, 255, 113, 0.08);
+  border-color: rgba(182, 255, 113, 0.25);
+}
+
+.status-pill--warning {
+  color: #fbbf24;
+  background: rgba(251, 191, 36, 0.08);
+  border-color: rgba(251, 191, 36, 0.25);
+}
+
+.status-pill--danger {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.25);
+}
+
+.status-pill--request {
+  color: var(--pink);
+  background: rgba(255, 113, 189, 0.08);
+  border-color: rgba(255, 113, 189, 0.25);
+}
+
+.status-pill--brand {
+  color: var(--gold);
+  background: rgba(255, 211, 109, 0.08);
+  border-color: rgba(255, 211, 109, 0.25);
+}
+
+.status-pill__dot {
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  filter: blur(100px);
-  opacity: 0.3;
-  pointer-events: none;
+  flex-shrink: 0;
 }
 
-.bg-orb-1 {
-  width: 400px;
-  height: 400px;
-  background: var(--primary-600);
-  top: -100px;
-  right: -100px;
+.status-pill__dot--live {
+  background: var(--cyan);
+  box-shadow: 0 0 8px rgba(99, 237, 255, 0.5);
 }
 
-.bg-orb-2 {
-  width: 300px;
-  height: 300px;
-  background: var(--primary-800);
-  bottom: 20%;
-  left: -100px;
+.status-pill__dot--success {
+  background: var(--lime);
 }
 
-/* Responsive utilities */
+.status-pill__dot--warning {
+  background: #fbbf24;
+}
+
+.status-pill__dot--danger {
+  background: #ef4444;
+}
+
+/* ============================================
+   ALERTS
+   ============================================ */
+
+.event-alert {
+  padding: 12px 16px;
+  border-radius: 10px;
+  font-size: 13px;
+  line-height: 1.6;
+  border: 1px solid transparent;
+}
+
+.event-alert--success {
+  color: #bbf7a8;
+  background: rgba(182, 255, 113, 0.06);
+  border-color: rgba(182, 255, 113, 0.2);
+}
+
+.event-alert--warning {
+  color: #fde68a;
+  background: rgba(251, 191, 36, 0.06);
+  border-color: rgba(251, 191, 36, 0.2);
+}
+
+.event-alert--danger {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.06);
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+.event-alert--info {
+  color: #a5f3fc;
+  background: rgba(99, 237, 255, 0.06);
+  border-color: rgba(99, 237, 255, 0.2);
+}
+
+/* ============================================
+   OPERATOR PANEL
+   ============================================ */
+
+.operator-panel {
+  background: var(--bg-operator);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+/* ============================================
+   TERMINAL / EMPTY / LOADING STATES
+   ============================================ */
+
+.terminal-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  gap: 16px;
+  text-align: center;
+  padding: 40px 24px;
+}
+
+.terminal-state__icon {
+  font-size: 32px;
+  color: var(--gold);
+  opacity: 0.6;
+}
+
+.terminal-state__title {
+  font-family: var(--font-cormorant), Georgia, serif;
+  font-size: 24px;
+  font-weight: 400;
+  color: var(--cream);
+  letter-spacing: -0.02em;
+}
+
+.terminal-state__body {
+  font-size: 14px;
+  color: var(--text-secondary);
+  max-width: 400px;
+  line-height: 1.7;
+}
+
+/* ============================================
+   MONOSPACE METADATA
+   ============================================ */
+
+.mono-meta {
+  font-family: var(--font-space-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+/* ============================================
+   LIVE BADGE
+   ============================================ */
+
+.live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 20px;
+  font-family: var(--font-space-mono), monospace;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #fca5a5;
+}
+
+.live-badge::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  background: #ef4444;
+  border-radius: 50%;
+  animation: breathe 1.5s ease-in-out infinite;
+}
+
+/* ============================================
+   CROSSFADER
+   ============================================ */
+
+.crossfader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+}
+
+.crossfader__track {
+  flex: 1;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  position: relative;
+  cursor: pointer;
+}
+
+.crossfader__fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  background: linear-gradient(90deg, var(--gold), var(--cyan));
+  border-radius: 2px;
+  transition: width 0.1s linear;
+}
+
+.crossfader__thumb {
+  position: absolute;
+  top: 50%;
+  width: 16px;
+  height: 16px;
+  background: var(--cream);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 10px rgba(255, 246, 223, 0.3);
+  cursor: grab;
+}
+
+/* ============================================
+   STAGE TILE OVERRIDES
+   ============================================ */
+
+.stage-tile--spotlight {
+  border-color: rgba(99, 237, 255, 0.3);
+  box-shadow: 0 0 20px rgba(99, 237, 255, 0.08), inset 0 0 30px rgba(99, 237, 255, 0.03);
+}
+
+.stage-tile--speaking {
+  border-color: rgba(99, 237, 255, 0.5);
+  box-shadow: 0 0 16px rgba(99, 237, 255, 0.15);
+}
+
+/* ============================================
+   RESPONSIVE
+   ============================================ */
+
 @media (max-width: 768px) {
-  .glass-card {
+  .event-card {
     border-radius: 12px;
+    padding: 16px;
   }
 
-  .tab-item {
-    padding: 10px 6px;
-    font-size: 0.7rem;
+  .event-button {
+    min-height: 44px;
+    padding: 0 18px;
+    font-size: 10px;
   }
 
-  .tab-item svg {
-    width: 20px;
-    height: 20px;
+  .terminal-state__title {
+    font-size: 20px;
   }
 }
 
-/* Reduced motion preferences */
+/* ============================================
+   REDUCED MOTION
+   ============================================ */
+
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse-glow,
-  .animate-float,
   .animate-breathe,
-  .audio-bar,
-  .animate-pulse {
+  .animate-live-pulse {
     animation: none;
   }
 
@@ -569,12 +653,13 @@ body {
     transform: none;
   }
 
-  .glass-card,
-  .btn-primary,
-  .btn-secondary,
-  .input-field,
-  .tab-item,
-  .meditation-card {
+  .event-card,
+  .event-button,
+  .event-field {
     transition: none;
+  }
+
+  .live-badge::before {
+    animation: none;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,40 @@
 import type { Metadata, Viewport } from "next";
+import { Cormorant_Garamond, Syne, Space_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
 
+const cormorant = Cormorant_Garamond({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  style: ["normal", "italic"],
+  variable: "--font-cormorant",
+  display: "swap",
+});
+
+const syne = Syne({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-syne",
+  display: "swap",
+});
+
+const spaceMono = Space_Mono({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-space-mono",
+  display: "swap",
+});
+
 export const metadata: Metadata = {
-  title: "Harmonic Beacon | Live Psychodrama",
-  description: "Join a live bilingual psychodrama session with Julián and the Harmonic Beacon.",
-  keywords: ["psychodrama", "live event", "bilingual", "harmonic beacon"],
+  title: "Harmonic Projection | Harmonic Beacon",
+  description:
+    "A live online experience to enter your inner landscape through body, sound and the images already living inside you.",
+  keywords: ["harmonic projection", "live event", "bilingual", "harmonic beacon", "psychodrama"],
   authors: [{ name: "Harmonic Beacon" }],
   openGraph: {
-    title: "Harmonic Beacon | Live Psychodrama",
-    description: "Join a live bilingual psychodrama session with Julián and the Harmonic Beacon.",
+    title: "Harmonic Projection | Harmonic Beacon",
+    description:
+      "A live online experience to enter your inner landscape through body, sound and the images already living inside you.",
     type: "website",
   },
 };
@@ -17,7 +42,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  themeColor: "#0a0a1a",
+  themeColor: "#080B16",
 };
 
 export default function RootLayout({
@@ -26,28 +51,50 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${cormorant.variable} ${syne.variable} ${spaceMono.variable}`}>
       <body className="antialiased">
-        {/* Background orbs - Adjusted for deep space feel */}
+        {/* Restrained dark event atmosphere */}
         <div className="fixed inset-0 overflow-hidden pointer-events-none z-0">
-          <div className="bg-orb bg-orb-1 opacity-20 mix-blend-screen" />
-          <div className="bg-orb bg-orb-2 opacity-15 mix-blend-screen" />
+          <div
+            className="absolute opacity-[0.04]"
+            style={{
+              width: "600px",
+              height: "600px",
+              borderRadius: "50%",
+              filter: "blur(120px)",
+              background: "radial-gradient(circle, rgba(158,114,255,0.3), transparent 70%)",
+              top: "-10%",
+              right: "-5%",
+            }}
+          />
+          <div
+            className="absolute opacity-[0.03]"
+            style={{
+              width: "500px",
+              height: "500px",
+              borderRadius: "50%",
+              filter: "blur(100px)",
+              background: "radial-gradient(circle, rgba(99,237,255,0.2), transparent 70%)",
+              bottom: "10%",
+              left: "-10%",
+            }}
+          />
         </div>
 
         {/* Main content */}
-        <div className="relative z-10">
-          {children}
-        </div>
+        <div className="relative z-10">{children}</div>
 
         <Toaster
           theme="dark"
           position="top-center"
           toastOptions={{
             style: {
-              background: 'rgba(0, 0, 0, 0.8)',
-              backdropFilter: 'blur(16px)',
-              border: '1px solid rgba(255, 255, 255, 0.1)',
-              color: '#fff',
+              background: "rgba(8, 11, 22, 0.96)",
+              backdropFilter: "blur(16px)",
+              border: "1px solid rgba(255, 255, 255, 0.1)",
+              color: "#FFF6DF",
+              fontFamily: "var(--font-syne), system-ui, sans-serif",
+              fontSize: "13px",
             },
           }}
         />

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -9,9 +9,6 @@
  * now redirects there.
  *
  * Bilingual by showing both languages at once rather than by detecting one.
- * Session 1 is Spanish (morning) and Session 2 is English (afternoon), both Saturday, the two audiences
- * share this page, and an attendee who cannot read the half addressed to someone
- * else must still be able to get into the event they paid for.
  */
 
 import { useState } from "react";
@@ -61,12 +58,7 @@ export default function LoginClient({ next }: { next?: string }) {
 
             if (response.ok) {
                 const { scheduledSessionId } = (await response.json()) as { scheduledSessionId: string };
-                // `next` is already validated server-side; the ticket's own session
-                // is the fallback so a first-time visitor still lands in the right
-                // room without choosing one.
                 router.push(next ?? `/session/${scheduledSessionId}`);
-                // The cookie was set by the response, and the room page resolves it
-                // server-side, so the router cache has to be dropped.
                 router.refresh();
                 return;
             }
@@ -88,11 +80,13 @@ export default function LoginClient({ next }: { next?: string }) {
     }
 
     return (
-        <form onSubmit={onSubmit} className="space-y-4" noValidate>
-            <div className="space-y-1">
-                <label htmlFor="ticket-code" className="block text-sm font-medium">
+        <form onSubmit={onSubmit} className="space-y-5" noValidate>
+            <div className="space-y-1.5">
+                <label htmlFor="ticket-code" className="block text-sm font-medium text-[var(--cream)]">
                     Ticket code
-                    <span className="block text-xs text-[var(--text-secondary)]">Código de entrada</span>
+                    <span className="mt-0.5 block text-xs font-normal text-[var(--text-muted)]">
+                        Código de entrada
+                    </span>
                 </label>
                 <input
                     id="ticket-code"
@@ -103,14 +97,14 @@ export default function LoginClient({ next }: { next?: string }) {
                     autoComplete="off"
                     autoCapitalize="characters"
                     spellCheck={false}
-                    className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-mono tracking-wider"
+                    className="event-field font-mono tracking-wider"
                 />
             </div>
 
-            <div className="space-y-1">
-                <label htmlFor="ticket-email" className="block text-sm font-medium">
+            <div className="space-y-1.5">
+                <label htmlFor="ticket-email" className="block text-sm font-medium text-[var(--cream)]">
                     Email used to buy the ticket
-                    <span className="block text-xs text-[var(--text-secondary)]">
+                    <span className="mt-0.5 block text-xs font-normal text-[var(--text-muted)]">
                         Correo con el que compraste la entrada
                     </span>
                 </label>
@@ -123,31 +117,29 @@ export default function LoginClient({ next }: { next?: string }) {
                     required
                     autoComplete="email"
                     spellCheck={false}
-                    className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2"
+                    className="event-field"
                 />
             </div>
 
             {error && (
-                <p role="alert" className="text-sm text-[var(--danger-400,#fca5a5)]">
+                <div role="alert" className="event-alert event-alert--danger">
                     <span className="block">{MESSAGES[error].en}</span>
-                    <span className="block opacity-80">{MESSAGES[error].es}</span>
-                </p>
+                    <span className="mt-1 block opacity-80">{MESSAGES[error].es}</span>
+                </div>
             )}
 
             <button
                 type="submit"
                 disabled={submitting}
-                className="w-full rounded-lg bg-[var(--primary-600)] px-4 py-2.5 font-medium disabled:opacity-60"
+                className="event-button event-button--primary w-full"
             >
                 {submitting ? "Signing in… / Ingresando…" : "Enter the event / Entrar al evento"}
             </button>
 
-            <p className="text-xs text-[var(--text-secondary)]">
-                Your ticket admits one person. The same code and email work again after a refresh or a dropped
-                connection.
-                <span className="block">
-                    Tu entrada admite a una persona. El mismo código y correo funcionan de nuevo si recargás o se corta
-                    la conexión.
+            <p className="text-[11px] leading-relaxed text-[var(--text-muted)]">
+                Your ticket admits one person. The same code and email work again after a refresh or a dropped connection.
+                <span className="mt-1 block opacity-80">
+                    Tu entrada admite a una persona. El mismo código y correo funcionan de nuevo si recargás o se corta la conexión.
                 </span>
             </p>
         </form>

--- a/src/app/ops/health/OpsHealthClient.tsx
+++ b/src/app/ops/health/OpsHealthClient.tsx
@@ -27,19 +27,19 @@ const CHECK_LABELS: Array<{ key: keyof OperatorHealthReport['checks']; label: st
 
 const LEVEL_STYLES: Record<HealthLevel, { banner: string; dot: string; text: string }> = {
     green: {
-        banner: 'border-green-600 bg-green-950/40 text-green-300',
-        dot: 'bg-green-500',
-        text: 'text-green-400',
+        banner: 'border-[var(--lime)]/40 bg-[var(--lime)]/10 text-[var(--lime)]',
+        dot: 'bg-[var(--lime)]',
+        text: 'text-[var(--lime)]',
     },
     yellow: {
-        banner: 'border-amber-500 bg-amber-950/40 text-amber-300',
-        dot: 'bg-amber-400',
-        text: 'text-amber-400',
+        banner: 'border-[var(--warning)]/40 bg-[var(--warning)]/10 text-[var(--warning)]',
+        dot: 'bg-[var(--warning)]',
+        text: 'text-[var(--warning)]',
     },
     red: {
-        banner: 'border-red-600 bg-red-950/40 text-red-300',
-        dot: 'bg-red-500',
-        text: 'text-red-400',
+        banner: 'border-[var(--danger)]/40 bg-[var(--danger)]/10 text-[var(--danger)]',
+        dot: 'bg-[var(--danger)]',
+        text: 'text-[var(--danger)]',
     },
 };
 
@@ -52,26 +52,26 @@ const LEVEL_HEADLINES: Record<HealthLevel, string> = {
 function CheckRow({ label, check }: { label: string; check: SubsystemCheck }) {
     const styles = LEVEL_STYLES[check.status];
     return (
-        <li className="flex items-start gap-3 rounded border border-[var(--border,#333)] px-4 py-3">
+        <li className="flex items-start gap-3 rounded border border-[var(--border-subtle)] px-4 py-3">
             <span
                 aria-hidden
                 className={`mt-1.5 inline-block h-3 w-3 shrink-0 rounded-full ${styles.dot}`}
             />
             <div className="min-w-0 flex-1">
                 <div className="flex items-baseline justify-between gap-3">
-                    <span className="font-medium">{label}</span>
+                    <span className="font-medium text-[var(--cream)]">{label}</span>
                     <span className={`text-xs font-semibold uppercase ${styles.text}`}>
                         {check.status}
                     </span>
                 </div>
                 <p className="text-sm text-[var(--text-secondary)]">{check.detail}</p>
                 {check.error ? (
-                    <p className="mt-1 break-words font-mono text-xs text-[var(--text-secondary)]">
+                    <p className="mt-1 break-words font-mono text-xs text-[var(--text-muted)]">
                         {check.error}
                     </p>
                 ) : null}
             </div>
-            <span className="shrink-0 text-xs text-[var(--text-secondary)]">
+            <span className="shrink-0 font-mono text-xs text-[var(--text-muted)]">
                 {check.latencyMs} ms
             </span>
         </li>
@@ -96,8 +96,6 @@ export default function OpsHealthClient({ role }: { role: string }) {
                 setEndpointError(null);
             }
         } catch (error) {
-            // The endpoint itself failing is its own alarm: the app may be
-            // down, which is exactly what this page exists to catch.
             if (mounted.current) {
                 setEndpointError(
                     error instanceof Error ? error.message : 'Health endpoint unreachable',
@@ -137,7 +135,7 @@ export default function OpsHealthClient({ role }: { role: string }) {
 
             {report?.session ? (
                 <p className="text-sm text-[var(--text-secondary)]">
-                    Watching session <span className="font-medium">{report.session.title}</span>{' '}
+                    Watching session <span className="font-medium text-[var(--cream)]">{report.session.title}</span>{' '}
                     ({report.session.status}) — signed in as {role}.
                 </p>
             ) : (
@@ -165,7 +163,7 @@ export default function OpsHealthClient({ role }: { role: string }) {
                 <button
                     type="button"
                     onClick={() => void refresh()}
-                    className="rounded border border-current px-3 py-1 text-xs hover:opacity-80"
+                    className="rounded border border-[var(--border-subtle)] px-3 py-1 text-xs hover:bg-white/5"
                 >
                     Refresh now
                 </button>

--- a/src/app/ops/layout.tsx
+++ b/src/app/ops/layout.tsx
@@ -38,16 +38,16 @@ export default async function OpsLayout({
     ];
 
     return (
-        <div className="min-h-screen">
-            <nav className="border-b border-white/10 bg-black/40 px-4 py-2.5">
+        <div className="min-h-screen bg-[var(--ink)]">
+            <nav className="border-b border-[var(--border-subtle)] bg-[var(--deep)]/80 px-4 py-2.5">
                 <div className="mx-auto flex max-w-5xl flex-wrap items-center gap-x-4 gap-y-1 text-sm">
                     <Link
                         href="/ops/health"
-                        className="font-semibold text-[var(--text-primary)]"
+                        className="font-semibold text-[var(--cream)]"
                     >
                         Beacon Ops
                     </Link>
-                    <span className="text-[var(--text-secondary)]">
+                    <span className="font-mono text-[10px] text-[var(--text-muted)]">
                         {staff.name} · {staff.role}
                     </span>
                     <span className="mx-1 hidden text-white/20 sm:inline">|</span>
@@ -55,13 +55,13 @@ export default async function OpsLayout({
                     <span className="mx-1 hidden text-white/20 sm:inline">|</span>
                     <Link
                         href="/"
-                        className="text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                        className="text-[var(--text-secondary)] hover:text-[var(--cream)]"
                     >
                         Public site
                     </Link>
                 </div>
             </nav>
-            {children}
+            <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
         </div>
     );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,9 +6,13 @@
  * visitor is — the form's response does that. Purchase happens on the external
  * ticketing platform.
  *
- * Bilingual EN/ES on one page. Session 1 is Spanish (8:30 AM Costa Rica) and Session 2 is English (12:30 PM Costa Rica), both Saturday, both
- * audiences arrive at the same URL, and a Spanish-speaking attendee must be able
- * to log in without reading English.
+ * Bilingual EN/ES on one page. Session 1 is Spanish and Session 2 is English,
+ * both Saturday, both audiences arrive at the same URL, and a Spanish-speaking
+ * attendee must be able to log in without reading English.
+ *
+ * VISUAL NOTE: The marketing site shows Spanish at 08:30 CR and English at 14:00 CR.
+ * The app database comment says English is 12:30 CR. This discrepancy is reported
+ * in the handoff for the event owner to confirm.
  */
 
 import Link from "next/link";
@@ -17,9 +21,8 @@ import { prisma } from "@/lib/db";
 import { redactError } from "@/lib/redact";
 
 import LoginClient from "./login/LoginClient";
+import BrandLockup from "@/components/brand/BrandLockup";
 
-// The event list comes from the database and the page sets a session cookie, so
-// there is nothing here to prerender or cache at the edge.
 export const dynamic = "force-dynamic";
 
 type WeekendEvent = {
@@ -28,18 +31,10 @@ type WeekendEvent = {
     scheduledAt: Date;
 };
 
-/**
- * Where `middleware.ts` sends an attendee who reached a room without a cookie:
- * `/session` or `/session/<id>`, and nothing else. No dots, so no `..` segment
- * can walk the path back up to another surface after the check passes.
- */
 const INTERNAL_NEXT = /^\/session(\/[A-Za-z0-9_-]+)*$/;
 
 function safeNext(raw: string | string[] | undefined): string | undefined {
     const value = Array.isArray(raw) ? raw[0] : raw;
-    // Anything else — a protocol-relative URL, a host, a backslash, a traversal —
-    // is dropped rather than corrected, so a crafted login link cannot redirect
-    // an attendee anywhere except into a room.
     return value && INTERNAL_NEXT.test(value) ? value : undefined;
 }
 
@@ -51,8 +46,6 @@ async function weekendEvents(): Promise<WeekendEvent[] | null> {
             select: { id: true, language: true, scheduledAt: true },
         });
     } catch (error) {
-        // The form still works without this list: it needs the database, but the
-        // attendee holding a code does not need us to render the schedule first.
         console.error(`[landing] could not load the event schedule: ${redactError(error)}`);
         return null;
     }
@@ -70,6 +63,14 @@ function formatEventTime(at: Date, locale: string, timeZone: string): string {
     }).format(at);
 }
 
+function formatTimeOnly(at: Date, locale: string, timeZone: string): string {
+    return new Intl.DateTimeFormat(locale, {
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone,
+    }).format(at);
+}
+
 export default async function LandingPage({
     searchParams,
 }: {
@@ -77,116 +78,143 @@ export default async function LandingPage({
 }) {
     const next = safeNext((await searchParams).next);
     const events = await weekendEvents();
-    // Per-session ticket purchase links; unset until WS6-01/02 configure them.
     const purchaseUrlSession1 = process.env.TICKET_PURCHASE_URL_SESSION_1 || process.env.TICKET_PURCHASE_URL;
     const purchaseUrlSession2 = process.env.TICKET_PURCHASE_URL_SESSION_2 || process.env.TICKET_PURCHASE_URL;
     const purchaseUrlFor = (language: string) =>
         language === "SPANISH" ? purchaseUrlSession1 : purchaseUrlSession2;
 
     return (
-        <main className="mx-auto flex min-h-screen max-w-2xl flex-col gap-10 px-6 py-12">
-            <header className="space-y-2">
-                <h1 className="text-3xl font-bold">Harmonic Beacon</h1>
-                <p className="text-[var(--text-secondary)]">
-                    A live psychodrama session with Julián, held twice this weekend.
-                    <span className="block">
-                        Una sesión de psicodrama en vivo con Julián, en dos encuentros este fin de semana.
-                    </span>
-                </p>
-            </header>
+        <main className="event-shell">
+            <div className="relative z-10 mx-auto flex min-h-screen max-w-2xl flex-col gap-10 px-6 py-12">
+                {/* Brand */}
+                <header className="flex items-center justify-between">
+                    <BrandLockup />
+                </header>
 
-            <section className="space-y-3" aria-labelledby="events-heading">
-                <h2 id="events-heading" className="text-lg font-semibold">
-                    The two sessions <span className="text-[var(--text-secondary)]">/ Los dos encuentros</span>
-                </h2>
-
-                {events === null ? (
-                    <p className="text-sm text-[var(--text-secondary)]">
-                        Session times are temporarily unavailable — your ticket code still works.
-                        <span className="block">
-                            Los horarios no están disponibles por el momento — tu código de entrada sigue funcionando.
+                {/* Hero */}
+                <section className="space-y-4">
+                    <p className="flex items-center gap-2.5 text-[10px] font-mono uppercase tracking-[0.18em] text-[var(--gold)]">
+                        <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--pink)] shadow-[0_0_10px_var(--pink)]" />
+                        Harmonic Projection · Virtual Session
+                    </p>
+                    <h1 className="font-serif text-[clamp(2.8rem,8vw,5rem)] font-normal leading-[0.85] tracking-[-0.04em] text-[var(--cream)]">
+                        The myth<br /><em className="text-[var(--lime)] not-italic" style={{ textShadow: "0 0 28px rgba(182,255,113,0.25)" }}>is alive.</em>
+                    </h1>
+                    <p className="max-w-md text-[15px] leading-[1.75] text-[var(--text-secondary)]">
+                        A live online experience to enter your inner landscape through body, sound and the images already living inside you.
+                        <span className="mt-1 block opacity-80">
+                            Una experiencia online en vivo para entrar en tu paisaje interior a través del cuerpo, el sonido y las imágenes que ya viven dentro tuyo.
                         </span>
                     </p>
-                ) : (
-                    <ul className="space-y-3">
-                        {events.map((event) => (
-                            <li key={event.id} className="rounded-lg border border-white/10 bg-black/20 p-4">
-                                <p className="font-medium">
-                                    {event.language === "ENGLISH" ? "In English" : "En español"}
-                                </p>
-                                <p className="text-sm">
-                                    <span className="font-medium">Costa Rica: </span>
-                                    {formatEventTime(
-                                        event.scheduledAt,
-                                        event.language === "ENGLISH" ? "en-US" : "es-CR",
-                                        "America/Costa_Rica",
-                                    )}
-                                </p>
-                                <p className="text-sm text-[var(--text-secondary)]">
-                                    <span className="font-medium">Argentina: </span>
-                                    {formatEventTime(
-                                        event.scheduledAt,
-                                        event.language === "ENGLISH" ? "en-GB" : "es-AR",
-                                        "America/Argentina/Buenos_Aires",
-                                    )}
-                                </p>
-                                <p className="text-sm text-[var(--text-secondary)]">
-                                    <span className="font-medium">UTC: </span>
-                                    {formatEventTime(
-                                        event.scheduledAt,
-                                        event.language === "ENGLISH" ? "en-GB" : "es-AR",
-                                        "UTC",
-                                    )}
-                                </p>
-                                <p className="mt-3 text-sm">
-                                    {event.language === "ENGLISH"
-                                        ? "Tickets: USD $50 Global North · USD $20 Global South"
-                                        : "Entradas: USD $50 Norte Global · USD $20 Sur Global"}
-                                </p>
-                                {purchaseUrlFor(event.language) ? (
-                                    <a
-                                        href={purchaseUrlFor(event.language)}
-                                        className="btn-primary mt-3 inline-flex min-h-12 w-full items-center justify-center text-center sm:w-auto"
-                                        rel="noreferrer noopener"
-                                        target="_blank"
-                                    >
+                </section>
+
+                {/* Sessions */}
+                <section className="space-y-4" aria-labelledby="events-heading">
+                    <h2 id="events-heading" className="text-xs font-mono uppercase tracking-[0.14em] text-[var(--muted)]">
+                        Choose your portal / Elegí tu portal
+                    </h2>
+
+                    {events === null ? (
+                        <div className="event-alert event-alert--warning">
+                            Session times are temporarily unavailable — your ticket code still works.
+                            <span className="mt-1 block opacity-80">
+                                Los horarios no están disponibles por el momento — tu código de entrada sigue funcionando.
+                            </span>
+                        </div>
+                    ) : events.length === 0 ? (
+                        <div className="event-alert event-alert--info">
+                            No sessions are currently scheduled. Check back soon.
+                            <span className="mt-1 block opacity-80">
+                                No hay sesiones programadas por el momento. Volvé a consultar pronto.
+                            </span>
+                        </div>
+                    ) : (
+                        <ul className="space-y-4">
+                            {events.map((event) => (
+                                <li key={event.id} className="event-card">
+                                    <div className="flex flex-wrap items-start justify-between gap-3">
+                                        <div className="space-y-1">
+                                            <p className="text-[11px] font-mono uppercase tracking-[0.11em] text-[var(--cream)]">
+                                                {event.language === "ENGLISH" ? "English" : "Español"}
+                                            </p>
+                                            <p className="text-sm text-[var(--text-secondary)]">
+                                                <span className="font-medium text-[var(--cream)]">Costa Rica: </span>
+                                                {formatEventTime(event.scheduledAt, event.language === "ENGLISH" ? "en-US" : "es-CR", "America/Costa_Rica")}
+                                            </p>
+                                            <p className="text-xs text-[var(--text-muted)]">
+                                                <span className="font-medium">Argentina: </span>
+                                                {formatEventTime(event.scheduledAt, event.language === "ENGLISH" ? "en-GB" : "es-AR", "America/Argentina/Buenos_Aires")}
+                                            </p>
+                                            <p className="text-xs text-[var(--text-muted)]">
+                                                <span className="font-medium">UTC: </span>
+                                                {formatEventTime(event.scheduledAt, event.language === "ENGLISH" ? "en-GB" : "es-AR", "UTC")}
+                                            </p>
+                                        </div>
+                                        <div className="text-right">
+                                            <p className="font-mono text-lg font-normal text-[var(--gold)]">
+                                                {formatTimeOnly(event.scheduledAt, event.language === "ENGLISH" ? "en-US" : "es-CR", "America/Costa_Rica")}
+                                            </p>
+                                            <p className="text-[10px] font-mono text-[var(--cyan)]">
+                                                {event.language === "ENGLISH" ? "US $50" : "US $20"}
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <p className="mt-3 text-xs text-[var(--text-secondary)]">
                                         {event.language === "ENGLISH"
-                                            ? "Buy a ticket"
-                                            : "Comprar entrada"}
-                                    </a>
-                                ) : (
-                                    <p className="mt-2 text-sm text-[var(--text-secondary)]">
-                                        {event.language === "ENGLISH"
-                                            ? "Ticket sales open shortly."
-                                            : "Las entradas se abren en breve."}
+                                            ? "Tickets: USD $50 Global North · USD $20 Global South"
+                                            : "Entradas: USD $50 Norte Global · USD $20 Sur Global"}
                                     </p>
-                                )}
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </section>
 
-            <section className="space-y-3" aria-labelledby="login-heading">
-                <h2 id="login-heading" className="text-lg font-semibold">
-                    Already have a ticket? <span className="text-[var(--text-secondary)]">/ ¿Ya tenés tu entrada?</span>
-                </h2>
-                <LoginClient next={next} />
-            </section>
+                                    {purchaseUrlFor(event.language) ? (
+                                        <a
+                                            href={purchaseUrlFor(event.language)}
+                                            className="event-button event-button--primary mt-4 inline-flex w-full text-center sm:w-auto"
+                                            rel="noreferrer noopener"
+                                            target="_blank"
+                                        >
+                                            {event.language === "ENGLISH" ? "Buy a ticket" : "Comprar entrada"}
+                                            <span aria-hidden="true" className="text-base">↗</span>
+                                        </a>
+                                    ) : (
+                                        <p className="mt-3 text-xs text-[var(--text-muted)]">
+                                            {event.language === "ENGLISH"
+                                                ? "Ticket sales open shortly."
+                                                : "Las entradas se abren en breve."}
+                                        </p>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </section>
 
-            <footer className="mt-auto flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--text-secondary)]">
-                <a
-                    href="https://harmonicbeacon.com/politica/"
-                    className="underline"
-                    rel="noreferrer noopener"
-                    target="_blank"
-                >
-                    Terms &amp; privacy <span>/ Términos y privacidad</span>
-                </a>
-                <Link href="/staff/login" className="underline">
-                    Staff sign-in <span>/ Ingreso del equipo</span>
-                </Link>
-            </footer>
+                {/* Login */}
+                <section className="space-y-4" aria-labelledby="login-heading">
+                    <h2 id="login-heading" className="text-xs font-mono uppercase tracking-[0.14em] text-[var(--muted)]">
+                        Already have a ticket? / ¿Ya tenés tu entrada?
+                    </h2>
+                    <LoginClient next={next} />
+                </section>
+
+                {/* Footer */}
+                <footer className="mt-auto flex flex-wrap gap-x-5 gap-y-2 text-[11px] text-[var(--text-muted)]">
+                    <a
+                        href="https://harmonicbeacon.com/politica/"
+                        className="underline underline-offset-2 transition-colors hover:text-[var(--cream)]"
+                        rel="noreferrer noopener"
+                        target="_blank"
+                    >
+                        Terms &amp; privacy / Términos y privacidad
+                    </a>
+                    <Link
+                        href="/staff/login"
+                        className="underline underline-offset-2 transition-colors hover:text-[var(--cream)]"
+                    >
+                        Staff sign-in / Ingreso del equipo
+                    </Link>
+                </footer>
+            </div>
         </main>
     );
 }

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -187,7 +187,7 @@ describe('SessionRoomPage - server-ended disconnect', () => {
 
         await waitFor(() => expect(document.activeElement).toBe(status));
 
-        fireEvent.click(screen.getByRole('button', { name: 'Back to Sessions' }));
+        fireEvent.click(screen.getByRole('button', { name: /Back to Sessions/i }));
         expect(mockPush).toHaveBeenCalledWith('/');
     });
 
@@ -214,7 +214,7 @@ describe('SessionRoomPage - transport-failure disconnect', () => {
         const status = await screen.findByRole('status');
         expect(within(status).getByText('Connection lost')).toBeInTheDocument();
         expect(within(status).getByText('Your connection to this session was lost.')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Rejoin' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Rejoin/i })).toBeInTheDocument();
     });
 
     it('reconnects when Rejoin is clicked', async () => {
@@ -224,12 +224,12 @@ describe('SessionRoomPage - transport-failure disconnect', () => {
         act(() => {
             currentRoom().emit('disconnected', DisconnectReason.CONNECTION_TIMEOUT);
         });
-        await screen.findByRole('button', { name: 'Rejoin' });
+        await screen.findByRole('button', { name: /Rejoin/i });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Rejoin' }));
+        fireEvent.click(screen.getByRole('button', { name: /Rejoin/i }));
 
         // Back to the connecting state immediately, then reconnected.
-        expect(screen.getByText('Connecting to session...')).toBeInTheDocument();
+        expect(screen.getByText('Connecting')).toBeInTheDocument();
         await waitFor(() => expect(screen.getByText('Test Session')).toBeInTheDocument());
         expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(fetchCallsBefore);
     });
@@ -247,7 +247,7 @@ describe('SessionRoomPage - ambiguous disconnect', () => {
         const status = await screen.findByRole('status');
         expect(within(status).getByText('Disconnected')).toBeInTheDocument();
         expect(within(status).getByText(/can't tell whether it ended or your connection dropped/i)).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Rejoin' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Rejoin/i })).toBeInTheDocument();
     });
 });
 
@@ -324,7 +324,7 @@ describe('SessionRoomPage - initial connection failure', () => {
         expect(await screen.findByText('Room is temporarily unavailable')).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
-        expect(screen.getByText('Connecting to session...')).toBeInTheDocument();
+        expect(screen.getByText('Connecting')).toBeInTheDocument();
         await waitFor(() => expect(screen.getByText('Test Session')).toBeInTheDocument());
     });
 });

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -21,24 +21,10 @@ import ThumbnailSender from "@/components/session/ThumbnailSender";
 import ThumbnailTapestry from "@/components/session/ThumbnailTapestry";
 import type { StageVideoPublication } from "@/components/session/StageTile";
 import type { StageConnectionQuality } from "@/lib/stage-layout";
-import { redactErrorDetail } from '@/lib/redact';
+import { redactErrorDetail } from "@/lib/redact";
 
 const LIVEKIT_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || "wss://live.altermundi.net";
 
-/**
- * WEEKEND_MVP_ROADMAP.md §1: "The stage publishes simulcast. The active
- * speaker/Julián tile requests the 720p layer; at most five auxiliary tiles
- * request 360p."
- *
- * - `adaptiveStream` lets the SFU stop sending video for tiles that are
- *   scrolled out of view or in a backgrounded tab; each tile then pins the layer
- *   it wants while visible (see StageTile).
- * - `dynacast` stops publishing layers nobody subscribes to, which is the other
- *   half of the same saving: with 150 subscribers all on 360p auxiliaries, the
- *   720p layer of those five publishers is never encoded.
- * - The publisher sends 720p + 360p + 180p. 180p exists for the mobile strip and
- *   for a publisher whose uplink collapses.
- */
 const STAGE_ROOM_OPTIONS: RoomOptions = {
     adaptiveStream: true,
     dynacast: true,
@@ -52,17 +38,9 @@ const STAGE_ROOM_OPTIONS: RoomOptions = {
     },
 };
 
-/** Role words minted by `resolveRoomPrincipal` — never an email or a code. */
 const FACILITATOR_LABEL = "Facilitator";
 const FALLBACK_LABEL = "Participant";
 
-/**
- * Room events arrive per participant. At the 150-attendee cap a join burst is
- * 150 `ParticipantConnected` events in a few seconds; each one would otherwise
- * rebuild the stage snapshot and re-render. Coalescing into one read per frame
- * budget keeps the cost proportional to the six tiles that can change, not to
- * the audience size.
- */
 const STAGE_REFRESH_MS = 100;
 
 interface SessionInfo {
@@ -72,15 +50,6 @@ interface SessionInfo {
     startedAt: string | null;
 }
 
-// What RoomEvent.Disconnected tells us, collapsed to the three things a
-// participant can be told without guessing:
-// - "ended": someone deliberately ended the room server-side (Admin kill
-//   switch or Provider ending their own session). Say the session ended;
-//   don't speculate about who did it or why.
-// - "transport": a network-shaped failure. Say the connection dropped and
-//   offer to rejoin.
-// - "unknown": the SDK gave no reason, or one we don't have a bucket for.
-//   Don't guess which of the above it was — say we can't tell.
 type DisconnectKind = "ended" | "transport" | "unknown";
 
 function classifyDisconnectReason(reason?: DisconnectReason): DisconnectKind {
@@ -105,17 +74,12 @@ function classifyDisconnectReason(reason?: DisconnectReason): DisconnectKind {
 
 const STAGE_QUALITIES: readonly string[] = ["excellent", "good", "poor", "lost", "unknown"];
 
-/**
- * `ConnectionQuality` is a string enum whose values already match the tile's
- * vocabulary. Reading it as a string keeps the SDK enum out of the components.
- */
 function toStageQuality(quality: unknown): StageConnectionQuality {
     return typeof quality === "string" && STAGE_QUALITIES.includes(quality)
         ? (quality as StageConnectionQuality)
         : "unknown";
 }
 
-/** How the room-level `ConnectionState` reads in the header. */
 const CONNECTION_COPY: Record<string, string> = {
     connected: "Connected",
     connecting: "Connecting",
@@ -125,28 +89,17 @@ const CONNECTION_COPY: Record<string, string> = {
 };
 
 const CONNECTION_DOT: Record<string, string> = {
-    connected: "bg-green-400 animate-pulse",
-    connecting: "bg-amber-400 animate-pulse",
-    reconnecting: "bg-amber-400 animate-pulse",
-    signalReconnecting: "bg-amber-400 animate-pulse",
-    disconnected: "bg-red-400",
+    connected: "bg-[var(--lime)] animate-breathe",
+    connecting: "bg-[var(--warning)] animate-breathe",
+    reconnecting: "bg-[var(--warning)] animate-breathe",
+    signalReconnecting: "bg-[var(--warning)] animate-breathe",
+    disconnected: "bg-[var(--danger)]",
 };
 
-/**
- * A stage tile belongs to a stage grant, not to attendance. The 150 subscribe-only
- * attendees have `canPublish: false` and publish nothing, so they never produce a
- * tile. The publication fallback covers the window where a grant is live on the
- * wire before the permission update has been applied locally.
- */
 function isStagePublisher(participant: Participant): boolean {
     return Boolean(participant.permissions?.canPublish) || participant.trackPublications.size > 0;
 }
 
-/**
- * The stage token grants only MICROPHONE and CAMERA (see `createSessionToken`),
- * so a participant's single video publication is their camera. No screen share
- * can appear here and be mistaken for one.
- */
 function cameraPublication(participant: Participant): StageVideoPublication | null {
     const [publication] = participant.videoTrackPublications.values();
     return publication ?? null;
@@ -178,7 +131,7 @@ function SessionRoom() {
     const [activeSpeakerIdentity, setActiveSpeakerIdentity] = useState<string | null>(null);
     const [participantCount, setParticipantCount] = useState(0);
     const [volume, setVolume] = useState(0.8);
-    const [mix, setMix] = useState(0.8); // 0 = all beacon, 1 = all session
+    const [mix, setMix] = useState(0.8);
     const [duration, setDuration] = useState(0);
     const [disconnectState, setDisconnectState] = useState<DisconnectKind | null>(null);
     const [retryToken, setRetryToken] = useState(0);
@@ -188,25 +141,14 @@ function SessionRoom() {
     const audioElementsRef = useRef<Map<string, HTMLAudioElement>>(new Map());
     const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const volumeRef = useRef(volume);
-    // Read inside room event handlers, which are registered once per connection
-    // and would otherwise close over a stale `audioOnly`.
     const audioOnlyRef = useRef(audioOnly);
-    // Slot number per identity, assigned on first sighting of a stage grant and
-    // never recycled. Deliberately outside the connect effect: a rejoin reuses
-    // the numbers, so the same identities come back to the same tiles.
     const slotOrderRef = useRef<Map<string, number>>(new Map());
     const nextSlotRef = useRef(0);
-    // Highest slot number ever on stage. A newly granted publisher exceeds it,
-    // which is how "the spotlight follows the facilitator-promoted publisher".
     const highestSlotRef = useRef(-1);
     const stageRefreshRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    // Set right before we call room.disconnect() ourselves (leave, end session)
-    // so the room-level Disconnected handler below can tell "we did this on
-    // purpose" apart from the server or the network doing it to us.
     const intentionalDisconnectRef = useRef(false);
     const terminalViewRef = useRef<HTMLDivElement>(null);
 
-    // Keep volumeRef in sync with state
     useEffect(() => { volumeRef.current = volume; }, [volume]);
 
     const slotFor = useCallback((identity: string): number => {
@@ -217,12 +159,6 @@ function SessionRoom() {
         return slot;
     }, []);
 
-    /**
-     * Rebuild the whole stage snapshot from the room. One reader for every event
-     * rather than a partial update per event: with permissions, mute state,
-     * speaking state, subscriptions and quality all changing independently, the
-     * only cheap way to stay consistent is to re-derive.
-     */
     const readStage = useCallback(() => {
         const room = roomRef.current;
         if (!room) return;
@@ -257,8 +193,6 @@ function SessionRoom() {
 
         const newestSlot = publishers.reduce((max, p) => Math.max(max, p.grantOrder), -1);
         if (newestSlot > highestSlotRef.current) {
-            // Someone was just given the floor. Hand them the spotlight rather
-            // than leaving it on whoever spoke last.
             highestSlotRef.current = newestSlot;
             setActiveSpeakerIdentity(null);
             return;
@@ -266,8 +200,6 @@ function SessionRoom() {
 
         const onStage = new Set(publishers.map((p) => p.identity));
         const speaker = room.activeSpeakers.find((p) => onStage.has(p.identity));
-        // Sticky: `activeSpeakers` empties the moment audio level drops, and a
-        // spotlight that snapped back between sentences would be unwatchable.
         if (speaker) setActiveSpeakerIdentity(speaker.identity);
     }, [slotFor]);
 
@@ -279,13 +211,6 @@ function SessionRoom() {
         }, STAGE_REFRESH_MS);
     }, [readStage]);
 
-    /**
-     * Audio-only degradation. This drops the video *subscriptions* — nothing is
-     * sent to this client and nothing decodes — while the stage audio elements
-     * and the separate Beacon bed connection are left completely alone. It is
-     * not a scope cut (roadmap §5): a publisher's own camera is governed by the
-     * camera button, not by this.
-     */
     const applyVideoSubscriptions = useCallback((subscribed: boolean) => {
         const room = roomRef.current;
         if (!room) return;
@@ -308,7 +233,6 @@ function SessionRoom() {
             intentionalDisconnectRef.current = true;
             roomRef.current.disconnect();
         }
-
         router.push("/");
     }, [router]);
 
@@ -362,7 +286,6 @@ function SessionRoom() {
 
                 setSessionInfo(data.session);
                 setCanPublish(data.canPublish);
-                // Initialize timer from session startedAt
                 if (data.session.startedAt) {
                     const elapsed = Math.floor((Date.now() - new Date(data.session.startedAt).getTime()) / 1000);
                     setDuration(Math.max(0, elapsed));
@@ -373,22 +296,13 @@ function SessionRoom() {
 
                 room.on(RoomEvent.TrackSubscribed, async (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
                     if (track.kind === Track.Kind.Audio) {
-                        // Stage voice lives in hidden elements owned by the page,
-                        // not by a tile: it has to survive audio-only mode and
-                        // any tile unmounting, and it is what the crossfader
-                        // attenuates against the Beacon bed.
                         const audioElement = track.attach() as HTMLAudioElement;
                         audioElement.volume = volumeRef.current;
                         audioElement.style.display = "none";
                         document.body.appendChild(audioElement);
                         audioElementsRef.current.set(participant.identity, audioElement);
-                        try {
-                            await audioElement.play();
-                        } catch {
-                            // Autoplay blocked
-                        }
+                        try { await audioElement.play(); } catch { /* Autoplay blocked */ }
                     } else if (audioOnlyRef.current) {
-                        // Auto-subscribe raced our preference; undo it.
                         publication.setSubscribed(false);
                     }
                     scheduleStageRefresh();
@@ -423,15 +337,11 @@ function SessionRoom() {
                 room.on(RoomEvent.Reconnected, scheduleStageRefresh);
 
                 room.on(RoomEvent.ConnectionQualityChanged, (_quality: unknown, participant: Participant) => {
-                    // The audience reports quality too. Only the six tiles show it.
                     if (isStagePublisher(participant)) scheduleStageRefresh();
                 });
 
                 room.on(RoomEvent.ParticipantPermissionsChanged, (_prev: unknown, participant: Participant) => {
                     if (participant === room.localParticipant && !participant.permissions?.canPublish) {
-                        // Demoted. Unpublish and stop both devices now rather
-                        // than waiting for the operator's force-mute to land:
-                        // WS2-02 requires this inside two seconds.
                         Promise.all([
                             room.localParticipant.setCameraEnabled(false),
                             room.localParticipant.setMicrophoneEnabled(false),
@@ -446,10 +356,6 @@ function SessionRoom() {
 
                 room.on(RoomEvent.Disconnected, (reason?: DisconnectReason) => {
                     setIsConnected(false);
-                    // We already know why: either this effect is tearing down
-                    // (cancelled) or we called disconnect() ourselves (leave/end).
-                    // Neither needs the terminal view — the caller is already
-                    // navigating away.
                     if (cancelled || intentionalDisconnectRef.current) return;
                     setDisconnectState(classifyDisconnectReason(reason));
                 });
@@ -462,7 +368,6 @@ function SessionRoom() {
 
                 setIsConnected(true);
                 setIsConnecting(false);
-                // A rejoin while audio-only must not quietly start pulling video.
                 if (audioOnlyRef.current) applyVideoSubscriptions(false);
                 readStage();
             } catch (e) {
@@ -504,16 +409,12 @@ function SessionRoom() {
         };
     }, [isConnected]);
 
-    // Move focus into the terminal view when it replaces the live session UI,
-    // so a screen reader user lands on the announcement rather than on
-    // whatever the focused control used to be.
     useEffect(() => {
         if (disconnectState) {
             terminalViewRef.current?.focus();
         }
     }, [disconnectState]);
 
-    // Apply mix: distribute master volume between session and beacon
     useEffect(() => {
         const sessionVol = volume * mix;
         const beaconVol = volume * (1 - mix);
@@ -554,10 +455,17 @@ function SessionRoom() {
     // Loading state
     if (isConnecting) {
         return (
-            <main className="min-h-screen flex items-center justify-center">
-                <div className="text-center">
-                    <div className="animate-spin w-10 h-10 border-2 border-[var(--primary-500)] border-t-transparent rounded-full mx-auto mb-4"></div>
-                    <p className="text-[var(--text-muted)]">Connecting to session...</p>
+            <main className="event-shell">
+                <div className="relative z-10 flex min-h-screen items-center justify-center">
+                    <div className="terminal-state">
+                        <div className="terminal-state__icon">&#10022;</div>
+                        <p className="terminal-state__title" style={{ fontFamily: "var(--font-cormorant), Georgia, serif" }}>
+                            Connecting
+                        </p>
+                        <p className="terminal-state__body">
+                            Entering the Harmonic field…
+                        </p>
+                    </div>
                 </div>
             </main>
         );
@@ -566,75 +474,73 @@ function SessionRoom() {
     // Error state
     if (error) {
         return (
-            <main className="min-h-screen flex items-center justify-center px-4">
-                <div className="glass-card p-8 text-center max-w-sm w-full">
-                    <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-500/20 flex items-center justify-center">
-                        <svg className="w-8 h-8 text-red-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                        </svg>
-                    </div>
-                    <h2 className="text-xl font-semibold mb-2">Connection Error</h2>
-                    <p className="text-sm text-[var(--text-muted)] mb-4">{error}</p>
-                    <div className="flex flex-col gap-2">
-                        <button onClick={rejoin} className="btn-primary">
-                            Try again
-                        </button>
-                        <button onClick={() => router.push("/")} className="btn-secondary">
-                            Back to Sessions
-                        </button>
+            <main className="event-shell">
+                <div className="relative z-10 flex min-h-screen items-center justify-center px-4">
+                    <div className="event-card w-full max-w-sm text-center">
+                        <div className="terminal-state__icon text-[var(--danger)]">&#9888;</div>
+                        <h2 className="terminal-state__title">Connection Error</h2>
+                        <p className="terminal-state__body">{error}</p>
+                        <div className="mt-4 flex flex-col gap-2">
+                            <button onClick={rejoin} className="event-button event-button--primary w-full">
+                                Try again
+                            </button>
+                            <button onClick={() => router.push("/")} className="event-button event-button--secondary w-full">
+                                Back to Sessions
+                            </button>
+                        </div>
                     </div>
                 </div>
             </main>
         );
     }
 
-    // Terminal state: the room-level Disconnected event fired for a reason
-    // that wasn't us leaving on purpose. What we say depends on what LiveKit
-    // told us — see classifyDisconnectReason above.
+    // Terminal state
     if (disconnectState) {
         const copy = {
             ended: {
                 heading: "Session ended",
                 body: "This session has ended. You're no longer connected.",
+                esBody: "Esta sesión ha terminado. Ya no estás conectado.",
                 showRejoin: false,
             },
             transport: {
                 heading: "Connection lost",
                 body: "Your connection to this session was lost.",
+                esBody: "Se perdió la conexión con esta sesión.",
                 showRejoin: true,
             },
             unknown: {
                 heading: "Disconnected",
                 body: "You're no longer connected to this session. We can't tell whether it ended or your connection dropped.",
+                esBody: "Ya no estás conectado a esta sesión. No podemos saber si terminó o se cortó la conexión.",
                 showRejoin: true,
             },
         }[disconnectState];
 
         return (
-            <main className="min-h-screen flex items-center justify-center px-4">
-                <div
-                    ref={terminalViewRef}
-                    role="status"
-                    aria-live="polite"
-                    tabIndex={-1}
-                    className="glass-card p-8 text-center max-w-sm w-full outline-none"
-                >
-                    <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-white/10 flex items-center justify-center">
-                        <svg className="w-8 h-8 text-[var(--text-muted)]" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M18.364 5.636a9 9 0 010 12.728m-3.536-3.536a4 4 0 010-5.656M5.636 5.636a9 9 0 000 12.728" />
-                        </svg>
-                    </div>
-                    <h2 className="text-xl font-semibold mb-2">{copy.heading}</h2>
-                    <p className="text-sm text-[var(--text-muted)] mb-4">{copy.body}</p>
-                    <div className="flex flex-col gap-2">
-                        {copy.showRejoin && (
-                            <button onClick={rejoin} className="btn-primary">
-                                Rejoin
+            <main className="event-shell">
+                <div className="relative z-10 flex min-h-screen items-center justify-center px-4">
+                    <div
+                        ref={terminalViewRef}
+                        role="status"
+                        aria-live="polite"
+                        tabIndex={-1}
+                        className="event-card w-full max-w-sm text-center outline-none"
+                    >
+                        <div className="terminal-state__icon">&#10022;</div>
+                        <h2 className="terminal-state__title">{copy.heading}</h2>
+                        <p className="terminal-state__body">{copy.body}</p>
+                        <p className="mt-1 text-xs text-[var(--text-muted)] opacity-70">{copy.esBody}</p>
+                        <div className="mt-4 flex flex-col gap-2">
+                            {copy.showRejoin && (
+                                <button onClick={rejoin} className="event-button event-button--primary w-full">
+                                    Rejoin / Volver a entrar
+                                </button>
+                            )}
+                            <button onClick={() => router.push("/")} className="event-button event-button--secondary w-full">
+                                Back to Sessions / Volver
                             </button>
-                        )}
-                        <button onClick={() => router.push("/")} className="btn-secondary">
-                            Back to Sessions
-                        </button>
+                        </div>
                     </div>
                 </div>
             </main>
@@ -645,206 +551,197 @@ function SessionRoom() {
     const needsDeviceGesture = canPublish && !isMicOn && !isCameraOn;
 
     return (
-        <main className="min-h-screen flex flex-col">
-            {/* Header */}
-            <header className="p-4 flex items-center justify-between border-b border-[var(--border-subtle)]">
-                <div className="min-w-0 flex-1">
-                    <h1 className="font-semibold truncate">{sessionInfo?.title || "Session"}</h1>
-                    {/* aria-live without role="status": the terminal view owns the
-                        page's only status role, and a second one would compete
-                        with it for assistive-technology attention. */}
-                    <p className="text-xs text-[var(--text-muted)]" aria-live="polite">
-                        {participantCount} participant{participantCount !== 1 ? "s" : ""}
-                        <span
-                            className="ml-2 inline-flex items-center gap-1"
-                            data-testid="connection-state"
-                            data-state={connectionState}
-                        >
-                            <span className={`w-1.5 h-1.5 rounded-full ${CONNECTION_DOT[connectionState] ?? "bg-white/30"}`}></span>
-                            {connectionLabel}
-                        </span>
-                    </p>
-                </div>
-                <span className="text-sm font-mono text-[var(--text-muted)]">{formatTime(duration)}</span>
-            </header>
-
-            {/* Stage */}
-            <div className="flex-1 flex flex-col items-center justify-center gap-6 px-3 py-4 sm:px-4">
-                <StageLayout
-                    publishers={stagePublishers}
-                    activeSpeakerIdentity={activeSpeakerIdentity}
-                    audioOnly={audioOnly}
-                />
-
-                {!isBeaconPlaying && (
-                    <div className="glass-card w-full max-w-md p-4 text-center" role="group" aria-label="Audio activation">
-                        <p className="mb-3 text-sm text-[var(--text-secondary)]">
-                            Press once to hear the session and Beacon.
-                            <span className="block">Presiona una vez para escuchar la sesión y el Beacon.</span>
+        <main className="event-shell">
+            <div className="relative z-10 flex min-h-screen flex-col">
+                {/* Header */}
+                <header className="flex items-center justify-between border-b border-[var(--border-subtle)] px-4 py-3">
+                    <div className="min-w-0 flex-1">
+                        <h1 className="truncate text-sm font-semibold text-[var(--cream)]">
+                            {sessionInfo?.title || "Session"}
+                        </h1>
+                        <p className="text-[10px] text-[var(--text-muted)]" aria-live="polite">
+                            <span className="font-mono">{participantCount}</span> participant{participantCount !== 1 ? "s" : ""}
+                            <span
+                                className="ml-2 inline-flex items-center gap-1"
+                                data-testid="connection-state"
+                                data-state={connectionState}
+                            >
+                                <span className={`inline-block h-1.5 w-1.5 rounded-full ${CONNECTION_DOT[connectionState] ?? "bg-white/30"}`} />
+                                {connectionLabel}
+                            </span>
                         </p>
-                        <button onClick={startListening} className="btn-primary min-h-12 w-full">
-                            Start audio · Iniciar audio
-                        </button>
-                        {(audioActivationError || beaconAudioError) && (
-                            <p className="mt-3 text-sm text-red-300" role="alert">
-                                {audioActivationError || beaconAudioError}
+                    </div>
+                    <span className="font-mono text-xs text-[var(--gold)]">{formatTime(duration)}</span>
+                </header>
+
+                {/* Stage */}
+                <div className="flex flex-1 flex-col items-center justify-center gap-5 px-3 py-4 sm:px-4">
+                    <StageLayout
+                        publishers={stagePublishers}
+                        activeSpeakerIdentity={activeSpeakerIdentity}
+                        audioOnly={audioOnly}
+                    />
+
+                    {!isBeaconPlaying && (
+                        <div className="event-card w-full max-w-md text-center" role="group" aria-label="Audio activation">
+                            <p className="mb-3 text-sm text-[var(--text-secondary)]">
+                                Press once to hear the session and Beacon.
+                                <span className="mt-1 block opacity-80">Presiona una vez para escuchar la sesión y el Beacon.</span>
                             </p>
-                        )}
-                    </div>
-                )}
+                            <button onClick={startListening} className="event-button event-button--primary w-full">
+                                Start audio · Iniciar audio
+                            </button>
+                            {(audioActivationError || beaconAudioError) && (
+                                <p className="mt-3 text-sm text-[var(--danger)]" role="alert">
+                                    {audioActivationError || beaconAudioError}
+                                </p>
+                            )}
+                        </div>
+                    )}
 
-                {/* A grant is not consent to open a device. Nothing is enabled
-                    until the promoted participant presses a button. */}
-                {needsDeviceGesture && (
-                    <p className="text-sm text-[var(--accent-400)] text-center">
-                        Your turn—enable camera and mic
-                    </p>
-                )}
+                    {needsDeviceGesture && (
+                        <p className="text-center text-sm text-[var(--lime)]">
+                            Your turn — enable camera and mic
+                            <span className="mt-0.5 block text-xs opacity-80">Tu turno — activá cámara y micrófono</span>
+                        </p>
+                    )}
 
-                <ThumbnailSender
-                    sessionId={id}
-                    connected={isConnected}
-                    // A stage grant owns the camera. Stop the optional stream as
-                    // soon as promotion lands, before a stage camera is enabled.
-                    isPublishing={canPublish}
-                />
+                    <ThumbnailSender
+                        sessionId={id}
+                        connected={isConnected}
+                        isPublishing={canPublish}
+                    />
 
-                {process.env.NEXT_PUBLIC_TAPESTRY_PUBLIC_ENABLED === "true" && (
-                    <ThumbnailTapestry sessionId={id} />
-                )}
+                    {process.env.NEXT_PUBLIC_TAPESTRY_PUBLIC_ENABLED === "true" && (
+                        <ThumbnailTapestry sessionId={id} />
+                    )}
 
-                {/* Volume + Mix controls */}
-                <div className="w-full max-w-xs space-y-4">
-                    {/* Master volume */}
-                    <div className="flex items-center gap-3">
-                        <svg className="w-4 h-4 text-[var(--text-muted)] flex-shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M15.536 8.464a5 5 0 010 7.072M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
-                        </svg>
-                        <input
-                            type="range"
-                            min="0"
-                            max="1"
-                            step="0.01"
-                            value={volume}
-                            onChange={(e) => setVolume(parseFloat(e.target.value))}
-                            className="flex-1 accent-[var(--primary-500)]"
-                            aria-label="Master volume"
-                        />
-                    </div>
-                    {/* Crossfader: beacon <-> session */}
-                    <div>
-                        <div className="flex items-center gap-3">
-                            <span className="text-[10px] text-[var(--text-muted)] w-12 text-right">Beacon</span>
+                    {/* Volume + Mix controls */}
+                    <div className="w-full max-w-xs space-y-4">
+                        <div className="crossfader">
+                            <svg className="h-4 w-4 shrink-0 text-[var(--text-muted)]" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M15.536 8.464a5 5 0 010 7.072M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+                            </svg>
                             <input
                                 type="range"
                                 min="0"
                                 max="1"
                                 step="0.01"
-                                value={mix}
-                                onChange={(e) => setMix(parseFloat(e.target.value))}
-                                className="flex-1 accent-[var(--primary-500)]"
-                                aria-label="Beacon and session mix"
+                                value={volume}
+                                onChange={(e) => setVolume(parseFloat(e.target.value))}
+                                className="flex-1 accent-[var(--gold)]"
+                                aria-label="Master volume"
                             />
-                            <span className="text-[10px] text-[var(--text-muted)] w-12">Session</span>
+                        </div>
+                        <div>
+                            <div className="flex items-center gap-2">
+                                <span className="w-10 text-right font-mono text-[9px] uppercase tracking-wider text-[var(--gold)]">Beacon</span>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    value={mix}
+                                    onChange={(e) => setMix(parseFloat(e.target.value))}
+                                    className="flex-1 accent-[var(--cyan)]"
+                                    aria-label="Beacon and session mix"
+                                />
+                                <span className="w-10 font-mono text-[9px] uppercase tracking-wider text-[var(--cyan)]">Session</span>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
 
-            {/* Bottom controls */}
-            <div className="p-6 border-t border-[var(--border-subtle)]">
-                {isConnected && (
-                    <div className="mb-4 flex justify-center">
-                        <HandRaiseButton
-                            sessionId={id}
-                            onPublishGrantChange={setCanPublish}
-                        />
-                    </div>
-                )}
-                <div className="flex items-start justify-center gap-4">
-                    {/* Mic toggle (only for publishers) */}
-                    {canPublish && (
-                        <div className="flex flex-col items-center gap-1">
-                            <button
-                                onClick={toggleMic}
-                                className={`w-14 h-14 rounded-full flex items-center justify-center transition-all ${
-                                    isMicOn
-                                        ? "bg-[var(--primary-600)] text-white"
-                                        : "bg-white/10 text-[var(--text-muted)] hover:bg-white/20"
-                                }`}
-                                aria-label={isMicOn ? "Mute microphone" : "Unmute microphone"}
-                                aria-pressed={isMicOn}
-                            >
-                                {isMicOn ? (
-                                    <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
-                                    </svg>
-                                ) : (
-                                    <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
-                                        <line x1="2" y1="2" x2="22" y2="22" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                                    </svg>
-                                )}
-                            </button>
-                            <span className="text-[10px] text-[var(--text-muted)]">Mic</span>
+                {/* Bottom controls */}
+                <div className="border-t border-[var(--border-subtle)] px-4 py-4">
+                    {isConnected && (
+                        <div className="mb-4 flex justify-center">
+                            <HandRaiseButton
+                                sessionId={id}
+                                onPublishGrantChange={setCanPublish}
+                            />
                         </div>
                     )}
+                    <div className="flex items-start justify-center gap-4">
+                        {canPublish && (
+                            <div className="flex flex-col items-center gap-1">
+                                <button
+                                    onClick={toggleMic}
+                                    className={`flex h-14 w-14 items-center justify-center rounded-full transition-all ${
+                                        isMicOn
+                                            ? "bg-[var(--cyan)] text-[var(--ink)]"
+                                            : "bg-white/10 text-[var(--text-muted)] hover:bg-white/20"
+                                    }`}
+                                    aria-label={isMicOn ? "Mute microphone" : "Unmute microphone"}
+                                    aria-pressed={isMicOn}
+                                >
+                                    {isMicOn ? (
+                                        <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                                        </svg>
+                                    ) : (
+                                        <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                                            <line x1="2" y1="2" x2="22" y2="22" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                                        </svg>
+                                    )}
+                                </button>
+                                <span className="text-[9px] text-[var(--text-muted)]">Mic</span>
+                            </div>
+                        )}
 
-                    {/* Camera toggle (only for publishers) */}
-                    {canPublish && (
+                        {canPublish && (
+                            <div className="flex flex-col items-center gap-1">
+                                <button
+                                    onClick={toggleCamera}
+                                    className={`flex h-14 w-14 items-center justify-center rounded-full transition-all ${
+                                        isCameraOn
+                                            ? "bg-[var(--cyan)] text-[var(--ink)]"
+                                            : "bg-white/10 text-[var(--text-muted)] hover:bg-white/20"
+                                    }`}
+                                    aria-label={isCameraOn ? "Turn camera off" : "Turn camera on"}
+                                    aria-pressed={isCameraOn}
+                                >
+                                    <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                        {!isCameraOn && <line x1="3" y1="3" x2="21" y2="21" strokeLinecap="round" />}
+                                    </svg>
+                                </button>
+                                <span className="text-[9px] text-[var(--text-muted)]">Camera</span>
+                            </div>
+                        )}
+
                         <div className="flex flex-col items-center gap-1">
                             <button
-                                onClick={toggleCamera}
-                                className={`w-14 h-14 rounded-full flex items-center justify-center transition-all ${
-                                    isCameraOn
-                                        ? "bg-[var(--primary-600)] text-white"
+                                onClick={toggleAudioOnly}
+                                className={`flex h-14 w-14 items-center justify-center rounded-full transition-all ${
+                                    audioOnly
+                                        ? "bg-[var(--gold)] text-[var(--ink)]"
                                         : "bg-white/10 text-[var(--text-muted)] hover:bg-white/20"
                                 }`}
-                                aria-label={isCameraOn ? "Turn camera off" : "Turn camera on"}
-                                aria-pressed={isCameraOn}
+                                aria-label={audioOnly ? "Turn video back on" : "Switch to audio only"}
+                                aria-pressed={audioOnly}
                             >
-                                <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                    {!isCameraOn && <line x1="3" y1="3" x2="21" y2="21" strokeLinecap="round" />}
+                                <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 19V6l7-3v13M9 19a3 3 0 11-6 0 3 3 0 016 0zm7-3a3 3 0 11-6 0 3 3 0 016 0z" />
                                 </svg>
                             </button>
-                            <span className="text-[10px] text-[var(--text-muted)]">Camera</span>
+                            <span className="text-[9px] text-[var(--text-muted)]">Audio only</span>
                         </div>
-                    )}
 
-                    {/* Audio-only fallback — available to everyone, publisher or not */}
-                    <div className="flex flex-col items-center gap-1">
-                        <button
-                            onClick={toggleAudioOnly}
-                            className={`w-14 h-14 rounded-full flex items-center justify-center transition-all ${
-                                audioOnly
-                                    ? "bg-[var(--accent-500)] text-black"
-                                    : "bg-white/10 text-[var(--text-muted)] hover:bg-white/20"
-                            }`}
-                            aria-label={audioOnly ? "Turn video back on" : "Switch to audio only"}
-                            aria-pressed={audioOnly}
-                        >
-                            <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M9 19V6l7-3v13M9 19a3 3 0 11-6 0 3 3 0 016 0zm7-3a3 3 0 11-6 0 3 3 0 016 0z" />
-                            </svg>
-                        </button>
-                        <span className="text-[10px] text-[var(--text-muted)]">Audio only</span>
+                        <div className="flex flex-col items-center gap-1">
+                            <button
+                                onClick={leaveSession}
+                                className="flex h-14 w-14 items-center justify-center rounded-full bg-white/10 text-[var(--text-muted)] transition-all hover:bg-white/20"
+                                aria-label="Leave session"
+                            >
+                                <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                                </svg>
+                            </button>
+                            <span className="text-[9px] text-[var(--text-muted)]">Leave</span>
+                        </div>
                     </div>
-
-                    {/* Leave button */}
-                    <div className="flex flex-col items-center gap-1">
-                        <button
-                            onClick={leaveSession}
-                            className="w-14 h-14 rounded-full bg-white/10 text-[var(--text-muted)] flex items-center justify-center hover:bg-white/20 transition-all"
-                            aria-label="Leave session"
-                        >
-                            <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-                            </svg>
-                        </button>
-                        <span className="text-[10px] text-[var(--text-muted)]">Leave</span>
-                    </div>
-
                 </div>
             </div>
         </main>

--- a/src/app/staff/login/StaffLoginClient.tsx
+++ b/src/app/staff/login/StaffLoginClient.tsx
@@ -60,9 +60,9 @@ export default function StaffLoginClient() {
     }
 
     return (
-        <form onSubmit={onSubmit} className="space-y-4" noValidate>
-            <div className="space-y-1">
-                <label htmlFor="staff-email" className="block text-sm font-medium">
+        <form onSubmit={onSubmit} className="space-y-5" noValidate>
+            <div className="space-y-1.5">
+                <label htmlFor="staff-email" className="block text-sm font-medium text-[var(--cream)]">
                     Staff email
                 </label>
                 <input
@@ -74,12 +74,12 @@ export default function StaffLoginClient() {
                     required
                     autoComplete="username"
                     spellCheck={false}
-                    className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2"
+                    className="event-field"
                 />
             </div>
 
-            <div className="space-y-1">
-                <label htmlFor="staff-password" className="block text-sm font-medium">
+            <div className="space-y-1.5">
+                <label htmlFor="staff-password" className="block text-sm font-medium text-[var(--cream)]">
                     Password
                 </label>
                 <input
@@ -90,20 +90,20 @@ export default function StaffLoginClient() {
                     onChange={(event) => setPassword(event.target.value)}
                     required
                     autoComplete="current-password"
-                    className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2"
+                    className="event-field"
                 />
             </div>
 
             {error && (
-                <p role="alert" className="text-sm text-[var(--danger-400,#fca5a5)]">
+                <div role="alert" className="event-alert event-alert--danger">
                     {MESSAGES[error]}
-                </p>
+                </div>
             )}
 
             <button
                 type="submit"
                 disabled={submitting}
-                className="w-full rounded-lg bg-[var(--primary-600)] px-4 py-2.5 font-medium disabled:opacity-60"
+                className="event-button event-button--primary w-full"
             >
                 {submitting ? "Signing in…" : "Sign in"}
             </button>

--- a/src/app/staff/login/page.tsx
+++ b/src/app/staff/login/page.tsx
@@ -12,41 +12,49 @@ import Link from "next/link";
 import { currentPrincipal } from "@/lib/auth";
 
 import StaffLoginClient from "./StaffLoginClient";
+import BrandLockup from "@/components/brand/BrandLockup";
 
 export const dynamic = "force-dynamic";
 
 export default async function StaffLoginPage() {
-    // Resolved authoritatively, unlike the cookie check in `middleware.ts`: an
-    // operator whose account was disabled mid-event should see the form again,
-    // not a stale "you are signed in".
     const principal = await currentPrincipal().catch(() => null);
     const signedInRole = principal?.kind === "staff" ? principal.role : null;
 
     return (
-        <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6 py-12">
-            <header className="space-y-1">
-                <h1 className="text-2xl font-bold">Staff sign-in</h1>
-                <p className="text-sm text-[var(--text-secondary)]">Harmonic Beacon event operations</p>
-            </header>
-
-            {signedInRole ? (
-                <div className="space-y-3">
-                    <p className="text-sm">
-                        Signed in as <span className="font-medium">{signedInRole}</span>.
+        <main className="event-shell">
+            <div className="relative z-10 mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6 py-12">
+                <header className="space-y-1">
+                    <BrandLockup href="/" />
+                    <h1 className="pt-4 font-serif text-2xl font-normal text-[var(--cream)]">
+                        Staff sign-in
+                    </h1>
+                    <p className="text-sm text-[var(--text-muted)]">
+                        Harmonic Beacon event operations
                     </p>
-                    <Link href="/ops/health" className="inline-block text-sm underline">
-                        Go to operator controls
-                    </Link>
-                </div>
-            ) : (
-                <StaffLoginClient />
-            )}
+                </header>
 
-            <footer className="text-xs text-[var(--text-secondary)]">
-                <Link href="/" className="underline">
-                    Attendee sign-in
-                </Link>
-            </footer>
+                {signedInRole ? (
+                    <div className="space-y-4">
+                        <div className="event-alert event-alert--info">
+                            Signed in as <span className="font-medium text-[var(--cream)]">{signedInRole}</span>.
+                        </div>
+                        <Link
+                            href="/ops/health"
+                            className="event-button event-button--primary inline-flex w-full"
+                        >
+                            Go to operator controls
+                        </Link>
+                    </div>
+                ) : (
+                    <StaffLoginClient />
+                )}
+
+                <footer className="text-xs text-[var(--text-muted)]">
+                    <Link href="/" className="underline underline-offset-2 transition-colors hover:text-[var(--cream)]">
+                        Attendee sign-in / Ingreso de participantes
+                    </Link>
+                </footer>
+            </div>
         </main>
     );
 }

--- a/src/components/brand/BrandLockup.tsx
+++ b/src/components/brand/BrandLockup.tsx
@@ -1,0 +1,28 @@
+/**
+ * Brand lockup component: HARMONIC BEACON mark + wordmark.
+ * Used across landing, login, and operator surfaces.
+ */
+
+interface BrandLockupProps {
+  href?: string;
+  className?: string;
+}
+
+export default function BrandLockup({ href = "/", className = "" }: BrandLockupProps) {
+  const Tag = href ? "a" : "span";
+  return (
+    <Tag
+      href={href}
+      className={`brand-lockup ${className}`}
+    >
+      <span className="brand-lockup__mark" aria-hidden="true">
+        &#10022;
+      </span>
+      <span>
+        HARMONIC
+        <br />
+        <i className="brand-lockup__accent">BEACON</i>
+      </span>
+    </Tag>
+  );
+}

--- a/src/components/ops/AdmissionConsole.tsx
+++ b/src/components/ops/AdmissionConsole.tsx
@@ -190,10 +190,10 @@ export default function AdmissionConsole({ role, events }: Props) {
     return (
         <div className="space-y-10">
             <section>
-                <h2 className="mb-2 text-lg font-medium">Ticket lookup</h2>
+                <h2 className="mb-2 text-lg font-medium text-[var(--cream)]">Ticket lookup</h2>
                 <form onSubmit={runLookup} className="flex gap-2">
                     <input
-                        className="w-full rounded border px-3 py-2"
+                        className="event-field flex-1"
                         placeholder="Attendee email, code last four, or entitlement ID"
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}
@@ -201,7 +201,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                     <button
                         type="submit"
                         disabled={busy || !query.trim()}
-                        className="rounded bg-gray-900 px-4 py-2 text-white disabled:opacity-50"
+                        className="event-button event-button--primary"
                     >
                         Look up
                     </button>
@@ -210,26 +210,26 @@ export default function AdmissionConsole({ role, events }: Props) {
                 {results && results.length > 0 && (
                     <div className="mt-4 space-y-4">
                         {results.map((item) => (
-                            <div key={item.id} className="rounded border p-3 text-sm">
+                            <div key={item.id} className="operational-panel text-sm">
                                 <div className="flex flex-wrap gap-x-6 gap-y-1">
-                                    <span><strong>State:</strong> {item.state}</span>
-                                    <span><strong>Tier:</strong> {item.tier}</span>
-                                    <span><strong>Last four:</strong> {item.codeLastFour}</span>
-                                    <span><strong>Bound email:</strong> {item.boundEmail ?? '—'}</span>
-                                    <span><strong>Event:</strong> {item.event.title}</span>
-                                    <span><strong>Expires:</strong> {new Date(item.expiresAt).toLocaleString()}</span>
+                                    <span><strong className="text-[var(--cream)]">State:</strong> {item.state}</span>
+                                    <span><strong className="text-[var(--cream)]">Tier:</strong> {item.tier}</span>
+                                    <span><strong className="text-[var(--cream)]">Last four:</strong> <span className="font-mono">{item.codeLastFour}</span></span>
+                                    <span><strong className="text-[var(--cream)]">Bound email:</strong> {item.boundEmail ?? '—'}</span>
+                                    <span><strong className="text-[var(--cream)]">Event:</strong> {item.event.title}</span>
+                                    <span><strong className="text-[var(--cream)]">Expires:</strong> {new Date(item.expiresAt).toLocaleString()}</span>
                                 </div>
-                                <div className="mt-1 text-xs text-gray-500">ID: {item.id}</div>
+                                <div className="mt-1 font-mono text-[10px] text-[var(--text-muted)]">ID: {item.id}</div>
                                 {item.revokedAt && (
-                                    <div className="mt-1 text-xs text-red-700">
+                                    <div className="mt-1 text-xs text-[var(--danger)]">
                                         Revoked {new Date(item.revokedAt).toLocaleString()} — {item.revocationReason}
                                     </div>
                                 )}
 
                                 {canMutate && item.state !== 'REVOKED' && (
-                                    <div className="mt-3 flex flex-wrap items-center gap-2 border-t pt-3">
+                                    <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[var(--border-subtle)] pt-3">
                                         <input
-                                            className="min-w-56 flex-1 rounded border px-2 py-1"
+                                            className="event-field min-w-56 flex-1"
                                             placeholder="Reason (required, no PII)"
                                             value={reasons[item.id] ?? ''}
                                             onChange={(event) =>
@@ -237,7 +237,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                             }
                                         />
                                         <input
-                                            className="min-w-56 flex-1 rounded border px-2 py-1"
+                                            className="event-field min-w-56 flex-1"
                                             placeholder="New email (optional rebind)"
                                             value={emails[item.id] ?? ''}
                                             onChange={(event) =>
@@ -248,7 +248,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                             type="button"
                                             disabled={busy || !(reasons[item.id] ?? '').trim()}
                                             onClick={() => runEntitlementAction(item.id, 'rebind', emails[item.id] ?? '')}
-                                            className="rounded border px-3 py-1 disabled:opacity-50"
+                                            className="event-button event-button--secondary disabled:opacity-50"
                                         >
                                             {(emails[item.id] ?? '').trim() ? 'Rebind to email' : 'Clear binding'}
                                         </button>
@@ -256,7 +256,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                             type="button"
                                             disabled={busy || !(reasons[item.id] ?? '').trim()}
                                             onClick={() => runEntitlementAction(item.id, 'revoke')}
-                                            className="rounded bg-red-700 px-3 py-1 text-white disabled:opacity-50"
+                                            className="event-button bg-[var(--danger)] text-white hover:bg-[var(--danger)]/80 disabled:opacity-50"
                                         >
                                             Revoke
                                         </button>
@@ -270,10 +270,10 @@ export default function AdmissionConsole({ role, events }: Props) {
 
             {(canBatch || canMutate) && (
                 <section>
-                    <h2 className="mb-2 text-lg font-medium">Issue tickets</h2>
+                    <h2 className="mb-2 text-lg font-medium text-[var(--cream)]">Issue tickets</h2>
                     <div className="mb-3 flex flex-wrap gap-2">
                         <select
-                            className="rounded border px-2 py-1"
+                            className="event-field"
                             value={batchEvent}
                             onChange={(event) => setBatchEvent(event.target.value)}
                         >
@@ -286,11 +286,11 @@ export default function AdmissionConsole({ role, events }: Props) {
                     </div>
 
                     {canBatch && (
-                        <div className="mb-6 space-y-3 rounded border p-3">
-                            <h3 className="font-medium">Batch (ADMIN)</h3>
+                        <div className="operational-panel mb-6 space-y-3">
+                            <h3 className="font-medium text-[var(--cream)]">Batch (ADMIN)</h3>
                             <div className="flex flex-wrap items-center gap-2">
                                 <select
-                                    className="rounded border px-2 py-1"
+                                    className="event-field"
                                     value={batchTier}
                                     onChange={(event) => setBatchTier(event.target.value)}
                                 >
@@ -298,7 +298,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     <option value="GLOBAL_SOUTH">Global South ($20)</option>
                                 </select>
                                 <input
-                                    className="w-24 rounded border px-2 py-1"
+                                    className="event-field w-24"
                                     type="number"
                                     min={1}
                                     max={150}
@@ -309,13 +309,13 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     type="button"
                                     disabled={busy || !batchEvent}
                                     onClick={() => runBatch('generate')}
-                                    className="rounded bg-gray-900 px-3 py-1 text-white disabled:opacity-50"
+                                    className="event-button event-button--primary disabled:opacity-50"
                                 >
                                     Generate batch
                                 </button>
                             </div>
                             <textarea
-                                className="h-24 w-full rounded border px-2 py-1 font-mono text-xs"
+                                className="event-field h-24 font-mono text-xs"
                                 placeholder="Paste platform CSV to import (code column, header optional)"
                                 value={importCsv}
                                 onChange={(event) => setImportCsv(event.target.value)}
@@ -324,7 +324,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                 type="button"
                                 disabled={busy || !batchEvent || !importCsv.trim()}
                                 onClick={() => runBatch('import')}
-                                className="rounded border px-3 py-1 disabled:opacity-50"
+                                className="event-button event-button--secondary disabled:opacity-50"
                             >
                                 Import CSV (idempotent)
                             </button>
@@ -332,11 +332,11 @@ export default function AdmissionConsole({ role, events }: Props) {
                     )}
 
                     {canMutate && (
-                        <div className="space-y-3 rounded border p-3">
-                            <h3 className="font-medium">Comp / support override</h3>
+                        <div className="operational-panel space-y-3">
+                            <h3 className="font-medium text-[var(--cream)]">Comp / support override</h3>
                             <div className="flex flex-wrap items-center gap-2">
                                 <select
-                                    className="rounded border px-2 py-1"
+                                    className="event-field"
                                     value={compTier}
                                     onChange={(event) => setCompTier(event.target.value)}
                                 >
@@ -344,7 +344,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     <option value="SUPPORT_OVERRIDE">Support override</option>
                                 </select>
                                 <input
-                                    className="min-w-56 flex-1 rounded border px-2 py-1"
+                                    className="event-field min-w-56 flex-1"
                                     placeholder="Reason (required, no PII — e.g. support case reference)"
                                     value={compReason}
                                     onChange={(event) => setCompReason(event.target.value)}
@@ -353,7 +353,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     type="button"
                                     disabled={busy || !batchEvent || !compReason.trim()}
                                     onClick={runComp}
-                                    className="rounded bg-gray-900 px-3 py-1 text-white disabled:opacity-50"
+                                    className="event-button event-button--primary disabled:opacity-50"
                                 >
                                     Issue
                                 </button>
@@ -363,26 +363,26 @@ export default function AdmissionConsole({ role, events }: Props) {
                 </section>
             )}
 
-            {notice && <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-800">{notice}</p>}
-            {failure && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-800">{failure}</p>}
+            {notice && <p className="rounded border border-[var(--lime)]/30 bg-[var(--lime)]/10 px-3 py-2 text-sm text-[var(--lime)]">{notice}</p>}
+            {failure && <p className="rounded border border-[var(--danger)]/30 bg-[var(--danger)]/10 px-3 py-2 text-sm text-[var(--danger)]">{failure}</p>}
 
             {oneTimeCsv && (
-                <section className="rounded border-2 border-amber-500 p-3">
-                    <h3 className="mb-1 font-medium text-amber-800">One-time code export</h3>
-                    <p className="mb-2 text-sm text-amber-800">
+                <section className="rounded border-2 border-[var(--warning)] p-3">
+                    <h3 className="mb-1 font-medium text-[var(--warning)]">One-time code export</h3>
+                    <p className="mb-2 text-sm text-[var(--warning)]">
                         These plaintext codes are shown once and are never stored by the app. Save the CSV
                         under ops control now; do not commit it or paste it into tickets/chat.
                     </p>
                     <textarea
                         readOnly
-                        className="h-40 w-full rounded border px-2 py-1 font-mono text-xs"
+                        className="event-field h-40 font-mono text-xs"
                         value={oneTimeCsv}
                         onFocus={(event) => event.target.select()}
                     />
                     <button
                         type="button"
                         onClick={downloadCsv}
-                        className="mt-2 rounded bg-amber-600 px-3 py-1 text-white"
+                        className="event-button mt-2 bg-[var(--warning)] text-[var(--ink)] hover:bg-[var(--warning)]/80"
                     >
                         Download CSV
                     </button>

--- a/src/components/ops/OpsNavLinks.tsx
+++ b/src/components/ops/OpsNavLinks.tsx
@@ -23,15 +23,15 @@ export default function OpsNavLinks({ links }: { links: NavLink[] }) {
                     <Link
                         key={link.href}
                         href={link.href}
-                        className={`rounded-md px-2 py-1 transition-colors ${
+                        className={`rounded-md px-2 py-1 text-xs transition-colors ${
                             isActive
-                                ? 'bg-white/15 text-[var(--text-primary)]'
-                                : 'text-[var(--text-secondary)] hover:bg-white/5 hover:text-[var(--text-primary)]'
+                                ? 'bg-white/15 text-[var(--cream)]'
+                                : 'text-[var(--text-secondary)] hover:bg-white/5 hover:text-[var(--cream)]'
                         }`}
                     >
                         {link.label}
                         {link.live && (
-                            <span className="ml-1.5 inline-block h-2 w-2 rounded-full bg-green-400 align-middle" />
+                            <span className="ml-1.5 inline-block h-2 w-2 rounded-full bg-[var(--lime)] align-middle" />
                         )}
                     </Link>
                 );

--- a/src/components/ops/SpotlightConsole.tsx
+++ b/src/components/ops/SpotlightConsole.tsx
@@ -206,13 +206,8 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
             `${participant.displayName} has the floor`,
         );
         if (!promoted) {
-            // stage_full / LiveKit failure leave the hand raised; the banner
-            // above says which one happened.
             return;
         }
-        // The hand is served: remove it so a later demotion does not drop the
-        // attendee back into the queue at their original timestamp. Failure is
-        // non-fatal — the operator can still use Remove hand.
         await runAction(
             `lower:${participant.id}`,
             { action: 'lower_hand', participantId: participant.id, reason: 'Promoted to stage' },
@@ -267,22 +262,22 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
         <section className="space-y-6" aria-live="polite">
             {/* Status banners */}
             {pollError ? (
-                <div role="alert" className="rounded border border-red-600 bg-red-950/40 px-4 py-2 text-sm text-red-300">
+                <div role="alert" className="rounded border border-[var(--danger)]/40 bg-[var(--danger)]/10 px-4 py-2 text-sm text-[var(--danger)]">
                     Polling failed ({pollError}) — showing the last known state. Retrying every {POLL_INTERVAL_MS / 1000}s.
                 </div>
             ) : null}
             {snapshot && !snapshot.liveStateAvailable ? (
-                <div role="alert" className="rounded border border-amber-500 bg-amber-950/40 px-4 py-2 text-sm text-amber-300">
+                <div role="alert" className="rounded border border-[var(--warning)]/40 bg-[var(--warning)]/10 px-4 py-2 text-sm text-[var(--warning)]">
                     LiveKit live state unavailable — connection and media are unknown. Durable grants and the hand queue are still current.
                 </div>
             ) : null}
             {reconcilePending.length > 0 ? (
-                <div role="alert" className="rounded border border-amber-500 bg-amber-950/40 px-4 py-2 text-sm text-amber-300">
+                <div role="alert" className="rounded border border-[var(--warning)]/40 bg-[var(--warning)]/10 px-4 py-2 text-sm text-[var(--warning)]">
                     {reconcilePending.length} participant{reconcilePending.length !== 1 ? 's' : ''} need{reconcilePending.length === 1 ? 's' : ''} reconciliation — the durable grant and LiveKit disagree.
                 </div>
             ) : null}
             {actionError ? (
-                <div role="alert" className="rounded border border-red-600 bg-red-950/40 px-4 py-2 text-sm text-red-300">
+                <div role="alert" className="rounded border border-[var(--danger)]/40 bg-[var(--danger)]/10 px-4 py-2 text-sm text-[var(--danger)]">
                     {actionError.code === 'stage_full'
                         ? `Stage is full — this hand stays #${actionError.queuePosition ?? '?'} in the queue. Take a floor first.`
                         : actionError.code === 'livekit_failed'
@@ -291,13 +286,13 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                 </div>
             ) : null}
             {notice ? (
-                <div role="status" className="rounded border border-green-600 bg-green-950/40 px-4 py-2 text-sm text-green-300">
+                <div role="status" className="rounded border border-[var(--lime)]/40 bg-[var(--lime)]/10 px-4 py-2 text-sm text-[var(--lime)]">
                     {notice}
                 </div>
             ) : null}
 
             <div className="flex items-center justify-between text-sm">
-                <span>
+                <span className="text-[var(--text-secondary)]">
                     Stage: {snapshot ? `${snapshot.activePublishers}/${snapshot.maxPublishers}` : '…'} publishers ·{' '}
                     {queue.length} hand{queue.length !== 1 ? 's' : ''} raised
                 </span>
@@ -305,7 +300,7 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                     type="button"
                     onClick={() => void reconcile()}
                     disabled={busyKey === 'reconcile'}
-                    className="rounded border border-current px-3 py-1 text-xs hover:opacity-80 disabled:opacity-50"
+                    className="rounded border border-[var(--border-subtle)] px-3 py-1 text-xs hover:bg-white/5 disabled:opacity-50"
                 >
                     Reconcile grants
                 </button>
@@ -313,18 +308,18 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
 
             {/* Stage */}
             <div>
-                <h2 className="mb-2 text-lg font-semibold">On stage</h2>
+                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">On stage</h2>
                 {onStage.length === 0 ? (
                     <p className="text-sm text-[var(--text-secondary)]">Nobody has the floor yet.</p>
                 ) : (
                     <ul className="space-y-2">
                         {onStage.map((participant) => (
-                            <li key={participant.id} className="rounded border border-[var(--border,#333)] px-4 py-3">
+                            <li key={participant.id} className="operational-panel">
                                 <div className="flex items-center justify-between gap-3">
                                     <div className="min-w-0">
-                                        <span className="font-medium">{participant.displayName}</span>
+                                        <span className="font-medium text-[var(--cream)]">{participant.displayName}</span>
                                         {participant.staffRole ? (
-                                            <span className="ml-2 text-xs uppercase text-[var(--text-secondary)]">{participant.staffRole}</span>
+                                            <span className="ml-2 text-[10px] uppercase text-[var(--text-muted)]">{participant.staffRole}</span>
                                         ) : null}
                                         <div className="text-xs text-[var(--text-secondary)]">
                                             {connectionBadge(participant)}
@@ -340,7 +335,7 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                                                 type="button"
                                                 disabled={busyKey !== null}
                                                 onClick={() => void setTrackMuted(participant, track, !track.muted)}
-                                                className="rounded border border-current px-2 py-1 text-xs hover:opacity-80 disabled:opacity-50"
+                                                className="rounded border border-[var(--border-subtle)] px-2 py-1 text-xs hover:bg-white/5 disabled:opacity-50"
                                             >
                                                 {track.muted ? 'Unmute' : 'Mute'} {track.source.toLowerCase()}
                                             </button>
@@ -350,12 +345,12 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                                                 type="button"
                                                 disabled={busyKey !== null}
                                                 onClick={() => void takeFloor(participant)}
-                                                className="min-h-10 rounded border border-red-500 px-3 py-2 text-xs text-red-300 hover:opacity-80 disabled:opacity-50"
+                                                className="min-h-10 rounded border border-[var(--danger)] px-3 py-2 text-xs text-[var(--danger)] hover:bg-[var(--danger)]/10 disabled:opacity-50"
                                             >
                                                 Take floor
                                             </button>
                                         ) : (
-                                            <span className="text-xs font-medium text-[var(--text-secondary)]">
+                                            <span className="text-xs font-medium text-[var(--text-muted)]">
                                                 Reserved facilitator slot
                                             </span>
                                         )}
@@ -369,15 +364,15 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
 
             {/* Hand queue */}
             <div>
-                <h2 className="mb-2 text-lg font-semibold">Hand queue</h2>
+                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">Hand queue</h2>
                 {queue.length === 0 ? (
                     <p className="text-sm text-[var(--text-secondary)]">No hands raised.</p>
                 ) : (
                     <ul className="space-y-2">
                         {queue.map((participant) => (
-                            <li key={participant.id} className="flex items-center justify-between gap-3 rounded border border-[var(--border,#333)] px-4 py-3">
+                            <li key={participant.id} className="flex items-center justify-between gap-3 operational-panel">
                                 <div className="min-w-0">
-                                    <span className="font-medium">#{participant.queuePosition} — {participant.displayName}</span>
+                                    <span className="font-medium text-[var(--cream)]">#{participant.queuePosition} — {participant.displayName}</span>
                                     <div className="text-xs text-[var(--text-secondary)]">
                                         waiting {participant.raisedAt ? formatQueueAge(participant.raisedAt, nowMs) : '…'}
                                         {' · '}{connectionBadge(participant)}
@@ -390,7 +385,7 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                                         type="button"
                                         disabled={busyKey !== null}
                                         onClick={() => void giveFloor(participant)}
-                                        className="min-h-10 rounded border border-green-500 px-3 py-2 text-xs text-green-300 hover:opacity-80 disabled:opacity-50"
+                                        className="min-h-10 rounded border border-[var(--lime)] px-3 py-2 text-xs text-[var(--lime)] hover:bg-[var(--lime)]/10 disabled:opacity-50"
                                     >
                                         Give floor
                                     </button>
@@ -398,7 +393,7 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                                         type="button"
                                         disabled={busyKey !== null}
                                         onClick={() => void removeHand(participant)}
-                                        className="min-h-10 rounded border border-current px-3 py-2 text-xs hover:opacity-80 disabled:opacity-50"
+                                        className="min-h-10 rounded border border-[var(--border-subtle)] px-3 py-2 text-xs hover:bg-white/5 disabled:opacity-50"
                                     >
                                         Remove hand
                                     </button>
@@ -411,17 +406,17 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
 
             {/* Audience */}
             <div>
-                <h2 className="mb-2 text-lg font-semibold">Audience ({audience.length})</h2>
+                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">Audience ({audience.length})</h2>
                 {audience.length === 0 ? (
                     <p className="text-sm text-[var(--text-secondary)]">No other participants.</p>
                 ) : (
                     <ul className="space-y-1 text-sm">
                         {audience.map((participant) => (
                             <li key={participant.id} className="flex items-center justify-between rounded px-2 py-1">
-                                <span>
+                                <span className="text-[var(--cream)]">
                                     {participant.displayName}
                                     {participant.staffRole ? (
-                                        <span className="ml-2 text-xs uppercase text-[var(--text-secondary)]">{participant.staffRole}</span>
+                                        <span className="ml-2 text-[10px] uppercase text-[var(--text-muted)]">{participant.staffRole}</span>
                                     ) : null}
                                 </span>
                                 <span className="text-xs text-[var(--text-secondary)]">
@@ -434,7 +429,7 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                 )}
             </div>
 
-            <p className="text-xs text-[var(--text-secondary)]">
+            <p className="text-xs text-[var(--text-muted)]">
                 Signed in as {role}. Queue refreshes every {POLL_INTERVAL_MS / 1000}s; durable grants are the authority.
             </p>
         </section>

--- a/src/components/session/HandRaiseButton.tsx
+++ b/src/components/session/HandRaiseButton.tsx
@@ -2,14 +2,6 @@
 
 /**
  * Attendee hand control for the paid room (WS3-02).
- *
- * Polls the attendee hand endpoint every two seconds — the same
- * database-backed state the operator console sees — so a promotion granted
- * while the room page is open shows up here without a reconnect. When the
- * durable grant flips, `onPublishGrantChange` lets the room page reveal the
- * mic/camera controls; the devices themselves still need an explicit gesture,
- * which is the roadmap's "a promoted participant must explicitly enable
- * microphone/camera after the grant".
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -100,25 +92,27 @@ export default function HandRaiseButton({ sessionId, onPublishGrantChange }: Pro
                 type="button"
                 onClick={() => void setHand(!(state?.raised ?? false))}
                 disabled={busy}
-                className={`rounded-full px-4 py-2 text-sm transition-all ${
+                className={`rounded-full px-5 py-2.5 text-sm font-medium transition-all ${
                     state?.raised
-                        ? 'bg-[var(--primary-600)] text-white'
+                        ? 'bg-[var(--pink)] text-[var(--ink)] shadow-[0_0_16px_rgba(255,113,189,0.3)]'
                         : 'bg-white/10 text-[var(--text-muted)] hover:bg-white/20'
                 } disabled:opacity-50`}
             >
-                {state?.raised ? 'Lower hand' : 'Raise hand'}
+                {state?.raised ? 'Lower hand / Bajar mano' : 'Raise hand / Levantar mano'}
             </button>
             {state?.canPublish ? (
-                <p role="status" className="text-xs text-[var(--primary-400)]">
+                <p role="status" className="text-xs text-[var(--lime)]">
                     Your turn — enable mic and camera below.
+                    <span className="mt-0.5 block opacity-80">Tu turno — activá micrófono y cámara abajo.</span>
                 </p>
             ) : state?.raised && state.queuePosition !== null ? (
                 <p role="status" className="text-xs text-[var(--text-muted)]">
                     Hand raised — you are #{state.queuePosition} in the queue.
+                    <span className="mt-0.5 block opacity-80">Mano levantada — sos #{state.queuePosition} en la fila.</span>
                 </p>
             ) : null}
             {error ? (
-                <p role="alert" className="text-xs text-red-400">{error}</p>
+                <p role="alert" className="text-xs text-[var(--danger)]">{error}</p>
             ) : null}
         </div>
     );

--- a/src/components/session/StageLayout.tsx
+++ b/src/components/session/StageLayout.tsx
@@ -9,40 +9,16 @@ import {
 import StageTile, { type StageVideoPublication } from "./StageTile";
 
 export interface StagePublisherView extends StagePublisher {
-    /** Camera publication for this identity, if there is one. */
     videoPublication?: StageVideoPublication | null;
 }
 
 export interface StageLayoutProps {
-    /** Only participants holding a stage grant. Never the audience. */
     publishers: readonly StagePublisherView[];
     activeSpeakerIdentity?: string | null;
-    /** Operator pin; wins over the active speaker when set. */
     pinnedIdentity?: string | null;
-    /**
-     * Attendee chose audio-only. Video subscriptions are dropped by the room
-     * owner; this component additionally renders no `<video>` element at all,
-     * so nothing decodes even if a subscription lingers.
-     */
     audioOnly?: boolean;
 }
 
-/**
- * The six-person stage: one spotlight at the 720p layout plus up to five
- * auxiliaries at 360p.
- *
- * Every tile is a direct child of a single CSS grid, keyed by participant
- * identity. That is deliberate: when the active speaker changes, the promoted
- * tile keeps its React position and only its grid span and requested layer
- * change, so its `<video>` element is reused rather than torn down and rebuilt.
- * Splitting the spotlight and the strip into two parent elements would remount
- * the tile on every speaker change — one detach/attach cycle, one black frame,
- * and one more chance to leak an element per switch.
- *
- * Mobile gets the same grid, which lands as a full-width spotlight above a strip
- * of five fifth-width auxiliaries rather than six equal decoders
- * (WEEKEND_MVP_ROADMAP.md WS2-02 risk note).
- */
 export default function StageLayout({
     publishers,
     activeSpeakerIdentity,
@@ -61,7 +37,7 @@ export default function StageLayout({
             aria-label="Stage"
             data-testid="stage-layout"
             data-overflow={overflow.length || undefined}
-            className="w-full max-w-4xl mx-auto"
+            className="mx-auto w-full max-w-4xl"
         >
             {audioOnly && (
                 <p
@@ -70,15 +46,23 @@ export default function StageLayout({
                 >
                     Audio-only mode. Video is off; you are still hearing the stage and
                     the Beacon bed.
+                    <span className="mt-0.5 block opacity-70">
+                        Modo solo audio. El video está apagado; seguís escuchando el escenario y el Beacon.
+                    </span>
                 </p>
             )}
 
             {tiles.length === 0 ? (
-                <p className="py-10 text-center text-sm text-[var(--text-muted)]">
-                    Waiting for the facilitator to open the stage.
-                </p>
+                <div className="terminal-state py-10">
+                    <p className="terminal-state__body">
+                        Waiting for the facilitator to open the stage.
+                        <span className="mt-1 block opacity-70">
+                            Esperando que el facilitador abra el escenario.
+                        </span>
+                    </p>
+                </div>
             ) : (
-                <ul className="grid grid-cols-5 gap-1.5 sm:gap-3 list-none p-0 m-0">
+                <ul className="m-0 grid list-none grid-cols-5 gap-1.5 p-0 sm:gap-3">
                     {tiles.map((publisher) => (
                         <StageTile
                             key={publisher.identity}

--- a/src/components/session/StageTile.tsx
+++ b/src/components/session/StageTile.tsx
@@ -9,27 +9,18 @@ import {
     type StageVideoDimensions,
 } from "@/lib/stage-layout";
 
-/**
- * The parts of a LiveKit `TrackPublication` this tile touches, as a structural
- * type. Both `RemoteTrackPublication` and `LocalTrackPublication` satisfy it —
- * only the remote one carries `setVideoDimensions`, which is why that member is
- * optional. Keeping the type structural means the tile can be tested without a
- * room, a peer connection, or an SDK mock.
- */
 export interface StageVideoPublication {
     trackSid: string;
     videoTrack?: {
         attach(element: HTMLMediaElement): HTMLMediaElement;
         detach(element: HTMLMediaElement): HTMLMediaElement;
     } | null;
-    /** Present on remote publications: asks the SFU for a simulcast layer. */
     setVideoDimensions?(dimensions: StageVideoDimensions): void;
 }
 
 export type StageTileVariant = "spotlight" | "auxiliary";
 
 export interface StageTileProps {
-    /** Non-PII role word, e.g. "Facilitator". Never an email or ticket code. */
     label: string;
     variant: StageTileVariant;
     isLocal: boolean;
@@ -49,16 +40,16 @@ const QUALITY_COPY: Record<StageConnectionQuality, string> = {
 };
 
 const QUALITY_COLOR: Record<StageConnectionQuality, string> = {
-    excellent: "bg-green-400",
-    good: "bg-green-400/60",
-    poor: "bg-amber-400",
-    lost: "bg-red-400",
+    excellent: "bg-[var(--lime)]",
+    good: "bg-[var(--lime)]/60",
+    poor: "bg-[var(--warning)]",
+    lost: "bg-[var(--danger)]",
     unknown: "bg-white/30",
 };
 
 function MicOffIcon() {
     return (
-        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+        <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m-4 0h8m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
             <line x1="3" y1="3" x2="21" y2="21" strokeLinecap="round" />
         </svg>
@@ -67,23 +58,13 @@ function MicOffIcon() {
 
 function CameraOffIcon() {
     return (
-        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+        <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
             <line x1="3" y1="3" x2="21" y2="21" strokeLinecap="round" />
         </svg>
     );
 }
 
-/**
- * One publisher on the stage.
- *
- * The tile owns the lifecycle of exactly one `<video>` element: it is created by
- * this render, attached in an effect, and detached by that effect's cleanup.
- * Nothing else in the app attaches video, so a publisher moving between the
- * spotlight and the auxiliary strip cannot leave an orphan element behind —
- * provided the parent keeps the tile mounted (see `StageLayout`, which renders
- * every tile inside one grid so a promotion is a CSS change, not a remount).
- */
 export default function StageTile({
     label,
     variant,
@@ -97,9 +78,6 @@ export default function StageTile({
     const videoRef = useRef<HTMLVideoElement | null>(null);
     const isSpotlight = variant === "spotlight";
 
-    // A muted camera keeps its publication but stops producing frames. Dropping
-    // the element rather than showing its last decoded frame avoids a tile that
-    // looks live while the participant has their camera off.
     const track = cameraOn ? videoPublication?.videoTrack ?? null : null;
 
     useEffect(() => {
@@ -111,10 +89,6 @@ export default function StageTile({
         };
     }, [track]);
 
-    // Ask the SFU for the layer that matches how large this tile is drawn. This
-    // is what makes one 720p spotlight and five 360p auxiliaries true on the
-    // wire rather than only in CSS. `adaptiveStream` still pauses the flow when
-    // the element is off-screen; explicit dimensions win while it is visible.
     useEffect(() => {
         videoPublication?.setVideoDimensions?.(
             isSpotlight ? SPOTLIGHT_DIMENSIONS : AUXILIARY_DIMENSIONS,
@@ -128,10 +102,10 @@ export default function StageTile({
             data-identity-label={label}
             aria-label={`${label}${isLocal ? " (you)" : ""}`}
             className={[
-                "relative overflow-hidden rounded-lg bg-white/5 border aspect-video",
-                isSpotlight ? "col-span-5" : "col-span-1",
+                "relative aspect-video overflow-hidden rounded-lg border bg-white/5",
+                isSpotlight ? "col-span-5 stage-tile--spotlight" : "col-span-1",
                 isSpeaking
-                    ? "border-[var(--primary-400)] ring-2 ring-[var(--primary-500)]"
+                    ? "stage-tile--speaking"
                     : "border-[var(--border-subtle)]",
             ].join(" ")}
         >
@@ -141,13 +115,11 @@ export default function StageTile({
                     data-testid="stage-tile-video"
                     autoPlay
                     playsInline
-                    // The local preview is our own capture: never play its audio
-                    // back, and mirror it the way every other camera UI does.
                     muted={isLocal}
-                    className={`w-full h-full object-cover ${isLocal ? "scale-x-[-1]" : ""}`}
+                    className={`h-full w-full object-cover ${isLocal ? "scale-x-[-1]" : ""}`}
                 />
             ) : (
-                <div className="w-full h-full flex items-center justify-center">
+                <div className="flex h-full w-full items-center justify-center">
                     <span
                         className={`text-[var(--text-muted)] ${isSpotlight ? "text-sm" : "text-[9px]"}`}
                     >
@@ -156,8 +128,7 @@ export default function StageTile({
                 </div>
             )}
 
-            {/* Overlay: label plus the per-tile media and quality indicators. */}
-            <div className="absolute inset-x-0 bottom-0 flex items-center gap-1 px-1.5 py-1 bg-black/50">
+            <div className="absolute inset-x-0 bottom-0 flex items-center gap-1 bg-black/60 px-1.5 py-1">
                 <span
                     className={`truncate text-white ${isSpotlight ? "text-xs" : "text-[9px]"}`}
                 >
@@ -165,12 +136,12 @@ export default function StageTile({
                 </span>
                 <span className="flex-1" />
                 {!micOn && (
-                    <span role="img" aria-label={`${label} microphone muted`} className="text-red-300">
+                    <span role="img" aria-label={`${label} microphone muted`} className="text-[var(--danger)]">
                         <MicOffIcon />
                     </span>
                 )}
                 {!cameraOn && (
-                    <span role="img" aria-label={`${label} camera off`} className="text-red-300">
+                    <span role="img" aria-label={`${label} camera off`} className="text-[var(--danger)]">
                         <CameraOffIcon />
                     </span>
                 )}
@@ -178,7 +149,7 @@ export default function StageTile({
                     role="img"
                     aria-label={`${label} ${QUALITY_COPY[connectionQuality].toLowerCase()}`}
                     data-quality={connectionQuality}
-                    className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${QUALITY_COLOR[connectionQuality]}`}
+                    className={`h-1.5 w-1.5 flex-shrink-0 rounded-full ${QUALITY_COLOR[connectionQuality]}`}
                 />
             </div>
         </li>

--- a/src/components/session/ThumbnailSender.tsx
+++ b/src/components/session/ThumbnailSender.tsx
@@ -6,7 +6,6 @@ const CAPTURE_INTERVAL_MS = 2_500;
 
 type Props = { sessionId: string; connected: boolean; isPublishing: boolean };
 
-/** Optional, independent 100px snapshot source for audience members. */
 export default function ThumbnailSender({ sessionId, connected, isPublishing }: Props) {
     const streamRef = useRef<MediaStream | null>(null);
     const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -41,7 +40,7 @@ export default function ThumbnailSender({ sessionId, connected, isPublishing }: 
                 method: 'POST', headers: { 'content-type': 'image/jpeg' }, body: frame, cache: 'no-store',
             });
         } catch {
-            // The tapestry is cuttable; a failed snapshot never affects the room.
+            // The tapestry is cuttable
         } finally {
             sendingRef.current = false;
         }
@@ -85,7 +84,7 @@ export default function ThumbnailSender({ sessionId, connected, isPublishing }: 
     return <section className="w-full max-w-xs text-center" aria-live="polite">
         <video ref={videoRef} muted playsInline className="hidden" />
         {enabled ? <button type="button" className="text-xs text-[var(--text-muted)] underline" onClick={stop}>Stop tapestry camera</button> :
-            <button type="button" className="text-xs text-[var(--accent-400)] underline" onClick={() => void enable()} disabled={!connected}>Share an optional camera snapshot</button>}
+            <button type="button" className="text-xs text-[var(--gold)] underline" onClick={() => void enable()} disabled={!connected}>Share an optional camera snapshot</button>}
         {message ? <p className="mt-1 text-xs text-[var(--text-muted)]">{message}</p> : null}
     </section>;
 }

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 
 type Props = { sessionId: string; staffOnly?: boolean };
 
-/** Refreshes the small composite without ever putting a session cookie on public requests. */
 export default function ThumbnailTapestry({ sessionId, staffOnly = false }: Props) {
     const [src, setSrc] = useState<string | null>(null);
     useEffect(() => {
@@ -28,12 +27,10 @@ export default function ThumbnailTapestry({ sessionId, staffOnly = false }: Prop
         return () => { active = false; clearInterval(timer); if (previous) URL.revokeObjectURL(previous); };
     }, [sessionId, staffOnly]);
     return <section aria-label="Tapestry" className="w-full">
-        <h2 className="mb-2 text-sm font-medium">Tapestry</h2>
+        <h2 className="mb-2 text-sm font-medium text-[var(--cream)]">Tapestry</h2>
         {src ? (
-            // A blob URL refreshed every two seconds cannot use Next's image
-            // optimizer; it is already the service's 100px-tile composite.
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={src} alt="Latest participant tapestry" className="w-full rounded border border-[var(--border-subtle)]" />
+            <img src={src} alt="Latest participant tapestry" className="w-full rounded-lg border border-[var(--border-subtle)]" />
         ) : <p className="text-xs text-[var(--text-muted)]">Waiting for snapshots.</p>}
     </section>;
 }

--- a/src/components/session/__tests__/HandRaiseButton.test.tsx
+++ b/src/components/session/__tests__/HandRaiseButton.test.tsx
@@ -56,8 +56,8 @@ describe('HandRaiseButton', () => {
         vi.stubGlobal('fetch', fetchMock);
         render(<HandRaiseButton sessionId="event-1" />);
 
-        await waitFor(() => screen.getByRole('button', { name: 'Raise hand' }));
-        await userEvent.click(screen.getByRole('button', { name: 'Raise hand' }));
+        await waitFor(() => screen.getByRole('button', { name: /Raise hand/i }));
+        await userEvent.click(screen.getByRole('button', { name: /Raise hand/i }));
 
         await waitFor(() => {
             expect(screen.getByRole('status')).toHaveTextContent('you are #2 in the queue');
@@ -66,7 +66,7 @@ describe('HandRaiseButton', () => {
             url: '/api/scheduled-sessions/event-1/hand',
             method: 'POST',
         });
-        expect(screen.getByRole('button', { name: 'Lower hand' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Lower hand/i })).toBeInTheDocument();
     });
 
     it('lowers a raised hand with DELETE', async () => {
@@ -77,8 +77,8 @@ describe('HandRaiseButton', () => {
         vi.stubGlobal('fetch', fetchMock);
         render(<HandRaiseButton sessionId="event-1" />);
 
-        await waitFor(() => screen.getByRole('button', { name: 'Lower hand' }));
-        await userEvent.click(screen.getByRole('button', { name: 'Lower hand' }));
+        await waitFor(() => screen.getByRole('button', { name: /Lower hand/i }));
+        await userEvent.click(screen.getByRole('button', { name: /Lower hand/i }));
 
         await waitFor(() => {
             expect(calls).toContainEqual({
@@ -86,7 +86,7 @@ describe('HandRaiseButton', () => {
                 method: 'DELETE',
             });
         });
-        await waitFor(() => screen.getByRole('button', { name: 'Raise hand' }));
+        await waitFor(() => screen.getByRole('button', { name: /Raise hand/i }));
     });
 
     it('notifies the room page when polling observes a promotion, without a reconnect', async () => {

--- a/src/components/session/__tests__/StageTile.test.tsx
+++ b/src/components/session/__tests__/StageTile.test.tsx
@@ -153,10 +153,10 @@ describe('StageTile - per-tile indicators', () => {
 
     it('marks the active speaker so the audience can see who has the floor', () => {
         const { rerender } = render(<StageTile {...BASE_PROPS} isSpeaking={false} />);
-        expect(screen.getByTestId('stage-tile').className).not.toMatch(/ring-2/);
+        expect(screen.getByTestId('stage-tile').className).not.toMatch(/stage-tile--speaking/);
 
         rerender(<StageTile {...BASE_PROPS} isSpeaking />);
-        expect(screen.getByTestId('stage-tile').className).toMatch(/ring-2/);
+        expect(screen.getByTestId('stage-tile').className).toMatch(/stage-tile--speaking/);
     });
 
     it('labels a tile with the non-PII role word only', () => {

--- a/src/components/ui/EventButton.tsx
+++ b/src/components/ui/EventButton.tsx
@@ -1,0 +1,37 @@
+/**
+ * Event button: primary CTA, secondary, danger, and ghost variants.
+ * All buttons use the event design system tokens.
+ */
+
+import type { ButtonHTMLAttributes } from "react";
+
+type ButtonVariant = "primary" | "secondary" | "danger" | "ghost";
+
+interface EventButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  children: React.ReactNode;
+}
+
+const variantClass: Record<ButtonVariant, string> = {
+  primary: "event-button--primary",
+  secondary: "event-button--secondary",
+  danger: "event-button--danger",
+  ghost: "event-button--ghost",
+};
+
+export default function EventButton({
+  variant = "primary",
+  children,
+  className = "",
+  ...props
+}: EventButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`event-button ${variantClass[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/EventField.tsx
+++ b/src/components/ui/EventField.tsx
@@ -1,0 +1,35 @@
+/**
+ * Event field: text input styled for the event design system.
+ */
+
+import type { InputHTMLAttributes } from "react";
+
+interface EventFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: React.ReactNode;
+  error?: string;
+}
+
+export default function EventField({
+  label,
+  error,
+  className = "",
+  id,
+  ...props
+}: EventFieldProps) {
+  const fieldId = id || (typeof label === "string" ? label.toLowerCase().replace(/\s+/g, "-") : undefined);
+  return (
+    <div className={`space-y-1 ${className}`}>
+      {label && (
+        <label htmlFor={fieldId} className="block text-sm font-medium text-[var(--cream)]">
+          {label}
+        </label>
+      )}
+      <input id={fieldId} className="event-field" {...props} />
+      {error && (
+        <p role="alert" className="text-xs text-[var(--danger)]">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/EventShell.tsx
+++ b/src/components/ui/EventShell.tsx
@@ -1,0 +1,27 @@
+/**
+ * Event shell: the root container for public attendee-facing pages.
+ * Provides the dark atmosphere, safe-area padding, and max-width constraint.
+ */
+
+interface EventShellProps {
+  children: React.ReactNode;
+  className?: string;
+  centered?: boolean;
+}
+
+export default function EventShell({
+  children,
+  className = "",
+  centered = false,
+}: EventShellProps) {
+  return (
+    <div className={`event-shell ${className}`}>
+      <div
+        className={`relative z-10 mx-auto flex min-h-screen max-w-2xl flex-col px-6 py-12 ${centered ? "justify-center" : ""}`}
+        style={{ paddingTop: "max(48px, var(--safe-top) + 24px)", paddingBottom: "max(48px, var(--safe-bottom) + 24px)" }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/OperationalPanel.tsx
+++ b/src/components/ui/OperationalPanel.tsx
@@ -1,0 +1,27 @@
+/**
+ * Operational panel: compact container for operator surfaces.
+ * Same brand family, utilitarian presentation.
+ */
+
+interface OperationalPanelProps {
+  children: React.ReactNode;
+  className?: string;
+  title?: string;
+}
+
+export default function OperationalPanel({
+  children,
+  className = "",
+  title,
+}: OperationalPanelProps) {
+  return (
+    <div className={`operator-panel ${className}`}>
+      {title && (
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          {title}
+        </h3>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/StatusPill.tsx
+++ b/src/components/ui/StatusPill.tsx
@@ -1,0 +1,38 @@
+/**
+ * Status pill: compact label for states (live, success, warning, danger, request, brand).
+ */
+
+type PillVariant = "live" | "success" | "warning" | "danger" | "request" | "brand";
+
+interface StatusPillProps {
+  variant: PillVariant;
+  children: React.ReactNode;
+  dot?: boolean;
+}
+
+const variantClass: Record<PillVariant, string> = {
+  live: "status-pill--live",
+  success: "status-pill--success",
+  warning: "status-pill--warning",
+  danger: "status-pill--danger",
+  request: "status-pill--request",
+  brand: "status-pill--brand",
+};
+
+const dotClass: Record<PillVariant, string> = {
+  live: "status-pill__dot--live",
+  success: "status-pill__dot--success",
+  warning: "status-pill__dot--warning",
+  danger: "status-pill__dot--danger",
+  request: "status-pill__dot--danger",
+  brand: "status-pill__dot--success",
+};
+
+export default function StatusPill({ variant, children, dot = true }: StatusPillProps) {
+  return (
+    <span className={`status-pill ${variantClass[variant]}`}>
+      {dot && <span className={`status-pill__dot ${dotClass[variant]}`} aria-hidden="true" />}
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
Summary

Introduces a cohesive "Harmonic Projection" visual language and applies it to every surface of the session app — landing, ticket/staff login, the attendee room, and the operator consoles. It aligns the app with the harmonicbeacon.com/inscripcion/confirmacion brand so an attendee's journey from registration → event feels like one product. Presentational only; no behavioral changes.

Design language

- Palette: warm-black / ink base (--ink #080B16, --deep) with cream (--cream #FFF6DF) text and a jewel accent set — gold (brand), cyan (live), pink (request/input focus), lime (success), violet (aura). Defined as core → semantic → status tokens in globals.css, mapped into Tailwind v4 via @theme inline.
- Type: three-family system — Cormorant Garamond (editorial serif, for titles/terminal states), Syne (geometric display sans, UI/body), Space Mono (technical mono, for buttons, pills, timestamps, metadata). Mythic-but-technical, fitting a psychodrama/projection event.
- Texture: a fixed radial-gradient "aura" background (.event-shell), soft glows, breathe/pulse/live animations, and gold focus rings.

What's in it

- A full token layer in src/app/globals.css (~840 lines): core + semantic + status tokens, shadows, safe-area insets, animation keyframes, and component classes.
- A reusable primitive kit (src/components/ui/): EventShell, EventButton (primary gold→lime→cyan gradient / secondary / danger / ghost), EventField, StatusPill (live/success/warning/danger/request/brand), OperationalPanel, plus brand/BrandLockup — thin, typed wrappers over the CSS system.
- Applied across all four surfaces: landing + auth (Phase 2), attendee room + session components — stage tiles/layout, hand-raise, tapestry, crossfader (Phase 3), and the operator consoles — admission, spotlight, ops nav/health (Phase 4).

Structure

Four reviewable phases: 1 fonts/tokens/shared primitives → 2 landing & authentication → 3 attendee room & session components → 4 operator surfaces.

Accessibility

:focus-visible gold rings throughout, a full prefers-reduced-motion block (disables animations/transitions), safe-area insets, and mobile-responsive sizing.

Scope & safety

- Presentational — restyles markup, adds no logic. Component tests that asserted old markup/copy were updated to match.
- Green: npm run build compiles clean; 401/401 tests pass.
- Up to date with main (built on 63bdc9e).

How to review

Best reviewed visually across the four surfaces (landing → login → a session room → /ops/*), with a designer's eye for brand consistency against harmonicbeacon.com. Code-wise, globals.css is the heart; the ui/* primitives are the vocabulary; the page/component dif