### PR TITLE
fix: E2E findings — hand control by role + tapestry-cam default-on

### DIFF
--- a/src/app/api/scheduled-sessions/[id]/token/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/token/route.ts
@@ -37,6 +37,10 @@ export async function GET(
             identity: principal.identity,
             room: principal.session.roomName,
             canPublish: principal.canPublish,
+            displayName: principal.displayName,
+            // Lets the room page gate attendee-only controls (hand queue)
+            // without probing an endpoint that 403s for staff.
+            principalKind: principal.ticketEntitlementId ? 'ticket' : 'staff',
             session: {
                 id: principal.session.id,
                 title: principal.session.title,

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -123,6 +123,7 @@ function SessionRoom() {
     const [isConnecting, setIsConnecting] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [canPublish, setCanPublish] = useState(false);
+    const [principalKind, setPrincipalKind] = useState<"ticket" | "staff">("ticket");
     const [isMicOn, setIsMicOn] = useState(false);
     const [isCameraOn, setIsCameraOn] = useState(false);
     const [audioOnly, setAudioOnly] = useState(false);
@@ -286,6 +287,7 @@ function SessionRoom() {
 
                 setSessionInfo(data.session);
                 setCanPublish(data.canPublish);
+                setPrincipalKind(data.principalKind === "staff" ? "staff" : "ticket");
                 if (data.session.startedAt) {
                     const elapsed = Math.floor((Date.now() - new Date(data.session.startedAt).getTime()) / 1000);
                     setDuration(Math.max(0, elapsed));
@@ -612,9 +614,7 @@ function SessionRoom() {
                         isPublishing={canPublish}
                     />
 
-                    {process.env.NEXT_PUBLIC_TAPESTRY_PUBLIC_ENABLED === "true" && (
-                        <ThumbnailTapestry sessionId={id} />
-                    )}
+                    <ThumbnailTapestry sessionId={id} />
 
                     {/* Volume + Mix controls */}
                     <div className="w-full max-w-xs space-y-4">
@@ -654,7 +654,7 @@ function SessionRoom() {
 
                 {/* Bottom controls */}
                 <div className="border-t border-[var(--border-subtle)] px-4 py-4">
-                    {isConnected && (
+                    {isConnected && principalKind === "ticket" && (
                         <div className="mb-4 flex justify-center">
                             <HandRaiseButton
                                 sessionId={id}

--- a/src/components/session/ThumbnailSender.tsx
+++ b/src/components/session/ThumbnailSender.tsx
@@ -2,7 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-const CAPTURE_INTERVAL_MS = 2_500;
+// Product decision (2026-07-31, Nico): the tapestry camera is ON BY DEFAULT
+// for every attendee — each participant appears in the composite as a small
+// jpeg refreshed at ~1 FPS. Explicit opt-out via the stop button.
+const CAPTURE_INTERVAL_MS = 1_000;
 
 type Props = { sessionId: string; connected: boolean; isPublishing: boolean };
 
@@ -11,6 +14,9 @@ export default function ThumbnailSender({ sessionId, connected, isPublishing }: 
     const videoRef = useRef<HTMLVideoElement | null>(null);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const sendingRef = useRef(false);
+    // Set only by the explicit opt-out button; lifecycle stops (tab hidden,
+    // disconnect, promotion to publisher) never opt the attendee out.
+    const optedOutRef = useRef(false);
     const [enabled, setEnabled] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
 
@@ -66,7 +72,7 @@ export default function ThumbnailSender({ sessionId, connected, isPublishing }: 
     useEffect(() => { if (isPublishing || !connected) stop(); }, [connected, isPublishing, stop]);
     useEffect(() => () => stop(), [stop]);
 
-    const enable = async () => {
+    const enable = useCallback(async () => {
         if (isPublishing) return;
         setMessage(null);
         try {
@@ -78,13 +84,33 @@ export default function ThumbnailSender({ sessionId, connected, isPublishing }: 
         } catch {
             setMessage('Camera permission was not granted. You can still take part in the session.');
         }
-    };
+    }, [isPublishing]);
+
+    // Default-on: as soon as the room is connected (and the attendee is not
+    // a publisher), start the tapestry camera unless they opted out. A denied
+    // permission leaves `enabled` false and shows the message without looping
+    // (the effect deps stay stable until something real changes).
+    useEffect(() => {
+        if (connected && !isPublishing && !enabled && !optedOutRef.current) {
+            void enable();
+        }
+    }, [connected, isPublishing, enabled, enable]);
+
+    const optOut = useCallback(() => {
+        optedOutRef.current = true;
+        stop();
+    }, [stop]);
+
+    const optIn = useCallback(() => {
+        optedOutRef.current = false;
+        void enable();
+    }, [enable]);
 
     if (isPublishing) return null;
     return <section className="w-full max-w-xs text-center" aria-live="polite">
         <video ref={videoRef} muted playsInline className="hidden" />
-        {enabled ? <button type="button" className="text-xs text-[var(--text-muted)] underline" onClick={stop}>Stop tapestry camera</button> :
-            <button type="button" className="text-xs text-[var(--gold)] underline" onClick={() => void enable()} disabled={!connected}>Share an optional camera snapshot</button>}
+        {enabled ? <button type="button" className="text-xs text-[var(--text-muted)] underline" onClick={optOut}>Stop tapestry camera</button> :
+            <button type="button" className="text-xs text-[var(--gold)] underline" onClick={optIn} disabled={!connected}>Share a camera snapshot</button>}
         {message ? <p className="mt-1 text-xs text-[var(--text-muted)]">{message}</p> : null}
     </section>;
 }

--- a/src/components/session/__tests__/ThumbnailSender.test.tsx
+++ b/src/components/session/__tests__/ThumbnailSender.test.tsx
@@ -6,21 +6,24 @@ import ThumbnailSender from '../ThumbnailSender';
 
 afterEach(() => vi.restoreAllMocks());
 
+function mockCamera() {
+    const stop = vi.fn();
+    const stream = { getTracks: () => [{ stop }] } as unknown as MediaStream;
+    const getUserMedia = vi.fn().mockResolvedValue(stream);
+    Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: { getUserMedia } });
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({ drawImage: vi.fn() } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((callback) => callback(new Blob(['jpeg'], { type: 'image/jpeg' })));
+    global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    return { stop, getUserMedia };
+}
+
 describe('ThumbnailSender', () => {
-    it('does not request a camera until opt-in, and releases it on stage promotion', async () => {
-        const stop = vi.fn();
-        const stream = { getTracks: () => [{ stop }] } as unknown as MediaStream;
-        const getUserMedia = vi.fn().mockResolvedValue(stream);
-        Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: { getUserMedia } });
-        vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
-        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({ drawImage: vi.fn() } as unknown as CanvasRenderingContext2D);
-        vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((callback) => callback(new Blob(['jpeg'], { type: 'image/jpeg' })));
-        global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    it('starts the camera by default once connected, and releases it on stage promotion', async () => {
+        const { stop, getUserMedia } = mockCamera();
 
         const view = render(<ThumbnailSender sessionId="session-1" connected isPublishing={false} />);
-        expect(getUserMedia).not.toHaveBeenCalled();
-
-        fireEvent.click(screen.getByRole('button', { name: 'Share an optional camera snapshot' }));
+        // Default-on (product decision 2026-07-31): no click needed.
         await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
         await waitFor(() => expect(fetch).toHaveBeenCalled());
         expect(String(vi.mocked(fetch).mock.calls[0][0])).toBe('/api/tapestry/frame?sessionId=session-1');
@@ -28,5 +31,23 @@ describe('ThumbnailSender', () => {
         view.rerender(<ThumbnailSender sessionId="session-1" connected isPublishing />);
         await waitFor(() => expect(stop).toHaveBeenCalled());
         expect(screen.queryByRole('button', { name: /tapestry/i })).not.toBeInTheDocument();
+    });
+
+    it('stays off after an explicit opt-out until the attendee opts back in', async () => {
+        const { stop, getUserMedia } = mockCamera();
+
+        const view = render(<ThumbnailSender sessionId="session-1" connected isPublishing={false} />);
+        await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Stop tapestry camera' }));
+        await waitFor(() => expect(stop).toHaveBeenCalled());
+
+        // A re-render (e.g. state change elsewhere in the room) must not
+        // restart the camera after an explicit opt-out.
+        view.rerender(<ThumbnailSender sessionId="session-1" connected isPublishing={false} />);
+        expect(getUserMedia).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Share a camera snapshot' }));
+        await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
     });
 });


### PR DESCRIPTION
Implements the fixes for BUG 1 and BUG 2/3-app-side from the E2E test report (issues #51, #52; refs #50 for the ops deploy).

- #51: token API returns principalKind/displayName; room page renders HandRaiseButton only for ticket principals. Staff no longer see 'Hand status unavailable'.
- #52: ThumbnailSender is now default-on at 1 FPS with explicit opt-out (product decision: every attendee appears in the tapestry composite).
- Room page always renders ThumbnailTapestry (the NEXT_PUBLIC_TAPESTRY_PUBLIC_ENABLED gate is gone).
- Tests updated to the default-on contract (47/47 files).

Verification: lint 0 issues, full suite green.