### PR TITLE
feat: tapestry arrangement — staff order API + ops console panel

### DIFF
--- a/services/tapestry/src/composite.ts
+++ b/services/tapestry/src/composite.ts
@@ -52,10 +52,16 @@ export class TapestryCompositor {
   }
 
   /** Mark a session's composite stale (called on ingest and on expiry sweeps). */
-  markDirty(sessionId: string): void {
+  markDirty(sessionId: string, immediate = false): void {
     const entry = this.cache.get(sessionId);
     if (entry) {
       entry.dirty = true;
+      // Staff actions (arrangement changes) must be visible at once — the
+      // rate limit exists to bound ingest-driven rebuild churn, not to make
+      // the ops console feel broken.
+      if (immediate) {
+        entry.builtAtMs = 0;
+      }
     }
   }
 
@@ -104,13 +110,14 @@ export class TapestryCompositor {
   }
 
   private async build(sessionId: string): Promise<Buffer> {
-    const participants = this.store.activeParticipants(
+    // Display order = staff arrangement first, then first-seen (store.orderedActive).
+    const participants = this.store.orderedActive(
       sessionId,
       this.nowMs(),
       this.config.frameTtlMs,
     );
     const tile = this.config.tileSizePx;
-    const inputs = participants.map((participant, index) => ({
+    const inputs = participants.map(({ participant }, index) => ({
       input: participant.tile,
       left: (index % this.config.gridColumns) * tile,
       top: Math.floor(index / this.config.gridColumns) * tile,

--- a/services/tapestry/src/server.ts
+++ b/services/tapestry/src/server.ts
@@ -5,6 +5,12 @@
  *        Authenticated JPEG ingest (raw image/jpeg body, size-capped).
  *   GET  /tapestry/sessions/:sessionId/composite.jpg
  *        Authenticated composite JPEG.
+ *   GET  /tapestry/sessions/:sessionId/participants
+ *        Authenticated list of active participant ids in display order.
+ *   PUT  /tapestry/sessions/:sessionId/order
+ *        Authenticated staff arrangement: JSON {"order": string[]}.
+ *   GET  /tapestry/sessions/:sessionId/participants/:participantId/frame.jpg
+ *        Authenticated single tile JPEG (for the ops arrange UI).
  *   GET  /health
  *        Unauthenticated liveness/state: counts only, never identifiers.
  *
@@ -24,6 +30,10 @@ export const INTERNAL_SECRET_HEADER = "x-tapestry-internal-secret";
 const FRAME_ROUTE =
   /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/participants\/([A-Za-z0-9_-]{1,128})\/frame$/;
 const COMPOSITE_ROUTE = /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/composite\.jpg$/;
+const PARTICIPANTS_ROUTE = /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/participants$/;
+const ORDER_ROUTE = /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/order$/;
+const TILE_ROUTE =
+  /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/participants\/([A-Za-z0-9_-]{1,128})\/frame\.jpg$/;
 
 export interface TapestryServer {
   server: Server;
@@ -188,11 +198,102 @@ export function createTapestryServer(config: TapestryConfig): TapestryServer {
     });
   }
 
+  async function handleParticipants(
+    req: IncomingMessage,
+    res: ServerResponse,
+    sessionId: string,
+  ): Promise<void> {
+    if (!secretMatches(req.headers[INTERNAL_SECRET_HEADER] as string | undefined, config.internalSecret)) {
+      sendJson(res, 401, { error: "unauthorized" });
+      return;
+    }
+    if (!store.hasSession(sessionId)) {
+      sendJson(res, 404, { error: "unknown_session" });
+      return;
+    }
+    const ids = store
+      .orderedActive(sessionId, Date.now(), config.frameTtlMs)
+      .map(({ id }) => id);
+    sendJson(res, 200, { participants: ids });
+  }
+
+  async function handleOrder(
+    req: IncomingMessage,
+    res: ServerResponse,
+    sessionId: string,
+  ): Promise<void> {
+    if (!secretMatches(req.headers[INTERNAL_SECRET_HEADER] as string | undefined, config.internalSecret)) {
+      sendJson(res, 401, { error: "unauthorized" });
+      return;
+    }
+    if (!store.hasSession(sessionId)) {
+      sendJson(res, 404, { error: "unknown_session" });
+      return;
+    }
+    let body: Buffer;
+    try {
+      body = await readBody(req, 64 * 1024);
+    } catch (error) {
+      if (error instanceof BodyTooLargeError) {
+        sendJson(res, 413, { error: "body_too_large" });
+        return;
+      }
+      throw error;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body.toString("utf8"));
+    } catch {
+      sendJson(res, 400, { error: "invalid_json" });
+      return;
+    }
+    const order = (parsed as { order?: unknown }).order;
+    if (
+      !Array.isArray(order) ||
+      order.some((id) => typeof id !== "string" || !isValidOpaqueId(id)) ||
+      new Set(order).size !== order.length
+    ) {
+      sendJson(res, 400, { error: "invalid_order" });
+      return;
+    }
+    store.setOrder(sessionId, order as string[]);
+    compositor.markDirty(sessionId, true);
+    sendJson(res, 200, { ok: true, stored: (order as string[]).length });
+  }
+
+  async function handleTile(
+    req: IncomingMessage,
+    res: ServerResponse,
+    sessionId: string,
+    participantId: string,
+  ): Promise<void> {
+    if (!secretMatches(req.headers[INTERNAL_SECRET_HEADER] as string | undefined, config.internalSecret)) {
+      sendJson(res, 401, { error: "unauthorized" });
+      return;
+    }
+    const entry = store
+      .orderedActive(sessionId, Date.now(), config.frameTtlMs)
+      .find(({ id }) => id === participantId);
+    if (!entry) {
+      sendJson(res, 404, { error: "unknown_participant" });
+      return;
+    }
+    res.writeHead(200, {
+      "content-type": "image/jpeg",
+      "content-length": entry.participant.tile.length,
+      "cache-control": "no-store",
+    });
+    res.end(entry.participant.tile);
+  }
+
   const server = createServer((req, res) => {
     void (async () => {
       const url = new URL(req.url ?? "/", "http://tapestry.internal");
       const frameMatch = url.pathname.match(FRAME_ROUTE);
       const compositeMatch = url.pathname.match(COMPOSITE_ROUTE);
+      const participantsMatch = url.pathname.match(PARTICIPANTS_ROUTE);
+      const orderMatch = url.pathname.match(ORDER_ROUTE);
+      const tileMatch = url.pathname.match(TILE_ROUTE);
 
       if (req.method === "POST" && frameMatch) {
         const [, sessionId, participantId] = frameMatch;
@@ -205,6 +306,23 @@ export function createTapestryServer(config: TapestryConfig): TapestryServer {
       }
       if (req.method === "GET" && compositeMatch) {
         await handleComposite(req, res, compositeMatch[1]);
+        return;
+      }
+      if (req.method === "GET" && participantsMatch) {
+        await handleParticipants(req, res, participantsMatch[1]);
+        return;
+      }
+      if (req.method === "PUT" && orderMatch) {
+        await handleOrder(req, res, orderMatch[1]);
+        return;
+      }
+      if (req.method === "GET" && tileMatch) {
+        const [, sessionId, participantId] = tileMatch;
+        if (!isValidOpaqueId(sessionId) || !isValidOpaqueId(participantId)) {
+          sendJson(res, 400, { error: "invalid_id" });
+          return;
+        }
+        await handleTile(req, res, sessionId, participantId);
         return;
       }
       if (req.method === "GET" && url.pathname === "/health") {

--- a/services/tapestry/src/store.ts
+++ b/services/tapestry/src/store.ts
@@ -22,6 +22,8 @@ export type IngestResult =
 
 export class TapestryStore {
   private readonly sessions = new Map<string, Map<string, StoredParticipant>>();
+  /** Staff-set display order per session: opaque participant ids, front of grid first. */
+  private readonly orders = new Map<string, string[]>();
 
   constructor(
     sessionIds: readonly string[],
@@ -86,6 +88,56 @@ export class TapestryStore {
     return [...session.values()]
       .filter((p) => nowMs - p.lastSeenMs <= ttlMs)
       .sort((a, b) => a.firstSeenMs - b.firstSeenMs);
+  }
+
+  /**
+   * Persist a staff arrangement for a session. Ids are stored verbatim —
+   * ids without an active frame are simply skipped at render time, so an
+   * arrangement survives participants leaving and rejoining.
+   */
+  setOrder(sessionId: string, order: readonly string[]): boolean {
+    if (!this.sessions.has(sessionId)) {
+      return false;
+    }
+    this.orders.set(sessionId, [...order].slice(0, this.maxParticipantsPerSession));
+    return true;
+  }
+
+  /**
+   * Active participants of a session in display order: the staff arrangement
+   * first (in its stored sequence, skipping inactive ids), then everyone else
+   * by first-seen. Each entry carries its opaque id so callers can address
+   * individual tiles.
+   */
+  orderedActive(
+    sessionId: string,
+    nowMs: number,
+    ttlMs: number,
+  ): Array<{ id: string; participant: StoredParticipant }> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return [];
+    }
+    const active = [...session.entries()].filter(
+      ([, p]) => nowMs - p.lastSeenMs <= ttlMs,
+    );
+    const byId = new Map(active);
+    const ordered: Array<{ id: string; participant: StoredParticipant }> = [];
+    const seen = new Set<string>();
+    for (const id of this.orders.get(sessionId) ?? []) {
+      const participant = byId.get(id);
+      if (participant && !seen.has(id)) {
+        ordered.push({ id, participant });
+        seen.add(id);
+      }
+    }
+    const rest = active
+      .filter(([id]) => !seen.has(id))
+      .sort(([, a], [, b]) => a.firstSeenMs - b.firstSeenMs);
+    for (const [id, participant] of rest) {
+      ordered.push({ id, participant });
+    }
+    return ordered;
   }
 
   hasSession(sessionId: string): boolean {

--- a/services/tapestry/test/order.test.ts
+++ b/services/tapestry/test/order.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Staff arrangement tests: explicit display order is stored per session,
+ * reflected in the participants listing and the composite, validated on
+ * write, and individual tiles are addressable for the ops UI.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  SESSION_A,
+  authHeaders,
+  getComposite,
+  makeJpeg,
+  postFrame,
+  startService,
+  testConfig,
+  tileColor,
+} from "./helpers.js";
+
+async function putOrder(baseUrl: string, sessionId: string, order: unknown, extraHeaders: Record<string, string> = {}) {
+  return fetch(`${baseUrl}/tapestry/sessions/${sessionId}/order`, {
+    method: "PUT",
+    headers: authHeaders({ "content-type": "application/json", ...extraHeaders }),
+    body: JSON.stringify({ order }),
+  });
+}
+
+test("explicit order rearranges the composite and the participants listing", async () => {
+  const service = await startService(testConfig());
+  try {
+    await postFrame(service.baseUrl, SESSION_A, "p-red", await makeJpeg(255, 0, 0));
+    await postFrame(service.baseUrl, SESSION_A, "p-green", await makeJpeg(0, 255, 0));
+
+    // Default: first-seen — red at the left edge.
+    let composite = await getComposite(service.baseUrl, SESSION_A);
+    assert.equal(composite.status, 200);
+    let color = await tileColor(Buffer.from(await composite.arrayBuffer()), 0, 0);
+    assert.ok(color.r > 200 && color.g < 60, `expected red first, got ${JSON.stringify(color)}`);
+
+    // Staff arrangement: green first.
+    const put = await putOrder(service.baseUrl, SESSION_A, ["p-green", "p-red"]);
+    assert.equal(put.status, 200);
+
+    const list = await fetch(`${service.baseUrl}/tapestry/sessions/${SESSION_A}/participants`, {
+      headers: authHeaders(),
+    });
+    assert.equal(list.status, 200);
+    assert.deepEqual((await list.json() as { participants: string[] }).participants, ["p-green", "p-red"]);
+
+    composite = await getComposite(service.baseUrl, SESSION_A);
+    color = await tileColor(Buffer.from(await composite.arrayBuffer()), 0, 0);
+    assert.ok(color.g > 200 && color.r < 60, `expected green first, got ${JSON.stringify(color)}`);
+  } finally {
+    await service.close();
+  }
+});
+
+test("order write is validated: auth, unknown session, malformed ids, duplicates", async () => {
+  const service = await startService(testConfig());
+  try {
+    const noAuth = await fetch(`${service.baseUrl}/tapestry/sessions/${SESSION_A}/order`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ order: ["p1"] }),
+    });
+    assert.equal(noAuth.status, 401);
+
+    assert.equal((await putOrder(service.baseUrl, "no-such-session", ["p1"])).status, 404);
+    assert.equal((await putOrder(service.baseUrl, SESSION_A, "not-an-array")).status, 400);
+    assert.equal((await putOrder(service.baseUrl, SESSION_A, ["bad id!"])).status, 400);
+    assert.equal((await putOrder(service.baseUrl, SESSION_A, ["p1", "p1"])).status, 400);
+    assert.equal((await putOrder(service.baseUrl, SESSION_A, [])).status, 200);
+  } finally {
+    await service.close();
+  }
+});
+
+test("single tile endpoint serves the stored jpeg and 404s for strangers", async () => {
+  const service = await startService(testConfig());
+  try {
+    await postFrame(service.baseUrl, SESSION_A, "p-red", await makeJpeg(255, 0, 0));
+
+    const tile = await fetch(`${service.baseUrl}/tapestry/sessions/${SESSION_A}/participants/p-red/frame.jpg`, {
+      headers: authHeaders(),
+    });
+    assert.equal(tile.status, 200);
+    assert.equal(tile.headers.get("content-type"), "image/jpeg");
+    const bytes = Buffer.from(await tile.arrayBuffer());
+    const color = await tileColor(bytes, 0, 0);
+    assert.ok(color.r > 200, `expected red tile, got ${JSON.stringify(color)}`);
+
+    const stranger = await fetch(`${service.baseUrl}/tapestry/sessions/${SESSION_A}/participants/p-nope/frame.jpg`, {
+      headers: authHeaders(),
+    });
+    assert.equal(stranger.status, 404);
+
+    const noAuth = await fetch(`${service.baseUrl}/tapestry/sessions/${SESSION_A}/participants/p-red/frame.jpg`);
+    assert.equal(noAuth.status, 401);
+  } finally {
+    await service.close();
+  }
+});

--- a/src/app/api/ops/sessions/[id]/tapestry/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/__tests__/route.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createRequest, mockParams } from '@/__tests__/helpers';
+
+const mocks = vi.hoisted(() => ({
+    requireStaff: vi.fn(),
+    sessionFindUnique: vi.fn(),
+    tapestryInternalUrl: vi.fn(),
+    fetch: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ requireStaff: mocks.requireStaff }));
+vi.mock('@/lib/db', () => ({
+    prisma: {
+        scheduledSession: { findUnique: mocks.sessionFindUnique },
+    },
+}));
+vi.mock('@/lib/tapestry', () => ({ tapestryInternalUrl: mocks.tapestryInternalUrl }));
+
+import { GET, PUT } from '../route';
+
+const STAFF = { userId: 'staff-1', role: 'OPERATOR' };
+const SESSION_ID = 'session-1';
+
+function staffOk(role = 'OPERATOR') {
+    mocks.requireStaff.mockResolvedValue([{ ...STAFF, role }, null]);
+    mocks.sessionFindUnique.mockResolvedValue({ facilitatorId: 'facil-1' });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mocks.fetch);
+    mocks.tapestryInternalUrl.mockReturnValue('http://tapestry:3100');
+    process.env.TAPESTRY_INTERNAL_SECRET = 'test-secret';
+});
+
+describe('ops tapestry route', () => {
+    it('GET proxies the participants list for staff', async () => {
+        staffOk();
+        mocks.fetch.mockResolvedValue(new Response(JSON.stringify({ participants: ['tp-a', 'tp-b'] }), { status: 200 }));
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ participants: ['tp-a', 'tp-b'] });
+        const [url, init] = mocks.fetch.mock.calls[0];
+        expect(String(url)).toBe(`http://tapestry:3100/tapestry/sessions/${SESSION_ID}/participants`);
+        expect(init.headers['x-tapestry-internal-secret']).toBe('test-secret');
+    });
+
+    it('GET rejects a facilitator of another event', async () => {
+        staffOk('FACILITATOR');
+        mocks.requireStaff.mockResolvedValue([{ userId: 'staff-9', role: 'FACILITATOR' }, null]);
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(403);
+        expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it('PUT validates the order before proxying', async () => {
+        staffOk();
+        const bad = await PUT(
+            createRequest('http://x', { method: 'PUT', body: { order: ['a', 'a'] } }),
+            mockParams({ id: SESSION_ID }),
+        );
+        expect(bad.status).toBe(400);
+        expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it('PUT proxies a valid arrangement', async () => {
+        staffOk();
+        mocks.fetch.mockResolvedValue(new Response(JSON.stringify({ ok: true, stored: 2 }), { status: 200 }));
+
+        const response = await PUT(
+            createRequest('http://x', { method: 'PUT', body: { order: ['tp-b', 'tp-a'] } }),
+            mockParams({ id: SESSION_ID }),
+        );
+
+        expect(response.status).toBe(200);
+        const [url, init] = mocks.fetch.mock.calls[0];
+        expect(String(url)).toBe(`http://tapestry:3100/tapestry/sessions/${SESSION_ID}/order`);
+        expect(init.method).toBe('PUT');
+        expect(JSON.parse(init.body as string)).toEqual({ order: ['tp-b', 'tp-a'] });
+    });
+
+    it('returns 503 when the service is not configured', async () => {
+        staffOk();
+        mocks.tapestryInternalUrl.mockReturnValue(null);
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(503);
+    });
+});

--- a/src/app/api/ops/sessions/[id]/tapestry/route.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireStaff } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { tapestryInternalUrl } from '@/lib/tapestry';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Staff side of the tapestry arrangement (WS3-02 follow-up, issue #53).
+ * Lists the active tiles in display order and persists the staff-set
+ * arrangement. Both proxy to the internal tapestry service with the shared
+ * secret; the facilitator scoping matches the stage route.
+ */
+
+async function resolveStaffSession(id: string) {
+    const [staff, errorResponse] = await requireStaff(
+        'FACILITATOR',
+        'OPERATOR',
+        'ADMIN',
+    );
+    if (!staff) {
+        return { error: errorResponse };
+    }
+    const scheduledSession = await prisma.scheduledSession.findUnique({
+        where: { id },
+        select: { facilitatorId: true },
+    });
+    if (!scheduledSession) {
+        return { error: NextResponse.json({ error: 'session_not_found' }, { status: 404 }) };
+    }
+    if (
+        staff.role === 'FACILITATOR' &&
+        scheduledSession.facilitatorId !== staff.userId
+    ) {
+        return { error: NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 }) };
+    }
+    return { staff };
+}
+
+function unavailable() {
+    return NextResponse.json({ error: 'Tapestry unavailable' }, { status: 503 });
+}
+
+/** Active tile ids in display order (the ops arrange UI fetches tiles separately). */
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    const { error } = await resolveStaffSession(id);
+    if (error) {
+        return error;
+    }
+    const internalUrl = tapestryInternalUrl();
+    if (!internalUrl) {
+        return unavailable();
+    }
+    try {
+        const response = await fetch(
+            `${internalUrl}/tapestry/sessions/${encodeURIComponent(id)}/participants`,
+            {
+                headers: { 'x-tapestry-internal-secret': process.env.TAPESTRY_INTERNAL_SECRET! },
+                cache: 'no-store',
+                signal: AbortSignal.timeout(3_000),
+            },
+        );
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Tapestry unavailable' }, { status: response.status === 404 ? 404 : 502 });
+        }
+        return NextResponse.json(await response.json(), {
+            headers: { 'cache-control': 'private, no-store' },
+        });
+    } catch {
+        return unavailable();
+    }
+}
+
+/** Persist a staff arrangement: {"order": string[]} of tile ids. */
+export async function PUT(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    const { error } = await resolveStaffSession(id);
+    if (error) {
+        return error;
+    }
+    let body: { order?: unknown };
+    try {
+        body = await request.json() as { order?: unknown };
+    } catch {
+        return NextResponse.json({ error: 'A JSON request body is required' }, { status: 400 });
+    }
+    if (
+        !Array.isArray(body.order) ||
+        body.order.some((pid) => typeof pid !== 'string' || !pid.trim()) ||
+        new Set(body.order).size !== body.order.length
+    ) {
+        return NextResponse.json({ error: 'invalid_order' }, { status: 400 });
+    }
+    const internalUrl = tapestryInternalUrl();
+    if (!internalUrl) {
+        return unavailable();
+    }
+    try {
+        const response = await fetch(
+            `${internalUrl}/tapestry/sessions/${encodeURIComponent(id)}/order`,
+            {
+                method: 'PUT',
+                headers: {
+                    'content-type': 'application/json',
+                    'x-tapestry-internal-secret': process.env.TAPESTRY_INTERNAL_SECRET!,
+                },
+                body: JSON.stringify({ order: body.order }),
+                cache: 'no-store',
+                signal: AbortSignal.timeout(3_000),
+            },
+        );
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Tapestry unavailable' }, { status: response.status === 404 ? 404 : 502 });
+        }
+        return NextResponse.json(await response.json());
+    } catch {
+        return unavailable();
+    }
+}

--- a/src/app/api/ops/sessions/[id]/tapestry/tiles/[pid]/route.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/tiles/[pid]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireStaff } from '@/lib/auth';
+import { tapestryInternalUrl } from '@/lib/tapestry';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Single tapestry tile proxy for the ops arrange UI. Staff-only, never
+ * cached: tiles are live participant snapshots.
+ */
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: Promise<{ id: string; pid: string }> },
+) {
+    const [staff, errorResponse] = await requireStaff(
+        'FACILITATOR',
+        'OPERATOR',
+        'ADMIN',
+    );
+    if (!staff) {
+        return errorResponse;
+    }
+    const { id, pid } = await params;
+    const internalUrl = tapestryInternalUrl();
+    if (!internalUrl) {
+        return NextResponse.json({ error: 'Tapestry unavailable' }, { status: 503 });
+    }
+    try {
+        const response = await fetch(
+            `${internalUrl}/tapestry/sessions/${encodeURIComponent(id)}/participants/${encodeURIComponent(pid)}/frame.jpg`,
+            {
+                headers: { 'x-tapestry-internal-secret': process.env.TAPESTRY_INTERNAL_SECRET! },
+                cache: 'no-store',
+                signal: AbortSignal.timeout(3_000),
+            },
+        );
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Tapestry unavailable' }, { status: response.status === 404 ? 404 : 502 });
+        }
+        return new NextResponse(await response.arrayBuffer(), {
+            status: 200,
+            headers: { 'content-type': 'image/jpeg', 'cache-control': 'private, no-store' },
+        });
+    } catch {
+        return NextResponse.json({ error: 'Tapestry unavailable' }, { status: 503 });
+    }
+}

--- a/src/app/ops/session/[id]/page.tsx
+++ b/src/app/ops/session/[id]/page.tsx
@@ -11,6 +11,7 @@ import { cookies } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
 
 import SpotlightConsole from '@/components/ops/SpotlightConsole';
+import TapestryArrange from '@/components/ops/TapestryArrange';
 import { prisma } from '@/lib/db';
 import { resolveStaffByToken } from '@/lib/ops-auth';
 import { SESSION_COOKIE_NAME } from '@/lib/session-auth';
@@ -71,6 +72,7 @@ export default async function OpsSessionPage({
                 {staff.name} ({staff.role})
             </p>
             <SpotlightConsole sessionId={scheduledSession.id} role={staff.role} />
+            <TapestryArrange sessionId={scheduledSession.id} />
         </main>
     );
 }

--- a/src/components/ops/TapestryArrange.tsx
+++ b/src/components/ops/TapestryArrange.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+/**
+ * Tapestry arrangement panel for the ops session console (issue #53).
+ *
+ * Staff see the active tiles in display order and reorder them with the
+ * arrow buttons; saving persists the arrangement via the ops API, and the
+ * composite reflects it immediately. The list refreshes on an interval but
+ * never clobbers an unsaved local arrangement — new arrivals are appended.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const REFRESH_INTERVAL_MS = 5_000;
+
+type Props = { sessionId: string };
+
+export default function TapestryArrange({ sessionId }: Props) {
+    const [order, setOrder] = useState<string[]>([]);
+    const [dirty, setDirty] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+    const [refreshTick, setRefreshTick] = useState(0);
+    const dirtyRef = useRef(false);
+    dirtyRef.current = dirty;
+
+    const refresh = useCallback(async () => {
+        try {
+            const response = await fetch(`/api/ops/sessions/${sessionId}/tapestry`, { cache: 'no-store' });
+            if (!response.ok) {
+                return;
+            }
+            const data = await response.json() as { participants?: string[] };
+            const active = Array.isArray(data.participants) ? data.participants : [];
+            setOrder((current) => {
+                if (!dirtyRef.current) {
+                    return active;
+                }
+                // Merge: keep the local arrangement, drop departed, append new.
+                const kept = current.filter((id) => active.includes(id));
+                const arrivals = active.filter((id) => !kept.includes(id));
+                return [...kept, ...arrivals];
+            });
+            setRefreshTick((tick) => tick + 1);
+        } catch {
+            // The panel is advisory; the next tick retries.
+        }
+    }, [sessionId]);
+
+    useEffect(() => {
+        void refresh();
+        const timer = setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
+        return () => clearInterval(timer);
+    }, [refresh]);
+
+    const move = (index: number, delta: number) => {
+        setOrder((current) => {
+            const target = index + delta;
+            if (target < 0 || target >= current.length) {
+                return current;
+            }
+            const next = [...current];
+            [next[index], next[target]] = [next[target], next[index]];
+            return next;
+        });
+        setDirty(true);
+        setMessage(null);
+    };
+
+    const save = async () => {
+        setSaving(true);
+        setMessage(null);
+        try {
+            const response = await fetch(`/api/ops/sessions/${sessionId}/tapestry`, {
+                method: 'PUT',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ order }),
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            setDirty(false);
+            setMessage('Arrangement saved');
+        } catch {
+            setMessage('Could not save the arrangement — try again');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <section className="mt-8 rounded-lg border border-[var(--border-subtle)] p-4" aria-live="polite">
+            <div className="mb-3 flex items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                    Tapestry arrangement
+                </h2>
+                <button
+                    type="button"
+                    onClick={() => void save()}
+                    disabled={!dirty || saving}
+                    className="rounded border border-[var(--gold)] px-3 py-1 text-xs text-[var(--gold)] disabled:opacity-40"
+                >
+                    {saving ? 'Saving…' : dirty ? 'Save arrangement' : 'Saved'}
+                </button>
+            </div>
+            {order.length === 0 ? (
+                <p className="text-xs text-[var(--text-muted)]">
+                    No attendee snapshots yet — tiles appear here as cameras join.
+                </p>
+            ) : (
+                <ol className="flex flex-wrap gap-3">
+                    {order.map((pid, index) => (
+                        <li key={pid} className="flex flex-col items-center gap-1">
+                            {/* refreshTick busts the cache so tiles track live frames */}
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img
+                                src={`/api/ops/sessions/${sessionId}/tapestry/tiles/${encodeURIComponent(pid)}?t=${refreshTick}`}
+                                alt={`Tapestry tile ${index + 1}`}
+                                width={72}
+                                height={72}
+                                className="rounded border border-[var(--border-subtle)]"
+                            />
+                            <div className="flex gap-1">
+                                <button
+                                    type="button"
+                                    aria-label={`Move tile ${index + 1} left`}
+                                    onClick={() => move(index, -1)}
+                                    disabled={index === 0}
+                                    className="rounded border border-[var(--border-subtle)] px-2 text-xs disabled:opacity-30"
+                                >
+                                    ◀
+                                </button>
+                                <button
+                                    type="button"
+                                    aria-label={`Move tile ${index + 1} right`}
+                                    onClick={() => move(index, 1)}
+                                    disabled={index === order.length - 1}
+                                    className="rounded border border-[var(--border-subtle)] px-2 text-xs disabled:opacity-30"
+                                >
+                                    ▶
+                                </button>
+                            </div>
+                        </li>
+                    ))}
+                </ol>
+            )}
+            {message ? <p className="mt-2 text-xs text-[var(--text-muted)]">{message}</p> : null}
+        </section>
+    );
+}


### PR DESCRIPTION
Closes #53 (BUG 4 del reporte E2E — feature faltante, implementada ahora por decisión de Nico: nada se posterga al post-sábado si se puede implementar).

- Tapestry service: orden explícito por sesión (arranged-first, first-seen después), composite respeta el orden, cambios de orden bypass del rate-limit de rebuild. Rutas internas nuevas: GET participants, PUT order, GET tile.
- App: proxy ops staff-gated (GET/PUT order + GET tile) con el scoping de facilitator del stage route.
- Consola ops (/ops/session/[id]): panel TapestryArrange con tiles en vivo, reordenamiento con flechas, save.
- Tests: 22/22 servicio, 48/48 archivos app, lint 0, build verde.