### PR TITLE
fix(playlist-bot): upgrade @livekit/rtc-node to 0.13.32 (publisher PC fix)

### DIFF
--- a/services/playlist-bot/package-lock.json
+++ b/services/playlist-bot/package-lock.json
@@ -7,8 +7,9 @@
     "": {
       "name": "harmonic-beacon-playlist-bot",
       "version": "1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@livekit/rtc-node": "^0.13.0",
+        "@livekit/rtc-node": "^0.13.32",
         "livekit-server-sdk": "^2.9.0"
       },
       "devDependencies": {
@@ -486,34 +487,29 @@
         "@bufbuild/protobuf": "^1.10.0"
       }
     },
-    "node_modules/@livekit/rtc-node": {
-      "version": "0.13.24",
-      "resolved": "https://registry.npmjs.org/@livekit/rtc-node/-/rtc-node-0.13.24.tgz",
-      "integrity": "sha512-06pF8YJlJk11R6J7kFXFpwV8etpbmCskoXFvwfwcDDixMqaP6qtS5srq3G23mDaRjx7ofz/PXg2GtiZbqNGT5A==",
+    "node_modules/@livekit/rtc-ffi-bindings": {
+      "version": "0.12.68",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings/-/rtc-ffi-bindings-0.12.68.tgz",
+      "integrity": "sha512-PNr+EOwsT/ZUHALjTdSh+y1Dcj5Msnh0p5C8DaGBF9dCrFVZOxwp1rZovZo3cM+hiYo8TAvrjMEK3V5qD3++8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "^1.10.1",
-        "@datastructures-js/deque": "1.0.8",
-        "@livekit/mutex": "^1.0.0",
-        "@livekit/typed-emitter": "^3.0.0",
-        "pino": "^9.0.0",
-        "pino-pretty": "^13.0.0"
+        "@bufbuild/protobuf": "^1.10.1"
       },
       "engines": {
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@livekit/rtc-node-darwin-arm64": "0.13.24",
-        "@livekit/rtc-node-darwin-x64": "0.13.24",
-        "@livekit/rtc-node-linux-arm64-gnu": "0.13.24",
-        "@livekit/rtc-node-linux-x64-gnu": "0.13.24",
-        "@livekit/rtc-node-win32-x64-msvc": "0.13.24"
+        "@livekit/rtc-ffi-bindings-darwin-arm64": "0.12.68",
+        "@livekit/rtc-ffi-bindings-darwin-x64": "0.12.68",
+        "@livekit/rtc-ffi-bindings-linux-arm64-gnu": "0.12.68",
+        "@livekit/rtc-ffi-bindings-linux-x64-gnu": "0.12.68",
+        "@livekit/rtc-ffi-bindings-win32-x64-msvc": "0.12.68"
       }
     },
-    "node_modules/@livekit/rtc-node-darwin-arm64": {
-      "version": "0.13.24",
-      "resolved": "https://registry.npmjs.org/@livekit/rtc-node-darwin-arm64/-/rtc-node-darwin-arm64-0.13.24.tgz",
-      "integrity": "sha512-gm5xOpGu6Rj/mNU2jEijcGhQGN2GdxV2dNYQm3NCKN7ow0BmMFZvXSCAWOWf+9oTutPXHnrc7EN1mt2v+lfqhA==",
+    "node_modules/@livekit/rtc-ffi-bindings-darwin-arm64": {
+      "version": "0.12.68",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-darwin-arm64/-/rtc-ffi-bindings-darwin-arm64-0.12.68.tgz",
+      "integrity": "sha512-xyBakR8fo3RC8CdrfV6/9U14JlmxXUYqB4eLITEsB+iCKW0CE7JfMqDFqV/JIlq43+xzf7wLJsNktgQRrlcdJg==",
       "cpu": [
         "arm64"
       ],
@@ -523,13 +519,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 18"
       }
     },
-    "node_modules/@livekit/rtc-node-darwin-x64": {
-      "version": "0.13.24",
-      "resolved": "https://registry.npmjs.org/@livekit/rtc-node-darwin-x64/-/rtc-node-darwin-x64-0.13.24.tgz",
-      "integrity": "sha512-jZSK5lHDp7+u0jby7PEWMzbxc0F0nLx6FT3FVjuMlT13ZY6QWKDUUCFbfDOtbdhiOZJYc5A4SwvubY6woEJXTg==",
+    "node_modules/@livekit/rtc-ffi-bindings-darwin-x64": {
+      "version": "0.12.68",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-darwin-x64/-/rtc-ffi-bindings-darwin-x64-0.12.68.tgz",
+      "integrity": "sha512-nJFgFEbDePvPF9v9nqTBlKZ1otGSBgB3DJO+qjw+KowaE2AVubb6/qCF3gjJK/xxfyMcTgVnPr2SgcXWtNZ5Kg==",
       "cpu": [
         "x64"
       ],
@@ -539,13 +535,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 18"
       }
     },
-    "node_modules/@livekit/rtc-node-linux-arm64-gnu": {
-      "version": "0.13.24",
-      "resolved": "https://registry.npmjs.org/@livekit/rtc-node-linux-arm64-gnu/-/rtc-node-linux-arm64-gnu-0.13.24.tgz",
-      "integrity": "sha512-I+IeZET2h+viZ48moEFF0EWDHa+kLii5yuEsw38ya4mHZaZtlfbzrYKGKdONqbI9M9ldvv8XXuD0wFPjuH5CZw==",
+    "node_modules/@livekit/rtc-ffi-bindings-linux-arm64-gnu": {
+      "version": "0.12.68",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-linux-arm64-gnu/-/rtc-ffi-bindings-linux-arm64-gnu-0.12.68.tgz",
+      "integrity": "sha512-Hl9R9ZXqvq7lCbPqXnSNnojfxv8tmLISoxuv7zd0iA4Q7V99v/XCiali1jKpggXn5IqlyF3PHeW11a41glFjTw==",
       "cpu": [
         "arm64"
       ],
@@ -555,13 +551,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 18"
       }
     },
-    "node_modules/@livekit/rtc-node-linux-x64-gnu": {
-      "version": "0.13.24",
-      "resolved": "https://registry.npmjs.org/@livekit/rtc-node-linux-x64-gnu/-/rtc-node-linux-x64-gnu-0.13.24.tgz",
-      "integrity": "sha512-vKOxzN/SsrtV8zIVwZCi31bZUhlb6RhJZ0NnY5MwKGSRFPi7Dwt8fmr0Vh0YmsY/p+4eZjKxvFmy7L3WVE54zw==",
+    "node_modules/@livekit/rtc-ffi-bindings-linux-x64-gnu": {
+      "version": "0.12.68",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-linux-x64-gnu/-/rtc-ffi-bindings-linux-x64-gnu-0.12.68.tgz",
+      "integrity": "sha512-2r99lXSkrmiHjhizCquQwPEbP7mCV/zESVXq1pdEliNvbBJXibMEYbRmuSr1lf4/VZhPpRGcF+Laqg5DgFoe+A==",
       "cpu": [
         "x64"
       ],
@@ -571,13 +567,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 18"
       }
     },
-    "node_modules/@livekit/rtc-node-win32-x64-msvc": {
-      "version": "0.13.24",
-      "resolved": "https://registry.npmjs.org/@livekit/rtc-node-win32-x64-msvc/-/rtc-node-win32-x64-msvc-0.13.24.tgz",
-      "integrity": "sha512-yTzqwndq2oKLUkXW2i/BkZMJC6kZOpRO/DKvkkKQvqc3Q+JuWz1m48GmyjIwTOKF28QjqEU3+IrnD65Uu+mFOg==",
+    "node_modules/@livekit/rtc-ffi-bindings-win32-x64-msvc": {
+      "version": "0.12.68",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-win32-x64-msvc/-/rtc-ffi-bindings-win32-x64-msvc-0.12.68.tgz",
+      "integrity": "sha512-ec7MJBWx4mz40GvfXQ2Bn9uqvp2HueldTouPi5jzYUG2DECmhYhwai0cBcRFJOya3hBm/nRXP0A+pUBdWnY7Fg==",
       "cpu": [
         "x64"
       ],
@@ -587,7 +583,24 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@livekit/rtc-node": {
+      "version": "0.13.32",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-node/-/rtc-node-0.13.32.tgz",
+      "integrity": "sha512-vub0piQa5RB0bMMTegudc97C88kgONgMWCLr3PWBts7wrXwMXNm7nHDX5lR0FwxfmfHU7g+Av0D3+L/6HGu7Hg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datastructures-js/deque": "1.0.8",
+        "@livekit/mutex": "^1.0.0",
+        "@livekit/rtc-ffi-bindings": "0.12.68",
+        "@livekit/typed-emitter": "^3.0.0",
+        "pino": "^9.0.0",
+        "pino-pretty": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@livekit/typed-emitter": {

--- a/services/playlist-bot/package.json
+++ b/services/playlist-bot/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@livekit/rtc-node": "^0.13.0",
+    "@livekit/rtc-node": "^0.13.32",
     "livekit-server-sdk": "^2.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
El bed no sonaba: el playlist-bot nunca completaba la conexión (wait_pc_connection timed out).

Diagnóstico con probes mínimos: subscriber PC OK, publisher PC timeout con rtc-node 0.13.24 contra livekit-server 1.13.4, desde dos redes distintas (descarta hairpin NAT). Con 0.13.32 el mismo probe publica sin problema.

Incluye también el deploy ops ya aplicado en mona (docker-compose.override.yml local, no en repo): network_mode host + LIVEKIT_URL=wss://live.harmonicbeacon.com para el bot, y advertise_internal_ip: true en livekit.yaml.