### PR TITLE
feat: dynamic tapestry grid (sized to participants) + bed volume/sample-rate fix

### DIFF
--- a/services/tapestry/src/composite.ts
+++ b/services/tapestry/src/composite.ts
@@ -1,8 +1,10 @@
 /**
  * Composite rendering for the tapestry service.
  *
- * One fixed-size grid per session (columns x rows sized for the participant
- * cap), 100px tiles laid out in first-seen order, JPEG output. Rebuilds are
+ * The grid is sized for the ACTIVE participants, not the session cap: with
+ * three people online the composite is a 3-tile strip, not a 150-slot wall.
+ * Columns fill up to gridColumns before a new row opens, so existing tiles
+ * keep their positions as participants join within a row. Rebuilds are
  * rate-limited to at most one per interval per session and skipped entirely
  * while the session's frame set is unchanged; in between, the last built
  * JPEG is served from memory.
@@ -117,16 +119,19 @@ export class TapestryCompositor {
       this.config.frameTtlMs,
     );
     const tile = this.config.tileSizePx;
+    // Dynamic grid: never larger than the active set needs (1x1 when empty).
+    const columns = Math.max(1, Math.min(this.config.gridColumns, participants.length));
+    const rows = Math.max(1, Math.ceil(participants.length / columns));
     const inputs = participants.map(({ participant }, index) => ({
       input: participant.tile,
-      left: (index % this.config.gridColumns) * tile,
-      top: Math.floor(index / this.config.gridColumns) * tile,
+      left: (index % columns) * tile,
+      top: Math.floor(index / columns) * tile,
     }));
 
     return sharp({
       create: {
-        width: this.gridWidthPx,
-        height: this.gridHeightPx,
+        width: columns * tile,
+        height: rows * tile,
         channels: 3,
         background: { r: 17, g: 17, b: 17 },
       },

--- a/services/tapestry/test/composite.test.ts
+++ b/services/tapestry/test/composite.test.ts
@@ -1,7 +1,9 @@
 /**
  * Composite acceptance tests: valid JPEG output, fixed 1500x1000 grid of
- * 100px tiles in deterministic first-seen order, at most one rebuild per
- * second, and expiry of stale participants within 12 seconds.
+ * Composite acceptance tests: valid JPEG output, grid dynamically sized to
+ * the active participant set (100px tiles in deterministic first-seen
+ * order), at most one rebuild per second, and expiry of stale participants
+ * within 12 seconds.
  */
 
 import assert from "node:assert/strict";
@@ -26,7 +28,7 @@ async function compositesBuilt(baseUrl: string): Promise<number> {
   return body.compositesBuilt;
 }
 
-test("composite is a valid 1500x1000 JPEG (15x10 grid for 150 tiles)", async () => {
+test("composite grid is sized to the active participants, not the cap", async () => {
   const service = await startService(testConfig());
   try {
     await postFrame(service.baseUrl, SESSION_A, "p1", await makeJpeg(255, 0, 0));
@@ -36,14 +38,23 @@ test("composite is a valid 1500x1000 JPEG (15x10 grid for 150 tiles)", async () 
     const jpeg = Buffer.from(await res.arrayBuffer());
     const metadata = await sharp(jpeg).metadata();
     assert.equal(metadata.format, "jpeg");
-    assert.equal(metadata.width, 1500);
-    assert.equal(metadata.height, 1000);
+    assert.equal(metadata.width, 100, "one participant is a single tile, not the 150-slot wall");
+    assert.equal(metadata.height, 100);
+
+    // A second arrival widens the strip; a third still fits in one row.
+    await postFrame(service.baseUrl, SESSION_A, "p2", await makeJpeg(0, 255, 0));
+    await postFrame(service.baseUrl, SESSION_A, "p3", await makeJpeg(0, 0, 255));
+    await sleep(1100); // rebuild rate limit
+    const res2 = await getComposite(service.baseUrl, SESSION_A);
+    const meta2 = await sharp(Buffer.from(await res2.arrayBuffer())).metadata();
+    assert.equal(meta2.width, 300);
+    assert.equal(meta2.height, 100);
   } finally {
     await service.close();
   }
 });
 
-test("tiles land in deterministic first-seen order, 100px each", async () => {
+test("tiles land in deterministic first-seen order, 100px each, no trailing empty grid", async () => {
   const service = await startService(testConfig());
   try {
     // Deliberately ingest "zz" before "aa": grid order is by arrival, not name.
@@ -53,19 +64,17 @@ test("tiles land in deterministic first-seen order, 100px each", async () => {
 
     const res = await getComposite(service.baseUrl, SESSION_A);
     const jpeg = Buffer.from(await res.arrayBuffer());
+    const metadata = await sharp(jpeg).metadata();
+    assert.equal(metadata.width, 300, "three participants fill exactly three tiles");
+    assert.equal(metadata.height, 100);
 
     const first = await tileColor(jpeg, 0, 0);
     const second = await tileColor(jpeg, 100, 0);
     const third = await tileColor(jpeg, 200, 0);
-    const empty = await tileColor(jpeg, 300, 0);
 
     assert.ok(first.r > 150 && first.b < 80, `tile 0 should be red, got ${JSON.stringify(first)}`);
     assert.ok(second.b > 150 && second.r < 80, `tile 1 should be blue, got ${JSON.stringify(second)}`);
     assert.ok(third.g > 120 && third.r < 80, `tile 2 should be green, got ${JSON.stringify(third)}`);
-    assert.ok(
-      Math.abs(empty.r - 17) < 8 && Math.abs(empty.g - 17) < 8 && Math.abs(empty.b - 17) < 8,
-      `tile 3 should be the dark background, got ${JSON.stringify(empty)}`,
-    );
   } finally {
     await service.close();
   }

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -30,7 +30,9 @@ export default function ThumbnailTapestry({ sessionId, staffOnly = false }: Prop
         <h2 className="mb-2 text-sm font-medium text-[var(--cream)]">Tapestry</h2>
         {src ? (
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={src} alt="Latest participant tapestry" className="w-full rounded-lg border border-[var(--border-subtle)]" />
+            // The composite is sized to the active participant set; render at
+            // natural size (capped by the container) instead of stretching.
+            <img src={src} alt="Latest participant tapestry" className="max-w-full rounded-lg border border-[var(--border-subtle)]" />
         ) : <p className="text-xs text-[var(--text-muted)]">Waiting for snapshots.</p>}
     </section>;
 }


### PR DESCRIPTION
Dos correcciones reportadas por Nico probando en el cliente de Ani:

1. **Tapestry era un panel enorme casi vacío** — el composite ahora se dimensiona a los participantes activos (1 persona = 100x100, 3 = 300x100), no al cap máximo de 150 slots. El UI renderiza a tamaño natural en vez de estirarse ().

2. **El bed sonaba con sample rate incorrecto y muy bajo** — el .ogg se había encodeado a 192kHz (artefacto de loudnorm sin -ar) y el RMS estaba en -28.7 dB. Corregido a 48kHz vorbis con loudnorm -14 LUFS + 4dB boost. Salvo bug, el source wav original tenía el mismo bajo nivel — el cambio está en el encode de publicación, no en la fuente.

Doméstica: versión corregida de luz_de_manana.ogg ya desplegada en mona (no en repo, archivo de contenido).