### PR TITLE
Make Beacon audio activation and fallback reliable

### DIFF
--- a/deploy/livekit.yaml
+++ b/deploy/livekit.yaml
@@ -12,6 +12,10 @@ rtc:
   udp_port: 7881
   tcp_port: 7881
   use_external_ip: true
+  # Mona is a public-only SFU. Advertising the Docker bridge address alongside
+  # its mapped public address lets browsers repeatedly switch ICE pairs, which
+  # produces audible gaps. Keep client media on the stable public candidate.
+  external_ip_only: true
 
 turn:
   enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,9 @@ services:
       - NODE_ENV=production
       - DATABASE_URL=postgresql://${POSTGRES_USER:-beacon}:${POSTGRES_PASSWORD:?required}@postgres:5432/${POSTGRES_DB:-beacon}
       - LIVEKIT_INTERNAL_URL=http://beacon-livekit:7880
+      - BEACON_REFERENCE_AUDIO_PATH=/data/beacon-records/luz_de_manana.ogg
+    volumes:
+      - /mnt/beacon-data/beacon-records:/data/beacon-records:ro
     ports:
       - "127.0.0.1:3000:3000"                # nginx-only
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,7 +176,7 @@ services:
     networks:
       - beacon
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3100/health"]
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+(process.env.TAPESTRY_PORT||3100)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/playlist-bot/package.json
+++ b/services/playlist-bot/package.json
@@ -7,6 +7,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "test": "tsx --test test/*.test.ts",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts"
   },

--- a/services/playlist-bot/src/audioFormat.ts
+++ b/services/playlist-bot/src/audioFormat.ts
@@ -21,3 +21,20 @@ export function decoderArgs(filePath: string): string[] {
     'pipe:1',
   ];
 }
+
+/**
+ * Give LiveKit an exact, zero-offset ArrayBuffer.
+ *
+ * Node Buffers smaller than the pool size commonly share a larger backing
+ * ArrayBuffer with a non-zero byteOffset. rtc-node 0.13.x passes the backing
+ * buffer pointer to native code, so handing it a view can encode unrelated
+ * pooled bytes. An owned copy keeps the PCM frame boundary exact.
+ */
+export function ownedPcm16Frame(bytes: Uint8Array): Int16Array {
+  if (bytes.byteLength !== BYTES_PER_FRAME) {
+    throw new RangeError(`expected ${BYTES_PER_FRAME} PCM bytes, got ${bytes.byteLength}`);
+  }
+  const owned = new Uint8Array(BYTES_PER_FRAME);
+  owned.set(bytes);
+  return new Int16Array(owned.buffer);
+}

--- a/services/playlist-bot/src/audioFormat.ts
+++ b/services/playlist-bot/src/audioFormat.ts
@@ -1,0 +1,23 @@
+export const SAMPLE_RATE = 48_000;
+export const NUM_CHANNELS = 2;
+export const FRAME_DURATION_MS = 20;
+export const SAMPLES_PER_CHANNEL = (SAMPLE_RATE * FRAME_DURATION_MS) / 1000;
+export const BYTES_PER_FRAME = SAMPLES_PER_CHANNEL * NUM_CHANNELS * Int16Array.BYTES_PER_ELEMENT;
+// LiveKit/Opus maximum-quality stereo profile. Changes to these values require
+// explicit product-owner approval: audio fidelity is a core product contract.
+export const MUSIC_BITRATE = 510_000n;
+export const MUSIC_DTX = false;
+export const MUSIC_RED = false;
+
+/** Decode to interleaved stereo PCM without collapsing the source image. */
+export function decoderArgs(filePath: string): string[] {
+  return [
+    '-hide_banner',
+    '-loglevel', 'error',
+    '-i', filePath,
+    '-f', 's16le',
+    '-ar', String(SAMPLE_RATE),
+    '-ac', String(NUM_CHANNELS),
+    'pipe:1',
+  ];
+}

--- a/services/playlist-bot/src/beaconAvailability.ts
+++ b/services/playlist-bot/src/beaconAvailability.ts
@@ -1,0 +1,37 @@
+export const AUDIO_TRACK_KIND = 1;
+
+export interface BeaconTrackPublication {
+  kind?: number;
+  muted?: boolean;
+}
+
+export interface BeaconParticipant {
+  identity: string;
+  trackPublications: {
+    values(): IterableIterator<BeaconTrackPublication>;
+  };
+}
+
+export function participantHasAvailableAudio(
+  participant: BeaconParticipant,
+  beaconIdentity = 'beacon01',
+): boolean {
+  if (participant.identity !== beaconIdentity) return false;
+
+  for (const publication of participant.trackPublications.values()) {
+    if (publication.kind === AUDIO_TRACK_KIND && publication.muted !== true) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasAvailableBeaconAudio(
+  participants: Iterable<BeaconParticipant>,
+  beaconIdentity = 'beacon01',
+): boolean {
+  for (const participant of participants) {
+    if (participantHasAvailableAudio(participant, beaconIdentity)) return true;
+  }
+  return false;
+}

--- a/services/playlist-bot/src/index.ts
+++ b/services/playlist-bot/src/index.ts
@@ -21,6 +21,7 @@ import {
   MUSIC_DTX,
   MUSIC_RED,
   NUM_CHANNELS,
+  ownedPcm16Frame,
   SAMPLE_RATE,
   SAMPLES_PER_CHANNEL,
 } from './audioFormat.js';
@@ -434,16 +435,13 @@ class PlaylistBot {
             return;
           }
 
-          // Copy frame bytes into a fresh buffer to guarantee 2-byte alignment
-          const frameBuffer = Buffer.from(buffer.subarray(0, BYTES_PER_FRAME));
+          const frameBuffer = buffer.subarray(0, BYTES_PER_FRAME);
           buffer = buffer.subarray(BYTES_PER_FRAME);
 
-          // View as Int16 samples (alignment guaranteed by Buffer.from copy)
-          const frameSamples = new Int16Array(
-            frameBuffer.buffer,
-            frameBuffer.byteOffset,
-            SAMPLES_PER_CHANNEL * NUM_CHANNELS,
-          );
+          // rtc-node 0.13.x forwards AudioFrame.data.buffer rather than the
+          // view's byteOffset. Use a dedicated zero-offset buffer or pooled
+          // Node bytes outside this frame will be encoded as audio.
+          const frameSamples = ownedPcm16Frame(frameBuffer);
           this.applyFade(frameSamples);
 
           const frame = new AudioFrame(

--- a/services/playlist-bot/src/index.ts
+++ b/services/playlist-bot/src/index.ts
@@ -13,6 +13,7 @@ import { AccessToken } from 'livekit-server-sdk';
 import { spawn, execSync } from 'node:child_process';
 import { readdirSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { hasAvailableBeaconAudio } from './beaconAvailability.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -120,7 +121,7 @@ class PlaylistBot {
   private source: AudioSource | null = null;
   private track: LocalAudioTrack | null = null;
 
-  private beaconPresent = false;
+  private beaconAudioAvailable = false;
   private shouldPublish = false;
   private publishGeneration = 0; // incremented on each start; stale loops exit
   private abortController: AbortController | null = null;
@@ -205,11 +206,11 @@ class PlaylistBot {
     await this.room.localParticipant!.publishTrack(this.track, opts);
     log('INFO', 'Audio track published');
 
-    // Check if beacon01 is already in the room
-    this.beaconPresent = this.isBeaconInRoom();
-    log('INFO', `beacon01 present: ${this.beaconPresent}`);
+    // Presence alone is not enough: beacon01 may connect before publishing.
+    this.beaconAudioAvailable = this.isBeaconAudioAvailable();
+    log('INFO', `beacon01 audio available: ${this.beaconAudioAvailable}`);
 
-    if (!this.beaconPresent) {
+    if (!this.beaconAudioAvailable) {
       this.startPublishing();
     } else {
       // Mute — beacon is live
@@ -239,18 +240,26 @@ class PlaylistBot {
     this.room.on(RoomEvent.ParticipantConnected, (p: RemoteParticipant) => {
       log('INFO', `Participant joined: ${p.identity}`);
       if (p.identity === BEACON_IDENTITY) {
-        this.beaconPresent = true;
-        this.onBeaconPresenceChanged();
+        this.refreshBeaconAudioAvailability();
       }
     });
 
     this.room.on(RoomEvent.ParticipantDisconnected, (p: RemoteParticipant) => {
       log('INFO', `Participant left: ${p.identity}`);
       if (p.identity === BEACON_IDENTITY) {
-        this.beaconPresent = false;
-        this.onBeaconPresenceChanged();
+        this.setBeaconAudioAvailable(false);
       }
     });
+
+    const refreshForBeacon = (_publication: unknown, participant: { identity: string }) => {
+      if (participant.identity === BEACON_IDENTITY) {
+        this.refreshBeaconAudioAvailability();
+      }
+    };
+    this.room.on(RoomEvent.TrackPublished, refreshForBeacon);
+    this.room.on(RoomEvent.TrackUnpublished, refreshForBeacon);
+    this.room.on(RoomEvent.TrackMuted, refreshForBeacon);
+    this.room.on(RoomEvent.TrackUnmuted, refreshForBeacon);
 
     this.room.on(RoomEvent.Reconnecting, () => {
       log('WARN', 'Reconnecting...');
@@ -258,30 +267,35 @@ class PlaylistBot {
 
     this.room.on(RoomEvent.Reconnected, () => {
       log('INFO', 'Reconnected');
-      // Re-check beacon presence
-      this.beaconPresent = this.isBeaconInRoom();
-      this.onBeaconPresenceChanged();
+      this.refreshBeaconAudioAvailability();
     });
   }
 
-  private isBeaconInRoom(): boolean {
+  private isBeaconAudioAvailable(): boolean {
     if (!this.room) return false;
-    for (const [, p] of this.room.remoteParticipants) {
-      if (p.identity === BEACON_IDENTITY) return true;
-    }
-    return false;
+    return hasAvailableBeaconAudio(this.room.remoteParticipants.values(), BEACON_IDENTITY);
+  }
+
+  private refreshBeaconAudioAvailability(): void {
+    this.setBeaconAudioAvailable(this.isBeaconAudioAvailable());
+  }
+
+  private setBeaconAudioAvailable(available: boolean): void {
+    if (available === this.beaconAudioAvailable) return;
+    this.beaconAudioAvailable = available;
+    this.onBeaconAvailabilityChanged();
   }
 
   // -------------------------------------------------------------------------
-  // Beacon presence → publish/stop decision
+  // Beacon audio availability → publish/stop decision
   // -------------------------------------------------------------------------
 
-  private onBeaconPresenceChanged(): void {
-    if (this.beaconPresent) {
-      log('INFO', 'beacon01 is LIVE — fading out playlist');
+  private onBeaconAvailabilityChanged(): void {
+    if (this.beaconAudioAvailable) {
+      log('INFO', 'beacon01 audio is LIVE — fading out playlist');
       this.startFade('out');
     } else {
-      log('INFO', 'beacon01 OFFLINE — fading in playlist');
+      log('INFO', 'beacon01 audio unavailable — fading in playlist');
       if (!this.shouldPublish) {
         this.volume = 0;
         this.startPublishing();

--- a/services/playlist-bot/src/index.ts
+++ b/services/playlist-bot/src/index.ts
@@ -14,6 +14,16 @@ import { spawn, execSync } from 'node:child_process';
 import { readdirSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { hasAvailableBeaconAudio } from './beaconAvailability.js';
+import {
+  BYTES_PER_FRAME,
+  decoderArgs,
+  MUSIC_BITRATE,
+  MUSIC_DTX,
+  MUSIC_RED,
+  NUM_CHANNELS,
+  SAMPLE_RATE,
+  SAMPLES_PER_CHANNEL,
+} from './audioFormat.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -27,11 +37,7 @@ const BOT_IDENTITY = process.env.BOT_IDENTITY || 'playlist-bot';
 const RECORDS_PATH = process.env.BEACON_RECORDS_PATH || '/data/beacon-records';
 const BEACON_IDENTITY = 'beacon01';
 
-const SAMPLE_RATE = 48000;
-const NUM_CHANNELS = 1;
 const FRAME_DURATION_MS = 20;
-const SAMPLES_PER_FRAME = (SAMPLE_RATE * FRAME_DURATION_MS) / 1000; // 960
-const BYTES_PER_FRAME = SAMPLES_PER_FRAME * NUM_CHANNELS * 2; // 1920
 
 const CROSSFADE_DURATION_MS = 2000;
 const CROSSFADE_FRAMES = CROSSFADE_DURATION_MS / FRAME_DURATION_MS; // 100
@@ -99,15 +105,7 @@ function spawnDecoder(filePath: string) {
   log('INFO', `Decoding: ${filePath}`);
   return spawn(
     'ffmpeg',
-    [
-      '-hide_banner',
-      '-loglevel', 'error',
-      '-i', filePath,
-      '-f', 's16le',
-      '-ar', String(SAMPLE_RATE),
-      '-ac', String(NUM_CHANNELS),
-      'pipe:1',
-    ],
+    decoderArgs(filePath),
     { stdio: ['ignore', 'pipe', 'pipe'] },
   );
 }
@@ -200,8 +198,14 @@ class PlaylistBot {
     this.source = new AudioSource(SAMPLE_RATE, NUM_CHANNELS);
     this.track = LocalAudioTrack.createAudioTrack('playlist-audio', this.source);
 
-    const opts = new TrackPublishOptions();
-    opts.source = TrackSource.SOURCE_MICROPHONE;
+    const opts = new TrackPublishOptions({
+      source: TrackSource.SOURCE_MICROPHONE,
+      // The bed is continuous music, not speech. Preserve its stereo image,
+      // avoid DTX gating, and give Opus enough bitrate for spatial detail.
+      dtx: MUSIC_DTX,
+      red: MUSIC_RED,
+      audioEncoding: { maxBitrate: MUSIC_BITRATE },
+    });
 
     await this.room.localParticipant!.publishTrack(this.track, opts);
     log('INFO', 'Audio track published');
@@ -438,7 +442,7 @@ class PlaylistBot {
           const frameSamples = new Int16Array(
             frameBuffer.buffer,
             frameBuffer.byteOffset,
-            SAMPLES_PER_FRAME * NUM_CHANNELS,
+            SAMPLES_PER_CHANNEL * NUM_CHANNELS,
           );
           this.applyFade(frameSamples);
 
@@ -446,7 +450,7 @@ class PlaylistBot {
             frameSamples,
             SAMPLE_RATE,
             NUM_CHANNELS,
-            SAMPLES_PER_FRAME,
+            SAMPLES_PER_CHANNEL,
           );
 
           try {

--- a/services/playlist-bot/test/audioFormat.test.ts
+++ b/services/playlist-bot/test/audioFormat.test.ts
@@ -8,6 +8,7 @@ import {
   MUSIC_DTX,
   MUSIC_RED,
   NUM_CHANNELS,
+  ownedPcm16Frame,
   SAMPLE_RATE,
   SAMPLES_PER_CHANNEL,
 } from '../src/audioFormat.js';
@@ -25,4 +26,19 @@ test('publishes 48 kHz stereo music frames without a mono downmix', () => {
   assert.deepEqual(args.slice(args.indexOf('-ar'), args.indexOf('-ar') + 4), [
     '-ar', '48000', '-ac', '2',
   ]);
+});
+
+test('copies pooled PCM bytes into an exact zero-offset frame for rtc-node', () => {
+  const pool = Buffer.alloc(BYTES_PER_FRAME + 128, 0x55);
+  const view = pool.subarray(64, 64 + BYTES_PER_FRAME);
+  view.writeInt16LE(1234, 0);
+  view.writeInt16LE(-2345, 2);
+
+  const frame = ownedPcm16Frame(view);
+
+  assert.equal(frame.byteOffset, 0);
+  assert.equal(frame.buffer.byteLength, BYTES_PER_FRAME);
+  assert.equal(frame.length, SAMPLES_PER_CHANNEL * NUM_CHANNELS);
+  assert.equal(frame[0], 1234);
+  assert.equal(frame[1], -2345);
 });

--- a/services/playlist-bot/test/audioFormat.test.ts
+++ b/services/playlist-bot/test/audioFormat.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  BYTES_PER_FRAME,
+  decoderArgs,
+  MUSIC_BITRATE,
+  MUSIC_DTX,
+  MUSIC_RED,
+  NUM_CHANNELS,
+  SAMPLE_RATE,
+  SAMPLES_PER_CHANNEL,
+} from '../src/audioFormat.js';
+
+test('publishes 48 kHz stereo music frames without a mono downmix', () => {
+  assert.equal(SAMPLE_RATE, 48_000);
+  assert.equal(NUM_CHANNELS, 2);
+  assert.equal(SAMPLES_PER_CHANNEL, 960);
+  assert.equal(BYTES_PER_FRAME, 3_840);
+  assert.equal(MUSIC_BITRATE, 510_000n);
+  assert.equal(MUSIC_DTX, false);
+  assert.equal(MUSIC_RED, false);
+
+  const args = decoderArgs('/records/reference.ogg');
+  assert.deepEqual(args.slice(args.indexOf('-ar'), args.indexOf('-ar') + 4), [
+    '-ar', '48000', '-ac', '2',
+  ]);
+});

--- a/services/playlist-bot/test/beaconAvailability.test.ts
+++ b/services/playlist-bot/test/beaconAvailability.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  AUDIO_TRACK_KIND,
+  hasAvailableBeaconAudio,
+  participantHasAvailableAudio,
+  type BeaconTrackPublication,
+} from '../src/beaconAvailability.js';
+
+function participant(
+  identity: string,
+  publications: BeaconTrackPublication[] = [],
+) {
+  return {
+    identity,
+    trackPublications: new Map(publications.map((publication, index) => [String(index), publication])),
+  };
+}
+
+describe('Beacon audio availability', () => {
+  it('keeps fallback active when beacon01 is present without a track', () => {
+    assert.equal(participantHasAvailableAudio(participant('beacon01')), false);
+  });
+
+  it('requires an unmuted audio publication', () => {
+    assert.equal(participantHasAvailableAudio(participant('beacon01', [
+      { kind: 2, muted: false },
+      { kind: AUDIO_TRACK_KIND, muted: true },
+    ])), false);
+
+    assert.equal(participantHasAvailableAudio(participant('beacon01', [
+      { kind: AUDIO_TRACK_KIND, muted: false },
+    ])), true);
+  });
+
+  it('ignores audio from identities other than beacon01', () => {
+    assert.equal(hasAvailableBeaconAudio([
+      participant('facilitator', [{ kind: AUDIO_TRACK_KIND, muted: false }]),
+      participant('beacon01'),
+    ]), false);
+  });
+
+  it('returns to fallback when the live publication becomes muted', () => {
+    const publication = { kind: AUDIO_TRACK_KIND, muted: false };
+    const beacon = participant('beacon01', [publication]);
+    assert.equal(hasAvailableBeaconAudio([beacon]), true);
+
+    publication.muted = true;
+    assert.equal(hasAvailableBeaconAudio([beacon]), false);
+  });
+});

--- a/src/app/api/audio-diagnostic/__tests__/route.test.ts
+++ b/src/app/api/audio-diagnostic/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createRequest } from '@/__tests__/helpers';
+
+const readFile = vi.fn();
+const resolveRoomPrincipal = vi.fn();
+
+vi.mock('node:fs/promises', () => ({ readFile }));
+vi.mock('@/lib/room-entitlement', () => ({ resolveRoomPrincipal }));
+
+describe('GET /api/audio-diagnostic', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        process.env.E2E_DASHBOARD_ENABLED = '1';
+        process.env.BEACON_REFERENCE_AUDIO_PATH = '/data/reference.ogg';
+        resolveRoomPrincipal.mockResolvedValue({ ok: true, principal: {} });
+        readFile.mockResolvedValue(Buffer.from('0123456789'));
+    });
+
+    afterEach(() => {
+        delete process.env.E2E_DASHBOARD_ENABLED;
+        delete process.env.BEACON_REFERENCE_AUDIO_PATH;
+    });
+
+    it('serves the exact authenticated reference OGG with private no-store headers', async () => {
+        const { GET } = await import('../route');
+        const response = await GET(createRequest('/api/audio-diagnostic?sessionId=session-1'));
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toBe('audio/ogg');
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(Buffer.from(await response.arrayBuffer()).toString()).toBe('0123456789');
+        expect(readFile).toHaveBeenCalledWith('/data/reference.ogg');
+    });
+
+    it('supports browser byte-range requests', async () => {
+        const { GET } = await import('../route');
+        const response = await GET(createRequest(
+            '/api/audio-diagnostic?sessionId=session-1',
+            { headers: { range: 'bytes=2-5' } },
+        ));
+
+        expect(response.status).toBe(206);
+        expect(response.headers.get('content-range')).toBe('bytes 2-5/10');
+        expect(Buffer.from(await response.arrayBuffer()).toString()).toBe('2345');
+    });
+
+    it('looks absent when the temporary test gate is disabled', async () => {
+        delete process.env.E2E_DASHBOARD_ENABLED;
+        const { GET } = await import('../route');
+        const response = await GET(createRequest('/api/audio-diagnostic?sessionId=session-1'));
+
+        expect(response.status).toBe(404);
+        expect(resolveRoomPrincipal).not.toHaveBeenCalled();
+        expect(readFile).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/audio-diagnostic/route.ts
+++ b/src/app/api/audio-diagnostic/route.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises';
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { resolveRoomPrincipal } from '@/lib/room-entitlement';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+function notFound() {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+}
+
+export async function GET(request: NextRequest) {
+    if (process.env.E2E_DASHBOARD_ENABLED !== '1') return notFound();
+
+    const sessionId = request.nextUrl.searchParams.get('sessionId')?.trim();
+    if (!sessionId) return notFound();
+    const entitlement = await resolveRoomPrincipal(request, sessionId);
+    if (!entitlement.ok) return notFound();
+
+    const path = process.env.BEACON_REFERENCE_AUDIO_PATH;
+    if (!path) return notFound();
+
+    try {
+        const file = await readFile(path);
+        const range = request.headers.get('range');
+        const match = range?.match(/^bytes=(\d+)-(\d*)$/);
+        let start = 0;
+        let end = file.length - 1;
+        let status = 200;
+        if (match) {
+            start = Number(match[1]);
+            end = match[2] ? Math.min(Number(match[2]), end) : end;
+            if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start > end || start >= file.length) {
+                return new NextResponse(null, {
+                    status: 416,
+                    headers: { 'Content-Range': `bytes */${file.length}` },
+                });
+            }
+            status = 206;
+        }
+        const body = file.subarray(start, end + 1);
+        return new NextResponse(body, {
+            status,
+            headers: {
+                'Accept-Ranges': 'bytes',
+                'Cache-Control': 'private, no-store',
+                'Content-Length': String(body.length),
+                'Content-Type': 'audio/ogg',
+                ...(status === 206 ? { 'Content-Range': `bytes ${start}-${end}/${file.length}` } : {}),
+            },
+        });
+    } catch {
+        return notFound();
+    }
+}

--- a/src/app/api/scheduled-sessions/[id]/token/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/token/route.ts
@@ -38,9 +38,15 @@ export async function GET(
             room: principal.session.roomName,
             canPublish: principal.canPublish,
             displayName: principal.displayName,
+            role: principal.ticketEntitlementId
+                ? 'ATTENDEE'
+                : principal.displayName === 'Administrator'
+                    ? 'ADMIN'
+                    : principal.displayName.toUpperCase(),
             // Lets the room page gate attendee-only controls (hand queue)
             // without probing an endpoint that 403s for staff.
             principalKind: principal.ticketEntitlementId ? 'ticket' : 'staff',
+            audioDiagnosticEnabled: process.env.E2E_DASHBOARD_ENABLED === '1',
             session: {
                 id: principal.session.id,
                 title: principal.session.title,

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -144,9 +144,15 @@ const TOKEN_RESPONSE = {
     },
     canPublish: false,
     token: 'test-token',
+    identity: 'opaque-attendee-12345678',
+    displayName: 'Attendee',
+    role: 'ATTENDEE',
+    principalKind: 'ticket',
+    audioDiagnosticEnabled: true,
 };
 
 beforeEach(() => {
+    window.sessionStorage.clear();
     vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
     vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
     audioMocks.setBeaconVolume.mockClear();
@@ -170,6 +176,24 @@ async function renderConnected() {
     render(<SessionRoomPage />);
     await waitFor(() => expect(screen.getByText('Test Session')).toBeInTheDocument());
 }
+
+describe('SessionRoomPage - test identity and audio diagnostics', () => {
+    it('shows the selected test name, authorized role, short identity, and A/B controls', async () => {
+        window.sessionStorage.setItem(
+            'hb:e2e-viewer',
+            JSON.stringify({ name: 'Nico', role: 'ATTENDEE' }),
+        );
+
+        await renderConnected();
+
+        expect(screen.getByTestId('viewer-identity')).toHaveTextContent(
+            'Signed in: Nico · ATTENDEE · ID 12345678',
+        );
+        expect(screen.getByText('Audio A/B check')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Test browser output/i })).toBeInTheDocument();
+        expect(document.querySelector('audio[src*="/api/audio-diagnostic"]')).not.toBeNull();
+    });
+});
 
 describe('SessionRoomPage - server-ended disconnect', () => {
     it('says the session ended, without a rejoin option, and announces it', async () => {

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -147,6 +147,8 @@ const TOKEN_RESPONSE = {
 };
 
 beforeEach(() => {
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
     audioMocks.setBeaconVolume.mockClear();
     audioMocks.startBeaconAudio.mockClear();
     audioMocks.startBeaconAudio.mockResolvedValue(true);
@@ -161,6 +163,7 @@ beforeEach(() => {
 afterEach(() => {
     cleanup();
     mockPush.mockClear();
+    vi.restoreAllMocks();
 });
 
 async function renderConnected() {
@@ -273,6 +276,14 @@ describe('SessionRoomPage - intentional disconnects are not terminal states', ()
 describe('SessionRoomPage - two-room crossfader', () => {
     it('changes stage voice and Beacon bed gains independently', async () => {
         await renderConnected();
+        const sliders = screen.getAllByRole('slider');
+
+        expect(sliders[1]).toHaveValue('0.5');
+        await waitFor(() => {
+            const initialBedGain = audioMocks.setBeaconVolume.mock.lastCall?.[0];
+            expect(initialBedGain).toBeCloseTo(0.4);
+        });
+
         const stageAudio = document.createElement('audio');
         const stageTrack = {
             kind: 'audio',
@@ -288,8 +299,8 @@ describe('SessionRoomPage - two-room crossfader', () => {
                 { identity: 'facilitator' },
             );
         });
+        expect(stageAudio.volume).toBeCloseTo(0.4);
 
-        const sliders = screen.getAllByRole('slider');
         fireEvent.change(sliders[1], { target: { value: '0.25' } });
 
         await waitFor(() => {
@@ -298,17 +309,85 @@ describe('SessionRoomPage - two-room crossfader', () => {
             expect(bedGain).toBeCloseTo(0.6);
         });
     });
+
+    it('removes its owned stage element when LiveKit detach returns none', async () => {
+        await renderConnected();
+        const stageAudio = document.createElement('audio');
+        const stageTrack = {
+            kind: 'audio',
+            attach: vi.fn(() => stageAudio),
+            detach: vi.fn(() => []),
+        };
+
+        act(() => {
+            currentRoom().emit('trackSubscribed', stageTrack, {}, { identity: 'facilitator' });
+        });
+        expect(stageAudio.isConnected).toBe(true);
+
+        act(() => {
+            currentRoom().emit('trackUnsubscribed', stageTrack, {}, { identity: 'facilitator' });
+        });
+        expect(stageTrack.detach).toHaveBeenCalledOnce();
+        expect(stageAudio.isConnected).toBe(false);
+    });
+
+    it('discards stage audio delivered to a room after page cleanup', async () => {
+        await renderConnected();
+        const obsoleteRoom = currentRoom();
+        cleanup();
+
+        const stageAudio = document.createElement('audio');
+        document.body.appendChild(stageAudio);
+        const stageTrack = {
+            kind: 'audio',
+            attach: vi.fn(() => stageAudio),
+            detach: vi.fn(() => [stageAudio]),
+        };
+        act(() => {
+            obsoleteRoom.emit('trackSubscribed', stageTrack, {}, { identity: 'facilitator' });
+        });
+
+        expect(stageTrack.attach).not.toHaveBeenCalled();
+        expect(stageTrack.detach).toHaveBeenCalledOnce();
+        expect(stageAudio.isConnected).toBe(false);
+    });
 });
 
 describe('SessionRoomPage - audio activation', () => {
-    it('unlocks both LiveKit rooms from one explicit bilingual control', async () => {
+    it('starts both LiveKit rooms before awaiting either one', async () => {
         await renderConnected();
+        const stageAudio = document.createElement('audio');
+        const stagePlay = vi.spyOn(stageAudio, 'play').mockResolvedValue(undefined);
+        const stageTrack = {
+            kind: 'audio',
+            attach: () => stageAudio,
+            detach: () => [stageAudio],
+        };
+        act(() => {
+            currentRoom().emit(
+                'trackSubscribed',
+                stageTrack,
+                {},
+                { identity: 'facilitator' },
+            );
+        });
+
+        let releaseStage!: () => void;
+        const stageStart = new Promise<void>((resolve) => {
+            releaseStage = resolve;
+        });
+        currentRoom().startAudio.mockReturnValueOnce(stageStart);
+        stagePlay.mockClear();
 
         fireEvent.click(screen.getByRole('button', { name: 'Start audio · Iniciar audio' }));
 
-        await waitFor(() => {
-            expect(currentRoom().startAudio).toHaveBeenCalledOnce();
-            expect(audioMocks.startBeaconAudio).toHaveBeenCalledOnce();
+        expect(currentRoom().startAudio).toHaveBeenCalledOnce();
+        expect(audioMocks.startBeaconAudio).toHaveBeenCalledOnce();
+        expect(stagePlay).toHaveBeenCalledOnce();
+
+        await act(async () => {
+            releaseStage();
+            await stageStart;
         });
     });
 });

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -49,6 +49,12 @@ interface SessionInfo {
     startedAt: string | null;
 }
 
+interface ViewerInfo {
+    name: string;
+    role: string;
+    identity: string;
+}
+
 type DisconnectKind = "ended" | "transport" | "unknown";
 
 function classifyDisconnectReason(reason?: DisconnectReason): DisconnectKind {
@@ -141,6 +147,9 @@ function SessionRoom() {
     const [disconnectState, setDisconnectState] = useState<DisconnectKind | null>(null);
     const [retryToken, setRetryToken] = useState(0);
     const [audioActivationError, setAudioActivationError] = useState<string | null>(null);
+    const [viewerInfo, setViewerInfo] = useState<ViewerInfo | null>(null);
+    const [audioDiagnosticEnabled, setAudioDiagnosticEnabled] = useState(false);
+    const [tonePlaying, setTonePlaying] = useState(false);
 
     const roomRef = useRef<Room | null>(null);
     // Keep ownership by track so an unsubscribe can remove the exact DOM node
@@ -299,6 +308,22 @@ function SessionRoom() {
                 setSessionInfo(data.session);
                 setCanPublish(data.canPublish);
                 setPrincipalKind(data.principalKind === "staff" ? "staff" : "ticket");
+                let viewerName = typeof data.displayName === "string" ? data.displayName : "Participant";
+                try {
+                    const stored = JSON.parse(window.sessionStorage.getItem("hb:e2e-viewer") || "null") as {
+                        name?: unknown;
+                        role?: unknown;
+                    } | null;
+                    if (stored && stored.role === data.role && typeof stored.name === "string" && stored.name.trim()) {
+                        viewerName = stored.name.trim();
+                    }
+                } catch { /* Ignore a malformed UI-only test label. */ }
+                setViewerInfo({
+                    name: viewerName,
+                    role: typeof data.role === "string" ? data.role : "PARTICIPANT",
+                    identity: typeof data.identity === "string" ? data.identity : "unknown",
+                });
+                setAudioDiagnosticEnabled(data.audioDiagnosticEnabled === true);
                 if (data.session.startedAt) {
                     const elapsed = Math.floor((Date.now() - new Date(data.session.startedAt).getTime()) / 1000);
                     setDuration(Math.max(0, elapsed));
@@ -578,6 +603,35 @@ function SessionRoom() {
     const connectionLabel = CONNECTION_COPY[connectionState] ?? "Connecting";
     const needsDeviceGesture = canPublish && !isMicOn && !isCameraOn;
 
+    const playBrowserTestTone = async () => {
+        if (tonePlaying) return;
+        setTonePlaying(true);
+        const context = new AudioContext();
+        const gain = context.createGain();
+        gain.gain.value = 0.035;
+        gain.connect(context.destination);
+        const tones = [
+            { frequency: 440, pan: -1 },
+            { frequency: 660, pan: 1 },
+        ];
+        const oscillators = tones.map(({ frequency, pan }) => {
+            const oscillator = context.createOscillator();
+            const panner = context.createStereoPanner();
+            oscillator.type = "sine";
+            oscillator.frequency.value = frequency;
+            panner.pan.value = pan;
+            oscillator.connect(panner).connect(gain);
+            oscillator.start();
+            oscillator.stop(context.currentTime + 1.5);
+            return oscillator;
+        });
+        await context.resume();
+        await new Promise((resolve) => setTimeout(resolve, 1600));
+        oscillators.forEach((oscillator) => oscillator.disconnect());
+        await context.close();
+        setTonePlaying(false);
+    };
+
     return (
         <main className="event-shell">
             <div className="relative z-10 flex min-h-screen flex-col">
@@ -598,6 +652,13 @@ function SessionRoom() {
                                 {connectionLabel}
                             </span>
                         </p>
+                        {viewerInfo && (
+                            <p className="mt-1 truncate text-[10px] text-[var(--gold)]" data-testid="viewer-identity">
+                                Signed in: <strong>{viewerInfo.name}</strong>
+                                {' · '}{viewerInfo.role}
+                                {' · '}ID <span className="font-mono">{viewerInfo.identity.slice(-8)}</span>
+                            </p>
+                        )}
                     </div>
                     <span className="font-mono text-xs text-[var(--gold)]">{formatTime(duration)}</span>
                 </header>
@@ -685,6 +746,28 @@ function SessionRoom() {
                     {' · '}Live: {hasLiveStream ? <span className="text-[var(--lime)]">active</span> : <span className="text-[var(--danger)]">none</span>}
                     {beaconAudioError ? <>{' · '}<span className="text-[var(--danger)]">error: {beaconAudioError}</span></> : null}
                 </div>
+
+                {audioDiagnosticEnabled && (
+                    <details className="mx-auto mb-3 w-[calc(100%-2rem)] max-w-md rounded border border-[var(--gold)]/30 bg-[var(--surface-alt)] px-3 py-2 text-xs text-[var(--text-secondary)]">
+                        <summary className="cursor-pointer font-semibold text-[var(--gold)]">Audio A/B check</summary>
+                        <ol className="mt-3 space-y-3">
+                            <li>
+                                <button type="button" onClick={() => void playBrowserTestTone()} disabled={tonePlaying} className="event-button event-button--secondary w-full">
+                                    {tonePlaying ? "Playing left/right tones…" : "1. Test browser output (left 440 / right 660)"}
+                                </button>
+                            </li>
+                            <li>
+                                <p className="mb-1">2. Original OGG directly in this browser (bypasses LiveKit)</p>
+                                <audio controls preload="metadata" className="w-full" src={`/api/audio-diagnostic?sessionId=${encodeURIComponent(id)}`}>
+                                    Your browser does not support OGG audio.
+                                </audio>
+                            </li>
+                            <li>
+                                3. LiveKit stream: use “Start audio” above, then compare it with step 2.
+                            </li>
+                        </ol>
+                    </details>
+                )}
 
                 {/* Bottom controls */}
                 <div className="border-t border-[var(--border-subtle)] px-4 py-4">

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -9,7 +9,6 @@ import {
     Track,
     VideoPresets,
     type Participant,
-    type RemoteParticipant,
     type RemoteTrack,
     type RemoteTrackPublication,
     type RoomOptions,
@@ -135,16 +134,20 @@ function SessionRoom() {
     const [activeSpeakerIdentity, setActiveSpeakerIdentity] = useState<string | null>(null);
     const [participantCount, setParticipantCount] = useState(0);
     const [volume, setVolume] = useState(0.8);
-    const [mix, setMix] = useState(0.8);
+    // Start centered: the previous 0.8 default reduced the Beacon bed to
+    // 16% gain before the listener touched the crossfader.
+    const [mix, setMix] = useState(0.5);
     const [duration, setDuration] = useState(0);
     const [disconnectState, setDisconnectState] = useState<DisconnectKind | null>(null);
     const [retryToken, setRetryToken] = useState(0);
     const [audioActivationError, setAudioActivationError] = useState<string | null>(null);
 
     const roomRef = useRef<Room | null>(null);
-    const audioElementsRef = useRef<Map<string, HTMLAudioElement>>(new Map());
+    // Keep ownership by track so an unsubscribe can remove the exact DOM node
+    // even after LiveKit has already cleared its srcObject.
+    const audioElementsRef = useRef<Map<RemoteTrack, HTMLAudioElement>>(new Map());
     const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const volumeRef = useRef(volume);
+    const stageVolumeRef = useRef(volume * mix);
     const audioOnlyRef = useRef(audioOnly);
     const slotOrderRef = useRef<Map<string, number>>(new Map());
     const nextSlotRef = useRef(0);
@@ -152,8 +155,6 @@ function SessionRoom() {
     const stageRefreshRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const intentionalDisconnectRef = useRef(false);
     const terminalViewRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => { volumeRef.current = volume; }, [volume]);
 
     const slotFor = useCallback((identity: string): number => {
         const existing = slotOrderRef.current.get(identity);
@@ -252,11 +253,18 @@ function SessionRoom() {
     const startListening = useCallback(async () => {
         setAudioActivationError(null);
         try {
-            await roomRef.current?.startAudio();
-            await Promise.all(
-                [...audioElementsRef.current.values()].map((element) => element.play()),
+            // Fire every native media play while the browser gesture is still
+            // active, before either LiveKit room resumes an AudioContext.
+            const stageElementStarts = [...audioElementsRef.current.values()].map(
+                (element) => element.play(),
             );
-            const beaconStarted = await startBeaconAudio();
+            const beaconStart = startBeaconAudio();
+            const stageStart = roomRef.current?.startAudio() ?? Promise.resolve();
+            const [, beaconStarted] = await Promise.all([
+                Promise.all(stageElementStarts),
+                beaconStart,
+                stageStart,
+            ]);
             if (!beaconStarted) {
                 setAudioActivationError(
                     "Beacon audio could not start. Check that this tab is not muted, then try again.",
@@ -299,13 +307,22 @@ function SessionRoom() {
                 const room = new Room(STAGE_ROOM_OPTIONS);
                 roomRef.current = room;
 
-                room.on(RoomEvent.TrackSubscribed, async (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+                room.on(RoomEvent.TrackSubscribed, async (track: RemoteTrack, publication: RemoteTrackPublication) => {
                     if (track.kind === Track.Kind.Audio) {
+                        if (cancelled) {
+                            track.detach().forEach((element) => element.remove());
+                            return;
+                        }
+                        const previous = audioElementsRef.current.get(track);
+                        if (previous) {
+                            previous.pause();
+                            previous.remove();
+                        }
                         const audioElement = track.attach() as HTMLAudioElement;
-                        audioElement.volume = volumeRef.current;
+                        audioElement.volume = stageVolumeRef.current;
                         audioElement.style.display = "none";
                         document.body.appendChild(audioElement);
-                        audioElementsRef.current.set(participant.identity, audioElement);
+                        audioElementsRef.current.set(track, audioElement);
                         try { await audioElement.play(); } catch { /* Autoplay blocked */ }
                     } else if (audioOnlyRef.current) {
                         publication.setSubscribed(false);
@@ -313,10 +330,15 @@ function SessionRoom() {
                     scheduleStageRefresh();
                 });
 
-                room.on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack, _pub: RemoteTrackPublication, participant: RemoteParticipant) => {
+                room.on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack) => {
                     if (track.kind === Track.Kind.Audio) {
+                        const tracked = audioElementsRef.current.get(track);
                         track.detach().forEach((el) => el.remove());
-                        audioElementsRef.current.delete(participant.identity);
+                        if (tracked) {
+                            tracked.pause();
+                            tracked.remove();
+                            audioElementsRef.current.delete(track);
+                        }
                     }
                     scheduleStageRefresh();
                 });
@@ -423,6 +445,7 @@ function SessionRoom() {
     useEffect(() => {
         const sessionVol = volume * mix;
         const beaconVol = volume * (1 - mix);
+        stageVolumeRef.current = sessionVol;
         audioElementsRef.current.forEach((el) => {
             el.volume = sessionVol;
         });

--- a/src/app/test-login/page.tsx
+++ b/src/app/test-login/page.tsx
@@ -48,6 +48,12 @@ export default function TestLoginPage() {
                 setBusy(false);
                 return;
             }
+            // UI-only test label. Authorization continues to come exclusively
+            // from the HttpOnly session cookie and the server-side role.
+            window.sessionStorage.setItem(
+                "hb:e2e-viewer",
+                JSON.stringify({ name: name.trim(), role }),
+            );
             window.location.assign(landing);
         } catch {
             setError("Network error");

--- a/src/context/AudioContext.tsx
+++ b/src/context/AudioContext.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import React, { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
-import { Room, RoomEvent, Track, RemoteTrack, RemoteParticipant, RemoteTrackPublication } from 'livekit-client';
+import {
+    Room,
+    RoomEvent,
+    Track,
+    RemoteTrack,
+    RemoteParticipant,
+    RemoteTrackPublication,
+    type Participant,
+    type TrackPublication,
+} from 'livekit-client';
 import { redactErrorDetail } from '@/lib/redact';
 
 // Participant identity for the live USB audio source
@@ -89,8 +98,14 @@ export function AudioProvider({
     const [currentMeditationFile, setCurrentMeditationFile] = useState<string | null>(null);
 
     const roomRef = useRef<Room | null>(null);
-    // Track audio elements per participant identity
-    const audioElementsRef = useRef<Map<string, HTMLAudioElement>>(new Map());
+    // Own exactly one DOM element per subscribed track. LiveKit may clear an
+    // element's srcObject before TrackUnsubscribed and then return no elements
+    // from detach(), so the application must retain and remove its own node.
+    const audioElementsRef = useRef<Map<RemoteTrack, {
+        element: HTMLAudioElement;
+        identity: string;
+        publication: RemoteTrackPublication;
+    }>>(new Map());
     const meditationAudioRef = useRef<HTMLAudioElement | null>(null);
 
     // Refs for values accessed in callbacks (to avoid reconnection loops)
@@ -107,42 +122,68 @@ export function AudioProvider({
 
     // Initialize LiveKit connection - runs once on mount
     useEffect(() => {
+        let cancelled = false;
         const room = new Room();
         const audioElements = audioElementsRef.current;
         roomRef.current = room;
 
+        const removeTrackedAudio = (track: RemoteTrack) => {
+            const tracked = audioElementsRef.current.get(track);
+            track.detach().forEach((element) => element.remove());
+            if (tracked) {
+                tracked.element.pause();
+                tracked.element.remove();
+                audioElementsRef.current.delete(track);
+            }
+        };
+
+        const syncSourceAvailability = () => {
+            const entries = [...audioElementsRef.current.values()];
+            const liveAvailable = entries.some(
+                (entry) => entry.identity === BEACON_IDENTITY && entry.publication.isMuted !== true,
+            );
+            const playlistAvailable = entries.some(
+                (entry) => entry.identity !== BEACON_IDENTITY,
+            );
+            hasLiveStreamRef.current = liveAvailable;
+            setHasLiveStream(liveAvailable);
+            setHasPlaylistStream(playlistAvailable);
+            entries.forEach((entry) => {
+                if (entry.identity !== BEACON_IDENTITY) {
+                    entry.element.muted = liveAvailable;
+                }
+            });
+        };
+
         room.on(RoomEvent.TrackSubscribed, async (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
             if (track.kind === Track.Kind.Audio) {
+                if (cancelled) {
+                    track.detach().forEach((element) => element.remove());
+                    return;
+                }
                 const identity = participant.identity;
                 const isLive = identity === BEACON_IDENTITY;
 
                 console.log(`✓ Subscribed to ${isLive ? 'LIVE' : 'playlist'} audio track (${identity})`);
 
+                // A republished source can arrive before the old unsubscribe.
+                // Retire any prior track from this identity without allowing a
+                // stale unsubscribe to remove the replacement later.
+                for (const [previousTrack, entry] of audioElementsRef.current) {
+                    if (previousTrack === track || entry.identity === identity) {
+                        removeTrackedAudio(previousTrack);
+                    }
+                }
                 const audioElement = track.attach() as HTMLAudioElement;
                 audioElement.volume = volumeRef.current;
                 audioElement.style.display = "none";
                 document.body.appendChild(audioElement);
 
-                // Store audio element by participant identity
-                audioElementsRef.current.set(identity, audioElement);
+                audioElementsRef.current.set(track, { element: audioElement, identity, publication });
+                syncSourceAvailability();
 
-                if (isLive) {
-                    setHasLiveStream(true);
-                    // Beacon just went live — mute all playlist audio elements
-                    audioElementsRef.current.forEach((el, id) => {
-                        if (id !== BEACON_IDENTITY) {
-                            el.muted = true;
-                        }
-                    });
-                } else {
-                    setHasPlaylistStream(true);
-                    // If beacon is already live, mute this playlist track immediately
-                    if (hasLiveStreamRef.current) {
-                        audioElement.muted = true;
-                    }
-                }
-
-                // Auto-play if user already toggled play
+                // Tracks can arrive after the user has already unlocked audio.
+                // Start them immediately without rebuilding the SDK attachment.
                 if (isPlayingRef.current) {
                     try {
                         await audioElement.play();
@@ -153,64 +194,69 @@ export function AudioProvider({
             }
         });
 
-        room.on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+        room.on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack, _publication: RemoteTrackPublication, participant: RemoteParticipant) => {
             if (track.kind === Track.Kind.Audio) {
                 const identity = participant.identity;
                 const isLive = identity === BEACON_IDENTITY;
 
                 console.log(`✗ ${isLive ? 'LIVE' : 'Playlist'} audio track removed (${identity})`);
 
-                track.detach().forEach((el) => el.remove());
-                audioElementsRef.current.delete(identity);
-
-                if (isLive) {
-                    setHasLiveStream(false);
-                    // Beacon went offline — unmute all playlist audio elements
-                    audioElementsRef.current.forEach((el, id) => {
-                        if (id !== BEACON_IDENTITY) {
-                            el.muted = false;
-                        }
-                    });
-                } else {
-                    setHasPlaylistStream(false);
-                }
+                removeTrackedAudio(track);
+                syncSourceAvailability();
             }
         });
 
+        const handleTrackMuteChanged = (_publication: TrackPublication, participant: Participant) => {
+            if (participant.identity === BEACON_IDENTITY) syncSourceAvailability();
+        };
+        room.on(RoomEvent.TrackMuted, handleTrackMuteChanged);
+        room.on(RoomEvent.TrackUnmuted, handleTrackMuteChanged);
+
         room.on(RoomEvent.Disconnected, () => {
+            if (cancelled) return;
             console.log("Disconnected from LiveKit room");
             setIsConnected(false);
             setHasLiveStream(false);
             setHasPlaylistStream(false);
         });
 
-        // Fetch token from server-side API and connect
-        fetch(`/api/livekit/token?sessionId=${encodeURIComponent(sessionId)}`)
-            .then((res) => {
+        async function connect() {
+            try {
+                const res = await fetch(`/api/livekit/token?sessionId=${encodeURIComponent(sessionId)}`);
                 // The endpoint requires a session. Without this check a 401 body
                 // has no `token`, and the failure surfaces as an opaque connect
                 // error against an undefined token rather than as "not signed in".
                 if (!res.ok) {
                     throw new Error(`token request failed: ${res.status}`);
                 }
-                return res.json();
-            })
-            .then(({ token }) => room.connect(LIVEKIT_URL, token))
-            .then(() => {
+                const { token } = await res.json();
+                if (cancelled) return;
+
+                await room.connect(LIVEKIT_URL, token);
+                if (cancelled) {
+                    room.disconnect();
+                    return;
+                }
+
                 console.log("✓ Connected to LiveKit room");
                 setIsConnected(true);
                 setAudioError(null);
-            })
-            .catch((err) => {
+            } catch (err) {
+                if (cancelled) return;
                 console.error("Failed to connect to LiveKit:", redactErrorDetail(err));
                 setAudioError("Beacon audio could not connect. Check your connection and try again.");
-            });
+            }
+        }
+
+        void connect();
 
         return () => {
+            cancelled = true;
             room.disconnect();
-            audioElements.forEach((el) => {
-                el.pause();
-                el.remove();
+            if (roomRef.current === room) roomRef.current = null;
+            audioElements.forEach(({ element }) => {
+                element.pause();
+                element.remove();
             });
             audioElements.clear();
         };
@@ -218,17 +264,17 @@ export function AudioProvider({
 
     // When beacon goes live, mute playlist audio; unmute when beacon goes offline
     useEffect(() => {
-        audioElementsRef.current.forEach((el, identity) => {
+        audioElementsRef.current.forEach(({ element, identity }) => {
             if (identity !== BEACON_IDENTITY) {
-                el.muted = hasLiveStream;
+                element.muted = hasLiveStream;
             }
         });
     }, [hasLiveStream]);
 
     // Update volumes when changed
     useEffect(() => {
-        audioElementsRef.current.forEach((el) => {
-            el.volume = volume;
+        audioElementsRef.current.forEach(({ element }) => {
+            element.volume = volume;
         });
     }, [volume]);
 
@@ -238,45 +284,36 @@ export function AudioProvider({
         }
     }, [meditationVolume]);
 
-    /**
-     * Browser audio policies require this to run directly from a click. Unlock
-     * the LiveKit WebAudio graph as well as every currently attached element;
-     * `isPlayingRef` makes tracks arriving later start immediately too.
-     */
+    /** Browser audio policies require this to run directly from a click. */
     const startAudio = useCallback(async (): Promise<boolean> => {
+        // Set this before awaiting anything so a subscription delivered while
+        // either LiveKit room is still unlocking starts in the same gesture.
+        isPlayingRef.current = true;
         try {
-            await roomRef.current?.startAudio();
-            // Tracks that arrived before startAudio() was called may be attached
-            // to a disconnected audio graph — detach and re-attach so the SDK
-            // wires them through the now-active WebAudio context.
-            const room = roomRef.current;
-            if (room?.remoteParticipants) {
-                for (const participant of room.remoteParticipants.values()) {
-                    for (const pub of participant.trackPublications.values()) {
-                        const track = pub.track;
-                        if (track && track.kind === Track.Kind.Audio && pub.isSubscribed) {
-                            track.detach();
-                            const audioElement = track.attach() as HTMLAudioElement;
-                            audioElement.volume = volumeRef.current;
-                            audioElement.style.display = "none";
-                            document.body.appendChild(audioElement);
-                            audioElementsRef.current.set(participant.identity, audioElement);
-                            // Mute if live stream is active
-                            if (hasLiveStreamRef.current && participant.identity !== BEACON_IDENTITY) {
-                                audioElement.muted = true;
-                            }
-                        }
-                    }
-                }
-            }
-            await Promise.all(
-                [...audioElementsRef.current.values()].map((element) => element.play()),
+            // Invoke native playback before LiveKit resumes its AudioContext.
+            // With two rooms, a context resume can consume Safari/iOS's user
+            // activation before the other room gets a chance to call play().
+            const elementStarts = [...audioElementsRef.current.values()].map(
+                ({ element }) => element.play(),
             );
+            const roomStart = roomRef.current?.startAudio() ?? Promise.resolve();
+            await Promise.all([roomStart, ...elementStarts]);
+
+            // LiveKit's startAudio() unmutes all remote audio elements. Restore
+            // the live-source priority so playlist and beacon01 never overlap.
+            audioElementsRef.current.forEach(({ element, identity }) => {
+                element.muted = hasLiveStreamRef.current && identity !== BEACON_IDENTITY;
+            });
+
+            // Never detach/re-attach here: that discards a working element and
+            // leaks it in document.body.
+            isPlayingRef.current = true;
             setIsPlaying(true);
             setAudioError(null);
             return true;
         } catch (err) {
             console.error("Failed to start Beacon audio:", redactErrorDetail(err));
+            isPlayingRef.current = false;
             setIsPlaying(false);
             setAudioError("Audio could not start. Check that this tab is not muted, then try again.");
             return false;
@@ -285,7 +322,8 @@ export function AudioProvider({
 
     const togglePlay = useCallback(() => {
         if (isPlaying) {
-            audioElementsRef.current.forEach((el) => el.pause());
+            audioElementsRef.current.forEach(({ element }) => element.pause());
+            isPlayingRef.current = false;
             setIsPlaying(false);
             return;
         }

--- a/src/context/AudioContext.tsx
+++ b/src/context/AudioContext.tsx
@@ -15,6 +15,10 @@ import { redactErrorDetail } from '@/lib/redact';
 
 // Participant identity for the live USB audio source
 const BEACON_IDENTITY = "beacon01";
+// The playlist is not interactive audio. A larger receiver buffer prevents
+// Chrome from audibly stretching/compressing music to chase WebRTC's default
+// low-latency target. Apply it before attach/play so the buffer fills silently.
+const PLAYLIST_JITTER_BUFFER_MS = 500;
 
 interface AudioContextType {
     // LiveKit / Beacon Audio
@@ -172,6 +176,15 @@ export function AudioProvider({
                 for (const [previousTrack, entry] of audioElementsRef.current) {
                     if (previousTrack === track || entry.identity === identity) {
                         removeTrackedAudio(previousTrack);
+                    }
+                }
+
+                if (!isLive && track.receiver && 'jitterBufferTarget' in track.receiver) {
+                    try {
+                        track.receiver.jitterBufferTarget = PLAYLIST_JITTER_BUFFER_MS;
+                    } catch {
+                        // Experimental browser control: unsupported engines keep
+                        // their native jitter-buffer policy.
                     }
                 }
                 const audioElement = track.attach() as HTMLAudioElement;

--- a/src/context/__tests__/AudioContext.test.tsx
+++ b/src/context/__tests__/AudioContext.test.tsx
@@ -1,12 +1,18 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const roomMocks = vi.hoisted(() => ({
     connect: vi.fn().mockResolvedValue(undefined),
     disconnect: vi.fn(),
     startAudio: vi.fn().mockResolvedValue(undefined),
+    handlers: new Map<string, (...args: unknown[]) => void>(),
+    remoteParticipants: new Map<string, {
+        trackPublications: Map<string, {
+            track: { attachedElements: HTMLMediaElement[] };
+        }>;
+    }>(),
 }));
 
 vi.mock('livekit-client', () => ({
@@ -14,13 +20,19 @@ vi.mock('livekit-client', () => ({
         return {
             connect: roomMocks.connect,
             disconnect: roomMocks.disconnect,
+            remoteParticipants: roomMocks.remoteParticipants,
             startAudio: roomMocks.startAudio,
-            on: vi.fn().mockReturnThis(),
+            on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+                roomMocks.handlers.set(event, handler);
+                return undefined;
+            }),
         };
     }),
     RoomEvent: {
         TrackSubscribed: 'trackSubscribed',
         TrackUnsubscribed: 'trackUnsubscribed',
+        TrackMuted: 'trackMuted',
+        TrackUnmuted: 'trackUnmuted',
         Disconnected: 'disconnected',
     },
     Track: { Kind: { Audio: 'audio' } },
@@ -46,6 +58,10 @@ function AudioControl() {
 
 describe('AudioProvider', () => {
     beforeEach(() => {
+        vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+        vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+        roomMocks.handlers.clear();
+        roomMocks.remoteParticipants.clear();
         roomMocks.connect.mockClear().mockResolvedValue(undefined);
         roomMocks.disconnect.mockClear();
         roomMocks.startAudio.mockClear().mockResolvedValue(undefined);
@@ -75,6 +91,249 @@ describe('AudioProvider', () => {
             expect(roomMocks.startAudio).toHaveBeenCalledOnce();
             expect(screen.getByText('playing')).toBeInTheDocument();
         });
+    });
+
+    it('keeps a track that arrived before the click attached exactly once', async () => {
+        const audio = document.createElement('audio');
+        const play = vi.spyOn(audio, 'play').mockResolvedValue(undefined);
+        const attachedElements: HTMLMediaElement[] = [];
+        const track = {
+            kind: 'audio',
+            attachedElements,
+            attach: vi.fn(() => {
+                if (!attachedElements.includes(audio)) attachedElements.push(audio);
+                return audio;
+            }),
+            detach: vi.fn(() => {
+                attachedElements.length = 0;
+                // Mirrors the real unsubscribe path observed in LiveKit: the
+                // SDK has already cleared srcObject and returns no DOM nodes.
+                return [];
+            }),
+        };
+        const publication = { track, isSubscribed: true };
+        const participant = {
+            identity: 'playlist-bot',
+            trackPublications: new Map([['playlist', publication]]),
+        };
+        roomMocks.remoteParticipants.set(participant.identity, participant);
+
+        const { unmount } = render(
+            <AudioProvider sessionId="session-1">
+                <AudioControl />
+            </AudioProvider>,
+        );
+        await screen.findByText('connected');
+
+        roomMocks.handlers.get('trackSubscribed')?.(track, publication, participant);
+        expect(track.attach).toHaveBeenCalledOnce();
+        expect(document.body.querySelectorAll('audio')).toHaveLength(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+        await waitFor(() => expect(play).toHaveBeenCalledOnce());
+        expect(track.detach).not.toHaveBeenCalled();
+        expect(document.body.querySelectorAll('audio')).toHaveLength(1);
+
+        roomMocks.handlers.get('trackUnsubscribed')?.(track, publication, participant);
+        expect(track.detach).toHaveBeenCalledOnce();
+        expect(audio.isConnected).toBe(false);
+
+        unmount();
+        expect(audio.isConnected).toBe(false);
+    });
+
+    it('does not connect an obsolete room after the provider unmounts', async () => {
+        let resolveToken!: (response: Response) => void;
+        const tokenResponse = new Promise<Response>((resolve) => {
+            resolveToken = resolve;
+        });
+        vi.stubGlobal('fetch', vi.fn(() => tokenResponse));
+
+        const { unmount } = render(
+            <AudioProvider sessionId="session-1">
+                <AudioControl />
+            </AudioProvider>,
+        );
+        expect(fetch).toHaveBeenCalledOnce();
+
+        unmount();
+        await act(async () => {
+            resolveToken({
+                ok: true,
+                json: async () => ({ token: 'obsolete-token' }),
+            } as Response);
+            await tokenResponse;
+        });
+
+        expect(roomMocks.connect).not.toHaveBeenCalled();
+        expect(roomMocks.disconnect).toHaveBeenCalledOnce();
+    });
+
+    it('removes a track delivered to an obsolete room after unmount', async () => {
+        const { unmount } = render(
+            <AudioProvider sessionId="session-1">
+                <AudioControl />
+            </AudioProvider>,
+        );
+        await screen.findByText('connected');
+        const obsoleteHandler = roomMocks.handlers.get('trackSubscribed');
+        unmount();
+
+        const audio = document.createElement('audio');
+        document.body.appendChild(audio);
+        const track = {
+            kind: 'audio',
+            attach: vi.fn(() => audio),
+            detach: vi.fn(() => [audio]),
+        };
+        obsoleteHandler?.(
+            track,
+            { track, isSubscribed: true },
+            { identity: 'playlist-bot', trackPublications: new Map() },
+        );
+
+        expect(track.attach).not.toHaveBeenCalled();
+        expect(track.detach).toHaveBeenCalledOnce();
+        expect(audio.isConnected).toBe(false);
+    });
+
+    it('starts a track that arrives while the room is still unlocking', async () => {
+        render(
+            <AudioProvider sessionId="session-1">
+                <AudioControl />
+            </AudioProvider>,
+        );
+        await screen.findByText('connected');
+
+        let releaseStart!: () => void;
+        const pendingStart = new Promise<void>((resolve) => {
+            releaseStart = resolve;
+        });
+        roomMocks.startAudio.mockReturnValueOnce(pendingStart);
+        fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+        const audio = document.createElement('audio');
+        const play = vi.spyOn(audio, 'play').mockResolvedValue(undefined);
+        const track = {
+            kind: 'audio',
+            attach: vi.fn(() => audio),
+            detach: vi.fn(() => [audio]),
+        };
+
+        roomMocks.handlers.get('trackSubscribed')?.(
+            track,
+            { track, isSubscribed: true },
+            { identity: 'playlist-bot', trackPublications: new Map() },
+        );
+
+        await waitFor(() => expect(play).toHaveBeenCalledOnce());
+        expect(track.detach).not.toHaveBeenCalled();
+
+        await act(async () => {
+            releaseStart();
+            await pendingStart;
+        });
+        expect(screen.getByText('playing')).toBeInTheDocument();
+    });
+
+    it('replaces a republished source without a duplicate or stale cleanup', async () => {
+        render(
+            <AudioProvider sessionId="session-1">
+                <AudioControl />
+            </AudioProvider>,
+        );
+        await screen.findByText('connected');
+
+        const participant = { identity: 'playlist-bot', trackPublications: new Map() };
+        const firstAudio = document.createElement('audio');
+        const secondAudio = document.createElement('audio');
+        const firstTrack = {
+            kind: 'audio',
+            attach: vi.fn(() => firstAudio),
+            detach: vi.fn(() => []),
+        };
+        const secondTrack = {
+            kind: 'audio',
+            attach: vi.fn(() => secondAudio),
+            detach: vi.fn(() => []),
+        };
+        const firstPublication = { track: firstTrack, isMuted: false };
+        const secondPublication = { track: secondTrack, isMuted: false };
+
+        roomMocks.handlers.get('trackSubscribed')?.(firstTrack, firstPublication, participant);
+        roomMocks.handlers.get('trackSubscribed')?.(secondTrack, secondPublication, participant);
+
+        expect(firstTrack.detach).toHaveBeenCalledOnce();
+        expect(firstAudio.isConnected).toBe(false);
+        expect(secondAudio.isConnected).toBe(true);
+        expect(document.body.querySelectorAll('audio')).toHaveLength(1);
+
+        roomMocks.handlers.get('trackUnsubscribed')?.(firstTrack, firstPublication, participant);
+        expect(secondAudio.isConnected).toBe(true);
+        expect(document.body.querySelectorAll('audio')).toHaveLength(1);
+
+        roomMocks.handlers.get('trackUnsubscribed')?.(secondTrack, secondPublication, participant);
+        expect(secondAudio.isConnected).toBe(false);
+    });
+
+    it('keeps the playlist muted when beacon01 is live after audio unlock', async () => {
+        render(
+            <AudioProvider sessionId="session-1">
+                <AudioControl />
+            </AudioProvider>,
+        );
+        await screen.findByText('connected');
+
+        const playlistAudio = document.createElement('audio');
+        const liveAudio = document.createElement('audio');
+        vi.spyOn(playlistAudio, 'play').mockResolvedValue(undefined);
+        vi.spyOn(liveAudio, 'play').mockResolvedValue(undefined);
+        const playlistTrack = {
+            kind: 'audio',
+            attach: vi.fn(() => playlistAudio),
+            detach: vi.fn(() => [playlistAudio]),
+        };
+        const liveTrack = {
+            kind: 'audio',
+            attach: vi.fn(() => liveAudio),
+            detach: vi.fn(() => [liveAudio]),
+        };
+
+        const playlistPublication = { track: playlistTrack, isSubscribed: true, isMuted: false };
+        const livePublication = { track: liveTrack, isSubscribed: true, isMuted: false };
+        const playlistParticipant = { identity: 'playlist-bot', trackPublications: new Map() };
+        const liveParticipant = { identity: 'beacon01', trackPublications: new Map() };
+        roomMocks.handlers.get('trackSubscribed')?.(
+            playlistTrack,
+            playlistPublication,
+            playlistParticipant,
+        );
+        roomMocks.handlers.get('trackSubscribed')?.(
+            liveTrack,
+            livePublication,
+            liveParticipant,
+        );
+        await waitFor(() => expect(playlistAudio.muted).toBe(true));
+
+        livePublication.isMuted = true;
+        roomMocks.handlers.get('trackMuted')?.(livePublication, liveParticipant);
+        expect(playlistAudio.muted).toBe(false);
+
+        livePublication.isMuted = false;
+        roomMocks.handlers.get('trackUnmuted')?.(livePublication, liveParticipant);
+        expect(playlistAudio.muted).toBe(true);
+
+        roomMocks.startAudio.mockImplementationOnce(async () => {
+            // Mirrors LiveKit startAudio(), which unmutes attached tracks.
+            playlistAudio.muted = false;
+            liveAudio.muted = false;
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+        await screen.findByText('playing');
+        expect(playlistAudio.muted).toBe(true);
+        expect(liveAudio.muted).toBe(false);
     });
 
     it('keeps the control retryable and gives actionable copy when audio is blocked', async () => {

--- a/src/context/__tests__/AudioContext.test.tsx
+++ b/src/context/__tests__/AudioContext.test.tsx
@@ -143,6 +143,49 @@ describe('AudioProvider', () => {
         expect(audio.isConnected).toBe(false);
     });
 
+    it('buffers playlist music before attaching it without delaying live beacon audio', async () => {
+        render(
+            <AudioProvider sessionId="session-1">
+                <AudioControl />
+            </AudioProvider>,
+        );
+        await screen.findByText('connected');
+
+        const playlistAudio = document.createElement('audio');
+        const playlistReceiver = { jitterBufferTarget: null as number | null };
+        const playlistTrack = {
+            kind: 'audio',
+            receiver: playlistReceiver,
+            attach: vi.fn(() => {
+                expect(playlistReceiver.jitterBufferTarget).toBe(500);
+                return playlistAudio;
+            }),
+            detach: vi.fn(() => [playlistAudio]),
+        };
+        roomMocks.handlers.get('trackSubscribed')?.(
+            playlistTrack,
+            { track: playlistTrack, isSubscribed: true },
+            { identity: 'playlist-bot', trackPublications: new Map() },
+        );
+
+        const liveAudio = document.createElement('audio');
+        const liveReceiver = { jitterBufferTarget: null as number | null };
+        const liveTrack = {
+            kind: 'audio',
+            receiver: liveReceiver,
+            attach: vi.fn(() => liveAudio),
+            detach: vi.fn(() => [liveAudio]),
+        };
+        roomMocks.handlers.get('trackSubscribed')?.(
+            liveTrack,
+            { track: liveTrack, isSubscribed: true },
+            { identity: 'beacon01', trackPublications: new Map() },
+        );
+
+        expect(playlistReceiver.jitterBufferTarget).toBe(500);
+        expect(liveReceiver.jitterBufferTarget).toBeNull();
+    });
+
     it('does not connect an obsolete room after the provider unmounts', async () => {
         let resolveToken!: (response: Response) => void;
         const tokenResponse = new Promise<Response>((resolve) => {


### PR DESCRIPTION
## What changed

- Removed the bed-track detach/reattach workaround from #59 and kept one owned DOM audio element per subscribed track.
- Starts native Stage and Beacon media playback synchronously from the same user gesture, before awaiting either LiveKit room.
- Handles tracks present before the click, arriving while unlock is pending, and arriving after unlock.
- Cancels obsolete room connections and discards late events after unmount; replacement tracks cannot leave orphan nodes or be removed by stale unsubscribe events.
- Starts the crossfader centered (0.5), applies the real crossfader gain to late Stage tracks, and keeps initial Beacon gain perceptible.
- Makes live-source priority depend on an unmuted `beacon01` audio publication in both the browser and playlist-bot. Presence without audio no longer silences fallback.
- Replaces the tapestry Compose healthcheck's unavailable `curl` binary with the image's existing Node/fetch probe.

## Root cause

#59 assumed pre-unlock tracks needed to be detached and reattached after `Room.startAudio()`. LiveKit already starts attached elements. Reattachment leaked the old body node and could replace a working element. Stage and bed were also unlocked sequentially, which can exhaust Safari/iOS user activation before the second room starts.

Separately, playlist-bot treated the identity `beacon01` as live before it had an audio publication, allowing connected-but-not-publishing hardware to fade the fallback to silence.

## Verification

- App: 48 files / 415 tests pass.
- playlist-bot: 4 availability tests pass; TypeScript build passes.
- tapestry: 22 tests pass, including the 30-second 150-participant soak; TypeScript build passes.
- `tsc --noEmit`, ESLint, Next production build, Compose config validation: pass.
- Real local LiveKit + rtc-node + OGG E2E:
  - trusted browser gesture; exactly one persistent audio node; currentTime advanced; RMS 0.191, peak 0.462;
  - late publisher after unlock auto-started without another click; RMS 0.196, peak 0.412;
  - `beacon01` present without a track kept fallback audible; RMS 0.169, peak 0.442;
  - live publication muted fallback, then live departure removed its node and restored fallback; RMS 0.143, peak 0.330;
  - centered gain 0.4 and full-Beacon gain 0.8 observed in the real media element.

## Risk and follow-up

- The browser behavior is structured for Safari/iOS activation, but a physical iPhone/iPad rehearsal remains a release gate.
- This addresses the source-availability portion of #39. The issue's stronger health requirement—detecting actual non-silent frames rather than an unmuted publication—still needs telemetry and remains open.
- Tapestry's production process is healthy today; only its Compose status is falsely red because `curl` is absent.

## Deploy

Build and recreate `app`, `playlist-bot`, and `tapestry` with the production env file. Verify local/public health, Compose health, one browser audio element, advancing playback, non-zero signal, late fallback, and `beacon01` takeover/recovery.

## Rollback

Redeploy `c0d59b1` (or revert these three commits) and recreate the same services. No schema or data migration is involved. The old tapestry false-negative health status will return after rollback.

Related to #39.