### PR TITLE
Fix stale stage promotions

### DIFF
--- a/src/components/ops/SpotlightConsole.tsx
+++ b/src/components/ops/SpotlightConsole.tsx
@@ -125,6 +125,13 @@ function mediaSummary(participant: ConsoleParticipant): string {
         .join(' · ');
 }
 
+function participantLabel(participant: ConsoleParticipant): string {
+    if (participant.principalType === 'staff') {
+        return participant.displayName;
+    }
+    return `${participant.displayName} · ID ${participant.identity.slice(-8)}`;
+}
+
 export default function SpotlightConsole({ sessionId, role }: Props) {
     const [snapshot, setSnapshot] = useState<ParticipantsSnapshot | null>(null);
     const [pollError, setPollError] = useState<string | null>(null);
@@ -200,10 +207,18 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
     }
 
     async function giveFloor(participant: ConsoleParticipant) {
+        if (participant.connected !== true) {
+            setActionError({
+                code: 'participant_not_connected',
+                message: 'This participant is not connected. Wait for them to rejoin or remove the stale hand.',
+            });
+            return;
+        }
+        const label = participantLabel(participant);
         const promoted = await runAction(
             `promote:${participant.id}`,
             { action: 'promote', participantId: participant.id, reason: 'Hand queue' },
-            `${participant.displayName} has the floor`,
+            `${label} has the floor`,
         );
         if (!promoted) {
             return;
@@ -211,22 +226,29 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
         await runAction(
             `lower:${participant.id}`,
             { action: 'lower_hand', participantId: participant.id, reason: 'Promoted to stage' },
-            `${participant.displayName} has the floor`,
+            `${label} has the floor`,
         );
     }
+
+    const inviteToStage = (participant: ConsoleParticipant) =>
+        runAction(
+            `promote:${participant.id}`,
+            { action: 'promote', participantId: participant.id, reason: 'Invited from audience' },
+            `${participantLabel(participant)} was invited to the stage`,
+        );
 
     const takeFloor = (participant: ConsoleParticipant) =>
         runAction(
             `demote:${participant.id}`,
             { action: 'demote', participantId: participant.id, reason: 'Operator took the floor' },
-            `${participant.displayName} was taken off the stage`,
+            `${participantLabel(participant)} was taken off the stage`,
         );
 
     const removeHand = (participant: ConsoleParticipant) =>
         runAction(
             `lower:${participant.id}`,
             { action: 'lower_hand', participantId: participant.id, reason: 'Removed from hand queue' },
-            `${participant.displayName}'s hand was lowered`,
+            `${participantLabel(participant)}'s hand was lowered`,
         );
 
     const setTrackMuted = (participant: ConsoleParticipant, track: LiveTrack, muted: boolean) =>
@@ -280,7 +302,9 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                 <div role="alert" className="rounded border border-[var(--danger)]/40 bg-[var(--danger)]/10 px-4 py-2 text-sm text-[var(--danger)]">
                     {actionError.code === 'stage_full'
                         ? `Stage is full — this hand stays #${actionError.queuePosition ?? '?'} in the queue. Take a floor first.`
-                        : actionError.code === 'livekit_failed'
+                        : actionError.code === 'participant_not_connected'
+                          ? actionError.message
+                        : actionError.code === 'livekit_failed' && actionError.reconcileNeeded
                           ? `${actionError.message}. The durable grant was revoked; press Reconcile to retry the LiveKit update.`
                           : `${actionError.message} (${actionError.code})`}
                 </div>
@@ -317,7 +341,7 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                             <li key={participant.id} className="operational-panel">
                                 <div className="flex items-center justify-between gap-3">
                                     <div className="min-w-0">
-                                        <span className="font-medium text-[var(--cream)]">{participant.displayName}</span>
+                                        <span className="font-medium text-[var(--cream)]">{participantLabel(participant)}</span>
                                         {participant.staffRole ? (
                                             <span className="ml-2 text-[10px] uppercase text-[var(--text-muted)]">{participant.staffRole}</span>
                                         ) : null}
@@ -372,7 +396,7 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                         {queue.map((participant) => (
                             <li key={participant.id} className="flex items-center justify-between gap-3 operational-panel">
                                 <div className="min-w-0">
-                                    <span className="font-medium text-[var(--cream)]">#{participant.queuePosition} — {participant.displayName}</span>
+                                    <span className="font-medium text-[var(--cream)]">#{participant.queuePosition} — {participantLabel(participant)}</span>
                                     <div className="text-xs text-[var(--text-secondary)]">
                                         waiting {participant.raisedAt ? formatQueueAge(participant.raisedAt, nowMs) : '…'}
                                         {' · '}{connectionBadge(participant)}
@@ -383,11 +407,12 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                                 <div className="flex shrink-0 items-center gap-2">
                                     <button
                                         type="button"
-                                        disabled={busyKey !== null}
+                                        disabled={busyKey !== null || participant.connected !== true}
                                         onClick={() => void giveFloor(participant)}
+                                        title={participant.connected === true ? undefined : 'Participant must be connected before joining the stage'}
                                         className="min-h-10 rounded border border-[var(--lime)] px-3 py-2 text-xs text-[var(--lime)] hover:bg-[var(--lime)]/10 disabled:opacity-50"
                                     >
-                                        Give floor
+                                        {participant.connected === true ? 'Give floor' : 'Waiting for reconnect'}
                                     </button>
                                     <button
                                         type="button"
@@ -414,14 +439,26 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                         {audience.map((participant) => (
                             <li key={participant.id} className="flex items-center justify-between rounded px-2 py-1">
                                 <span className="text-[var(--cream)]">
-                                    {participant.displayName}
+                                    {participantLabel(participant)}
                                     {participant.staffRole ? (
                                         <span className="ml-2 text-[10px] uppercase text-[var(--text-muted)]">{participant.staffRole}</span>
                                     ) : null}
                                 </span>
-                                <span className="text-xs text-[var(--text-secondary)]">
-                                    {connectionBadge(participant)}
-                                    {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()}` : ''}
+                                <span className="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+                                    <span>
+                                        {connectionBadge(participant)}
+                                        {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()}` : ''}
+                                    </span>
+                                    {participant.connected === true ? (
+                                        <button
+                                            type="button"
+                                            disabled={busyKey !== null}
+                                            onClick={() => void inviteToStage(participant)}
+                                            className="min-h-10 rounded border border-[var(--lime)] px-3 py-2 text-xs text-[var(--lime)] hover:bg-[var(--lime)]/10 disabled:opacity-50"
+                                        >
+                                            Invite to stage
+                                        </button>
+                                    ) : null}
                                 </span>
                             </li>
                         ))}

--- a/src/components/ops/__tests__/SpotlightConsole.test.tsx
+++ b/src/components/ops/__tests__/SpotlightConsole.test.tsx
@@ -94,18 +94,49 @@ describe('SpotlightConsole', () => {
         render(<SpotlightConsole sessionId="event-1" role="OPERATOR" />);
 
         await waitFor(() => {
-            expect(screen.getByText('#1 — Attendee')).toBeInTheDocument();
+            expect(screen.getByText('#1 — Attendee · ID ue-first')).toBeInTheDocument();
         });
-        const queueItems = screen.getAllByText(/^#\d — Attendee$/);
+        const queueItems = screen.getAllByText(/^#\d — Attendee · ID /);
         expect(queueItems.map((item) => item.textContent)).toEqual([
-            '#1 — Attendee',
-            '#2 — Attendee',
+            '#1 — Attendee · ID ue-first',
+            '#2 — Attendee · ID e-second',
         ]);
         expect(screen.getByText('On stage')).toBeInTheDocument();
         expect(screen.getByText(/microphone muted/)).toBeInTheDocument();
         expect(screen.getByText(/left/)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Take floor' })).toBeInTheDocument();
         expect(screen.getAllByRole('button', { name: 'Give floor' })).toHaveLength(2);
+    });
+
+    it('does not offer the floor to a stale disconnected hand', async () => {
+        vi.stubGlobal('fetch', mockFetch(snapshot([
+            attendee('stale', {
+                raisedAt: '2026-08-01T15:10:00.000Z',
+                queuePosition: 1,
+                connected: false,
+            }),
+        ])));
+        render(<SpotlightConsole sessionId="event-1" role="FACILITATOR" />);
+
+        const reconnect = await screen.findByRole('button', { name: 'Waiting for reconnect' });
+        expect(reconnect).toBeDisabled();
+        await userEvent.click(reconnect);
+        expect(stagePosts).toHaveLength(0);
+    });
+
+    it('invites a connected audience member directly to the stage', async () => {
+        vi.stubGlobal('fetch', mockFetch(snapshot([attendee('audience')])));
+        render(<SpotlightConsole sessionId="event-1" role="FACILITATOR" />);
+
+        await userEvent.click(await screen.findByRole('button', { name: 'Invite to stage' }));
+
+        await waitFor(() => {
+            expect(stagePosts).toContainEqual({
+                action: 'promote',
+                participantId: 'audience',
+                reason: 'Invited from audience',
+            });
+        });
     });
 
     it('gives the floor by promoting through stage control, then clears the hand', async () => {
@@ -177,6 +208,30 @@ describe('SpotlightConsole', () => {
             expect(screen.getByRole('alert')).toHaveTextContent(
                 'LiveKit promotion failed. The durable grant was revoked; press Reconcile to retry',
             );
+        });
+    });
+
+    it('reports a disconnected promotion without asking for reconciliation', async () => {
+        vi.stubGlobal('fetch', mockFetch(
+            snapshot([attendee('first', {
+                raisedAt: '2026-08-01T15:10:00.000Z',
+                queuePosition: 1,
+            })]),
+            () => ({
+                status: 409,
+                data: {
+                    error: 'participant_not_connected',
+                    message: 'This participant is not connected. Wait for them to rejoin before giving the floor.',
+                },
+            }),
+        ));
+        render(<SpotlightConsole sessionId="event-1" role="OPERATOR" />);
+
+        await userEvent.click(await screen.findByRole('button', { name: 'Give floor' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert')).toHaveTextContent('This participant is not connected');
+            expect(screen.getByRole('alert')).not.toHaveTextContent('Reconcile');
         });
     });
 

--- a/src/lib/__tests__/stage-control.test.ts
+++ b/src/lib/__tests__/stage-control.test.ts
@@ -212,6 +212,29 @@ describe('stage control', () => {
         expect(participants[0].publishRevokedAt).toBeNull();
     });
 
+    it('rejects a disconnected participant without changing durable grant state', async () => {
+        participants = [attendee('target')];
+        mocks.listParticipants.mockResolvedValue([]);
+        const { promoteParticipant } = await import('../stage-control');
+
+        await expect(promoteParticipant({
+            scheduledSessionId: event.id,
+            participantId: 'target',
+            actorUserId: 'operator-1',
+        })).rejects.toMatchObject({
+            code: 'participant_not_connected',
+            status: 409,
+        });
+
+        expect(participants[0]).toMatchObject({
+            publishGrantedAt: null,
+            publishRevokedAt: null,
+            grantReconcileNeeded: false,
+            grantVersion: 0,
+        });
+        expect(mocks.updateParticipant).not.toHaveBeenCalled();
+    });
+
     it('serializes two promotions for the last slot so only one wins', async () => {
         participants = [
             attendee('active-1', true),

--- a/src/lib/stage-control.ts
+++ b/src/lib/stage-control.ts
@@ -38,6 +38,7 @@ export class StageControlError extends Error {
         public readonly code:
             | 'session_not_found'
             | 'participant_not_found'
+            | 'participant_not_connected'
             | 'stage_full'
             | 'not_publisher'
             | 'facilitator_required'
@@ -89,6 +90,47 @@ type MuteInput = {
     trackSid: string;
     muted: boolean;
 };
+
+async function requireConnectedParticipant(input: GrantInput): Promise<void> {
+    const participant = await prisma.sessionParticipant.findFirst({
+        where: {
+            id: input.participantId,
+            scheduledSessionId: input.scheduledSessionId,
+        },
+        select: {
+            participantIdentity: true,
+            scheduledSession: { select: { roomName: true } },
+        },
+    });
+    if (!participant) {
+        throw new StageControlError(
+            'participant_not_found',
+            404,
+            'Participant not found',
+        );
+    }
+
+    let connected: boolean;
+    try {
+        connected = (await getRoomService().listParticipants(
+            participant.scheduledSession.roomName,
+        )).some((liveParticipant) =>
+            liveParticipant.identity === participant.participantIdentity);
+    } catch {
+        throw new StageControlError(
+            'livekit_failed',
+            502,
+            'LiveKit participant state is unavailable; no grant was changed',
+        );
+    }
+    if (!connected) {
+        throw new StageControlError(
+            'participant_not_connected',
+            409,
+            'This participant is not connected. Wait for them to rejoin before giving the floor.',
+        );
+    }
+}
 
 /**
  * Lock the ScheduledSession row before reading or changing grants. PostgreSQL
@@ -239,6 +281,10 @@ async function markReconcileNeeded(
 export async function promoteParticipant(
     input: GrantInput,
 ): Promise<StageGrantResult> {
+    // Updating permissions for a disconnected LiveKit identity always fails.
+    // Reject before reserving a durable slot so a stale hand cannot create a
+    // false reconciliation incident or occupy the stage after a long absence.
+    await requireConnectedParticipant(input);
     const now = input.now ?? new Date();
     const reservation = await prisma.$transaction(async (transaction) => {
         await lockScheduledSession(transaction, input.scheduledSessionId);


### PR DESCRIPTION
## What changed

- prevent stale disconnected hands from being promoted or creating false reconciliation incidents
- add privacy-safe short participant IDs that match the ID shown in the attendee room
- allow facilitators to invite any connected audience or staff participant directly to the stage
- keep explicit attendee camera and microphone activation unchanged

## Root cause

The failed `Give floor` action targeted a hand raised almost ten hours earlier by a disconnected LiveKit identity. The durable grant was reserved first, then LiveKit correctly rejected the missing participant, forcing compensation and a reconciliation warning. Every ticket holder was also labeled only `Attendee`, making the stale identity indistinguishable from the currently connected attendee.

## Validation

- reproduced in production with Kimi WebBridge
- promoted the actual connected attendee successfully through the authenticated production API
- 49 test files / 424 tests passed
- TypeScript passed
- ESLint passed
- production build passed

## Deploy and rollback

Only the Next.js app needs rebuilding. Roll back to merge commit `e2174d6` and recreate the app container if post-deploy stage verification regresses.
