### PR TITLE
Preserve participant media consent

### DIFF
--- a/src/app/api/ops/sessions/[id]/stage/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/stage/__tests__/route.test.ts
@@ -163,11 +163,11 @@ describe('POST /api/ops/sessions/[id]/stage', () => {
         });
     });
 
-    it('passes mute and unmute state to the track controller', async () => {
+    it('passes a mute request to the track controller', async () => {
         mocks.muteParticipantTrack.mockResolvedValue({
             participantId: 'participant-1',
             trackSid: 'TR_audio',
-            muted: false,
+            muted: true,
         });
         const { POST } = await import('../route');
         const response = await POST(
@@ -175,7 +175,7 @@ describe('POST /api/ops/sessions/[id]/stage', () => {
                 action: 'mute',
                 participantId: 'participant-1',
                 trackSid: 'TR_audio',
-                muted: false,
+                muted: true,
             }),
             mockParams({ id: 'event-1' }),
         );
@@ -186,8 +186,24 @@ describe('POST /api/ops/sessions/[id]/stage', () => {
             participantId: 'participant-1',
             actorUserId: 'operator-1',
             trackSid: 'TR_audio',
-            muted: false,
+            muted: true,
         });
+    });
+
+    it('rejects remote unmute before calling the track controller', async () => {
+        const { POST } = await import('../route');
+        const response = await POST(
+            stageRequest({
+                action: 'mute',
+                participantId: 'participant-1',
+                trackSid: 'TR_video',
+                muted: false,
+            }),
+            mockParams({ id: 'event-1' }),
+        );
+
+        expect(response.status).toBe(400);
+        expect(mocks.muteParticipantTrack).not.toHaveBeenCalled();
     });
 
     it('lowers a served hand through the audited queue operation', async () => {

--- a/src/app/api/ops/sessions/[id]/stage/route.ts
+++ b/src/app/api/ops/sessions/[id]/stage/route.ts
@@ -98,10 +98,10 @@ export async function POST(
             if (
                 !participantId ||
                 typeof body.trackSid !== 'string' ||
-                typeof body.muted !== 'boolean'
+                body.muted !== true
             ) {
                 return invalidRequest(
-                    'Participant ID, track SID, and muted state are required',
+                    'Participant ID and track SID are required; staff may mute but cannot remotely unmute participant media',
                 );
             }
             const result = await muteParticipantTrack({

--- a/src/components/ops/SpotlightConsole.tsx
+++ b/src/components/ops/SpotlightConsole.tsx
@@ -251,16 +251,16 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
             `${participantLabel(participant)}'s hand was lowered`,
         );
 
-    const setTrackMuted = (participant: ConsoleParticipant, track: LiveTrack, muted: boolean) =>
+    const muteTrack = (participant: ConsoleParticipant, track: LiveTrack) =>
         runAction(
             `mute:${track.trackSid}`,
             {
                 action: 'mute',
                 participantId: participant.id,
                 trackSid: track.trackSid,
-                muted,
+                muted: true,
             },
-            `${track.source.toLowerCase()} ${muted ? 'muted' : 'unmuted'}`,
+            `${track.source.toLowerCase()} muted; the participant can re-enable it`,
         );
 
     const reconcile = () =>
@@ -353,15 +353,19 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                                         </div>
                                     </div>
                                     <div className="flex shrink-0 flex-wrap items-center gap-2">
-                                        {participant.media.map((track) => (
+                                        {participant.media.map((track) => track.muted ? (
+                                            <span key={track.trackSid} className="text-xs text-[var(--text-muted)]">
+                                                Participant must re-enable {track.source.toLowerCase()}
+                                            </span>
+                                        ) : (
                                             <button
                                                 key={track.trackSid}
                                                 type="button"
                                                 disabled={busyKey !== null}
-                                                onClick={() => void setTrackMuted(participant, track, !track.muted)}
+                                                onClick={() => void muteTrack(participant, track)}
                                                 className="rounded border border-[var(--border-subtle)] px-2 py-1 text-xs hover:bg-white/5 disabled:opacity-50"
                                             >
-                                                {track.muted ? 'Unmute' : 'Mute'} {track.source.toLowerCase()}
+                                                Mute {track.source.toLowerCase()}
                                             </button>
                                         ))}
                                         {participant.staffRole !== 'FACILITATOR' ? (

--- a/src/components/ops/__tests__/SpotlightConsole.test.tsx
+++ b/src/components/ops/__tests__/SpotlightConsole.test.tsx
@@ -284,6 +284,19 @@ describe('SpotlightConsole', () => {
         });
     });
 
+    it('does not offer remote unmute for participant media', async () => {
+        vi.stubGlobal('fetch', mockFetch(snapshot([
+            attendee('on-stage', {
+                canPublish: true,
+                media: [{ trackSid: 'TR_video', source: 'CAMERA', muted: true }],
+            }),
+        ])));
+        render(<SpotlightConsole sessionId="event-1" role="OPERATOR" />);
+
+        expect(await screen.findByText('Participant must re-enable camera')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Unmute camera/i })).not.toBeInTheDocument();
+    });
+
     it('marks the facilitator slot as reserved instead of offering demotion', async () => {
         vi.stubGlobal('fetch', mockFetch(snapshot([
             attendee('facilitator', {

--- a/src/components/session/HandRaiseButton.tsx
+++ b/src/components/session/HandRaiseButton.tsx
@@ -21,11 +21,48 @@ type Props = {
     onPublishGrantChange?: (canPublish: boolean) => void;
 };
 
+class HandRequestError extends Error {
+    constructor(
+        readonly status: number,
+        readonly code: string | null,
+    ) {
+        super(code ?? `HTTP ${status}`);
+        this.name = 'HandRequestError';
+    }
+}
+
+async function handStateFrom(response: Response): Promise<OwnHandState> {
+    const body = (await response.json().catch(() => ({}))) as Partial<OwnHandState> & {
+        error?: unknown;
+    };
+    if (!response.ok) {
+        throw new HandRequestError(
+            response.status,
+            typeof body.error === 'string' ? body.error : null,
+        );
+    }
+    return body as OwnHandState;
+}
+
+function handFailureMessage(error: unknown, action: 'status' | 'raise' | 'lower'): string {
+    if (error instanceof HandRequestError && error.status === 403) {
+        if (error.code === 'Insufficient permissions') {
+            return 'This browser is signed in as staff. Open the attendee in a private window or separate browser profile.';
+        }
+        return 'This attendee session is no longer authorized. Sign in again in a private window or separate browser profile.';
+    }
+    if (action === 'raise') return 'Could not raise hand';
+    if (action === 'lower') return 'Could not lower hand';
+    return 'Hand status unavailable';
+}
+
 export default function HandRaiseButton({ sessionId, onPublishGrantChange }: Props) {
     const [state, setState] = useState<OwnHandState | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [busy, setBusy] = useState(false);
+    const [authorizationBlocked, setAuthorizationBlocked] = useState(false);
     const mounted = useRef(true);
+    const authorizationBlockedRef = useRef(false);
     const lastGrant = useRef<boolean | null>(null);
 
     const applyState = useCallback((next: OwnHandState) => {
@@ -37,21 +74,23 @@ export default function HandRaiseButton({ sessionId, onPublishGrantChange }: Pro
     }, [onPublishGrantChange]);
 
     const refresh = useCallback(async () => {
+        if (authorizationBlockedRef.current) return;
         try {
             const response = await fetch(
                 `/api/scheduled-sessions/${sessionId}/hand`,
                 { cache: 'no-store' },
             );
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
-            }
+            const next = await handStateFrom(response);
             if (mounted.current) {
-                applyState((await response.json()) as OwnHandState);
+                applyState(next);
                 setError(null);
             }
-        } catch {
+        } catch (failure) {
             if (mounted.current) {
-                setError('Hand status unavailable');
+                const blocked = failure instanceof HandRequestError && failure.status === 403;
+                authorizationBlockedRef.current = blocked;
+                setAuthorizationBlocked(blocked);
+                setError(handFailureMessage(failure, 'status'));
             }
         }
     }, [sessionId, applyState]);
@@ -74,12 +113,12 @@ export default function HandRaiseButton({ sessionId, onPublishGrantChange }: Pro
                 `/api/scheduled-sessions/${sessionId}/hand`,
                 { method: raised ? 'POST' : 'DELETE' },
             );
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
-            }
-            applyState((await response.json()) as OwnHandState);
-        } catch {
-            setError(raised ? 'Could not raise hand' : 'Could not lower hand');
+            applyState(await handStateFrom(response));
+        } catch (failure) {
+            const blocked = failure instanceof HandRequestError && failure.status === 403;
+            authorizationBlockedRef.current = blocked;
+            setAuthorizationBlocked(blocked);
+            setError(handFailureMessage(failure, raised ? 'raise' : 'lower'));
         } finally {
             setBusy(false);
             void refresh();
@@ -91,7 +130,7 @@ export default function HandRaiseButton({ sessionId, onPublishGrantChange }: Pro
             <button
                 type="button"
                 onClick={() => void setHand(!(state?.raised ?? false))}
-                disabled={busy}
+                disabled={busy || authorizationBlocked}
                 className={`rounded-full px-5 py-2.5 text-sm font-medium transition-all ${
                     state?.raised
                         ? 'bg-[var(--pink)] text-[var(--ink)] shadow-[0_0_16px_rgba(255,113,189,0.3)]'

--- a/src/components/session/__tests__/HandRaiseButton.test.tsx
+++ b/src/components/session/__tests__/HandRaiseButton.test.tsx
@@ -127,4 +127,22 @@ describe('HandRaiseButton', () => {
         }, { timeout: 4000 });
         expect(screen.getByRole('status')).toHaveTextContent('you are #1 in the queue');
     });
+
+    it('explains a staff-cookie collision and stops attendee actions', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 403,
+            json: async () => ({ error: 'Insufficient permissions' }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        render(<HandRaiseButton sessionId="event-1" />);
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(
+            'signed in as staff',
+        );
+        const button = screen.getByRole('button', { name: /Raise hand/i });
+        expect(button).toBeDisabled();
+        await userEvent.click(button);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/lib/__tests__/stage-control.test.ts
+++ b/src/lib/__tests__/stage-control.test.ts
@@ -360,7 +360,7 @@ describe('stage control', () => {
         expect(mocks.mutePublishedTrack).not.toHaveBeenCalled();
     });
 
-    it('mutes and unmutes only a current publisher track', async () => {
+    it('mutes a current publisher track', async () => {
         participants = [attendee('target', true)];
         const { muteParticipantTrack } = await import('../stage-control');
 
@@ -371,28 +371,29 @@ describe('stage control', () => {
             trackSid: 'TR_audio',
             muted: true,
         });
-        await muteParticipantTrack({
-            scheduledSessionId: event.id,
-            participantId: 'target',
-            actorUserId: 'operator-1',
-            trackSid: 'TR_audio',
-            muted: false,
-        });
-
-        expect(mocks.mutePublishedTrack).toHaveBeenNthCalledWith(
-            1,
+        expect(mocks.mutePublishedTrack).toHaveBeenCalledWith(
             event.roomName,
             'opaque-target',
             'TR_audio',
             true,
         );
-        expect(mocks.mutePublishedTrack).toHaveBeenNthCalledWith(
-            2,
-            event.roomName,
-            'opaque-target',
-            'TR_audio',
-            false,
-        );
+    });
+
+    it('requires the participant to re-enable muted media', async () => {
+        participants = [attendee('target', true)];
+        const { muteParticipantTrack } = await import('../stage-control');
+
+        await expect(muteParticipantTrack({
+            scheduledSessionId: event.id,
+            participantId: 'target',
+            actorUserId: 'operator-1',
+            trackSid: 'TR_video',
+            muted: false,
+        })).rejects.toMatchObject({
+            code: 'invalid_request',
+            status: 400,
+        });
+        expect(mocks.mutePublishedTrack).not.toHaveBeenCalled();
     });
 
     it('reconciles durable grants into LiveKit and clears successful flags', async () => {

--- a/src/lib/stage-control.ts
+++ b/src/lib/stage-control.ts
@@ -528,6 +528,13 @@ export async function demoteParticipant(
 export async function muteParticipantTrack(
     input: MuteInput,
 ): Promise<TrackMuteResult> {
+    if (!input.muted) {
+        throw new StageControlError(
+            'invalid_request',
+            400,
+            'Staff may mute participant media, but the participant must re-enable it',
+        );
+    }
     if (!input.trackSid.trim()) {
         throw new StageControlError(
             'invalid_request',
@@ -560,7 +567,7 @@ export async function muteParticipantTrack(
             participant.scheduledSession.roomName,
             participant.participantIdentity,
             input.trackSid,
-            input.muted,
+            true,
         );
     } catch {
         throw new StageControlError(
@@ -573,7 +580,7 @@ export async function muteParticipantTrack(
     await prisma.auditLog.create({
         data: {
             actorUserId: input.actorUserId,
-            action: input.muted ? 'stage.mute' : 'stage.unmute',
+            action: 'stage.mute',
             targetType: 'SESSION_PARTICIPANT',
             targetId: participant.id,
             metadata: { trackSid: input.trackSid },
@@ -582,7 +589,7 @@ export async function muteParticipantTrack(
     return {
         participantId: participant.id,
         trackSid: input.trackSid,
-        muted: input.muted,
+        muted: true,
     };
 }
 


### PR DESCRIPTION
## What changed

- explain attendee hand failures caused by a staff session replacing the shared browser cookie
- stop polling and disable the hand control after that authorization conflict instead of showing two generic errors every two seconds
- remove remote `Unmute` controls from Ops and require participants to re-enable their own camera or microphone
- reject remote-unmute API calls before they reach LiveKit

## Root cause

The attendee and facilitator were tested in two tabs of the same Chrome profile. Both roles use the single `hb_session` cookie, so the later staff login replaced the attendee HTTP session. The attendee's already-established LiveKit connection remained alive, but `/hand` correctly returned HTTP 403 `Insufficient permissions` for the new staff cookie.

The Ops console also treated LiveKit track mute as symmetrical. Remote unmute is disabled by the deployed LiveKit configuration and would violate the product's explicit participant-consent rule even if enabled.

## Validation

- confirmed repeated GET/POST `/hand` responses were HTTP 403 in production access logs
- reproduced the exact 403 response from the authenticated browser
- 49 test files / 428 tests passed
- TypeScript, ESLint, and production build passed

## Test instruction

Use a private window, separate browser profile, or separate browser for the attendee while Julián remains signed in as staff. Tabs in one profile share authentication cookies.

## Rollback

Only the Next.js app changes. Rebuild the previous `main` commit and recreate only `beacon-app`.
