### PR TITLE
Make facilitator session flow explicit

### DIFF
--- a/prisma/migrations/20260731223000_web_session_display_name/migration.sql
+++ b/prisma/migrations/20260731223000_web_session_display_name/migration.sql
@@ -1,0 +1,11 @@
+-- A participant-chosen room label belongs to the browser session, not to the
+-- ticket entitlement or email identity. Existing sessions keep the safe
+-- "Attendee" fallback until their holder signs in again.
+ALTER TABLE "web_sessions" ADD COLUMN "display_name" TEXT;
+
+ALTER TABLE "web_sessions"
+ADD CONSTRAINT "web_sessions_display_name_length"
+CHECK (
+    "display_name" IS NULL
+    OR char_length("display_name") BETWEEN 1 AND 60
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,6 +119,7 @@ model TicketEntitlement {
 model WebSession {
   id                  String              @id @default(uuid()) @db.Uuid
   tokenDigest         String              @unique @map("token_digest")
+  displayName         String?             @map("display_name")
   staffUserId         String?             @map("staff_user_id") @db.Uuid
   staffUser           User?               @relation("StaffWebSessions", fields: [staffUserId], references: [id], onDelete: Cascade)
   ticketEntitlementId String?             @map("ticket_entitlement_id") @db.Uuid

--- a/src/app/api/auth/ticket/__tests__/route.test.ts
+++ b/src/app/api/auth/ticket/__tests__/route.test.ts
@@ -15,6 +15,7 @@ const PEPPER = 'route-test-pepper-with-at-least-32-characters';
 const CODE = 'HB26-A7NQ-92KM-4XZP';
 const OTHER_CODE = 'HB26-ZZZZ-0000-9YQT';
 const EMAIL = 'ana@example.com';
+const NAME = 'Ana';
 const CLIENT = '203.0.113.9';
 
 type EntitlementRow = {
@@ -46,7 +47,12 @@ function ticketRow(overrides: Partial<EntitlementRow> = {}): EntitlementRow {
     };
 }
 
-type WebSessionRow = { tokenDigest: string; ticketEntitlementId?: string; expiresAt: Date };
+type WebSessionRow = {
+    tokenDigest: string;
+    displayName?: string;
+    ticketEntitlementId?: string;
+    expiresAt: Date;
+};
 
 type FakePrisma = {
     $transaction: <T>(fn: (tx: FakePrisma) => Promise<T>) => Promise<T>;
@@ -115,9 +121,12 @@ function mountDb(rows: EntitlementRow[]) {
 }
 
 function loginRequest(body: unknown, address = CLIENT) {
+    const namedBody = body && typeof body === 'object' && !Array.isArray(body)
+        ? { name: NAME, ...body as Record<string, unknown> }
+        : body;
     return createRequest('/api/auth/ticket', {
         method: 'POST',
-        body,
+        body: namedBody,
         headers: { 'x-forwarded-for': address },
     });
 }
@@ -174,15 +183,21 @@ describe('POST /api/auth/ticket', () => {
         expect(db.webSessions[0].tokenDigest).toBe(digestSessionToken(cookie!.value));
         expect(JSON.stringify(db.webSessions[0])).not.toContain(cookie!.value);
         expect(db.webSessions[0].ticketEntitlementId).toBe('ticket-1');
+        expect(db.webSessions[0].displayName).toBe(NAME);
     });
 
     it('normalizes the bound email so a refresh and a later login both work', async () => {
         const db = mountDb([ticketRow()]);
         const { POST } = await importRoute();
 
-        const first = await POST(loginRequest({ code: `  ${CODE.toLowerCase()} `, email: '  Ana@Example.COM ' }));
+        const first = await POST(loginRequest({
+            name: '  Ana   María  ',
+            code: `  ${CODE.toLowerCase()} `,
+            email: '  Ana@Example.COM ',
+        }));
         expect(first.status).toBe(200);
         expect(db.entitlements[0].boundEmail).toBe(EMAIL);
+        expect(db.webSessions[0].displayName).toBe('Ana María');
 
         // A second login — new browser, new tab, or a reconnect after the laptop
         // slept — issues a second session for the same ticket.
@@ -293,6 +308,11 @@ describe('POST /api/auth/ticket', () => {
         ]) {
             expect((await POST(loginRequest(body))).status).toBe(400);
         }
+        expect((await POST(createRequest('/api/auth/ticket', {
+            method: 'POST',
+            body: { code: CODE, email: EMAIL },
+            headers: { 'x-forwarded-for': CLIENT },
+        }))).status).toBe(400);
         expect(db.webSessions).toHaveLength(0);
         expect(db.entitlements[0].state).toBe('ISSUED');
     });

--- a/src/app/api/auth/ticket/route.ts
+++ b/src/app/api/auth/ticket/route.ts
@@ -19,7 +19,9 @@ import { prisma } from '@/lib/db';
 import { clientAddress } from '@/lib/client-address';
 import {
     isPlausibleEmail,
+    isValidDisplayName,
     newSessionToken,
+    normalizeDisplayName,
     normalizeLoginEmail,
     sessionCookie,
     webSessionExpiry,
@@ -31,7 +33,7 @@ import { digestTicketCode, normalizeTicketCode } from '@/lib/ticket-code';
 /** One message for every rejection. See the module comment. */
 const GENERIC_REJECTION = 'That ticket code and email do not match an active ticket.';
 const RATE_LIMITED = 'Too many attempts. Please wait and try again.';
-const MALFORMED_REQUEST = 'A ticket code and an email address are required.';
+const MALFORMED_REQUEST = 'A display name, ticket code and email address are required.';
 
 type FailureReason =
     | 'malformed_request'
@@ -60,17 +62,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     let code: string;
     let email: string;
+    let displayName: string;
     try {
         const body = (await request.json()) as unknown;
         const fields = (body ?? {}) as Record<string, unknown>;
         code = typeof fields.code === 'string' ? normalizeTicketCode(fields.code) : '';
         email = typeof fields.email === 'string' ? normalizeLoginEmail(fields.email) : '';
+        displayName = typeof fields.name === 'string' ? normalizeDisplayName(fields.name) : '';
     } catch {
         code = '';
         email = '';
+        displayName = '';
     }
 
-    if (code.length < 16 || !isPlausibleEmail(email)) {
+    if (code.length < 16 || !isPlausibleEmail(email) || !isValidDisplayName(displayName)) {
         return reject(address, 'malformed_request');
     }
 
@@ -87,7 +92,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     let attempt: Attempt;
     try {
-        attempt = await redeem(codeDigest, email);
+        attempt = await redeem(codeDigest, email, displayName);
     } catch (error) {
         console.error(`[auth] ticket login failed: client=${address} ${redactError(error)}`);
         return NextResponse.json({ error: 'Login is temporarily unavailable.' }, { status: 500 });
@@ -133,7 +138,12 @@ function reject(address: string, reason: FailureReason): NextResponse {
  * The same path also handles the ordinary repeat login: `count = 0` with a
  * matching email is a re-entry, not a conflict.
  */
-async function redeem(codeDigest: string, email: string, now = new Date()): Promise<Attempt> {
+async function redeem(
+    codeDigest: string,
+    email: string,
+    displayName: string,
+    now = new Date(),
+): Promise<Attempt> {
     return prisma.$transaction(async (tx) => {
         const entitlement = await tx.ticketEntitlement.findUnique({
             where: { codeDigest },
@@ -186,6 +196,7 @@ async function redeem(codeDigest: string, email: string, now = new Date()): Prom
         await tx.webSession.create({
             data: {
                 tokenDigest: issued.database.tokenDigest,
+                displayName,
                 ticketEntitlementId: entitlement.id,
                 expiresAt: webSessionExpiry(now),
                 lastSeenAt: now,

--- a/src/app/api/ops/sessions/[id]/participants/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/participants/__tests__/route.test.ts
@@ -31,6 +31,7 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
         listParticipants.mockResolvedValue([
             {
                 identity: 'opaque-publisher',
+                name: 'Ana',
                 tracks: [
                     {
                         sid: 'TR_audio',
@@ -92,7 +93,7 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
         expect(sessionFindUnique).not.toHaveBeenCalled();
     });
 
-    it('lists durable grants, queue positions, and reconcile state without PII', async () => {
+    it('lists room display names, durable grants, queue positions, and reconcile state without private admission data', async () => {
         const { GET } = await import('../route');
         const { status, body } = await parseResponse(await GET(
             createRequest('/api/ops/sessions/event-1/participants'),
@@ -107,6 +108,7 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
             participants: [
                 {
                     id: 'publisher',
+                    displayName: 'Ana',
                     canPublish: true,
                     queuePosition: null,
                     connected: true,

--- a/src/app/api/ops/sessions/[id]/participants/route.ts
+++ b/src/app/api/ops/sessions/[id]/participants/route.ts
@@ -71,6 +71,7 @@ export async function GET(
 
     let liveStateAvailable = true;
     let liveParticipants = new Map<string, {
+        name: string;
         media: Array<{ trackSid: string; source: string; muted: boolean }>;
     }>();
     try {
@@ -79,6 +80,7 @@ export async function GET(
                 .map((participant) => [
                     participant.identity,
                     {
+                        name: participant.name,
                         media: participant.tracks.map((track) => ({
                             trackSid: track.sid,
                             source: trackSourceLabel(track.source),
@@ -106,7 +108,7 @@ export async function GET(
         return {
             id: participant.id,
             identity: participant.participantIdentity,
-            displayName: participant.staffUser?.name ?? 'Attendee',
+            displayName: participant.staffUser?.name ?? (live?.name?.trim() || 'Attendee'),
             principalType: participant.staffUser ? 'staff' : 'attendee',
             staffRole: participant.staffUser?.role ?? null,
             joinedAt: participant.joinedAt.toISOString(),

--- a/src/app/api/scheduled-sessions/[id]/token/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/token/__tests__/route.test.ts
@@ -18,6 +18,7 @@ const principal = {
     },
     identity: 'event-stable-opaque',
     displayName: 'Attendee',
+    role: 'ATTENDEE',
     canPublish: false,
 };
 
@@ -64,6 +65,7 @@ describe('GET /api/scheduled-sessions/[id]/token', () => {
             'event-stable-opaque',
             'Attendee',
             false,
+            'ATTENDEE',
         );
         expect(body).toMatchObject({
             token: 'stage-jwt',
@@ -80,6 +82,7 @@ describe('GET /api/scheduled-sessions/[id]/token', () => {
             principal: {
                 ...principal,
                 displayName: 'Facilitator',
+                role: 'FACILITATOR',
                 canPublish: true,
             },
         });
@@ -95,6 +98,7 @@ describe('GET /api/scheduled-sessions/[id]/token', () => {
             'event-stable-opaque',
             'Facilitator',
             true,
+            'FACILITATOR',
         );
     });
 });

--- a/src/app/api/scheduled-sessions/[id]/token/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/token/route.ts
@@ -30,6 +30,7 @@ export async function GET(
             principal.identity,
             principal.displayName,
             principal.canPublish,
+            principal.role,
         );
 
         return NextResponse.json({
@@ -38,15 +39,10 @@ export async function GET(
             room: principal.session.roomName,
             canPublish: principal.canPublish,
             displayName: principal.displayName,
-            role: principal.ticketEntitlementId
-                ? 'ATTENDEE'
-                : principal.displayName === 'Administrator'
-                    ? 'ADMIN'
-                    : principal.displayName.toUpperCase(),
+            role: principal.role,
             // Lets the room page gate attendee-only controls (hand queue)
             // without probing an endpoint that 403s for staff.
             principalKind: principal.ticketEntitlementId ? 'ticket' : 'staff',
-            audioDiagnosticEnabled: process.env.E2E_DASHBOARD_ENABLED === '1',
             session: {
                 id: principal.session.id,
                 title: principal.session.title,

--- a/src/app/api/test-login/route.ts
+++ b/src/app/api/test-login/route.ts
@@ -19,7 +19,9 @@ import type { NextRequest } from 'next/server';
 import { prisma } from '@/lib/db';
 import { ticketExpiresAt } from '@/lib/admission';
 import {
+    isValidDisplayName,
     newSessionToken,
+    normalizeDisplayName,
     sessionCookie,
     webSessionExpiry,
 } from '@/lib/principal';
@@ -77,7 +79,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
         const body = (await request.json()) as unknown;
         const fields = (body ?? {}) as Record<string, unknown>;
-        name = typeof fields.name === 'string' ? fields.name.trim().slice(0, 60) : '';
+        name = typeof fields.name === 'string' ? normalizeDisplayName(fields.name) : '';
         role = ROLES.includes(fields.role as DashboardRole)
             ? (fields.role as DashboardRole)
             : 'ATTENDEE';
@@ -86,7 +88,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         return NextResponse.json({ error: 'Malformed request.' }, { status: 400 });
     }
 
-    if (name.length === 0 || !landing) {
+    if (!isValidDisplayName(name) || !landing) {
         return NextResponse.json(
             { error: 'A name, a role and a same-origin landing path are required.' },
             { status: 400 },
@@ -147,6 +149,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         await prisma.webSession.create({
             data: {
                 tokenDigest: issued.database.tokenDigest,
+                displayName: name,
                 staffUserId,
                 ticketEntitlementId,
                 expiresAt: webSessionExpiry(now),

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -22,8 +22,8 @@ const MESSAGES = {
         es: "El ingreso no está disponible en este momento. Probá de nuevo en un momento.",
     },
     required: {
-        en: "Enter your ticket code and the email you used to buy it.",
-        es: "Ingresá tu código de entrada y el correo con el que la compraste.",
+        en: "Enter your name, ticket code and the email you used to buy it.",
+        es: "Ingresá tu nombre, código de entrada y el correo con el que la compraste.",
     },
 } as const;
 
@@ -31,6 +31,7 @@ type MessageKey = keyof typeof MESSAGES;
 
 export default function LoginClient({ next }: { next?: string }) {
     const router = useRouter();
+    const [name, setName] = useState("");
     const [code, setCode] = useState("");
     const [email, setEmail] = useState("");
     const [submitting, setSubmitting] = useState(false);
@@ -47,7 +48,7 @@ export default function LoginClient({ next }: { next?: string }) {
             const response = await fetch("/api/auth/ticket", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ code, email }),
+                body: JSON.stringify({ name, code, email }),
             });
 
             if (response.ok) {
@@ -75,6 +76,23 @@ export default function LoginClient({ next }: { next?: string }) {
 
     return (
         <form onSubmit={onSubmit} className="space-y-5" noValidate>
+            <div className="space-y-1.5">
+                <label htmlFor="display-name" className="block text-sm font-medium text-[var(--paper)]">
+                    <span data-copy="en">Name shown in the room</span>
+                    <span data-copy="es">Nombre visible en la sala</span>
+                </label>
+                <input
+                    id="display-name"
+                    name="name"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    required
+                    maxLength={60}
+                    autoComplete="name"
+                    className="event-field"
+                />
+            </div>
+
             <div className="space-y-1.5">
                 <label htmlFor="ticket-code" className="block text-sm font-medium text-[var(--paper)]">
                     <span data-copy="en">Ticket code</span>

--- a/src/app/login/__tests__/LoginClient.test.tsx
+++ b/src/app/login/__tests__/LoginClient.test.tsx
@@ -20,6 +20,7 @@ import LoginClient from '../LoginClient';
 
 const CODE = 'HB26-A7NQ-92KM-4XZP';
 const EMAIL = 'ana@example.com';
+const NAME = 'Ana';
 
 function mockFetch(response: { status: number; body?: unknown }) {
     const fetchMock = vi.fn().mockResolvedValue({
@@ -33,6 +34,7 @@ function mockFetch(response: { status: number; body?: unknown }) {
 
 async function fillAndSubmit() {
     const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/Name shown in the room/), NAME);
     await user.type(screen.getByLabelText(/Ticket code/), CODE);
     await user.type(screen.getByLabelText(/Email used to buy the ticket/), EMAIL);
     await user.click(screen.getByRole('button', { name: /Enter the event/ }));
@@ -59,7 +61,7 @@ describe('LoginClient', () => {
         const [url, init] = fetchMock.mock.calls[0];
         expect(url).toBe('/api/auth/ticket');
         expect(init.method).toBe('POST');
-        expect(JSON.parse(init.body)).toEqual({ code: CODE, email: EMAIL });
+        expect(JSON.parse(init.body)).toEqual({ name: NAME, code: CODE, email: EMAIL });
 
         await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/session/session-saturday'));
         // The cookie arrived on the response, so the cached router tree is stale.
@@ -142,6 +144,7 @@ describe('LoginClient', () => {
         render(<LoginClient />);
 
         expect(screen.getByText('Código de entrada')).toBeInTheDocument();
+        expect(screen.getByText('Nombre visible en la sala')).toBeInTheDocument();
         expect(screen.getByText('Correo con el que compraste la entrada')).toBeInTheDocument();
         // The reconnect promise, which is the whole point of binding the email.
         expect(screen.getByText(/work again after a refresh or a dropped/)).toBeInTheDocument();

--- a/src/app/ops/layout.tsx
+++ b/src/app/ops/layout.tsx
@@ -23,6 +23,10 @@ export default async function OpsLayout({
     }
 
     const sessions = await prisma.scheduledSession.findMany({
+        where: {
+            status: { in: ['SCHEDULED', 'LIVE'] },
+            ...(staff.role === 'FACILITATOR' ? { facilitatorId: staff.id } : {}),
+        },
         select: { id: true, title: true, language: true, status: true },
         orderBy: { scheduledAt: 'asc' },
     });
@@ -30,11 +34,22 @@ export default async function OpsLayout({
     const links = [
         { href: '/ops/health', label: 'Health' },
         { href: '/ops/admission', label: 'Admission' },
-        ...sessions.map((s) => ({
-            href: `/ops/session/${s.id}`,
-            label: s.language === 'SPANISH' ? 'ES Spotlight' : 'EN Spotlight',
-            live: s.status === 'LIVE',
-        })),
+        ...sessions.flatMap((s) => {
+            const language = s.language === 'SPANISH' ? 'ES' : 'EN';
+            const test = s.title.toLowerCase().includes('(test)') ? ' test' : '';
+            return [
+                {
+                    href: `/session/${s.id}`,
+                    label: `${language} Room${test}`,
+                    live: s.status === 'LIVE',
+                },
+                {
+                    href: `/ops/session/${s.id}`,
+                    label: `${language} Spotlight${test}`,
+                    live: s.status === 'LIVE',
+                },
+            ];
+        }),
     ];
 
     return (

--- a/src/app/ops/session/[id]/page.tsx
+++ b/src/app/ops/session/[id]/page.tsx
@@ -8,6 +8,7 @@
  */
 
 import { cookies } from 'next/headers';
+import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 
 import SpotlightConsole from '@/components/ops/SpotlightConsole';
@@ -63,9 +64,17 @@ export default async function OpsSessionPage({
 
     return (
         <main className="mx-auto max-w-4xl px-4 py-8">
-            <h1 className="mb-1 text-2xl font-semibold">
-                Spotlight console — {scheduledSession.title}
-            </h1>
+            <div className="mb-1 flex flex-wrap items-center justify-between gap-3">
+                <h1 className="text-2xl font-semibold">
+                    Spotlight console — {scheduledSession.title}
+                </h1>
+                <Link
+                    href={`/session/${scheduledSession.id}`}
+                    className="rounded border border-[var(--gold)]/40 px-3 py-2 text-sm text-[var(--gold)] hover:bg-[var(--gold)]/10"
+                >
+                    Enter session room →
+                </Link>
+            </div>
             <p className="mb-6 text-sm text-[var(--text-secondary)]">
                 {scheduledSession.language} · {scheduledSession.status} ·{' '}
                 {scheduledSession.scheduledAt.toISOString()} · signed in as{' '}

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -145,10 +145,9 @@ const TOKEN_RESPONSE = {
     canPublish: false,
     token: 'test-token',
     identity: 'opaque-attendee-12345678',
-    displayName: 'Attendee',
+    displayName: 'Nico',
     role: 'ATTENDEE',
     principalKind: 'ticket',
-    audioDiagnosticEnabled: true,
 };
 
 beforeEach(() => {
@@ -177,21 +176,15 @@ async function renderConnected() {
     await waitFor(() => expect(screen.getByText('Test Session')).toBeInTheDocument());
 }
 
-describe('SessionRoomPage - test identity and audio diagnostics', () => {
-    it('shows the selected test name, authorized role, short identity, and A/B controls', async () => {
-        window.sessionStorage.setItem(
-            'hb:e2e-viewer',
-            JSON.stringify({ name: 'Nico', role: 'ATTENDEE' }),
-        );
-
+describe('SessionRoomPage - participant identity', () => {
+    it('shows the server-authorized display name, role and short identity without diagnostics', async () => {
         await renderConnected();
 
         expect(screen.getByTestId('viewer-identity')).toHaveTextContent(
             'Signed in: Nico · ATTENDEE · ID 12345678',
         );
-        expect(screen.getByText('Audio A/B check')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /Test browser output/i })).toBeInTheDocument();
-        expect(document.querySelector('audio[src*="/api/audio-diagnostic"]')).not.toBeNull();
+        expect(screen.queryByText('Audio A/B check')).not.toBeInTheDocument();
+        expect(document.querySelector('audio[src*="/api/audio-diagnostic"]')).toBeNull();
     });
 });
 

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import Link from "next/link";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import {
     DisconnectReason,
@@ -37,7 +38,6 @@ const STAGE_ROOM_OPTIONS: RoomOptions = {
     },
 };
 
-const FACILITATOR_LABEL = "Facilitator";
 const FALLBACK_LABEL = "Participant";
 
 const STAGE_REFRESH_MS = 100;
@@ -110,6 +110,15 @@ function cameraPublication(participant: Participant): StageVideoPublication | nu
     return publication ?? null;
 }
 
+function participantRole(participant: Participant): string | null {
+    try {
+        const metadata = JSON.parse(participant.metadata || "{}") as { role?: unknown };
+        return typeof metadata.role === "string" ? metadata.role : null;
+    } catch {
+        return null;
+    }
+}
+
 function SessionRoom() {
     const { id } = useParams<{ id: string }>();
     const searchParams = useSearchParams();
@@ -148,8 +157,6 @@ function SessionRoom() {
     const [retryToken, setRetryToken] = useState(0);
     const [audioActivationError, setAudioActivationError] = useState<string | null>(null);
     const [viewerInfo, setViewerInfo] = useState<ViewerInfo | null>(null);
-    const [audioDiagnosticEnabled, setAudioDiagnosticEnabled] = useState(false);
-    const [tonePlaying, setTonePlaying] = useState(false);
 
     const roomRef = useRef<Room | null>(null);
     // Keep ownership by track so an unsubscribe can remove the exact DOM node
@@ -188,7 +195,7 @@ function SessionRoom() {
                     identity: participant.identity,
                     label,
                     isLocal: participant === local,
-                    isFacilitator: label === FACILITATOR_LABEL,
+                    isFacilitator: participantRole(participant) === "FACILITATOR",
                     isSpeaking: participant.isSpeaking,
                     cameraOn: participant.isCameraEnabled,
                     micOn: participant.isMicrophoneEnabled,
@@ -308,22 +315,11 @@ function SessionRoom() {
                 setSessionInfo(data.session);
                 setCanPublish(data.canPublish);
                 setPrincipalKind(data.principalKind === "staff" ? "staff" : "ticket");
-                let viewerName = typeof data.displayName === "string" ? data.displayName : "Participant";
-                try {
-                    const stored = JSON.parse(window.sessionStorage.getItem("hb:e2e-viewer") || "null") as {
-                        name?: unknown;
-                        role?: unknown;
-                    } | null;
-                    if (stored && stored.role === data.role && typeof stored.name === "string" && stored.name.trim()) {
-                        viewerName = stored.name.trim();
-                    }
-                } catch { /* Ignore a malformed UI-only test label. */ }
                 setViewerInfo({
-                    name: viewerName,
+                    name: typeof data.displayName === "string" ? data.displayName : "Participant",
                     role: typeof data.role === "string" ? data.role : "PARTICIPANT",
                     identity: typeof data.identity === "string" ? data.identity : "unknown",
                 });
-                setAudioDiagnosticEnabled(data.audioDiagnosticEnabled === true);
                 if (data.session.startedAt) {
                     const elapsed = Math.floor((Date.now() - new Date(data.session.startedAt).getTime()) / 1000);
                     setDuration(Math.max(0, elapsed));
@@ -603,35 +599,6 @@ function SessionRoom() {
     const connectionLabel = CONNECTION_COPY[connectionState] ?? "Connecting";
     const needsDeviceGesture = canPublish && !isMicOn && !isCameraOn;
 
-    const playBrowserTestTone = async () => {
-        if (tonePlaying) return;
-        setTonePlaying(true);
-        const context = new AudioContext();
-        const gain = context.createGain();
-        gain.gain.value = 0.035;
-        gain.connect(context.destination);
-        const tones = [
-            { frequency: 440, pan: -1 },
-            { frequency: 660, pan: 1 },
-        ];
-        const oscillators = tones.map(({ frequency, pan }) => {
-            const oscillator = context.createOscillator();
-            const panner = context.createStereoPanner();
-            oscillator.type = "sine";
-            oscillator.frequency.value = frequency;
-            panner.pan.value = pan;
-            oscillator.connect(panner).connect(gain);
-            oscillator.start();
-            oscillator.stop(context.currentTime + 1.5);
-            return oscillator;
-        });
-        await context.resume();
-        await new Promise((resolve) => setTimeout(resolve, 1600));
-        oscillators.forEach((oscillator) => oscillator.disconnect());
-        await context.close();
-        setTonePlaying(false);
-    };
-
     return (
         <main className="event-shell">
             <div className="relative z-10 flex min-h-screen flex-col">
@@ -660,7 +627,17 @@ function SessionRoom() {
                             </p>
                         )}
                     </div>
-                    <span className="font-mono text-xs text-[var(--gold)]">{formatTime(duration)}</span>
+                    <div className="ml-3 flex shrink-0 items-center gap-3">
+                        {principalKind === "staff" && (
+                            <Link
+                                href={`/ops/session/${id}`}
+                                className="rounded border border-[var(--gold)]/40 px-2 py-1 text-xs text-[var(--gold)] hover:bg-[var(--gold)]/10"
+                            >
+                                Spotlight · hands
+                            </Link>
+                        )}
+                        <span className="font-mono text-xs text-[var(--gold)]">{formatTime(duration)}</span>
+                    </div>
                 </header>
 
                 {/* Stage */}
@@ -746,28 +723,6 @@ function SessionRoom() {
                     {' · '}Live: {hasLiveStream ? <span className="text-[var(--lime)]">active</span> : <span className="text-[var(--danger)]">none</span>}
                     {beaconAudioError ? <>{' · '}<span className="text-[var(--danger)]">error: {beaconAudioError}</span></> : null}
                 </div>
-
-                {audioDiagnosticEnabled && (
-                    <details className="mx-auto mb-3 w-[calc(100%-2rem)] max-w-md rounded border border-[var(--gold)]/30 bg-[var(--surface-alt)] px-3 py-2 text-xs text-[var(--text-secondary)]">
-                        <summary className="cursor-pointer font-semibold text-[var(--gold)]">Audio A/B check</summary>
-                        <ol className="mt-3 space-y-3">
-                            <li>
-                                <button type="button" onClick={() => void playBrowserTestTone()} disabled={tonePlaying} className="event-button event-button--secondary w-full">
-                                    {tonePlaying ? "Playing left/right tones…" : "1. Test browser output (left 440 / right 660)"}
-                                </button>
-                            </li>
-                            <li>
-                                <p className="mb-1">2. Original OGG directly in this browser (bypasses LiveKit)</p>
-                                <audio controls preload="metadata" className="w-full" src={`/api/audio-diagnostic?sessionId=${encodeURIComponent(id)}`}>
-                                    Your browser does not support OGG audio.
-                                </audio>
-                            </li>
-                            <li>
-                                3. LiveKit stream: use “Start audio” above, then compare it with step 2.
-                            </li>
-                        </ol>
-                    </details>
-                )}
 
                 {/* Bottom controls */}
                 <div className="border-t border-[var(--border-subtle)] px-4 py-4">

--- a/src/app/test-login/page.tsx
+++ b/src/app/test-login/page.tsx
@@ -48,12 +48,6 @@ export default function TestLoginPage() {
                 setBusy(false);
                 return;
             }
-            // UI-only test label. Authorization continues to come exclusively
-            // from the HttpOnly session cookie and the server-side role.
-            window.sessionStorage.setItem(
-                "hb:e2e-viewer",
-                JSON.stringify({ name: name.trim(), role }),
-            );
             window.location.assign(landing);
         } catch {
             setError("Network error");

--- a/src/components/ops/SpotlightConsole.tsx
+++ b/src/components/ops/SpotlightConsole.tsx
@@ -330,6 +330,52 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                 </button>
             </div>
 
+            {/* Hand queue comes first so a facilitator never has to hunt below the stage. */}
+            <div>
+                <h2 className="mb-1 text-lg font-semibold text-[var(--cream)]">Hand queue</h2>
+                <p className="mb-2 text-xs text-[var(--text-muted)]">
+                    Raised hands appear here automatically. Give floor moves a connected person to the stage; Remove hand clears the request.
+                </p>
+                {queue.length === 0 ? (
+                    <p className="text-sm text-[var(--text-secondary)]">No hands raised.</p>
+                ) : (
+                    <ul className="space-y-2">
+                        {queue.map((participant) => (
+                            <li key={participant.id} className="flex items-center justify-between gap-3 operational-panel">
+                                <div className="min-w-0">
+                                    <span className="font-medium text-[var(--cream)]">#{participant.queuePosition} — {participantLabel(participant)}</span>
+                                    <div className="text-xs text-[var(--text-secondary)]">
+                                        waiting {participant.raisedAt ? formatQueueAge(participant.raisedAt, nowMs) : '…'}
+                                        {' · '}{connectionBadge(participant)}
+                                        {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()} quality` : ''}
+                                        {participant.reconcileNeeded ? ' · reconcile needed' : ''}
+                                    </div>
+                                </div>
+                                <div className="flex shrink-0 items-center gap-2">
+                                    <button
+                                        type="button"
+                                        disabled={busyKey !== null || participant.connected !== true}
+                                        onClick={() => void giveFloor(participant)}
+                                        title={participant.connected === true ? undefined : 'Participant must be connected before joining the stage'}
+                                        className="min-h-10 rounded border border-[var(--lime)] px-3 py-2 text-xs text-[var(--lime)] hover:bg-[var(--lime)]/10 disabled:opacity-50"
+                                    >
+                                        {participant.connected === true ? 'Give floor' : 'Waiting for reconnect'}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        disabled={busyKey !== null}
+                                        onClick={() => void removeHand(participant)}
+                                        className="min-h-10 rounded border border-[var(--border-subtle)] px-3 py-2 text-xs hover:bg-white/5 disabled:opacity-50"
+                                    >
+                                        Remove hand
+                                    </button>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+
             {/* Stage */}
             <div>
                 <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">On stage</h2>
@@ -383,49 +429,6 @@ export default function SpotlightConsole({ sessionId, role }: Props) {
                                             </span>
                                         )}
                                     </div>
-                                </div>
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </div>
-
-            {/* Hand queue */}
-            <div>
-                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">Hand queue</h2>
-                {queue.length === 0 ? (
-                    <p className="text-sm text-[var(--text-secondary)]">No hands raised.</p>
-                ) : (
-                    <ul className="space-y-2">
-                        {queue.map((participant) => (
-                            <li key={participant.id} className="flex items-center justify-between gap-3 operational-panel">
-                                <div className="min-w-0">
-                                    <span className="font-medium text-[var(--cream)]">#{participant.queuePosition} — {participantLabel(participant)}</span>
-                                    <div className="text-xs text-[var(--text-secondary)]">
-                                        waiting {participant.raisedAt ? formatQueueAge(participant.raisedAt, nowMs) : '…'}
-                                        {' · '}{connectionBadge(participant)}
-                                        {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()} quality` : ''}
-                                        {participant.reconcileNeeded ? ' · reconcile needed' : ''}
-                                    </div>
-                                </div>
-                                <div className="flex shrink-0 items-center gap-2">
-                                    <button
-                                        type="button"
-                                        disabled={busyKey !== null || participant.connected !== true}
-                                        onClick={() => void giveFloor(participant)}
-                                        title={participant.connected === true ? undefined : 'Participant must be connected before joining the stage'}
-                                        className="min-h-10 rounded border border-[var(--lime)] px-3 py-2 text-xs text-[var(--lime)] hover:bg-[var(--lime)]/10 disabled:opacity-50"
-                                    >
-                                        {participant.connected === true ? 'Give floor' : 'Waiting for reconnect'}
-                                    </button>
-                                    <button
-                                        type="button"
-                                        disabled={busyKey !== null}
-                                        onClick={() => void removeHand(participant)}
-                                        className="min-h-10 rounded border border-[var(--border-subtle)] px-3 py-2 text-xs hover:bg-white/5 disabled:opacity-50"
-                                    >
-                                        Remove hand
-                                    </button>
                                 </div>
                             </li>
                         ))}

--- a/src/components/session/HandRaiseButton.tsx
+++ b/src/components/session/HandRaiseButton.tsx
@@ -127,22 +127,24 @@ export default function HandRaiseButton({ sessionId, onPublishGrantChange }: Pro
 
     return (
         <div className="flex flex-col items-center gap-2">
-            <button
-                type="button"
-                onClick={() => void setHand(!(state?.raised ?? false))}
-                disabled={busy || authorizationBlocked}
-                className={`rounded-full px-5 py-2.5 text-sm font-medium transition-all ${
-                    state?.raised
-                        ? 'bg-[var(--pink)] text-[var(--ink)] shadow-[0_0_16px_rgba(255,113,189,0.3)]'
-                        : 'bg-white/10 text-[var(--text-muted)] hover:bg-white/20'
-                } disabled:opacity-50`}
-            >
-                {state?.raised ? 'Lower hand / Bajar mano' : 'Raise hand / Levantar mano'}
-            </button>
+            {!state?.canPublish ? (
+                <button
+                    type="button"
+                    onClick={() => void setHand(!(state?.raised ?? false))}
+                    disabled={busy || authorizationBlocked}
+                    className={`rounded-full px-5 py-2.5 text-sm font-medium transition-all ${
+                        state?.raised
+                            ? 'bg-[var(--pink)] text-[var(--ink)] shadow-[0_0_16px_rgba(255,113,189,0.3)]'
+                            : 'bg-white/10 text-[var(--text-muted)] hover:bg-white/20'
+                    } disabled:opacity-50`}
+                >
+                    {state?.raised ? 'Lower hand / Bajar mano' : 'Raise hand / Levantar mano'}
+                </button>
+            ) : null}
             {state?.canPublish ? (
                 <p role="status" className="text-xs text-[var(--lime)]">
-                    Your turn — enable mic and camera below.
-                    <span className="mt-0.5 block opacity-80">Tu turno — activá micrófono y cámara abajo.</span>
+                    You are on stage — enable mic and camera below.
+                    <span className="mt-0.5 block opacity-80">Estás en escena — activá micrófono y cámara abajo.</span>
                 </p>
             ) : state?.raised && state.queuePosition !== null ? (
                 <p role="status" className="text-xs text-[var(--text-muted)]">

--- a/src/components/session/__tests__/HandRaiseButton.test.tsx
+++ b/src/components/session/__tests__/HandRaiseButton.test.tsx
@@ -104,8 +104,9 @@ describe('HandRaiseButton', () => {
         // can now offer mic/camera. No token refetch, no reconnect.
         await waitFor(() => expect(onGrant).toHaveBeenCalledWith(true), { timeout: 4000 });
         await waitFor(() => {
-            expect(screen.getByText(/Your turn — enable mic and camera/)).toBeInTheDocument();
+            expect(screen.getByText(/You are on stage — enable mic and camera/)).toBeInTheDocument();
         });
+        expect(screen.queryByRole('button', { name: /hand/i })).not.toBeInTheDocument();
     });
 
     it('surfaces a polling failure without clearing the current state', async () => {

--- a/src/lib/__tests__/livekit-server.test.ts
+++ b/src/lib/__tests__/livekit-server.test.ts
@@ -3,12 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const addGrant = vi.fn();
 const toJwt = vi.fn().mockResolvedValue('jwt');
 const RoomServiceClient = vi.hoisted(() => vi.fn(function () {}));
+const AccessToken = vi.hoisted(() => vi.fn(function (
+    this: Record<string, unknown>,
+    _key: string,
+    _secret: string,
+    options: Record<string, unknown>,
+) {
+    this.options = options;
+    this.addGrant = addGrant;
+    this.toJwt = toJwt;
+}));
 
 vi.mock('livekit-server-sdk', () => ({
-    AccessToken: vi.fn(function (this: Record<string, unknown>) {
-        this.addGrant = addGrant;
-        this.toJwt = toJwt;
-    }),
+    AccessToken,
     RoomServiceClient,
     TrackSource: {
         MICROPHONE: 2,
@@ -41,7 +48,18 @@ describe('livekit-server', () => {
 
     it('limits publishing grants to microphone and camera', async () => {
         const { createSessionToken } = await import('../livekit-server');
-        await createSessionToken('stage', 'identity', 'Attendee', true);
+        await createSessionToken('stage', 'identity', 'Ana', true, 'ATTENDEE');
+
+        expect(AccessToken).toHaveBeenCalledWith(
+            'key',
+            'secret-long-enough',
+            {
+                identity: 'identity',
+                name: 'Ana',
+                metadata: JSON.stringify({ role: 'ATTENDEE' }),
+                ttl: '4h',
+            },
+        );
 
         expect(addGrant).toHaveBeenCalledWith({
             roomJoin: true,

--- a/src/lib/__tests__/room-entitlement.test.ts
+++ b/src/lib/__tests__/room-entitlement.test.ts
@@ -35,6 +35,7 @@ const activeEvent = {
     facilitatorId: 'facilitator-1',
 };
 const activeTicketSession = {
+    displayName: 'Ana',
     expiresAt: new Date('2026-08-03T00:00:00Z'),
     revokedAt: null,
     staffUser: null,
@@ -141,7 +142,8 @@ describe('resolveRoomPrincipal', () => {
             principal: {
                 identity: 'opaque:event-1:ticket:ticket-1',
                 canPublish: true,
-                displayName: 'Attendee',
+                displayName: 'Ana',
+                role: 'ATTENDEE',
             },
         });
         expect(upsertParticipant).toHaveBeenCalledWith(expect.objectContaining({
@@ -156,6 +158,7 @@ describe('resolveRoomPrincipal', () => {
             ticketEntitlement: null,
             staffUser: {
                 id: 'facilitator-1',
+                name: 'Julián',
                 role: 'FACILITATOR',
                 disabledAt: null,
             },
@@ -205,6 +208,7 @@ describe('resolveRoomPrincipal', () => {
             ticketEntitlement: null,
             staffUser: {
                 id: 'facilitator-1',
+                name: 'Julián',
                 role: 'FACILITATOR',
                 disabledAt: null,
             },
@@ -218,7 +222,7 @@ describe('resolveRoomPrincipal', () => {
 
         expect(result).toMatchObject({
             ok: true,
-            principal: { canPublish: true, displayName: 'Facilitator' },
+            principal: { canPublish: true, displayName: 'Julián', role: 'FACILITATOR' },
         });
         expect(upsertParticipant).toHaveBeenCalledWith(expect.objectContaining({
             create: expect.objectContaining({
@@ -235,6 +239,7 @@ describe('resolveRoomPrincipal', () => {
             ticketEntitlement: null,
             staffUser: {
                 id: 'operator-1',
+                name: 'Oliva',
                 role: 'OPERATOR',
                 disabledAt: null,
             },
@@ -244,7 +249,7 @@ describe('resolveRoomPrincipal', () => {
 
         expect(result).toMatchObject({
             ok: true,
-            principal: { canPublish: false, displayName: 'Operator' },
+            principal: { canPublish: false, displayName: 'Oliva', role: 'OPERATOR' },
         });
     });
 
@@ -255,6 +260,7 @@ describe('resolveRoomPrincipal', () => {
             ticketEntitlement: null,
             staffUser: {
                 id: 'facilitator-2',
+                name: 'Other facilitator',
                 role: 'FACILITATOR',
                 disabledAt: null,
             },

--- a/src/lib/livekit-server.ts
+++ b/src/lib/livekit-server.ts
@@ -68,11 +68,13 @@ export async function createSessionToken(
     identity: string,
     name: string,
     canPublish: boolean,
+    role?: 'ATTENDEE' | 'FACILITATOR' | 'OPERATOR' | 'ADMIN',
 ): Promise<string> {
     requireLiveKitCredentials();
     const token = new AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET, {
         identity,
         name,
+        metadata: role ? JSON.stringify({ role }) : undefined,
         ttl: '4h',
     });
 

--- a/src/lib/principal.ts
+++ b/src/lib/principal.ts
@@ -61,6 +61,15 @@ export function normalizeLoginEmail(rawEmail: string): string {
     return rawEmail.trim().toLowerCase();
 }
 
+/** A short participant-chosen label safe for room tiles and operator controls. */
+export function normalizeDisplayName(rawName: string): string {
+    return rawName.trim().replace(/\s+/g, ' ').slice(0, 60);
+}
+
+export function isValidDisplayName(name: string): boolean {
+    return name.length > 0 && name.length <= 60 && !/[\u0000-\u001f\u007f]/.test(name);
+}
+
 /**
  * Shape check only. There is no email delivery anywhere in this product, so an
  * address is a matching key rather than a channel and its deliverability is not

--- a/src/lib/room-entitlement.ts
+++ b/src/lib/room-entitlement.ts
@@ -16,7 +16,8 @@ export type RoomPrincipal = {
         startedAt: Date | null;
     };
     identity: string;
-    displayName: 'Attendee' | 'Facilitator' | 'Operator' | 'Administrator';
+    displayName: string;
+    role: 'ATTENDEE' | 'FACILITATOR' | 'OPERATOR' | 'ADMIN';
     canPublish: boolean;
     ticketEntitlementId: string | null;
     staffUserId: string | null;
@@ -51,11 +52,13 @@ export async function resolveRoomPrincipal(
     const webSession = await prisma.webSession.findUnique({
         where: { tokenDigest: digestSessionToken(cookieValue) },
         select: {
+            displayName: true,
             expiresAt: true,
             revokedAt: true,
             staffUser: {
                 select: {
                     id: true,
+                    name: true,
                     role: true,
                     disabledAt: true,
                 },
@@ -109,6 +112,7 @@ export async function resolveRoomPrincipal(
     let ticketEntitlementId: string | null = null;
     let staffUserId: string | null = null;
     let displayName: RoomPrincipal['displayName'];
+    let role: RoomPrincipal['role'];
     let facilitatorCanPublish = false;
 
     if (ticket) {
@@ -126,7 +130,8 @@ export async function resolveRoomPrincipal(
         principalId = ticket.id;
         principalKind = 'ticket';
         ticketEntitlementId = ticket.id;
-        displayName = 'Attendee';
+        displayName = webSession.displayName?.trim() || 'Attendee';
+        role = 'ATTENDEE';
     } else {
         if (
             !staff ||
@@ -150,12 +155,14 @@ export async function resolveRoomPrincipal(
         principalKind = 'staff';
         staffUserId = staff.id;
         facilitatorCanPublish = isFacilitator;
-        displayName =
+        displayName = staff.name?.trim() || (
             staff.role === 'FACILITATOR'
                 ? 'Facilitator'
                 : staff.role === 'OPERATOR'
                     ? 'Operator'
-                    : 'Administrator';
+                    : 'Administrator'
+        );
+        role = staff.role;
     }
 
     const identity = stableRoomIdentity(
@@ -228,6 +235,7 @@ export async function resolveRoomPrincipal(
             },
             identity,
             displayName,
+            role,
             canPublish:
                 participant.publishGrantedAt !== null &&
                 participant.publishRevokedAt === null,


### PR DESCRIPTION
## What changed

- persist a participant-chosen display name on the web session and use it as the LiveKit participant name
- use real staff names (for example, Julián) while keeping role metadata separate for stage policy
- show connected attendee names in Spotlight controls and stage tiles
- add active Room and Spotlight links to the staff navigation, scoped to the facilitator's assigned sessions
- add direct Room → Spotlight/hands and Spotlight → Room links
- move the hand queue above the stage controls and explain Give floor / Remove hand
- hide the attendee hand button once that person is already on stage
- remove the Audio A/B diagnostic UI and token flag; the protected diagnostic endpoint remains available for future incident response

## Root cause

The test dashboard stored the chosen name only in sessionStorage. LiveKit tokens were still minted with role words such as "Attendee" or "Facilitator", so every stage tile inherited the role instead of the person's name. The facilitator room and Spotlight console also had no bidirectional navigation, and the hand queue sat below the stage list.

## User impact

New attendee logins ask for a short "Name shown in the room". Existing attendee web sessions safely retain the "Attendee" fallback until the attendee signs in again. Staff names are sourced from the staff account. Display names are presentation only; authorization continues to use the opaque HttpOnly session and stable non-PII LiveKit identity.

## Database and deploy

This includes one additive nullable column plus a 1–60 character check constraint:

`prisma/migrations/20260731223000_web_session_display_name/migration.sql`

Deploy order is important: apply `npx prisma migrate deploy` before replacing/restarting the app container. Rollback is the previous app image/commit; the extra nullable column can remain unused.

## Verification

- Prisma schema validation
- TypeScript (`npx tsc --noEmit`)
- ESLint (0 errors; 2 pre-existing ThumbnailTapestry warnings)
- 49 test files / 428 tests
- production build
- focused tests cover name normalization/persistence, LiveKit role metadata, operator-visible names, hand lifecycle, and Audio A/B removal

## Risk

Low-to-moderate and localized to session identity/login UI. The schema change is additive. No Beacon audio transport, codec, buffering, gain, or crossfader code changed.