### PR TITLE
fix(ops): preserve mona nginx parity

### DIFF
--- a/deploy/nginx-harmonic-beacon.conf
+++ b/deploy/nginx-harmonic-beacon.conf
@@ -51,11 +51,11 @@ server {
     client_max_body_size 100M;
     server_name live.harmonicbeacon.com;
 
-    # SSL managed by Certbot — paths filled by `certbot --nginx`
+    # SSL managed by Certbot — paths filled by `certbot --nginx`. Keep this
+    # file aligned with mona: that host does not install the optional shared
+    # options or DH-parameter snippets.
     ssl_certificate     /etc/letsencrypt/live/live.harmonicbeacon.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/live.harmonicbeacon.com/privkey.pem;
-    include /etc/letsencrypt/options-ssl-nginx.conf;
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     # Security headers
     add_header X-Frame-Options SAMEORIGIN always;
@@ -141,6 +141,12 @@ server {
         proxy_set_header Host $host;
         proxy_connect_timeout 5s;
         proxy_read_timeout 5s;
+    }
+
+    # --- Static operator status page (kept outside the app for outages) ---
+    location = /status {
+        alias /var/www/harmonic-beacon/status.html;
+        default_type text/html;
     }
 
     # --- Next.js app (everything else) ---


### PR DESCRIPTION
Production parity hotfix discovered during the authorized #75 rollout.

- preserves the working `/status` static outage page
- removes references to optional Certbot snippets that are not installed on mona
- retains the #75 auth rate limit, internal-route deny, and tapestry proxy

The live config has not yet been replaced. Deployment will back up the current file, install this candidate, require `nginx -t`, reload, and verify health/status/auth/tapestry. Any validation failure restores the backup before reload.

No application or database code changes.