### PR TITLE
fix(ops): keep tapestry behind app authorization

### DIFF
--- a/deploy/nginx-harmonic-beacon.conf
+++ b/deploy/nginx-harmonic-beacon.conf
@@ -3,7 +3,7 @@
 # Enable:    ln -sf /etc/nginx/sites-available/harmonic-beacon /etc/nginx/sites-enabled/
 # SSL:       managed by Certbot (auto-modifies this file)
 #
-# Proxies: app (127.0.0.1:3000), LiveKit signaling+WS (127.0.0.1:7880), tapestry (127.0.0.1:3100)
+# Proxies: app (127.0.0.1:3000), LiveKit signaling+WS (127.0.0.1:7880)
 
 upstream harmonic_beacon_app {
     server 127.0.0.1:3000;
@@ -12,11 +12,6 @@ upstream harmonic_beacon_app {
 
 upstream livekit_signal {
     server 127.0.0.1:7880;
-    keepalive 32;
-}
-
-upstream tapestry_service {
-    server 127.0.0.1:3100;
     keepalive 32;
 }
 
@@ -88,16 +83,6 @@ server {
         proxy_connect_timeout 10s;
         proxy_send_timeout 30s;
         proxy_read_timeout 30s;
-    }
-
-    # --- Tapestry composite endpoint (public, no auth) ---
-    location ^~ /api/tapestry/ {
-        proxy_pass http://tapestry_service/;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_read_timeout 10s;
     }
 
     # --- LiveKit realtime signaling (WebSocket upgrade) ---


### PR DESCRIPTION
Follow-up found while validating the merged Nginx candidate against the real Tapestry service routes.

The direct `/api/tapestry/` proxy was both path-incompatible and missing the internal-secret/authentication behavior implemented by the Next.js route. Remove it so the generic app proxy remains the only public path, preserving current working behavior and authorization.

This bad route was never installed or reloaded on mona.