### PR TITLE
fix(ops): clear stale real-event reconciliation

### DIFF
--- a/docs/ops/WEEKEND_EVENT_RUNBOOK.md
+++ b/docs/ops/WEEKEND_EVENT_RUNBOOK.md
@@ -118,6 +118,10 @@ It never deletes data or disconnects participants. Never bypass these checks
 with ad-hoc SQL; if one fails, investigate the changed state and take a new
 backup/dry-run.
 
+Because all four rooms must be empty, apply also clears stale reconciliation
+flags on disconnected production participants. It does not revoke their
+durable grants or alter their hand state.
+
 Rollback: if verification immediately after apply fails, freeze admission and
 restore the just-verified pre-apply PostgreSQL backup before admitting anyone.
 The mutation is a single serializable transaction, so there is no partial

--- a/scripts/weekend-stabilize.ts
+++ b/scripts/weekend-stabilize.ts
@@ -223,6 +223,7 @@ async function applyStabilization(
             webSessionsRevoked: 0,
             grantsRevoked: 0,
             participantFlagsCleared: 0,
+            realReconciliationFlagsCleared: 0,
             livekitRooms,
         };
 
@@ -288,6 +289,19 @@ async function applyStabilization(
                     data: { raisedAt: null, grantReconcileNeeded: false },
                 });
                 summary.participantFlagsCleared += flags.count;
+            } else {
+                // Every stage room was checked empty twice. A reconciliation
+                // flag on a disconnected real-event participant cannot
+                // represent a live LiveKit disagreement and would otherwise
+                // create a false incident in the event cockpit.
+                const flags = await tx.sessionParticipant.updateMany({
+                    where: {
+                        scheduledSessionId: contract.id,
+                        grantReconcileNeeded: true,
+                    },
+                    data: { grantReconcileNeeded: false },
+                });
+                summary.realReconciliationFlagsCleared += flags.count;
             }
         }
 


### PR DESCRIPTION
Production dry-run found one stale reconciliation flag on an empty real event room. Leaving it would create a false cockpit incident when doors open.

Extend the guarded stabilization transaction to clear only `grantReconcileNeeded` on real-session participants after both LiveKit emptiness checks pass. Durable grants and hand state are unchanged. Test-session cleanup remains unchanged.

Targeted tests, TypeScript and ESLint pass. Production data is still untouched: the previous apply was rejected because the rehearsal room remains occupied.