### PR TITLE
feat(ops): terminate event media on close

### DIFF
--- a/docs/TRUST_AND_SAFETY.md
+++ b/docs/TRUST_AND_SAFETY.md
@@ -139,28 +139,32 @@ Legal and privacy considerations may delay disclosure; they never eliminate it.
 
 ## 4. The Session Kill Switch
 
-> **The Kill Switch exists**, at `POST /api/admin/sessions/[id]/terminate`. An
-> Admin can end any live session, including one whose Provider is the problem —
-> a compromised account, abuse from the host mic — which was the case with no
-> control at all. It stops any active egress, disconnects participants, moves the
-> session to ENDED, and requires a written reason: terminating someone else's live
-> session without recording why is what the audit log exists to prevent, so a
-> missing reason is a refusal rather than a default.
+> **The event Kill Switch exists** in the selected event's **Event doors**
+> control and at `POST /api/ops/sessions/[id]/lifecycle`. An authorized assigned
+> facilitator, operator, admin, or facilitator-operator can end a live session.
+> The durable status changes to `ENDED` before LiveKit is touched, so no new
+> tokens can be issued. The server then deletes that event's Stage room and
+> removes only its listeners from the shared Beacon room; the Beacon publisher
+> and other events are deliberately preserved.
 >
-> Three of the five behaviours below are delivered. Locking the session against
-> restart falls out of the status change, since starting requires SCHEDULED.
+> The action and each media-termination attempt are audited, including redacted
+> disconnection counts and failure categories. A partial failure is visible in
+> the cockpit and exposes an idempotent **Disconnect remaining clients** retry.
+> Locking the session against restart falls out of the status change, since
+> starting requires `SCHEDULED`.
 > **Not delivered:** suspending the Provider's ability to open new sessions
-> pending review — there is no suspension field on `User`, so this was left
-> unbuilt rather than invented — and the participant-facing message, which is
-> client-side. Both are tracked. **[Planned — Phase 1]** *(items 3 and 5)*
+> pending review — this event product has no Provider suspension model — and a
+> full incident snapshot. Both remain planned. **[Planned — Phase 1]** *(items
+> 3 and 4)*
 
-A single-click control, available to Admin on any live `ScheduledSession`, that will:
+A confirmation-guarded control on a live `ScheduledSession` that will:
 
 1. Terminate the LiveKit room, disconnecting all participants.
 2. Lock the session to prevent restart from the UI.
 3. Suspend the Provider's ability to start new sessions pending review.
-4. Capture a snapshot of the session metadata for incident records.
-5. Surface a generic "session ended" message to participants.
+4. Capture a full snapshot of the session metadata for incident records.
+5. Surface a generic "session ended" message to participants on the next
+   status poll.
 
 The Kill Switch will be used in response to:
 
@@ -169,7 +173,10 @@ The Kill Switch will be used in response to:
 - Legal compulsion.
 - Severe technical malfunction (inaudible, looping, or corrupted output).
 
-Use of the Kill Switch will be logged with the Admin identity, the timestamp, and the declared reason, and reviewed by a second Admin post-incident. That logging is the audit log of [BUSINESS_RULES.md §1.3](../BUSINESS_RULES.md), which does not exist either; the two ship together or the control ships unaccountable. **[Planned — Phase 1]**
+Use of the Kill Switch is logged with the staff identity, role, timestamp,
+lifecycle transition, disconnection counts and redacted failure categories.
+Admin cancellation additionally requires a printable non-PII reason. A second
+Admin review and the public post-incident workflow remain operational policy.
 
 ---
 

--- a/docs/ops/WEEKEND_EVENT_RUNBOOK.md
+++ b/docs/ops/WEEKEND_EVENT_RUNBOOK.md
@@ -19,15 +19,21 @@ longer require SQL.
    correct title, then press **Open doors**. A repeated press is harmless.
 2. Keep the waiting-room page open on a test attendee: it must move into the
    room automatically, without re-entering the ticket.
-3. After the session, press **Close event**, review the impact copy, and confirm.
-   Connected attendee clients move to the closing state and both media rooms
-   disconnect locally on their next status check.
+3. After the session, press **Close event**, review the impact copy, then press
+   **End & disconnect everyone**. The server first records `ENDED`, then deletes
+   that event's Stage room and removes only that event's listeners from the
+   shared Beacon room. The Beacon source and other events stay connected.
+   Browsers also move to the closing state on their next three-second status
+   check.
 4. Admin cancellation and opening outside the -10/+60 minute window require a
    short operational reason. Never put attendee names, emails, ticket codes or
    session tokens in that field.
 
-If a lifecycle action fails, do not edit the database. Record the response code,
-refresh the event console, and escalate to the incident commander.
+The response reports separate Stage and Beacon disconnection counts. If either
+LiveKit action or its audit is incomplete, use **Disconnect remaining clients**;
+the retry is idempotent and cannot reopen the event. If it still fails, do not
+edit the database. Record the response code, refresh the event console, and
+escalate to the incident commander.
 
 ---
 

--- a/e2e/tests/session-termination.spec.ts
+++ b/e2e/tests/session-termination.spec.ts
@@ -1,0 +1,71 @@
+import { expect, stackTest } from '../fixtures/stack';
+import { loginViaDashboard } from '../fixtures/auth';
+import { requireDirectDb, withSessionStatus } from '../fixtures/db';
+import { ROUTES, SESSION_ES } from '../fixtures/test-data';
+
+/**
+ * The operational kill path against real browsers, the fixture database and
+ * a real LiveKit server. This proves more than a durable ENDED flag: connected
+ * Stage and Beacon clients are expelled and render the terminal state.
+ */
+stackTest('ending an event immediately disconnects every selected-session client', async ({
+    browser,
+}, testInfo) => {
+    stackTest.slow();
+    const db = requireDirectDb(testInfo);
+    await withSessionStatus(db, SESSION_ES.id, 'LIVE', async () => {
+        const attendeeContext = await browser.newContext();
+        const operatorContext = await browser.newContext();
+        const attendee = await attendeeContext.newPage();
+        const operator = await operatorContext.newPage();
+
+        try {
+            await loginViaDashboard(
+                attendee,
+                'ATTENDEE',
+                'Termination Attendee',
+                ROUTES.session(SESSION_ES.id),
+            );
+            await expect(attendee.getByTestId('connection-state')).toHaveAttribute(
+                'data-state',
+                'connected',
+                { timeout: 20_000 },
+            );
+
+            await loginViaDashboard(
+                operator,
+                'OPERATOR',
+                'Termination Operator',
+                ROUTES.opsSession(SESSION_ES.id),
+            );
+            const room = operator.frameLocator('[data-testid="persistent-room"]');
+            await expect(room.getByTestId('connection-state')).toHaveAttribute(
+                'data-state',
+                'connected',
+                { timeout: 20_000 },
+            );
+
+            await operator.locator('[data-signal="door"]').click();
+            await operator.getByRole('button', { name: 'Close event' }).click();
+            await expect(operator.getByRole('alertdialog')).toContainText(
+                'Other events and the Beacon source stay online',
+            );
+            await operator.getByRole('button', {
+                name: 'End & disconnect everyone',
+            }).click();
+
+            await expect(operator.getByRole('status')).toContainText(
+                /Disconnected [1-9]\d* Stage and [1-9]\d* Beacon connections/,
+            );
+            await expect(attendee.getByRole('heading', {
+                name: /Session ended|La sesión terminó/i,
+            })).toBeVisible({ timeout: 10_000 });
+            await expect(room.getByRole('heading', {
+                name: /Session ended|La sesión terminó/i,
+            })).toBeVisible({ timeout: 10_000 });
+        } finally {
+            await attendeeContext.close();
+            await operatorContext.close();
+        }
+    });
+});

--- a/src/app/api/ops/sessions/[id]/lifecycle/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/lifecycle/__tests__/route.test.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRequest, mockParams, parseResponse } from '@/__tests__/helpers';
 import { SessionLifecycleError } from '@/lib/session-lifecycle';
 
-const { resolveStaffSession, transitionScheduledSession } = vi.hoisted(() => ({
+const { resolveStaffSession, transitionScheduledSession, terminateSessionMedia } = vi.hoisted(() => ({
     resolveStaffSession: vi.fn(),
     transitionScheduledSession: vi.fn(),
+    terminateSessionMedia: vi.fn(),
 }));
 
 vi.mock('@/lib/ops-auth', () => ({ resolveStaffSession }));
@@ -13,6 +14,7 @@ vi.mock('@/lib/session-lifecycle', async (importOriginal) => {
     const original = await importOriginal<typeof import('@/lib/session-lifecycle')>();
     return { ...original, transitionScheduledSession };
 });
+vi.mock('@/lib/session-termination', () => ({ terminateSessionMedia }));
 
 describe('POST /api/ops/sessions/[id]/lifecycle', () => {
     beforeEach(() => {
@@ -29,6 +31,12 @@ describe('POST /api/ops/sessions/[id]/lifecycle', () => {
             status: 'LIVE',
             startedAt: new Date('2026-08-01T18:00:00Z'),
             endedAt: null,
+        });
+        terminateSessionMedia.mockResolvedValue({
+            complete: true,
+            stageDisconnected: 2,
+            bedDisconnected: 2,
+            failures: [],
         });
     });
 
@@ -76,7 +84,41 @@ describe('POST /api/ops/sessions/[id]/lifecycle', () => {
             targetStatus: 'LIVE',
             reason: 'Doors ready',
         });
+        expect(terminateSessionMedia).not.toHaveBeenCalled();
     });
+
+    it.each(['ENDED', 'CANCELLED'] as const)(
+        'immediately terminates media for %s, including an idempotent retry',
+        async (targetStatus) => {
+            transitionScheduledSession.mockResolvedValue({
+                changed: false,
+                previousStatus: targetStatus,
+                status: targetStatus,
+                startedAt: new Date('2026-08-01T18:00:00Z'),
+                endedAt: new Date('2026-08-01T19:00:00Z'),
+            });
+            const { POST } = await import('../route');
+            const { status, body } = await parseResponse(await POST(
+                createRequest('/api/ops/sessions/event-1/lifecycle', {
+                    method: 'POST',
+                    body: { status: targetStatus, reason: 'End the experience' },
+                }),
+                mockParams({ id: 'event-1' }),
+            ));
+
+            expect(status).toBe(200);
+            expect(body).toMatchObject({
+                changed: false,
+                status: targetStatus,
+                termination: { complete: true, stageDisconnected: 2, bedDisconnected: 2 },
+            });
+            expect(terminateSessionMedia).toHaveBeenCalledWith({
+                sessionId: 'event-1',
+                actorUserId: 'operator-1',
+                actorRole: 'OPERATOR',
+            });
+        },
+    );
 
     it('preserves lifecycle conflict semantics', async () => {
         transitionScheduledSession.mockRejectedValue(

--- a/src/app/api/ops/sessions/[id]/lifecycle/route.ts
+++ b/src/app/api/ops/sessions/[id]/lifecycle/route.ts
@@ -6,6 +6,7 @@ import {
     transitionScheduledSession,
     type LifecycleTargetStatus,
 } from '@/lib/session-lifecycle';
+import { terminateSessionMedia } from '@/lib/session-termination';
 
 export const dynamic = 'force-dynamic';
 
@@ -55,10 +56,18 @@ export async function POST(
             targetStatus: body.status as LifecycleTargetStatus,
             reason,
         });
+        const termination = result.status === 'ENDED' || result.status === 'CANCELLED'
+            ? await terminateSessionMedia({
+                sessionId: id,
+                actorUserId: staff.id,
+                actorRole: staff.role,
+            })
+            : undefined;
         return NextResponse.json({
             ...result,
             startedAt: result.startedAt?.toISOString() ?? null,
             endedAt: result.endedAt?.toISOString() ?? null,
+            ...(termination ? { termination } : {}),
         });
     } catch (error) {
         if (error instanceof SessionLifecycleError) {

--- a/src/components/ops/SessionLifecycleControl.tsx
+++ b/src/components/ops/SessionLifecycleControl.tsx
@@ -50,7 +50,7 @@ export default function SessionLifecycleControl({
     }, [scheduledAt, nowMs]);
     const canOverrideWindow = role === 'ADMIN' || role === 'FACILITATOR_OP';
 
-    async function transition(targetStatus: 'LIVE' | 'ENDED') {
+    async function transition(targetStatus: 'LIVE' | 'ENDED' | 'CANCELLED') {
         setBusy(true);
         setError(null);
         setNotice(null);
@@ -67,6 +67,11 @@ export default function SessionLifecycleControl({
                 status?: string;
                 message?: string;
                 changed?: boolean;
+                termination?: {
+                    complete: boolean;
+                    stageDisconnected: number;
+                    bedDisconnected: number;
+                };
             };
             if (!response.ok) {
                 throw new Error(data.message || `Status change failed (HTTP ${response.status})`);
@@ -76,9 +81,18 @@ export default function SessionLifecycleControl({
             onStatusChange?.(nextStatus);
             setConfirmClose(false);
             setReason('');
-            setNotice(targetStatus === 'LIVE'
-                ? (data.changed === false ? 'Doors were already open.' : 'Doors are open. Attendees are entering now.')
-                : (data.changed === false ? 'Event was already closed.' : 'Event closed. Connected attendees will see the closing state.'));
+            if (targetStatus === 'LIVE') {
+                setNotice(data.changed === false
+                    ? 'Doors were already open.'
+                    : 'Doors are open. Attendees are entering now.');
+            } else if (data.termination?.complete) {
+                const outcome = targetStatus === 'CANCELLED' ? 'cancelled' : 'ended';
+                setNotice(
+                    `Event ${outcome} now. Disconnected ${data.termination.stageDisconnected} Stage and ${data.termination.bedDisconnected} Beacon connections.`,
+                );
+            } else {
+                setError('Event closed, but an immediate media disconnect was incomplete. Use “Disconnect remaining clients” to retry.');
+            }
         } catch (failure) {
             setError(failure instanceof Error ? failure.message : 'Status change failed');
         } finally {
@@ -119,9 +133,21 @@ export default function SessionLifecycleControl({
                         Close event
                     </button>
                 ) : (
-                    <span className="rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-muted)]">
-                        {status === 'ENDED' ? 'Event closed' : 'Event cancelled'}
-                    </span>
+                    <div className="flex flex-wrap items-center gap-2">
+                        <span className="rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-muted)]">
+                            {status === 'ENDED' ? 'Event closed' : 'Event cancelled'}
+                        </span>
+                        {status === 'ENDED' || canOverrideWindow ? (
+                            <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() => setConfirmClose(true)}
+                                className="event-button event-button--secondary"
+                            >
+                                Disconnect remaining clients
+                            </button>
+                        ) : null}
+                    </div>
                 )}
             </div>
 
@@ -148,18 +174,18 @@ export default function SessionLifecycleControl({
 
             {confirmClose ? (
                 <div role="alertdialog" aria-labelledby="close-event-heading" className="mt-3 rounded border border-[var(--warning)]/40 bg-[var(--warning)]/10 p-3">
-                    <h3 id="close-event-heading" className="font-medium text-[var(--cream)]">Close this event?</h3>
+                    <h3 id="close-event-heading" className="font-medium text-[var(--cream)]">End this experience for everyone?</h3>
                     <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                        New tokens will stop immediately. Connected attendees will move to the closing state on their next status check.
+                        New entries stop first. Then every Stage connection and this event&apos;s Beacon listeners are disconnected immediately. Other events and the Beacon source stay online.
                     </p>
                     <div className="mt-3 flex gap-2">
                         <button
                             type="button"
                             disabled={busy}
-                            onClick={() => void transition('ENDED')}
+                            onClick={() => void transition(status === 'CANCELLED' ? 'CANCELLED' : 'ENDED')}
                             className="event-button event-button--primary"
                         >
-                            {busy ? 'Closing…' : 'Confirm close'}
+                            {busy ? 'Disconnecting…' : 'End & disconnect everyone'}
                         </button>
                         <button
                             type="button"

--- a/src/components/ops/__tests__/SessionLifecycleControl.test.tsx
+++ b/src/components/ops/__tests__/SessionLifecycleControl.test.tsx
@@ -37,7 +37,11 @@ describe('SessionLifecycleControl', () => {
     it('requires explicit confirmation before closing', async () => {
         vi.mocked(fetch).mockResolvedValue({
             ok: true,
-            json: async () => ({ changed: true, status: 'ENDED' }),
+            json: async () => ({
+                changed: true,
+                status: 'ENDED',
+                termination: { complete: true, stageDisconnected: 3, bedDisconnected: 2 },
+            }),
         } as Response);
         render(<SessionLifecycleControl
             sessionId="event-1"
@@ -47,9 +51,73 @@ describe('SessionLifecycleControl', () => {
         />);
         fireEvent.click(screen.getByRole('button', { name: 'Close event' }));
         expect(fetch).not.toHaveBeenCalled();
-        fireEvent.click(screen.getByRole('button', { name: 'Confirm close' }));
+        expect(screen.getByText(/every Stage connection/)).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'End & disconnect everyone' }));
         await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
-        expect(await screen.findByText('Event closed. Connected attendees will see the closing state.')).toBeInTheDocument();
+        expect(await screen.findByText('Event ended now. Disconnected 3 Stage and 2 Beacon connections.')).toBeInTheDocument();
+    });
+
+    it('offers an idempotent disconnect retry after the event is closed', async () => {
+        vi.mocked(fetch).mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                changed: false,
+                status: 'ENDED',
+                termination: { complete: true, stageDisconnected: 1, bedDisconnected: 1 },
+            }),
+        } as Response);
+        render(<SessionLifecycleControl
+            sessionId="event-1"
+            initialStatus="ENDED"
+            scheduledAt="2026-08-01T18:00:00Z"
+            role="OPERATOR"
+        />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Disconnect remaining clients' }));
+        fireEvent.click(screen.getByRole('button', { name: 'End & disconnect everyone' }));
+
+        await screen.findByText('Event ended now. Disconnected 1 Stage and 1 Beacon connections.');
+        expect(fetch).toHaveBeenCalledWith(
+            '/api/ops/sessions/event-1/lifecycle',
+            expect.objectContaining({ body: JSON.stringify({ status: 'ENDED' }) }),
+        );
+    });
+
+    it('retries a cancelled event without attempting an invalid ENDED transition', async () => {
+        vi.mocked(fetch).mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                changed: false,
+                status: 'CANCELLED',
+                termination: { complete: true, stageDisconnected: 0, bedDisconnected: 2 },
+            }),
+        } as Response);
+        render(<SessionLifecycleControl
+            sessionId="event-1"
+            initialStatus="CANCELLED"
+            scheduledAt="2026-08-01T18:00:00Z"
+            role="FACILITATOR_OP"
+        />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Disconnect remaining clients' }));
+        fireEvent.click(screen.getByRole('button', { name: 'End & disconnect everyone' }));
+
+        await screen.findByText('Event cancelled now. Disconnected 0 Stage and 2 Beacon connections.');
+        expect(fetch).toHaveBeenCalledWith(
+            '/api/ops/sessions/event-1/lifecycle',
+            expect.objectContaining({ body: JSON.stringify({ status: 'CANCELLED' }) }),
+        );
+    });
+
+    it('does not offer an unauthorized cancellation retry to an operator', () => {
+        render(<SessionLifecycleControl
+            sessionId="event-1"
+            initialStatus="CANCELLED"
+            scheduledAt="2026-08-01T18:00:00Z"
+            role="OPERATOR"
+        />);
+
+        expect(screen.queryByRole('button', { name: 'Disconnect remaining clients' })).not.toBeInTheDocument();
     });
 
     it('blocks non-admin staff outside the opening window', () => {

--- a/src/lib/__tests__/session-termination.test.ts
+++ b/src/lib/__tests__/session-termination.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    findUnique: vi.fn(),
+    auditCreate: vi.fn(),
+    listParticipants: vi.fn(),
+    deleteRoom: vi.fn(),
+    removeParticipant: vi.fn(),
+    bedRoomIdentity: vi.fn((identity: string) => `bed-${identity}`),
+}));
+
+vi.mock('@/lib/db', () => ({
+    prisma: {
+        scheduledSession: { findUnique: mocks.findUnique },
+        auditLog: { create: mocks.auditCreate },
+    },
+}));
+vi.mock('@/lib/livekit-server', () => ({
+    bedRoomIdentity: mocks.bedRoomIdentity,
+    getRoomService: () => ({
+        listParticipants: mocks.listParticipants,
+        deleteRoom: mocks.deleteRoom,
+        removeParticipant: mocks.removeParticipant,
+    }),
+}));
+
+import { terminateSessionMedia } from '../session-termination';
+
+describe('terminateSessionMedia', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.findUnique.mockResolvedValue({
+            roomName: 'event-stage',
+            participants: [
+                { participantIdentity: 'event-a' },
+                { participantIdentity: 'event-b' },
+            ],
+        });
+        mocks.listParticipants
+            .mockResolvedValueOnce([{ identity: 'event-a' }, { identity: 'event-b' }])
+            .mockResolvedValueOnce([
+                { identity: 'playlist-bot' },
+                { identity: 'bed-event-a' },
+                { identity: 'bed-event-b' },
+                { identity: 'bed-another-event' },
+            ]);
+        mocks.deleteRoom.mockResolvedValue(undefined);
+        mocks.removeParticipant.mockResolvedValue(undefined);
+        mocks.auditCreate.mockResolvedValue({ id: 'audit-1' });
+    });
+
+    it('deletes the selected stage and removes only its listeners from the shared bed', async () => {
+        const result = await terminateSessionMedia({
+            sessionId: 'session-1',
+            actorUserId: 'operator-1',
+            actorRole: 'OPERATOR',
+        });
+
+        expect(result).toEqual({
+            complete: true,
+            stageDisconnected: 2,
+            bedDisconnected: 2,
+            failures: [],
+        });
+        expect(mocks.deleteRoom).toHaveBeenCalledWith('event-stage');
+        expect(mocks.removeParticipant.mock.calls).toEqual([
+            ['beacon', 'bed-event-a'],
+            ['beacon', 'bed-event-b'],
+        ]);
+        expect(mocks.removeParticipant).not.toHaveBeenCalledWith('beacon', 'playlist-bot');
+        expect(mocks.removeParticipant).not.toHaveBeenCalledWith('beacon', 'bed-another-event');
+        expect(mocks.auditCreate).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                actorUserId: 'operator-1',
+                actorRole: 'OPERATOR',
+                action: 'session.media_terminate',
+                metadata: {
+                    stageDisconnected: 2,
+                    bedDisconnected: 2,
+                    failures: [],
+                },
+            }),
+        });
+    });
+
+    it('is harmless when no selected-event connection remains', async () => {
+        mocks.listParticipants.mockReset();
+        mocks.listParticipants
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([{ identity: 'playlist-bot' }]);
+
+        await expect(terminateSessionMedia({
+            sessionId: 'session-1',
+            actorUserId: 'operator-1',
+            actorRole: 'FACILITATOR_OP',
+        })).resolves.toMatchObject({ complete: true, stageDisconnected: 0, bedDisconnected: 0 });
+        expect(mocks.deleteRoom).not.toHaveBeenCalled();
+        expect(mocks.removeParticipant).not.toHaveBeenCalled();
+    });
+
+    it('reports partial media failures and still audits the attempt', async () => {
+        mocks.deleteRoom.mockRejectedValue(new Error('LiveKit unavailable'));
+        mocks.removeParticipant
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new Error('participant raced'));
+
+        const result = await terminateSessionMedia({
+            sessionId: 'session-1',
+            actorUserId: 'operator-1',
+            actorRole: 'ADMIN',
+        });
+
+        expect(result).toEqual({
+            complete: false,
+            stageDisconnected: 0,
+            bedDisconnected: 1,
+            failures: ['stage', 'bed'],
+        });
+        expect(mocks.auditCreate).toHaveBeenCalledOnce();
+    });
+
+    it('still attempts the stage cut and identity-scoped bed removals when listing fails', async () => {
+        mocks.listParticipants.mockReset();
+        mocks.listParticipants
+            .mockRejectedValueOnce(new Error('stage listing unavailable'))
+            .mockRejectedValueOnce(new Error('bed listing unavailable'));
+
+        const result = await terminateSessionMedia({
+            sessionId: 'session-1',
+            actorUserId: 'operator-1',
+            actorRole: 'OPERATOR',
+        });
+
+        expect(mocks.deleteRoom).toHaveBeenCalledWith('event-stage');
+        expect(mocks.removeParticipant.mock.calls).toEqual([
+            ['beacon', 'bed-event-a'],
+            ['beacon', 'bed-event-b'],
+        ]);
+        expect(result).toMatchObject({
+            complete: false,
+            stageDisconnected: 0,
+            bedDisconnected: 2,
+            failures: ['stage', 'bed'],
+        });
+    });
+});

--- a/src/lib/session-termination.ts
+++ b/src/lib/session-termination.ts
@@ -1,0 +1,126 @@
+import type { StaffRole } from '@prisma/client';
+
+import { prisma } from '@/lib/db';
+import { bedRoomIdentity, getRoomService } from '@/lib/livekit-server';
+
+const BED_ROOM_NAME = process.env.LIVEKIT_ROOM_NAME || 'beacon';
+
+export type SessionTerminationResult = {
+    complete: boolean;
+    stageDisconnected: number;
+    bedDisconnected: number;
+    failures: Array<'stage' | 'bed' | 'audit'>;
+};
+
+/**
+ * Immediately remove the selected event from LiveKit after its durable status
+ * has stopped new token issuance. The shared Beacon source and listeners from
+ * other events are deliberately preserved.
+ *
+ * This operation is idempotent: an operator can repeat it after the session is
+ * already ENDED/CANCELLED to catch a client that briefly reconnected with an
+ * older token before observing the closing state.
+ */
+export async function terminateSessionMedia(input: {
+    sessionId: string;
+    actorUserId: string;
+    actorRole: StaffRole;
+}): Promise<SessionTerminationResult> {
+    const session = await prisma.scheduledSession.findUnique({
+        where: { id: input.sessionId },
+        select: {
+            roomName: true,
+            participants: { select: { participantIdentity: true } },
+        },
+    });
+    if (!session) {
+        return {
+            complete: false,
+            stageDisconnected: 0,
+            bedDisconnected: 0,
+            failures: ['stage', 'bed'],
+        };
+    }
+
+    const roomService = getRoomService();
+    const failures: SessionTerminationResult['failures'] = [];
+    const recordFailure = (failure: SessionTerminationResult['failures'][number]) => {
+        if (!failures.includes(failure)) failures.push(failure);
+    };
+    let stageDisconnected = 0;
+    let bedDisconnected = 0;
+
+    let stageListingSucceeded = false;
+    try {
+        const connected = await roomService.listParticipants(session.roomName);
+        stageListingSucceeded = true;
+        stageDisconnected = connected.length;
+    } catch {
+        recordFailure('stage');
+    }
+    // If listing failed, still attempt the destructive LiveKit operation. In
+    // an incident the inability to count must never prevent the actual cut.
+    if (!stageListingSucceeded || stageDisconnected > 0) {
+        try {
+            await roomService.deleteRoom(session.roomName);
+        } catch {
+            recordFailure('stage');
+            stageDisconnected = 0;
+        }
+    }
+
+    const targetBedIdentities = new Set(
+        session.participants.map(({ participantIdentity }) =>
+            bedRoomIdentity(participantIdentity)),
+    );
+    let connectedTargetIdentities: string[];
+    try {
+        const connectedBedParticipants = await roomService.listParticipants(BED_ROOM_NAME);
+        connectedTargetIdentities = connectedBedParticipants
+            .map(({ identity }) => identity)
+            .filter((identity) => targetBedIdentities.has(identity));
+    } catch {
+        // Removal is identity-scoped, so it is still safe to attempt every
+        // known identity for this event. Never delete the shared bed room.
+        connectedTargetIdentities = [...targetBedIdentities];
+        recordFailure('bed');
+    }
+    try {
+        const removals = await Promise.allSettled(
+            connectedTargetIdentities.map((identity) =>
+                roomService.removeParticipant(BED_ROOM_NAME, identity)),
+        );
+        bedDisconnected = removals.filter(({ status }) => status === 'fulfilled').length;
+        if (removals.some(({ status }) => status === 'rejected')) recordFailure('bed');
+    } catch {
+        recordFailure('bed');
+        bedDisconnected = 0;
+    }
+
+    try {
+        await prisma.auditLog.create({
+            data: {
+                actorUserId: input.actorUserId,
+                actorRole: input.actorRole,
+                action: 'session.media_terminate',
+                targetType: 'SCHEDULED_SESSION',
+                targetId: input.sessionId,
+                reason: 'Authorized staff terminated live event media',
+                metadata: {
+                    stageDisconnected,
+                    bedDisconnected,
+                    failures,
+                },
+            },
+        });
+    } catch {
+        recordFailure('audit');
+    }
+
+    return {
+        complete: failures.length === 0,
+        stageDisconnected,
+        bedDisconnected,
+        failures,
+    };
+}


### PR DESCRIPTION
## Outcome

Makes **Close event** a real, immediate event kill path rather than only a durable status change.

- records `ENDED`/`CANCELLED` first, stopping new token issuance;
- deletes the selected event's Stage room, disconnecting every Stage client;
- removes only identities belonging to this event from the shared Beacon room;
- preserves `playlist-bot`, `beacon01`, and listeners from other events;
- audits redacted Stage/Beacon counts and failure categories;
- exposes an idempotent **Disconnect remaining clients** retry for partial failures;
- updates the cockpit confirmation copy and the operational runbook.

This extends #65; it does not close that issue because its localization/rehearsal follow-up remains.

## Failure model

The durable close commits before LiveKit calls. If the process or LiveKit fails afterward, the event remains safely closed, the UI reports an incomplete disconnect, and authorized staff can retry without reopening it. A participant-list failure does not suppress the actual cut: Stage deletion is still attempted and Beacon removal falls back to the session's known identity set.

## Evidence

- `594/594` Vitest unit/integration tests passed.
- TypeScript (`npx tsc --noEmit`) passed.
- ESLint passed.
- Production-mode Next build passed as part of Playwright startup.
- New real E2E passed against fixture PostgreSQL + real LiveKit + two Chromium contexts: the attendee and operator cockpit connected to both rooms, the operator confirmed termination, LiveKit returned non-zero Stage/Beacon disconnect counts, and both browsers rendered the terminal state in 3.0 seconds.
- No frozen audio source, processing, codec, buffer, gain, playlist-bot, or LiveKit deployment configuration changed.

## Risk and rollback

Risk is limited to lifecycle close/cancel calls. Shared Beacon isolation is directly tested, including preservation of its publisher and another event's listener. Roll back the single commit and redeploy the prior app image; no schema or data migration is involved. A rollback does not reopen sessions already ended while the change was live.
