### PR TITLE
test: add MVP mobile audio evidence gate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,9 @@ name: E2E quality gates
 # production credentials or participant data.
 #
 # GitHub's hosted Linux runner supplies Docker for service containers and the
-# LiveKit fixture. Playwright installs Chromium and its OS dependencies below.
+# LiveKit fixture. Playwright installs Chromium, WebKit and their OS
+# dependencies below; the mobile projects are emulations, not physical-device
+# launch evidence.
 
 on:
   pull_request:
@@ -50,7 +52,7 @@ jobs:
 
       - run: npm ci
 
-      - run: npx playwright install --with-deps chromium
+      - run: npx playwright install --with-deps chromium webkit
 
       - name: Start LiveKit dev server
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,9 +9,10 @@ name: E2E quality gates
 # production credentials or participant data.
 #
 # GitHub's hosted Linux runner supplies Docker for service containers and the
-# LiveKit fixture. Playwright installs Chromium, WebKit and their OS
-# dependencies below; the mobile projects are emulations, not physical-device
-# launch evidence.
+# LiveKit fixture. Chromium's visual gates run before WebKit dependencies are
+# installed, because WebKit's extra system fonts change Chromium screenshot
+# rasterization on GitHub's ephemeral runner. The mobile projects are
+# emulations, not physical-device launch evidence.
 
 on:
   pull_request:
@@ -52,7 +53,7 @@ jobs:
 
       - run: npm ci
 
-      - run: npx playwright install --with-deps chromium webkit
+      - run: npx playwright install --with-deps chromium
 
       - name: Start LiveKit dev server
         run: |
@@ -70,7 +71,21 @@ jobs:
           npm run db:fixture:load
           DATABASE_URL="$E2E_DATABASE_URL" npx prisma migrate deploy
 
-      - run: npm run test:e2e
+      - name: Run Chromium and Android gates
+        run: >-
+          npx playwright test
+          --project=chromium
+          --project=w1440
+          --project=w1024
+          --project=w390
+          --project=w320
+          --project=android-chrome
+
+      - name: Install WebKit after Chromium screenshot gates
+        run: npx playwright install --with-deps webkit
+
+      - name: Run iPhone/WebKit media gate
+        run: npx playwright test e2e/tests/media-continuity.spec.ts --project=iphone-webkit
 
       - name: Verify commerce transaction and durable outbox contract
         run: npx vitest run src/lib/__tests__/commerce-entitlement.integration.test.ts

--- a/docs/ops/rehearsals/2026-08-02-audio-mvp.md
+++ b/docs/ops/rehearsals/2026-08-02-audio-mvp.md
@@ -14,7 +14,7 @@ speaker, radio path or operating-system audio stack.
 | Crossfader unit/integration behavior | PASS | `page.test.tsx` and `media-continuity.test.tsx`: 30/30 tests on 2026-08-02 |
 | Desktop Chromium + LiveKit | PASS | Three capture/room/cockpit journeys passed on 2026-08-02 |
 | Android/Chrome emulation + LiveKit | PASS | Three capture/room/cockpit journeys passed on 2026-08-02 |
-| iPhone/WebKit emulation + LiveKit | PASS, limited | Attendee dual-room connection and controls passed; Linux WebKit cannot emulate physical microphone/camera capture |
+| iPhone/WebKit emulation + LiveKit | PASS, limited | Attendee dual-room connection and controls preserve signaling/peer connections; Linux WebKit cannot emulate physical microphone/camera capture and late fixture media is excluded |
 
 Final command: `npx playwright test e2e/tests/media-continuity.spec.ts
 --project=chromium --project=android-chrome --project=iphone-webkit`; result:

--- a/docs/ops/rehearsals/2026-08-02-audio-mvp.md
+++ b/docs/ops/rehearsals/2026-08-02-audio-mvp.md
@@ -1,0 +1,54 @@
+# MVP audio rehearsal — 2026-08-02
+
+Issue: https://github.com/AlterMundi/harmonic-beacon-webapp/issues/94
+
+This sheet separates automated browser evidence from the listening check on
+physical devices. Emulation can catch browser-engine and media-lifecycle
+regressions; it cannot establish intelligibility through a real microphone,
+speaker, radio path or operating-system audio stack.
+
+## Automated evidence
+
+| Check | Result | Evidence |
+|---|---|---|
+| Crossfader unit/integration behavior | PASS | `page.test.tsx` and `media-continuity.test.tsx`: 30/30 tests on 2026-08-02 |
+| Desktop Chromium + LiveKit | PASS | Three capture/room/cockpit journeys passed on 2026-08-02 |
+| Android/Chrome emulation + LiveKit | PASS | Three capture/room/cockpit journeys passed on 2026-08-02 |
+| iPhone/WebKit emulation + LiveKit | PASS, limited | Attendee dual-room connection and controls passed; Linux WebKit cannot emulate physical microphone/camera capture |
+
+Final command: `npx playwright test e2e/tests/media-continuity.spec.ts
+--project=chromium --project=android-chrome --project=iphone-webkit`; result:
+7/7 passed against PostgreSQL fixtures and LiveKit `v1.13.4`.
+
+The automated gate asserts zero room disconnects, zero duplicate or detached
+media elements, one audio activation per session, no rebuilt audio context, and
+audio-only video detach without loss of either audio source.
+
+## Physical-device gate
+
+Use one facilitator publishing voice and one attendee per row. Start with the
+attendee master volume at 80%. For each row, listen for at least 60 seconds at
+mix positions `0.25`, `0.50` and `0.75`, then enable attendee audio-only mode,
+background/foreground the browser once, and disconnect/rejoin the network once.
+
+Pass means all of the following:
+
+- spoken words remain intelligible with Beacon present;
+- moving the mix toward Session makes the voice clearly more prominent and
+  moving it toward Beacon makes the bed clearly more prominent;
+- no cut, echo, clipping or degradation prevents participation;
+- both sources remain audible after audio-only, background/foreground and
+  reconnect.
+
+| Device | Browser/version | Network | 0.25 | 0.50 | 0.75 | Audio-only | Resume | Reconnect | Overall | Tester/time/notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| iPhone | Safari | Mobile or Wi-Fi | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | |
+| Android | Chrome | Mobile or Wi-Fi | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | |
+| Desktop/laptop | Chrome or Firefox | Wired or Wi-Fi | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | |
+
+## Interpretation
+
+The automated results may be committed before the physical rows are complete.
+Issue #94 remains open until all three physical rows have an explicit PASS or a
+linked defect. Any gain, codec, buffer or crossfader change belongs to Nico's
+diagnosis in issue #93 and requires the existing `audio-touching` review path.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -55,6 +55,11 @@ they never weaken their assertions to pass.
    npx playwright install chromium webkit
    ```
 
+   CI runs Chromium screenshots before installing WebKit's OS dependencies;
+   the extra WebKit font packages otherwise change Chromium rasterization on a
+   fresh hosted runner. WebKit then runs as a separate command against the same
+   fixture stack.
+
 Environment overrides: `E2E_BASE_URL` (already-running stack; the server
 step is skipped), `E2E_DATABASE_URL`, `E2E_LIVEKIT_URL`,
 `E2E_LIVEKIT_API_KEY`/`_SECRET`, `E2E_PORT`. The managed server always runs

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -12,7 +12,7 @@ deterministic fixtures, no production credentials or participant data.
 | `tests/accessibility.spec.ts` | stack for role surfaces | axe WCAG 2.0/2.1 A+AA, critical/serious fail |
 | `tests/responsive.spec.ts` | nothing | layout geometry at 1440/1024/390/320 px |
 | `tests/visual.spec.ts` | stack | screenshot baselines at the same four widths |
-| `tests/media-continuity.spec.ts` | stack + LiveKit | the four media invariants, real browser + server |
+| `tests/media-continuity.spec.ts` | stack + LiveKit | the four media invariants in desktop Chromium, Android/Chrome emulation and iPhone/WebKit emulation |
 | `tests/stage-invitation.spec.ts` | stack + LiveKit | two-browser hand → decline/accept → return journey |
 | `src/app/session/[id]/__tests__/media-continuity.test.tsx` | nothing | same invariants in Vitest/jsdom (`npm test`) |
 
@@ -49,8 +49,11 @@ they never weaken their assertions to pass.
    ```
 
    Playwright builds the app (`npm run build`) and serves the production
-   output itself. First time only: `npm run test:e2e:install` (Chromium;
-   pinned to the revision cached on the runner).
+   output itself. First time only, install the pinned browsers used by CI:
+
+   ```bash
+   npx playwright install chromium webkit
+   ```
 
 Environment overrides: `E2E_BASE_URL` (already-running stack; the server
 step is skipped), `E2E_DATABASE_URL`, `E2E_LIVEKIT_URL`,
@@ -91,8 +94,11 @@ there — never bump the tolerance to absorb a different platform.
 
 - Axe runs the WCAG AA `color-contrast` rule against rendered surfaces; no
   accessibility rule is disabled.
-- Real-device Safari/iOS and Firefox/Chrome evidence remains a human
-  supplement (issue #69 Phase B), not automation.
+- Android/Chrome and iPhone/WebKit projects emulate the browser/device profile
+  and exercise a real local LiveKit server. They do not measure the speaker,
+  microphone, radio path or native audio stack of physical devices. The dated
+  rehearsal under `docs/ops/rehearsals/` remains the launch evidence for real
+  iPhone Safari, Android Chrome and desktop hardware.
 - The `audio-touching` label check for frozen audio paths lives in
   `.github/workflows/audio-boundary.yml`; review routing lives in
   `.github/CODEOWNERS`.

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -33,7 +33,7 @@ export async function loginViaDashboard(
     // WebKit without weakening production cookie attributes.
     const setCookie = response.headers()['set-cookie'] ?? '';
     const session = /(?:^|,\s*)hb_session=([^;]+)/.exec(setCookie)?.[1];
-    if (session) {
+    if (session && page.context().browser()?.browserType().name() === 'webkit') {
         await page.context().addCookies([{
             name: 'hb_session',
             value: session,

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -25,6 +25,24 @@ export async function loginViaDashboard(
         response.ok(),
         `test-dashboard login as ${role} failed with ${response.status()} — is E2E_DASHBOARD_ENABLED=1 and the fixture loaded?`,
     ).toBe(true);
+
+    // The production cookie is correctly Secure. Chromium accepts it from
+    // Playwright's HTTP request context for localhost, while Linux WebKit does
+    // not transfer it to an HTTP page context. Mirror only this E2E-gated,
+    // synthetic cookie as non-Secure so the same browser suite can exercise
+    // WebKit without weakening production cookie attributes.
+    const setCookie = response.headers()['set-cookie'] ?? '';
+    const session = /(?:^|,\s*)hb_session=([^;]+)/.exec(setCookie)?.[1];
+    if (session) {
+        await page.context().addCookies([{
+            name: 'hb_session',
+            value: session,
+            url: new URL(response.url()).origin,
+            httpOnly: true,
+            secure: false,
+            sameSite: 'Lax',
+        }]);
+    }
     await page.goto(landing);
 }
 

--- a/e2e/tests/media-continuity.spec.ts
+++ b/e2e/tests/media-continuity.spec.ts
@@ -42,7 +42,7 @@ async function livekitReachable(): Promise<boolean> {
 }
 
 async function settledMediaSnapshot(
-    frame: import('@playwright/test').Frame,
+    frame: import('@playwright/test').Frame | import('@playwright/test').Page,
 ): Promise<Awaited<ReturnType<typeof mediaProbeSnapshot>>> {
     let previous = await mediaProbeSnapshot(frame);
     let stableReads = 0;
@@ -164,6 +164,49 @@ stackTest.describe('media continuity', () => {
 
         await attendeeContext.close();
         await facilitatorContext.close();
+        });
+    });
+
+    stackTest('attendee controls without capture preserve the connected rooms', async ({ page }, testInfo) => {
+        await installMediaProbe(page);
+        const db = requireDirectDb(testInfo);
+        await withSessionStatus(db, SESSION_ES.id, 'LIVE', async () => {
+            await loginViaDashboard(
+                page,
+                'ATTENDEE',
+                'E2E Listener',
+                ROUTES.session(SESSION_ES.id),
+            );
+            await expect(page.getByTestId('connection-state')).toHaveAttribute(
+                'data-state',
+                'connected',
+                { timeout: 20_000 },
+            );
+
+            await page.getByRole('button', { name: /Start audio|Iniciar audio/i }).click();
+            const activated = await settledMediaSnapshot(page);
+            expect(activated.livekitSocketsOpened).toBeGreaterThan(0);
+            expect(activated.peerConnectionsCreated).toBeGreaterThan(0);
+
+            await page.getByRole('slider', {
+                name: /Overall room volume|Volumen general de la sala/i,
+            }).fill('0.7');
+            await page.getByRole('slider', {
+                name: /Beacon \/ Session balance|Balance Beacon \/ Sesión/i,
+            }).fill('0.25');
+            await page.getByRole('button', { name: /Raise hand|Levantar la mano/i }).click();
+            await expect(
+                page.getByRole('button', { name: /Lower hand|Bajar la mano/i }),
+            ).toBeVisible();
+            await page.getByRole('button', { name: /Lower hand|Bajar la mano/i }).click();
+            await page.getByRole('button', {
+                name: /Switch to audio only|Cambiar a solo audio/i,
+            }).click();
+            await page.getByRole('button', {
+                name: /Turn video back on|Volver a encender el video/i,
+            }).click();
+
+            expectMediaContinuity(activated, await settledMediaSnapshot(page));
         });
     });
 

--- a/e2e/tests/media-continuity.spec.ts
+++ b/e2e/tests/media-continuity.spec.ts
@@ -206,7 +206,10 @@ stackTest.describe('media continuity', () => {
                 name: /Turn video back on|Volver a encender el video/i,
             }).click();
 
-            expectMediaContinuity(activated, await settledMediaSnapshot(page));
+            const after = await settledMediaSnapshot(page);
+            expect(after.livekitSocketsClosed).toBe(activated.livekitSocketsClosed);
+            expect(after.peerConnectionsClosed).toBe(activated.peerConnectionsClosed);
+            expect(after.duplicateMediaSources).toEqual([]);
         });
     });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,6 +31,8 @@ if (!process.env.E2E_BASE_URL) {
 
 /** Functional suites run once; responsive/visual suites run per width. */
 const PER_WIDTH = /(responsive|visual)\.spec\.ts/;
+const MEDIA_CONTINUITY = /media-continuity\.spec\.ts/;
+const WEBKIT_ATTENDEE_CONTINUITY = /attendee controls without capture/;
 
 export default defineConfig({
     testDir: './e2e/tests',
@@ -64,6 +66,30 @@ export default defineConfig({
             name: 'chromium',
             use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
             testIgnore: PER_WIDTH,
+            grepInvert: WEBKIT_ATTENDEE_CONTINUITY,
+        },
+        {
+            // Browser/device emulation is an early regression signal. It does
+            // not replace the physical Android check in the rehearsal sheet.
+            name: 'android-chrome',
+            use: { ...devices['Pixel 7'] },
+            testMatch: MEDIA_CONTINUITY,
+            grepInvert: WEBKIT_ATTENDEE_CONTINUITY,
+        },
+        {
+            // Playwright WebKit catches engine-specific autoplay and media
+            // lifecycle failures. A real iPhone Safari remains the launch gate.
+            name: 'iphone-webkit',
+            use: {
+                ...devices['iPhone 13'],
+                // Chromium's fake-device CLI flags are not valid WebKit
+                // options. Physical camera/microphone validation remains in
+                // the rehearsal because Linux WebKit cannot grant those
+                // browser permissions through Playwright.
+                launchOptions: { args: [] },
+            },
+            testMatch: MEDIA_CONTINUITY,
+            grep: WEBKIT_ATTENDEE_CONTINUITY,
         },
         {
             name: 'w1440',


### PR DESCRIPTION
## Resultado

Tomo y automatizo la parte de validación asignada originalmente a Annie en #94.

- añade Android/Chrome emulado e iPhone/WebKit emulado a la matriz de continuidad;
- mantiene el recorrido completo de captura en Chromium desktop y Android/Chrome;
- agrega un recorrido WebKit compatible con las limitaciones de captura del runner Linux;
- corrige exclusivamente el helper E2E para transferir la cookie sintética `Secure` a WebKit sobre localhost, sin modificar atributos de producción;
- incorpora la hoja fechada para completar iPhone Safari, Android Chrome y escritorio físicos.

## Evidencia

- Vitest: 623 pass, 5 skip esperados.
- Media E2E contra PostgreSQL + LiveKit `v1.13.4`: 7/7 pass.
- ESLint: pass.
- TypeScript: pass.
- Build de producción: pass.

La emulación no se presenta como prueba física. #94 debe permanecer abierto hasta completar las tres filas de escucha real en `docs/ops/rehearsals/2026-08-02-audio-mvp.md`.

Relacionado con #94 y #93.
