### PR TITLE
STAGE-01: remove phantom stage members after reconnect

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,7 +13,7 @@ deterministic fixtures, no production credentials or participant data.
 | `tests/responsive.spec.ts` | nothing | layout geometry at 1440/1024/390/320 px |
 | `tests/visual.spec.ts` | stack | screenshot baselines at the same four widths |
 | `tests/media-continuity.spec.ts` | stack + LiveKit | the four media invariants in desktop Chromium, Android/Chrome emulation and iPhone/WebKit emulation |
-| `tests/stage-invitation.spec.ts` | stack + LiveKit | two-browser hand → decline/accept → return journey |
+| `tests/stage-invitation.spec.ts` | stack + LiveKit | two-browser hand → decline/invite → fresh connection stays pending → accept → return journey |
 | `src/app/session/[id]/__tests__/media-continuity.test.tsx` | nothing | same invariants in Vitest/jsdom (`npm test`) |
 
 Suites that need the stack skip with a precise reason when it is missing —

--- a/e2e/tests/media-continuity.spec.ts
+++ b/e2e/tests/media-continuity.spec.ts
@@ -62,6 +62,16 @@ async function settledMediaSnapshot(
     throw new Error('cockpit preview media did not settle before panel exercise');
 }
 
+async function leaveConnectedRoom(
+    surface: import('@playwright/test').Frame | import('@playwright/test').Page,
+): Promise<void> {
+    const leave = surface.getByRole('button', { name: /Leave session|Salir de la sesión/i });
+    if (await leave.isVisible()) {
+        await leave.click();
+        await expect(surface.getByTestId('connection-state')).toHaveCount(0);
+    }
+}
+
 stackTest.describe('media continuity', () => {
     stackTest.beforeEach(async ({}, testInfo) => {
         testInfo.skip(
@@ -162,6 +172,12 @@ stackTest.describe('media continuity', () => {
         expect(snapshot.duplicateMediaSources).toEqual([]);
         expect(snapshot.livekitSocketsClosed).toBe(activated.livekitSocketsClosed);
 
+        // Send an intentional LiveKit leave before destroying the browser
+        // contexts. An abrupt context close keeps the publisher resumable for
+        // the server departure timeout and leaks a phantom facilitator into
+        // later visual tests that share the fixture room.
+        await leaveConnectedRoom(attendee);
+        await leaveConnectedRoom(facilitator);
         await attendeeContext.close();
         await facilitatorContext.close();
         });
@@ -292,6 +308,7 @@ stackTest.describe('media continuity', () => {
             ).toBeVisible();
             await expect(roomFrame.getByText(/access is open elsewhere|entrada está abierta en otro lugar/i))
                 .toHaveCount(0);
+            await leaveConnectedRoom(roomFrame);
         });
     });
 });

--- a/e2e/tests/stage-invitation.spec.ts
+++ b/e2e/tests/stage-invitation.spec.ts
@@ -5,10 +5,12 @@ import { ROUTES, SESSION_ES } from '../fixtures/test-data';
 
 /**
  * Complete consent journey with two real browser identities and real LiveKit:
- * hand → staff invitation → decline, then hand → invite → accept → return.
+ * hand → staff invitation → decline, then hand → invite → reload → accept →
+ * return. The reload reproduces a fresh LiveKit connection holding a durable
+ * grant: it must remain pending rather than becoming a phantom stage member.
  * Device access is only expected after the attendee's explicit accept click.
  */
-stackTest('attendee can decline or accept a stage invitation without either room remounting', async ({
+stackTest('a fresh connection stays invited until the attendee accepts the stage invitation', async ({
     browser,
 }, testInfo) => {
     stackTest.slow();
@@ -65,6 +67,25 @@ stackTest('attendee can decline or accept a stage invitation without either room
             });
             await queueRow.getByRole('button', { name: 'Give floor' }).click();
             await expect(invitation).toBeVisible({ timeout: 10_000 });
+
+            const pendingRow = drawer.locator('li').filter({ hasText: 'Journey Attendee' });
+            await expect(pendingRow.getByRole('button', { name: 'Cancel invitation' })).toBeVisible({
+                timeout: 10_000,
+            });
+            await expect(pendingRow.getByRole('button', { name: 'Take floor' })).toHaveCount(0);
+
+            await attendee.reload();
+            await expect(attendee.getByTestId('connection-state')).toHaveAttribute(
+                'data-state',
+                'connected',
+                { timeout: 20_000 },
+            );
+            await expect(invitation).toBeVisible({ timeout: 10_000 });
+            await expect(pendingRow.getByRole('button', { name: 'Cancel invitation' })).toBeVisible({
+                timeout: 10_000,
+            });
+            await expect(pendingRow.getByRole('button', { name: 'Take floor' })).toHaveCount(0);
+
             await invitation.getByRole('button', { name: /Accept and join|Aceptar y entrar/i }).click();
 
             await expect(

--- a/src/app/api/ops/sessions/[id]/participants/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/participants/__tests__/route.test.ts
@@ -109,10 +109,12 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
         ));
 
         expect(body).toMatchObject({
-            activePublishers: 1,
+            activePublishers: 0,
+            grantedPublishers: 1,
             participants: [{
                 staffRole: 'FACILITATOR_OP',
                 isAssignedFacilitator: true,
+                stageState: 'RECONNECTING',
             }],
         });
     });
@@ -146,12 +148,14 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
         expect(body).toMatchObject({
             sessionId: 'event-1',
             maxPublishers: 6,
-            activePublishers: 2,
+            activePublishers: 1,
+            grantedPublishers: 2,
             participants: [
                 {
                     id: 'publisher',
                     displayName: 'Ana',
                     canPublish: true,
+                    stageState: 'ON_STAGE',
                     queuePosition: null,
                     connected: true,
                     media: [
@@ -168,6 +172,7 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
                     queuePosition: 1,
                     reconcileNeeded: true,
                     connected: false,
+                    stageState: 'AUDIENCE',
                 },
             ],
         });
@@ -186,9 +191,30 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
         expect(body).toMatchObject({
             liveStateAvailable: false,
             participants: [
-                { id: 'publisher', connected: null, media: [] },
+                { id: 'publisher', connected: null, media: [], stageState: 'UNKNOWN' },
                 { id: 'waiting', connected: null, media: [] },
             ],
         });
+    });
+
+    it('keeps a granted reconnect out of the effective stage until media is published again', async () => {
+        listParticipants.mockResolvedValue([]);
+        const { GET } = await import('../route');
+        const { body } = await parseResponse(await GET(
+            createRequest('/api/ops/sessions/event-1/participants'),
+            mockParams({ id: 'event-1' }),
+        ));
+
+        expect(body).toMatchObject({
+            activePublishers: 0,
+            grantedPublishers: 2,
+        });
+        const snapshot = body as { participants: Array<{ id: string }> };
+        expect(snapshot.participants.find((participant) => participant.id === 'publisher'))
+            .toMatchObject({
+                canPublish: true,
+                connected: false,
+                stageState: 'RECONNECTING',
+            });
     });
 });

--- a/src/app/api/ops/sessions/[id]/participants/route.ts
+++ b/src/app/api/ops/sessions/[id]/participants/route.ts
@@ -4,6 +4,7 @@ import { TrackSource } from 'livekit-server-sdk';
 import { requireStaff } from '@/lib/auth';
 import { prisma } from '@/lib/db';
 import { getRoomService } from '@/lib/livekit-server';
+import { effectiveStageState } from '@/lib/stage-presence';
 import { eventStaffPolicy } from '@/lib/staff-capabilities';
 
 export const dynamic = 'force-dynamic';
@@ -104,6 +105,12 @@ export async function GET(
             queuePosition += 1;
         }
         const live = liveParticipants.get(participant.participantIdentity);
+        const connected = liveStateAvailable ? Boolean(live) : null;
+        const stageState = effectiveStageState({
+            hasActiveGrant: canPublish,
+            connected,
+            publishedTrackCount: live?.media.length ?? 0,
+        });
         const isAssignedFacilitator = participant.staffUser
             ? eventStaffPolicy(
                 participant.staffUser.role,
@@ -122,9 +129,10 @@ export async function GET(
             raisedAt: participant.raisedAt?.toISOString() ?? null,
             queuePosition: isWaiting ? queuePosition : null,
             canPublish,
+            stageState,
             grantVersion: participant.grantVersion,
             reconcileNeeded: participant.grantReconcileNeeded,
-            connected: liveStateAvailable ? Boolean(live) : null,
+            connected,
             media: live?.media ?? [],
             // RoomService's ParticipantInfo does not expose connection quality.
             // Keep the field explicit so the UI never invents a value.
@@ -136,10 +144,13 @@ export async function GET(
         sessionId: scheduledSession.id,
         sessionStatus: scheduledSession.status,
         maxPublishers: scheduledSession.maxPublishers,
+        activePublishers: participants.filter(
+            (participant) => participant.stageState === 'ON_STAGE',
+        ).length,
         // Julián's facilitator slot is reserved even before preflight creates
         // his participant row. Exclude an active facilitator row to avoid
         // double-counting that reservation.
-        activePublishers: 1 + participants.filter(
+        grantedPublishers: 1 + participants.filter(
             (participant) =>
                 participant.canPublish &&
                 !participant.isAssignedFacilitator,

--- a/src/components/ops/SpotlightConsole.tsx
+++ b/src/components/ops/SpotlightConsole.tsx
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { StaffRole } from '@prisma/client';
+import { effectiveStageState, type EffectiveStageState } from '@/lib/stage-presence';
 
 const POLL_INTERVAL_MS = 2_000;
 
@@ -35,6 +36,7 @@ type ConsoleParticipant = {
     raisedAt: string | null;
     queuePosition: number | null;
     canPublish: boolean;
+    stageState?: EffectiveStageState;
     grantVersion: number;
     reconcileNeeded: boolean;
     connected: boolean | null;
@@ -44,10 +46,19 @@ type ConsoleParticipant = {
 
 /** Normalize a participant from the API: fill optional live-state fields. */
 function normalizeParticipant(p: ConsoleParticipant): ConsoleParticipant {
+    const connected = p.connected ?? null;
+    const media = p.media ?? [];
     return {
         ...p,
-        connected: p.connected ?? null,
-        media: p.media ?? [],
+        connected,
+        media,
+        stageState: p.stageState ?? effectiveStageState({
+            hasActiveGrant: p.canPublish,
+            connected,
+            // A current publication is LiveKit's observable evidence that the
+            // attendee accepted this connection's invitation.
+            publishedTrackCount: media.length,
+        }),
         connectionQuality: p.connectionQuality ?? null,
         isAssignedFacilitator: p.isAssignedFacilitator ?? false,
     };
@@ -58,6 +69,7 @@ type ParticipantsSnapshot = {
     sessionStatus?: 'SCHEDULED' | 'LIVE' | 'ENDED' | 'CANCELLED';
     maxPublishers: number;
     activePublishers: number;
+    grantedPublishers?: number;
     liveStateAvailable: boolean;
     participants: ConsoleParticipant[];
 };
@@ -299,7 +311,10 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
         );
 
     const all = snapshot?.participants ?? [];
-    const onStage = all.filter((participant) => participant.canPublish);
+    const onStage = all.filter((participant) => participant.stageState === 'ON_STAGE');
+    const invited = all.filter(
+        (participant) => participant.canPublish && participant.stageState !== 'ON_STAGE',
+    );
     const queue = all
         .filter((participant) => participant.queuePosition !== null)
         .sort((left, right) => (left.queuePosition ?? 0) - (right.queuePosition ?? 0));
@@ -345,7 +360,10 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
 
             <div className="flex items-center justify-between text-sm">
                 <span className="text-[var(--text-secondary)]">
-                    Stage: {snapshot ? `${snapshot.activePublishers}/${snapshot.maxPublishers}` : '…'} publishers ·{' '}
+                    Stage: {snapshot ? `${snapshot.activePublishers}/${snapshot.maxPublishers}` : '…'} publishing
+                    {snapshot?.grantedPublishers !== undefined
+                        ? ` · ${snapshot.grantedPublishers}/${snapshot.maxPublishers} slots reserved`
+                        : ''} ·{' '}
                     {queue.length} hand{queue.length !== 1 ? 's' : ''} raised
                 </span>
                 <button
@@ -398,6 +416,37 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                         Remove hand
                                     </button>
                                 </div>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+
+            <div>
+                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">Invited / reconnecting</h2>
+                {invited.length === 0 ? (
+                    <p className="text-sm text-[var(--text-secondary)]">No pending stage invitations.</p>
+                ) : (
+                    <ul className="space-y-2">
+                        {invited.map((participant) => (
+                            <li key={participant.id} className="operational-panel flex items-center justify-between gap-3">
+                                <div className="min-w-0">
+                                    <span className="font-medium text-[var(--cream)]">{participantLabel(participant)}</span>
+                                    <div className="text-xs text-[var(--text-secondary)]">
+                                        {participant.stageState === 'RECONNECTING'
+                                            ? 'Disconnected — invitation will be shown again after re-entry'
+                                            : participant.stageState === 'UNKNOWN'
+                                              ? 'Live state unknown — grant retained'
+                                              : 'Connected — waiting for acceptance and media'}
+                                    </div>
+                                </div>
+                                {!participant.isAssignedFacilitator ? (
+                                    <button type="button" disabled={busyKey !== null} onClick={() => void takeFloor(participant)} className="min-h-11 rounded border border-[var(--danger)] px-3 py-2 text-xs text-[var(--danger)] hover:bg-[var(--danger)]/10 disabled:opacity-50">
+                                        Cancel invitation
+                                    </button>
+                                ) : (
+                                    <span className="text-xs font-medium text-[var(--text-muted)]">Reserved facilitator slot</span>
+                                )}
                             </li>
                         ))}
                     </ul>

--- a/src/components/ops/__tests__/SpotlightConsole.test.tsx
+++ b/src/components/ops/__tests__/SpotlightConsole.test.tsx
@@ -78,6 +78,7 @@ describe('SpotlightConsole', () => {
         vi.stubGlobal('fetch', mockFetch(snapshot([
             attendee('on-stage', {
                 canPublish: true,
+                stageState: 'ON_STAGE',
                 connectionQuality: 'GOOD',
                 media: [{ trackSid: 'TR_audio', source: 'MICROPHONE', muted: true }],
             }),
@@ -107,6 +108,22 @@ describe('SpotlightConsole', () => {
         expect(screen.getByText(/left/)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Take floor' })).toBeInTheDocument();
         expect(screen.getAllByRole('button', { name: 'Give floor' })).toHaveLength(2);
+    });
+
+    it('does not render a disconnected durable grant as on stage after re-entry', async () => {
+        vi.stubGlobal('fetch', mockFetch(snapshot([
+            attendee('stale-grant', {
+                canPublish: true,
+                stageState: 'RECONNECTING',
+                connected: false,
+                media: [],
+            }),
+        ], { activePublishers: 0, grantedPublishers: 2 })));
+        render(<SpotlightConsole sessionId="event-1" role="FACILITATOR" />);
+
+        expect(await screen.findByText(/Disconnected — invitation will be shown again/)).toBeInTheDocument();
+        expect(screen.getByText('Nobody has the floor yet.')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Cancel invitation' })).toBeInTheDocument();
     });
 
     it('does not offer the floor to a stale disconnected hand', async () => {

--- a/src/lib/__tests__/stage-presence.test.ts
+++ b/src/lib/__tests__/stage-presence.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { effectiveStageState } from '../stage-presence';
+
+describe('effectiveStageState', () => {
+    it.each([
+        [{ hasActiveGrant: false, connected: true, publishedTrackCount: 2 }, 'AUDIENCE'],
+        [{ hasActiveGrant: true, connected: null, publishedTrackCount: 0 }, 'UNKNOWN'],
+        [{ hasActiveGrant: true, connected: false, publishedTrackCount: 1 }, 'RECONNECTING'],
+        [{ hasActiveGrant: true, connected: true, publishedTrackCount: 0 }, 'INVITED'],
+        [{ hasActiveGrant: true, connected: true, publishedTrackCount: 1 }, 'ON_STAGE'],
+    ] as const)('maps %o to %s', (input, expected) => {
+        expect(effectiveStageState(input)).toBe(expected);
+    });
+});

--- a/src/lib/stage-presence.ts
+++ b/src/lib/stage-presence.ts
@@ -1,0 +1,22 @@
+export type EffectiveStageState =
+    | 'AUDIENCE'
+    | 'INVITED'
+    | 'RECONNECTING'
+    | 'ON_STAGE'
+    | 'UNKNOWN';
+
+export function effectiveStageState(input: {
+    hasActiveGrant: boolean;
+    connected: boolean | null;
+    publishedTrackCount: number;
+}): EffectiveStageState {
+    // Publication is deliberately stricter than a durable grant: a newly
+    // connected attendee has not accepted the invitation until the browser
+    // publishes at least one current track. Muted tracks still count because
+    // they prove acceptance while accurately rendering media as muted.
+    if (!input.hasActiveGrant) return 'AUDIENCE';
+    if (input.connected === null) return 'UNKNOWN';
+    if (!input.connected) return 'RECONNECTING';
+    if (input.publishedTrackCount === 0) return 'INVITED';
+    return 'ON_STAGE';
+}


### PR DESCRIPTION
## Outcome
- derive effective stage membership from durable grant + current LiveKit presence + a current media publication
- keep durable grants visible as invited/reconnecting instead of rendering phantom `On stage` tiles
- report publishing members separately from reserved grant capacity
- add a two-browser LiveKit regression for invite → fresh connection → no accept → no phantom stage

## Why
A durable publish grant survived a disconnect. The operator console treated that grant itself as stage presence, so a returning attendee could appear on stage before accepting the invitation or publishing media.

## Evidence
- `npm test`: 631 passed, 5 intentionally skipped
- `npx tsc --noEmit`: passed
- `npm run lint`: passed
- `npm run build`: passed
- focused stage matrix: 84 passed
- Chromium + real local LiveKit + two browser contexts: 1 passed
  - attendee declines once
  - is invited again
  - reloads into a fresh connection
  - remains in “Invited / reconnecting”
  - does not appear “On stage”
  - appears only after explicit acceptance publishes media

## Risk / rollback
Low, scoped to the operator participant snapshot and stage-status presentation. It does not modify audio, tokens, permissions, grant mutations, schema, or public media lifecycle. Rollback is a revert of commit `5a41298`.

Closes #100
