### PR TITLE
PERF-01: add guarded dual-LiveKit load harness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,6 +66,28 @@ jobs:
           echo "LiveKit did not become ready" >&2
           exit 1
 
+      - name: Install pinned LiveKit load tester
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/lk.tar.gz" \
+            https://github.com/livekit/livekit-cli/releases/download/v2.16.3/lk_2.16.3_linux_amd64.tar.gz
+          echo "57935ce348a634a1e12769b9eaf7e684cf46920ad65e4b6d88f87a9cd01de2d6  $RUNNER_TEMP/lk.tar.gz" \
+            | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/lk.tar.gz" -C "$RUNNER_TEMP" lk
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - name: Run small dual-LiveKit load profile
+        run: npm run load:livekit -- --profile ci --run-id "ci-${GITHUB_RUN_ID}"
+        env:
+          LIVEKIT_URL: ${{ env.E2E_LIVEKIT_URL }}
+          LIVEKIT_API_KEY: ${{ env.E2E_LIVEKIT_API_KEY }}
+          LIVEKIT_API_SECRET: ${{ env.E2E_LIVEKIT_API_SECRET }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: livekit-load-manifest
+          path: artifacts/load-test/
+
       - name: Restore fixture database
         run: |
           npm run db:fixture:load

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /test-results/
 /playwright-report/
 /e2e/.auth/
+/artifacts/load-test/
 
 # next.js
 /.next/

--- a/config/livekit-load-profiles.json
+++ b/config/livekit-load-profiles.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "profiles": {
+    "ci": {
+      "eventLanguage": "es",
+      "attendees": 4,
+      "stagePublishers": 2,
+      "beaconPublishers": 1,
+      "rampPerSecond": 4,
+      "rampDurationSeconds": 6,
+      "soakDurationSeconds": 8,
+      "reconnectDurationSeconds": 4,
+      "reconnectWaves": 1,
+      "reconnectMode": "simultaneous",
+      "interWaveSeconds": 1,
+      "maxDroppedPercent": 0
+    },
+    "rehearsal-es": {
+      "eventLanguage": "es",
+      "attendees": 150,
+      "stagePublishers": 6,
+      "beaconPublishers": 1,
+      "rampPerSecond": 10,
+      "rampDurationSeconds": 60,
+      "soakDurationSeconds": 1200,
+      "reconnectDurationSeconds": 60,
+      "reconnectWaves": 2,
+      "reconnectMode": "staggered",
+      "interWaveSeconds": 10,
+      "maxDroppedPercent": 0.1
+    },
+    "rehearsal-en": {
+      "eventLanguage": "en",
+      "attendees": 150,
+      "stagePublishers": 6,
+      "beaconPublishers": 1,
+      "rampPerSecond": 10,
+      "rampDurationSeconds": 60,
+      "soakDurationSeconds": 1200,
+      "reconnectDurationSeconds": 60,
+      "reconnectWaves": 2,
+      "reconnectMode": "staggered",
+      "interWaveSeconds": 10,
+      "maxDroppedPercent": 0.1
+    }
+  }
+}

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -1,0 +1,82 @@
+# Dual-LiveKit load harness
+
+This is the reproducible protocol-load layer for #99 and the capacity input
+to #24. It launches the official LiveKit CLI load tester against two synthetic
+rooms: one stage room and one Beacon room. Every declared attendee therefore
+has a simulated subscriber connection to each room; stage and Beacon publishers
+are additional conservative load.
+
+It does **not** certify perceived audio, browser DOM/media lifecycle, physical
+mobile routing, Bluetooth, TURN, or the operator journey. Those remain browser
+and human gates in #24.
+
+## Safety model
+
+- Room names are generated as `hb-load-<run>-<language>-stage|beacon`.
+- Real event room names are rejected.
+- `localhost`, `127.0.0.1`, and `::1` are allowed by default.
+- Every remote target requires both `--allow-remote` and an exact confirmation
+  containing both generated room names.
+- Credentials are read only from `LIVEKIT_API_KEY` and
+  `LIVEKIT_API_SECRET`. They are never arguments or manifest fields.
+- Manifests are mode `0600` and contain no identities, tokens, audio, video,
+  email, or raw CLI output.
+
+Preview a run without credentials or LiveKit:
+
+```bash
+npm run load:livekit -- --profile rehearsal-es --run-id rehearsal-20260803 --dry-run
+```
+
+Run the small local profile:
+
+```bash
+LIVEKIT_URL=ws://localhost:7880 \
+LIVEKIT_API_KEY=devkey \
+LIVEKIT_API_SECRET=secret \
+npm run load:livekit -- --profile ci --run-id local-ci
+```
+
+For a remote production-like LiveKit node, first dry-run and copy the exact
+confirmation printed in the refusal message:
+
+```bash
+npm run load:livekit -- \
+  --profile rehearsal-es \
+  --run-id mona-rehearsal-20260803 \
+  --url wss://test-live.example.invalid \
+  --allow-remote \
+  --confirm-test-rooms 'LOADTEST:hb-load-mona-rehearsal-20260803-es-stage:hb-load-mona-rehearsal-20260803-es-beacon'
+```
+
+Never point this command at an active event. The remote rooms must be synthetic
+and the operator must monitor LiveKit, CPU, memory, and network on the target.
+
+## Profiles and evidence
+
+- `ci`: four attendees, two stage publishers, one Beacon publisher, short
+  ramp/soak/reconnect.
+- `rehearsal-es` and `rehearsal-en`: 150 dual-room attendees, six simulcast
+  stage publishers, one Beacon audio publisher, 20-minute soak, and two
+  staggered reconnect waves.
+
+Reconnect waves deliberately reuse the same synthetic identity prefixes after
+the previous wave has converged to zero. This measures disconnect/rejoin churn;
+it is not an in-place ICE-resume measurement. Browser E2E and the physical
+rehearsal cover the SDK resume path.
+
+The JSON manifest binds parameters to the Beacon Git SHA, dirty-worktree bit,
+and LiveKit CLI version. It records exact/peak participants and publishers,
+poll-observed join p50/p95/p99, cleanup convergence, packet loss, generator
+CPU/memory/network deltas, and event-loop delay. Each phase fails unless both
+CLI processes exit zero, report every expected track, reach exact room counts,
+clean up to zero, and remain below the configured dropped-packet threshold.
+Run the full ES and EN profiles twice and attach all four manifests to #24.
+
+## Tooling
+
+Install the official `lk` CLI (the CI workflow pins v2.16.3). LiveKit recommends
+running large tests from a well-provisioned host and raising file-descriptor and
+network limits; do that on the load-generator host before a 150-person run. See
+the official [LiveKit benchmarking guide](https://docs.livekit.io/transport/self-hosting/benchmark)
+and [LiveKit CLI repository](https://github.com/livekit/livekit-cli).

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install chromium",
-    "test:e2e:update-snapshots": "playwright test --update-snapshots"
+    "test:e2e:update-snapshots": "playwright test --update-snapshots",
+    "load:livekit": "node scripts/livekit-load-harness.mjs"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.3.0",

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -1,0 +1,202 @@
+import { createHash } from 'node:crypto';
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+const ROOM_PATTERN = /^hb-load-[a-z0-9][a-z0-9-]{2,47}-(stage|beacon)$/;
+
+export function sanitizeRunId(value) {
+    const runId = String(value ?? '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 40);
+    if (runId.length < 3) {
+        throw new Error('run id must contain at least three safe characters');
+    }
+    return runId;
+}
+
+export function validateProfile(profile) {
+    const integerFields = [
+        'attendees',
+        'stagePublishers',
+        'beaconPublishers',
+        'rampPerSecond',
+        'rampDurationSeconds',
+        'soakDurationSeconds',
+        'reconnectDurationSeconds',
+        'reconnectWaves',
+        'interWaveSeconds',
+    ];
+    for (const field of integerFields) {
+        if (!Number.isInteger(profile[field]) || profile[field] < 0) {
+            throw new Error(`${field} must be a non-negative integer`);
+        }
+    }
+    if (profile.attendees < 1) throw new Error('attendees must be at least one');
+    if (profile.stagePublishers > 6) {
+        throw new Error('stagePublishers exceeds the product cap of six');
+    }
+    if (profile.beaconPublishers !== 1) {
+        throw new Error('beaconPublishers must be exactly one');
+    }
+    if (profile.rampPerSecond < 1) throw new Error('rampPerSecond must be at least one');
+    if (!['es', 'en'].includes(profile.eventLanguage)) {
+        throw new Error('eventLanguage must be es or en');
+    }
+    if (!['simultaneous', 'staggered'].includes(profile.reconnectMode)) {
+        throw new Error('reconnectMode must be simultaneous or staggered');
+    }
+    if (typeof profile.maxDroppedPercent !== 'number' ||
+        profile.maxDroppedPercent < 0 || profile.maxDroppedPercent > 100) {
+        throw new Error('maxDroppedPercent must be between zero and 100');
+    }
+    return profile;
+}
+
+export function roomNames(runId) {
+    const safeRunId = sanitizeRunId(runId);
+    return {
+        stage: `hb-load-${safeRunId}-stage`,
+        beacon: `hb-load-${safeRunId}-beacon`,
+    };
+}
+
+export function remoteConfirmation(rooms) {
+    return `LOADTEST:${rooms.stage}:${rooms.beacon}`;
+}
+
+export function assertSafeTarget({ url, rooms, allowRemote, confirmation }) {
+    const parsed = new URL(url.replace(/^ws:/, 'http:').replace(/^wss:/, 'https:'));
+    for (const room of Object.values(rooms)) {
+        if (!ROOM_PATTERN.test(room)) {
+            throw new Error(`unsafe room name: ${room}`);
+        }
+    }
+    if (LOCAL_HOSTS.has(parsed.hostname)) return { target: 'local', host: parsed.hostname };
+    if (!allowRemote) {
+        throw new Error(
+            `remote LiveKit targets require --allow-remote and --confirm-test-rooms ${remoteConfirmation(rooms)}`,
+        );
+    }
+    const expected = remoteConfirmation(rooms);
+    if (confirmation !== expected) {
+        throw new Error(`remote confirmation mismatch; expected ${expected}`);
+    }
+    return { target: 'remote-explicit', host: parsed.hostname };
+}
+
+function commandFor({ room, identityPrefix, durationSeconds, publishers, publisherKind, attendees, rampPerSecond }) {
+    const args = [
+        'load-test',
+        '--room', room,
+        '--identity-prefix', identityPrefix,
+        '--duration', `${durationSeconds}s`,
+        '--subscribers', String(attendees),
+        '--num-per-second', String(rampPerSecond),
+    ];
+    args.push(
+        publisherKind === 'video' ? '--video-publishers' : '--audio-publishers',
+        String(publishers),
+    );
+    if (publisherKind === 'video') {
+        args.push('--video-resolution', 'high');
+    }
+    return args;
+}
+
+export function buildPlan({ profileName, profile, runId, url, allowRemote = false, confirmation = '' }) {
+    validateProfile(profile);
+    const rooms = roomNames(`${sanitizeRunId(runId)}-${profile.eventLanguage}`);
+    const safety = assertSafeTarget({ url, rooms, allowRemote, confirmation });
+    const phases = [
+        { name: 'ramp', durationSeconds: profile.rampDurationSeconds, rampPerSecond: profile.rampPerSecond },
+        { name: 'soak', durationSeconds: profile.soakDurationSeconds, rampPerSecond: profile.rampPerSecond },
+    ];
+    for (let wave = 1; wave <= profile.reconnectWaves; wave += 1) {
+        phases.push({
+            name: `reconnect-${wave}`,
+            durationSeconds: profile.reconnectDurationSeconds,
+            rampPerSecond: profile.reconnectMode === 'simultaneous'
+                ? profile.attendees + profile.stagePublishers
+                : profile.rampPerSecond,
+        });
+    }
+    return {
+        schemaVersion: 1,
+        profileName,
+        profile: structuredClone(profile),
+        runId: sanitizeRunId(runId),
+        urlHost: safety.host,
+        target: safety.target,
+        rooms,
+        phases: phases.map((phase) => ({
+            ...phase,
+            stage: {
+                roomName: rooms.stage,
+                requestedConnections: profile.attendees + profile.stagePublishers,
+                args: commandFor({
+                    room: rooms.stage,
+                    identityPrefix: `hbload-${sanitizeRunId(runId)}-stage`,
+                    durationSeconds: phase.durationSeconds,
+                    publishers: profile.stagePublishers,
+                    publisherKind: 'video',
+                    attendees: profile.attendees,
+                    rampPerSecond: phase.rampPerSecond,
+                }),
+            },
+            beacon: {
+                roomName: rooms.beacon,
+                requestedConnections: profile.attendees + profile.beaconPublishers,
+                args: commandFor({
+                    room: rooms.beacon,
+                    identityPrefix: `hbload-${sanitizeRunId(runId)}-beacon`,
+                    durationSeconds: phase.durationSeconds,
+                    publishers: profile.beaconPublishers,
+                    publisherKind: 'audio',
+                    attendees: profile.attendees,
+                    rampPerSecond: phase.rampPerSecond,
+                }),
+            },
+        })),
+    };
+}
+
+function stripAnsi(value) {
+    return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+}
+
+export function parseLoadTestOutput(output) {
+    const lines = stripAnsi(output).split(/\r?\n/).filter(Boolean);
+    const totalLine = [...lines].reverse().find((line) => /[|│]\s*Total\s*[|│]/.test(line));
+    if (!totalLine) {
+        return { parsed: false, tracksReceived: null, tracksExpected: null, latencyMs: null, dropped: null, droppedPercent: null, errorCount: null };
+    }
+    const columns = totalLine.split(/[|│]/).map((column) => column.trim()).filter(Boolean);
+    const tracks = columns.find((column) => /^\d+\/\d+$/.test(column));
+    const latency = columns.find((column) => /^\d+(?:\.\d+)?(?:µs|ms|s)$/.test(column));
+    const dropped = columns.find((column) => /^\d+\s+\(\d+(?:\.\d+)?%\)$/.test(column));
+    const trackMatch = tracks?.match(/^(\d+)\/(\d+)$/);
+    const latencyMatch = latency?.match(/^(\d+(?:\.\d+)?)(µs|ms|s)$/);
+    const droppedMatch = dropped?.match(/^(\d+)\s+\((\d+(?:\.\d+)?)%\)$/);
+    const errorColumn = [...columns].reverse().find((column) => /^\d+$/.test(column));
+    const latencyFactor = latencyMatch?.[2] === 's' ? 1000 : latencyMatch?.[2] === 'µs' ? 0.001 : 1;
+    return {
+        parsed: Boolean(trackMatch && droppedMatch),
+        tracksReceived: trackMatch ? Number(trackMatch[1]) : null,
+        tracksExpected: trackMatch ? Number(trackMatch[2]) : null,
+        latencyMs: latencyMatch ? Number(latencyMatch[1]) * latencyFactor : null,
+        dropped: droppedMatch ? Number(droppedMatch[1]) : null,
+        droppedPercent: droppedMatch ? Number(droppedMatch[2]) : null,
+        errorCount: errorColumn ? Number(errorColumn) : null,
+    };
+}
+
+export function commandFingerprint(args) {
+    return createHash('sha256').update(JSON.stringify(args)).digest('hex');
+}
+
+export function manifestContainsSecret(value, secrets) {
+    const serialized = JSON.stringify(value);
+    return secrets.filter(Boolean).some((secret) => serialized.includes(secret));
+}

--- a/scripts/livekit-load-harness.mjs
+++ b/scripts/livekit-load-harness.mjs
@@ -1,0 +1,405 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { hostname } from 'node:os';
+import { basename, dirname, resolve } from 'node:path';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { RoomServiceClient } from 'livekit-server-sdk';
+
+import {
+    buildPlan,
+    commandFingerprint,
+    manifestContainsSecret,
+    parseLoadTestOutput,
+    remoteConfirmation,
+} from './lib/livekit-load-harness.mjs';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const OUTPUT_TAIL_LIMIT = 1024 * 1024;
+
+function appendOutputTail(current, chunk) {
+    const next = current + chunk.toString();
+    return next.length > OUTPUT_TAIL_LIMIT ? next.slice(-OUTPUT_TAIL_LIMIT) : next;
+}
+
+async function readGeneratorResources() {
+    try {
+        const [stat, meminfo, netdev] = await Promise.all([
+            readFile('/proc/stat', 'utf8'),
+            readFile('/proc/meminfo', 'utf8'),
+            readFile('/proc/net/dev', 'utf8'),
+        ]);
+        const cpu = stat.split('\n')[0].trim().split(/\s+/).slice(1).map(Number);
+        const memoryMatch = meminfo.match(/^MemAvailable:\s+(\d+)\s+kB$/m);
+        let networkRxBytes = 0;
+        let networkTxBytes = 0;
+        for (const line of netdev.split('\n').slice(2)) {
+            const [interfaceName, counters] = line.split(':');
+            if (!counters || interfaceName.trim() === 'lo') continue;
+            const values = counters.trim().split(/\s+/).map(Number);
+            networkRxBytes += values[0] ?? 0;
+            networkTxBytes += values[8] ?? 0;
+        }
+        return {
+            cpuTotal: cpu.reduce((sum, value) => sum + value, 0),
+            cpuIdle: (cpu[3] ?? 0) + (cpu[4] ?? 0),
+            memoryAvailableBytes: memoryMatch ? Number(memoryMatch[1]) * 1024 : null,
+            networkRxBytes,
+            networkTxBytes,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function summarizeGeneratorResources(before, after) {
+    if (!before || !after) return { available: false };
+    const totalDelta = after.cpuTotal - before.cpuTotal;
+    const idleDelta = after.cpuIdle - before.cpuIdle;
+    return {
+        available: true,
+        cpuBusyPercent: totalDelta > 0
+            ? Number(((1 - idleDelta / totalDelta) * 100).toFixed(2))
+            : null,
+        memoryAvailableBeforeBytes: before.memoryAvailableBytes,
+        memoryAvailableAfterBytes: after.memoryAvailableBytes,
+        networkRxBytes: after.networkRxBytes - before.networkRxBytes,
+        networkTxBytes: after.networkTxBytes - before.networkTxBytes,
+    };
+}
+
+function nanosecondsToMilliseconds(value) {
+    return Number.isFinite(value) ? Number((value / 1_000_000).toFixed(3)) : null;
+}
+
+function option(name, fallback = undefined) {
+    const index = process.argv.indexOf(name);
+    return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+function hasFlag(name) {
+    return process.argv.includes(name);
+}
+
+function generatedRunId() {
+    return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'z').toLowerCase();
+}
+
+function printHelp() {
+    process.stdout.write(`Usage: npm run load:livekit -- [options]\n\n` +
+        `  --profile NAME             ci, rehearsal-es, or rehearsal-en\n` +
+        `  --run-id ID                synthetic namespace recorded in the manifest\n` +
+        `  --url URL                  LiveKit URL (default LIVEKIT_URL or localhost)\n` +
+        `  --lk-bin PATH              pinned LiveKit CLI executable (default lk)\n` +
+        `  --manifest PATH            output JSON path\n` +
+        `  --dry-run                  validate and write a PLANNED manifest only\n` +
+        `  --allow-remote             acknowledge a non-local target\n` +
+        `  --confirm-test-rooms VALUE exact room confirmation required remotely\n`);
+}
+
+async function commandOutput(command, args) {
+    return new Promise((resolvePromise) => {
+        const child = spawn(command, args, { cwd: repositoryRoot, stdio: ['ignore', 'pipe', 'pipe'] });
+        let output = '';
+        child.stdout.on('data', (chunk) => { output = appendOutputTail(output, chunk); });
+        child.stderr.on('data', (chunk) => { output = appendOutputTail(output, chunk); });
+        child.on('error', (error) => resolvePromise({ exitCode: 127, output: error.message }));
+        child.on('close', (exitCode) => resolvePromise({ exitCode: exitCode ?? 1, output }));
+    });
+}
+
+async function runLoad(lkBinary, args, credentials) {
+    const startedAt = new Date();
+    return new Promise((resolvePromise) => {
+        const child = spawn(lkBinary, args, {
+            cwd: repositoryRoot,
+            env: {
+                ...process.env,
+                LIVEKIT_URL: credentials.url,
+                LIVEKIT_API_KEY: credentials.apiKey,
+                LIVEKIT_API_SECRET: credentials.apiSecret,
+            },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let output = '';
+        child.stdout.on('data', (chunk) => {
+            output = appendOutputTail(output, chunk);
+            process.stdout.write(chunk);
+        });
+        child.stderr.on('data', (chunk) => {
+            output = appendOutputTail(output, chunk);
+            process.stderr.write(chunk);
+        });
+        child.on('error', (error) => {
+            resolvePromise({
+                exitCode: 127,
+                error: error.message,
+                startedAt: startedAt.toISOString(),
+                endedAt: new Date().toISOString(),
+                durationMs: Date.now() - startedAt.getTime(),
+                summary: parseLoadTestOutput(output),
+            });
+        });
+        child.on('close', (exitCode) => {
+            resolvePromise({
+                exitCode: exitCode ?? 1,
+                startedAt: startedAt.toISOString(),
+                endedAt: new Date().toISOString(),
+                durationMs: Date.now() - startedAt.getTime(),
+                summary: parseLoadTestOutput(output),
+            });
+        });
+    });
+}
+
+function percentile(values, percentileValue) {
+    if (values.length === 0) return null;
+    const sorted = [...values].sort((left, right) => left - right);
+    return sorted[Math.min(sorted.length - 1, Math.ceil(percentileValue * sorted.length) - 1)];
+}
+
+function summarizeObservedRoom(observed, expectedConnections, expectedPublishers) {
+    return {
+        expectedConnections,
+        peakConnections: observed.peakConnections,
+        expectedPublishers,
+        peakPublishers: observed.peakPublishers,
+        peakTracks: observed.peakTracks,
+        joinObserved: observed.joinOffsetsMs.length,
+        joinMs: {
+            p50: percentile(observed.joinOffsetsMs, 0.5),
+            p95: percentile(observed.joinOffsetsMs, 0.95),
+            p99: percentile(observed.joinOffsetsMs, 0.99),
+        },
+    };
+}
+
+async function monitorRooms(roomService, phase, stopped) {
+    const startedAt = Date.now();
+    const rooms = {
+        stage: { seen: new Set(), joinOffsetsMs: [], peakConnections: 0, peakPublishers: 0, peakTracks: 0 },
+        beacon: { seen: new Set(), joinOffsetsMs: [], peakConnections: 0, peakPublishers: 0, peakTracks: 0 },
+    };
+    let apiErrors = 0;
+    let successfulSamples = 0;
+    while (!stopped.value) {
+        for (const [kind, roomName] of Object.entries({
+            stage: phase.stage.roomName,
+            beacon: phase.beacon.roomName,
+        })) {
+            try {
+                const participants = await roomService.listParticipants(roomName);
+                successfulSamples += 1;
+                const observed = rooms[kind];
+                observed.peakConnections = Math.max(observed.peakConnections, participants.length);
+                observed.peakPublishers = Math.max(
+                    observed.peakPublishers,
+                    participants.filter((participant) => participant.tracks.length > 0).length,
+                );
+                observed.peakTracks = Math.max(
+                    observed.peakTracks,
+                    participants.reduce((sum, participant) => sum + participant.tracks.length, 0),
+                );
+                for (const participant of participants) {
+                    if (!observed.seen.has(participant.sid)) {
+                        observed.seen.add(participant.sid);
+                        observed.joinOffsetsMs.push(Date.now() - startedAt);
+                    }
+                }
+            } catch {
+                apiErrors += 1;
+            }
+        }
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+    }
+    return {
+        apiErrors,
+        successfulSamples,
+        stage: summarizeObservedRoom(rooms.stage, phase.stage.requestedConnections, phase.profileStagePublishers),
+        beacon: summarizeObservedRoom(rooms.beacon, phase.beacon.requestedConnections, phase.profileBeaconPublishers),
+    };
+}
+
+async function waitForCleanup(roomService, roomNames, timeoutMs = 10_000) {
+    const startedAt = Date.now();
+    let remaining = { stage: null, beacon: null };
+    do {
+        try {
+            const [stage, beacon] = await Promise.all([
+                roomService.listParticipants(roomNames.stage),
+                roomService.listParticipants(roomNames.beacon),
+            ]);
+            remaining = { stage: stage.length, beacon: beacon.length };
+            if (stage.length === 0 && beacon.length === 0) {
+                return { passed: true, convergenceMs: Date.now() - startedAt, remaining };
+            }
+        } catch {
+            // Empty rooms can disappear between list calls. Retry until the
+            // bounded deadline so an API hiccup is never mistaken for clean.
+        }
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+    } while (Date.now() - startedAt < timeoutMs);
+    return { passed: false, convergenceMs: Date.now() - startedAt, remaining };
+}
+
+function publicPlan(plan, lkBinary) {
+    const executable = basename(lkBinary);
+    return {
+        ...plan,
+        phases: plan.phases.map((phase) => ({
+            ...phase,
+            stage: {
+                requestedConnections: phase.stage.requestedConnections,
+                command: `${executable} ${phase.stage.args.join(' ')}`,
+                fingerprint: commandFingerprint(phase.stage.args),
+            },
+            beacon: {
+                requestedConnections: phase.beacon.requestedConnections,
+                command: `${executable} ${phase.beacon.args.join(' ')}`,
+                fingerprint: commandFingerprint(phase.beacon.args),
+            },
+        })),
+    };
+}
+
+async function main() {
+    if (hasFlag('--help') || hasFlag('-h')) {
+        printHelp();
+        return;
+    }
+    const profileName = option('--profile', 'ci');
+    const runId = option('--run-id', generatedRunId());
+    const url = option('--url', process.env.LIVEKIT_URL ?? 'ws://localhost:7880');
+    const lkBinary = option('--lk-bin', process.env.LK_BIN ?? 'lk');
+    const dryRun = hasFlag('--dry-run');
+    const profilesPath = resolve(repositoryRoot, 'config/livekit-load-profiles.json');
+    const profilesDocument = JSON.parse(await readFile(profilesPath, 'utf8'));
+    const profile = profilesDocument.profiles?.[profileName];
+    if (!profile) throw new Error(`unknown profile: ${profileName}`);
+    const plan = buildPlan({
+        profileName,
+        profile,
+        runId,
+        url,
+        allowRemote: hasFlag('--allow-remote'),
+        confirmation: option('--confirm-test-rooms', ''),
+    });
+    const manifestPath = resolve(
+        repositoryRoot,
+        option('--manifest', `artifacts/load-test/${plan.runId}-${profileName}.json`),
+    );
+    const [git, gitStatus, lk] = await Promise.all([
+        commandOutput('git', ['rev-parse', 'HEAD']),
+        commandOutput('git', ['status', '--porcelain']),
+        dryRun ? Promise.resolve({ exitCode: 0, output: 'not checked in dry-run' }) : commandOutput(lkBinary, ['--version']),
+    ]);
+    const manifest = {
+        schemaVersion: 1,
+        kind: 'harmonic-beacon-livekit-load',
+        status: dryRun ? 'PLANNED' : 'RUNNING',
+        generatedAt: new Date().toISOString(),
+        harnessSha: git.output.trim() || 'unknown',
+        livekitCliVersion: lk.output.trim() || 'unknown',
+        harnessDirty: gitStatus.output.trim().length > 0,
+        generatorHostHash: commandFingerprint([hostname()]).slice(0, 12),
+        plan: publicPlan(plan, lkBinary),
+        limitations: [
+            'Protocol clients measure SFU capacity; they do not certify browser DOM, decode, physical speaker routing, or perceived audio quality.',
+            'Load-test summary latency is media latency, not per-user application login latency.',
+            'Physical iOS, Android, Bluetooth, TURN, and six-camera evidence remains in issue #24.',
+        ],
+        phases: [],
+    };
+
+    if (!dryRun) {
+        const credentials = {
+            url,
+            apiKey: process.env.LIVEKIT_API_KEY ?? '',
+            apiSecret: process.env.LIVEKIT_API_SECRET ?? '',
+        };
+        if (!credentials.apiKey || !credentials.apiSecret) {
+            throw new Error('LIVEKIT_API_KEY and LIVEKIT_API_SECRET are required');
+        }
+        if (lk.exitCode !== 0) throw new Error(`LiveKit CLI unavailable: ${lk.output.trim()}`);
+        const roomService = new RoomServiceClient(
+            url.replace(/^ws:/, 'http:').replace(/^wss:/, 'https:'),
+            credentials.apiKey,
+            credentials.apiSecret,
+        );
+        for (const [index, phase] of plan.phases.entries()) {
+            process.stdout.write(`\n[${phase.name}] starting stage and Beacon load\n`);
+            const resourceBefore = await readGeneratorResources();
+            const eventLoop = monitorEventLoopDelay({ resolution: 20 });
+            eventLoop.enable();
+            const stopped = { value: false };
+            const monitor = monitorRooms(roomService, {
+                ...phase,
+                profileStagePublishers: profile.stagePublishers,
+                profileBeaconPublishers: profile.beaconPublishers,
+            }, stopped);
+            const [stage, beacon] = await Promise.all([
+                runLoad(lkBinary, phase.stage.args, credentials),
+                runLoad(lkBinary, phase.beacon.args, credentials),
+            ]);
+            stopped.value = true;
+            const observed = await monitor;
+            const cleanup = await waitForCleanup(roomService, plan.rooms);
+            eventLoop.disable();
+            const resourceAfter = await readGeneratorResources();
+            const generatorResources = {
+                ...summarizeGeneratorResources(resourceBefore, resourceAfter),
+                eventLoopDelayMs: {
+                    mean: nanosecondsToMilliseconds(eventLoop.mean),
+                    p95: nanosecondsToMilliseconds(eventLoop.percentile(95)),
+                    p99: nanosecondsToMilliseconds(eventLoop.percentile(99)),
+                    max: nanosecondsToMilliseconds(eventLoop.max),
+                },
+            };
+            const passed = [stage, beacon].every((result) =>
+                result.exitCode === 0 &&
+                result.summary.parsed &&
+                result.summary.tracksReceived === result.summary.tracksExpected &&
+                result.summary.droppedPercent <= profile.maxDroppedPercent &&
+                (result.summary.errorCount === null || result.summary.errorCount === 0),
+            ) &&
+                observed.successfulSamples > 0 &&
+                observed.stage.peakConnections === phase.stage.requestedConnections &&
+                observed.stage.peakPublishers === profile.stagePublishers &&
+                observed.beacon.peakConnections === phase.beacon.requestedConnections &&
+                observed.beacon.peakPublishers === profile.beaconPublishers &&
+                cleanup.passed;
+            manifest.phases.push({
+                name: phase.name,
+                passed,
+                stage,
+                beacon,
+                observed,
+                cleanup,
+                generatorResources,
+            });
+            if (!passed) manifest.status = 'FAIL';
+            if (index < plan.phases.length - 1 && profile.interWaveSeconds > 0) {
+                await new Promise((resolvePromise) => setTimeout(resolvePromise, profile.interWaveSeconds * 1000));
+            }
+        }
+        if (manifest.status !== 'FAIL') manifest.status = 'PASS';
+        if (manifestContainsSecret(manifest, [credentials.apiKey, credentials.apiSecret])) {
+            throw new Error('refusing to write a manifest containing a credential');
+        }
+    }
+
+    await mkdir(dirname(manifestPath), { recursive: true });
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+    process.stdout.write(`\nManifest: ${manifestPath}\nStatus: ${manifest.status}\n`);
+    if (plan.target === 'remote-explicit') {
+        process.stdout.write(`Remote confirmation used: ${remoteConfirmation(plan.rooms)}\n`);
+    }
+    if (manifest.status === 'FAIL') process.exitCode = 1;
+}
+
+main().catch((error) => {
+    process.stderr.write(`load harness refused or failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+});

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    assertSafeTarget,
+    buildPlan,
+    manifestContainsSecret,
+    parseLoadTestOutput,
+    remoteConfirmation,
+    roomNames,
+    validateProfile,
+} from '../../../scripts/lib/livekit-load-harness.mjs';
+
+const profile = {
+    eventLanguage: 'es',
+    attendees: 150,
+    stagePublishers: 6,
+    beaconPublishers: 1,
+    rampPerSecond: 10,
+    rampDurationSeconds: 60,
+    soakDurationSeconds: 1200,
+    reconnectDurationSeconds: 60,
+    reconnectWaves: 2,
+    reconnectMode: 'staggered',
+    interWaveSeconds: 10,
+    maxDroppedPercent: 0.1,
+};
+
+describe('LiveKit load harness safety', () => {
+    it('builds two synthetic connections per attendee and caps the stage at six publishers', () => {
+        const plan = buildPlan({
+            profileName: 'rehearsal-es',
+            profile,
+            runId: 'event-weekend',
+            url: 'ws://localhost:7880',
+        });
+        expect(plan.rooms).toEqual({
+            stage: 'hb-load-event-weekend-es-stage',
+            beacon: 'hb-load-event-weekend-es-beacon',
+        });
+        expect(plan.phases.map((phase) => phase.name)).toEqual([
+            'ramp', 'soak', 'reconnect-1', 'reconnect-2',
+        ]);
+        expect(plan.phases[0].stage.requestedConnections).toBe(156);
+        expect(plan.phases[0].beacon.requestedConnections).toBe(151);
+        expect(plan.phases[0].stage.args).toContain('6');
+        expect(plan.phases[0].beacon.args).toContain('1');
+        expect(plan.phases[0].stage.args).toContain('hbload-event-weekend-stage');
+        expect(plan.phases[2].stage.args).toContain('hbload-event-weekend-stage');
+    });
+
+    it('rejects a seventh stage publisher before starting traffic', () => {
+        expect(() => validateProfile({ ...profile, stagePublishers: 7 }))
+            .toThrow(/cap of six/);
+    });
+
+    it('refuses remote targets unless the operator confirms both generated test rooms exactly', () => {
+        const rooms = roomNames('remote-check');
+        expect(() => assertSafeTarget({
+            url: 'wss://live.example.test', rooms, allowRemote: false, confirmation: '',
+        })).toThrow(/require --allow-remote/);
+        expect(() => assertSafeTarget({
+            url: 'wss://live.example.test', rooms, allowRemote: true, confirmation: 'yes',
+        })).toThrow(/confirmation mismatch/);
+        expect(assertSafeTarget({
+            url: 'wss://live.example.test',
+            rooms,
+            allowRemote: true,
+            confirmation: remoteConfirmation(rooms),
+        }).target).toBe('remote-explicit');
+    });
+
+    it('never accepts real event room names', () => {
+        expect(() => assertSafeTarget({
+            url: 'ws://localhost:7880',
+            rooms: { stage: 'real-spanish-event', beacon: 'beacon' },
+            allowRemote: false,
+            confirmation: '',
+        })).toThrow(/unsafe room name/);
+    });
+});
+
+describe('LiveKit load harness evidence', () => {
+    it('parses the official CLI total summary without retaining participant rows', () => {
+        const output = 'Summary | Tester | Tracks | Bitrate | Latency | Total Dropped\n' +
+            '        | Total | 5000/5000 | 678.7mbps | 79.923769ms | 0 (0%)\n';
+        expect(parseLoadTestOutput(output)).toEqual({
+            parsed: true,
+            tracksReceived: 5000,
+            tracksExpected: 5000,
+            latencyMs: 79.923769,
+            dropped: 0,
+            droppedPercent: 0,
+            errorCount: null,
+        });
+    });
+
+    it('parses the current Unicode CLI table and its error count', () => {
+        const output = '│ Total  │ 8/8 │ 6.3mbps (1.6mbps avg) │ 0 (0%) │ 0 │';
+        expect(parseLoadTestOutput(output)).toEqual({
+            parsed: true,
+            tracksReceived: 8,
+            tracksExpected: 8,
+            latencyMs: null,
+            dropped: 0,
+            droppedPercent: 0,
+            errorCount: 0,
+        });
+    });
+
+    it('fails closed when the CLI output has no machine-recognizable summary', () => {
+        expect(parseLoadTestOutput('load tester exited unexpectedly').parsed).toBe(false);
+    });
+
+    it('detects credentials anywhere in a candidate manifest', () => {
+        expect(manifestContainsSecret({ nested: ['safe', 'secret-value'] }, ['key', 'secret-value']))
+            .toBe(true);
+        expect(manifestContainsSecret({ nested: ['safe'] }, ['key', 'secret-value']))
+            .toBe(false);
+    });
+});


### PR DESCRIPTION
## Outcome
- add a guarded `npm run load:livekit` harness around the official LiveKit CLI
- model every attendee as a subscriber in a synthetic stage room and synthetic Beacon room
- support CI, 150-person ES, and 150-person EN ramp/20-minute-soak/rejoin profiles
- enforce six stage publishers, one Beacon publisher, synthetic identities, safe room names, and explicit remote confirmation
- emit mode-0600 redacted manifests bound to Git SHA/profile/CLI version
- measure exact and peak room/publisher/track counts, observed join p50/p95/p99, packet loss, cleanup convergence, generator CPU/memory/network, and event-loop delay
- run the small real dual-room profile in E2E CI using checksum-pinned LiveKit CLI v2.16.3

## Local evidence
- real LiveKit v1.13.4 + official `lk` v2.16.3
- ramp, soak, and simultaneous rejoin wave: PASS
- every phase reached exact stage/Beacon participant and publisher counts
- every expected track received; zero packet loss and zero CLI errors
- every phase converged to zero residual participants
- two consecutive executions passed
- final manifest mode 0600 and scan found no API key, secret, participant/track SID, raw identity, or local path
- 632 tests passed; 5 opt-in integration tests skipped
- TypeScript, lint, YAML parse, and production build passed

## Boundaries
Protocol clients cannot certify physical audio, browser decode/DOM lifecycle, Bluetooth, mobile call/media routing, TURN, or perceived quality. Rejoin waves reuse identities after clean disconnect; they are not in-place ICE resume. Those browser/physical gates remain in #24.

The 150-person remote profiles are implemented but intentionally not run against mona in this PR: remote execution requires the exact generated room confirmation and an operator watching the target. No production event room can pass the harness room allowlist.

## Risk / rollback
No application runtime or audio path changes. The only CI effect is a small throwaway LiveKit profile before browser gates. Rollback is reverting `94c3dc5`.

Refs #99
