### PR TITLE
INT-10: controlled promotional invitations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ LIVEKIT_ROOM_NAME=beacon
 # Generate independently with a cryptographically secure secret generator.
 TICKET_CODE_PEPPER=replace-with-at-least-32-random-characters
 TICKET_CODE_DIGEST_VERSION=1
+# Global kill switch for short, staff-created complimentary invitation codes.
+# Campaigns may be prepared while false; no public redemption is possible.
+PROMO_INVITATIONS_ENABLED=false
 # Private PMP worker authentication. Never expose these with NEXT_PUBLIC_.
 BEACON_COMMERCE_SERVICE_KEY_CURRENT_ID=local-v1
 BEACON_COMMERCE_SERVICE_KEY_CURRENT=replace-with-at-least-43-random-characters

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,7 +110,7 @@ jobs:
         run: npx playwright test e2e/tests/media-continuity.spec.ts --project=iphone-webkit
 
       - name: Verify commerce transaction and durable outbox contract
-        run: npx vitest run src/lib/__tests__/commerce-entitlement.integration.test.ts
+        run: npx vitest run --no-file-parallelism src/lib/__tests__/commerce-entitlement.integration.test.ts src/lib/__tests__/promo-invitation.integration.test.ts
         env:
           DATABASE_URL: ${{ env.E2E_DATABASE_URL }}
           COMMERCE_INTEGRATION_TEST: '1'

--- a/deploy/production.env.example
+++ b/deploy/production.env.example
@@ -21,6 +21,9 @@ LIVEKIT_IDENTITY_SECRET=<initially copy LIVEKIT_API_SECRET; rotate only with a r
 # ── Ticket admission ─────────────────────────────────────────────────
 TICKET_CODE_PEPPER=<generate: openssl rand -base64 48 | tr -d '=+/' | cut -c1-64>
 TICKET_CODE_DIGEST_VERSION=1
+# Disabled by default. Enable only after creating a bounded campaign and
+# rehearsing redemption/revocation; setting false immediately blocks new uses.
+PROMO_INVITATIONS_ENABLED=false
 
 # Commerce bearer credentials deliberately live in the app-only file
 # /etc/harmonic-beacon/commerce.env; see deploy/commerce.env.example. Never add

--- a/docs/architecture/PROMO_INVITATIONS.md
+++ b/docs/architecture/PROMO_INVITATIONS.md
@@ -1,0 +1,52 @@
+# Controlled promotional invitations
+
+Status: implemented behind `PROMO_INVITATIONS_ENABLED=false` by default.
+
+## Boundary
+
+A promotion campaign is a staff-created, session-scoped way to mint a normal
+`TicketEntitlement` with tier `COMP`. It is not an authentication bypass and it
+does not change the private Ticket Tailor commerce contract. After redemption,
+the existing `WebSession`, room-entitlement, LiveKit token, revocation and
+participant paths are authoritative; promotion provenance is the one-to-one
+`PromoRedemption` relation.
+
+The raw human code exists only in the staff member's browser while the campaign
+is created and in the invited person's possession. Beacon persists an HMAC
+digest domain-separated from ticket credentials. API responses, audit metadata
+and logs never contain the raw code or the redeemer email.
+
+## Threat model and invariants
+
+| Threat | Control |
+| --- | --- |
+| Brute force / enumeration | Same generic rejection and shared 20-failures-per-10-minute auth budget as tickets; outer Nginx/Cloudflare limit remains required. No response distinguishes unknown, disabled, expired, exhausted or wrong-email codes. |
+| Replay by the same person | Idempotent by campaign plus normalized-email HMAC. It creates a fresh `WebSession` for the same entitlement, never another seat. |
+| Shared code | Every distinct email consumes one bounded redemption and one event seat. Capacity can be 1; short campaigns expire within seven days. |
+| Last-slot race | Redemption locks the event row used by paid/import/comp issuance and then the campaign row before counting or incrementing. Concurrent contenders cannot exceed either cap. |
+| Cross-session use | The campaign selects the session server-side. The public request cannot provide or override a session id. |
+| Disabled/expired campaign | New redemptions fail generically. Existing entitlements continue normally unless staff explicitly chooses derived revocation. |
+| Derived revocation | The disable API requires an explicit boolean. With revocation selected it atomically revokes entitlements and web sessions, closes durable participant grants, then removes both stage and bed LiveKit identities. A 202 response exposes cleanup failure only to staff and the action is retryable. |
+| Feature exposure | Public redemption is impossible unless the exact server flag is `true`. Campaigns can be prepared while it is false. Production templates remain false. |
+
+Campaign codes are 6–15 uppercase letters/digits with optional internal hyphens.
+This is intentionally lower entropy than a ticket credential, so small capacity,
+short expiry and rate limiting are non-negotiable. Use a high-entropy normal
+ticket or comp code when a publicly shareable link is acceptable.
+
+## Rollout
+
+1. Deploy the additive migration with the flag still false.
+2. In Admission support, create a session-scoped campaign with the smallest
+   useful capacity and expiry.
+3. Rehearse create → redeem → refresh → fresh-browser replay → disable with
+   derived revocation. Confirm stage and bed identities disappear.
+4. Set `PROMO_INVITATIONS_ENABLED=true` and redeploy only when the campaign is
+   ready to distribute.
+5. The immediate kill switch is setting the flag false. This stops new public
+   redemption without invalidating paid or already-redeemed access.
+
+Rollback the application before rolling back the additive tables. Existing
+promo-derived `TicketEntitlement` rows remain valid ordinary COMP access even if
+the UI and redemption code are removed. Never drop the tables while such rows
+still need provenance or campaign-level revocation.

--- a/e2e/tests/promo-invitation.spec.ts
+++ b/e2e/tests/promo-invitation.spec.ts
@@ -1,0 +1,185 @@
+import { createHmac } from 'node:crypto';
+import pg from 'pg';
+import { RoomServiceClient } from 'livekit-server-sdk';
+
+import { expect, stackTest } from '../fixtures/stack';
+import { loginAttendeeWithTicket, loginViaDashboard } from '../fixtures/auth';
+import { requireDirectDb, withSessionStatus } from '../fixtures/db';
+import { ROUTES, SESSION_ES } from '../fixtures/test-data';
+
+const CAMPAIGN_LABEL = 'E2E controlled invitation';
+const PROMO_CODE = 'E2EPROMO';
+const PROMO_EMAIL = 'promo-guest@example.invalid';
+
+async function cleanupCampaign(databaseUrl: string): Promise<void> {
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        await client.query('begin');
+        const { rows } = await client.query<{ ticket_entitlement_id: string }>(`
+            select pr.ticket_entitlement_id
+            from promo_redemptions pr
+            join promo_invitations pi on pi.id = pr.promo_invitation_id
+            where pi.label = $1
+        `, [CAMPAIGN_LABEL]);
+        const entitlementIds = rows.map((row) => row.ticket_entitlement_id);
+        if (entitlementIds.length > 0) {
+            await client.query('delete from web_sessions where ticket_entitlement_id = any($1::uuid[])', [entitlementIds]);
+            await client.query('delete from session_participants where ticket_entitlement_id = any($1::uuid[])', [entitlementIds]);
+        }
+        await client.query('delete from promo_invitations where label = $1', [CAMPAIGN_LABEL]);
+        if (entitlementIds.length > 0) {
+            await client.query('delete from ticket_entitlements where id = any($1::uuid[])', [entitlementIds]);
+        }
+        await client.query('commit');
+    } catch (error) {
+        await client.query('rollback');
+        throw error;
+    } finally {
+        await client.end();
+    }
+}
+
+async function participantIdentityForCampaign(databaseUrl: string): Promise<string> {
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        const { rows } = await client.query<{ participant_identity: string }>(`
+            select sp.participant_identity
+            from session_participants sp
+            join promo_redemptions pr on pr.ticket_entitlement_id = sp.ticket_entitlement_id
+            join promo_invitations pi on pi.id = pr.promo_invitation_id
+            where pi.label = $1 and sp.left_at is null
+            order by sp.joined_at desc
+            limit 1
+        `, [CAMPAIGN_LABEL]);
+        if (!rows[0]) throw new Error('promotion participant did not join the fixture session');
+        return rows[0].participant_identity;
+    } finally {
+        await client.end();
+    }
+}
+
+function roomService(): RoomServiceClient {
+    const livekitUrl = (process.env.E2E_LIVEKIT_URL ?? 'ws://localhost:7880')
+        .replace(/^ws:/, 'http:')
+        .replace(/^wss:/, 'https:');
+    return new RoomServiceClient(
+        livekitUrl,
+        process.env.E2E_LIVEKIT_API_KEY ?? 'devkey',
+        process.env.E2E_LIVEKIT_API_SECRET ?? 'secret',
+    );
+}
+
+function bedIdentity(stageIdentity: string): string {
+    const secret = process.env.E2E_LIVEKIT_API_SECRET ?? 'secret';
+    const digest = createHmac('sha256', secret)
+        .update(`bed:${stageIdentity}`)
+        .digest('base64url')
+        .slice(0, 32);
+    return `bed-${digest}`;
+}
+
+function localDateTimeInput(value: Date): string {
+    const localTime = new Date(value.getTime() - value.getTimezoneOffset() * 60_000);
+    return localTime.toISOString().slice(0, 16);
+}
+
+stackTest('controlled invitation becomes normal access, replays, then revokes and disconnects', async ({
+    browser,
+}, testInfo) => {
+    stackTest.slow();
+    const databaseUrl = requireDirectDb(testInfo);
+    await cleanupCampaign(databaseUrl);
+
+    try {
+        await withSessionStatus(databaseUrl, SESSION_ES.id, 'LIVE', async () => {
+            const staffContext = await browser.newContext();
+            const firstGuestContext = await browser.newContext();
+            const returningGuestContext = await browser.newContext();
+            const staff = await staffContext.newPage();
+            const firstGuest = await firstGuestContext.newPage();
+            const returningGuest = await returningGuestContext.newPage();
+
+            try {
+                await loginViaDashboard(staff, 'ADMIN', 'Invitation Admin', ROUTES.opsAdmission);
+                await staff.getByRole('button', { name: 'Load invitations' }).click();
+                await expect(staff.getByRole('status')).toContainText('Public redemption is ON');
+                await staff.getByLabel(/Internal label/).fill(CAMPAIGN_LABEL);
+                await staff.getByLabel(/Human code/).fill(PROMO_CODE);
+                await staff.getByLabel(/Expires/).fill(
+                    localDateTimeInput(new Date(Date.now() + 6 * 60 * 60 * 1000)),
+                );
+                await staff.getByLabel(/Redemption capacity/).fill('1');
+                await staff.getByRole('button', { name: 'Create invitation' }).click();
+                const campaign = staff.locator('article').filter({ hasText: CAMPAIGN_LABEL });
+                await expect(campaign).toContainText('0/1 redeemed');
+
+                await loginAttendeeWithTicket(firstGuest, {
+                    name: 'Promotion Guest',
+                    email: PROMO_EMAIL,
+                    code: PROMO_CODE,
+                });
+                await expect(firstGuest).toHaveURL(new RegExp(`${ROUTES.session(SESSION_ES.id)}$`));
+                await expect(firstGuest.getByTestId('connection-state')).toHaveAttribute(
+                    'data-state',
+                    'connected',
+                    { timeout: 20_000 },
+                );
+                await firstGuest.reload();
+                await expect(firstGuest.getByTestId('connection-state')).toHaveAttribute(
+                    'data-state',
+                    'connected',
+                    { timeout: 20_000 },
+                );
+                await firstGuestContext.close();
+
+                // Same campaign + same normalized email replays the one redemption
+                // into a fresh browser session even though its capacity is full.
+                await loginAttendeeWithTicket(returningGuest, {
+                    name: 'Returning Promotion Guest',
+                    email: PROMO_EMAIL.toUpperCase(),
+                    code: PROMO_CODE.toLowerCase(),
+                });
+                await expect(returningGuest).toHaveURL(new RegExp(`${ROUTES.session(SESSION_ES.id)}$`));
+                await expect(returningGuest.getByTestId('connection-state')).toHaveAttribute(
+                    'data-state',
+                    'connected',
+                    { timeout: 20_000 },
+                );
+                const participantIdentity = await participantIdentityForCampaign(databaseUrl);
+
+                await staff.getByRole('button', { name: 'Refresh' }).click();
+                await expect(campaign).toContainText('1/1 redeemed');
+                await campaign.getByPlaceholder(/Disable reason/).fill('Synthetic campaign complete');
+                await campaign.getByRole('checkbox', { name: /Also revoke every entitlement/ }).check();
+                await campaign.getByRole('button', { name: 'Disable invitation' }).click();
+                await expect(campaign).toContainText('DISABLED');
+                await expect(staff.getByText(/1 derived access grant\(s\) revoked/)).toBeVisible();
+
+                await expect.poll(async () => {
+                    const response = await returningGuest.request.get(
+                        `/api/scheduled-sessions/${SESSION_ES.id}/entry`,
+                    );
+                    return response.status();
+                }, { timeout: 10_000 }).toBe(401);
+                const livekit = roomService();
+                await expect.poll(async () => ({
+                    stage: (await livekit.listParticipants(SESSION_ES.roomName)).map(({ identity }) => identity),
+                    bed: (await livekit.listParticipants('beacon')).map(({ identity }) => identity),
+                }), { timeout: 10_000 }).toEqual({
+                    stage: expect.not.arrayContaining([participantIdentity]),
+                    bed: expect.not.arrayContaining([bedIdentity(participantIdentity)]),
+                });
+            } finally {
+                await Promise.allSettled([
+                    staffContext.close(),
+                    firstGuestContext.close(),
+                    returningGuestContext.close(),
+                ]);
+            }
+        });
+    } finally {
+        await cleanupCampaign(databaseUrl);
+    }
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -138,6 +138,9 @@ export default defineConfig({
               env: {
                   DATABASE_URL,
                   TICKET_CODE_PEPPER: 'test-fixture-pepper-not-for-production',
+                  // Explicitly enabled only inside the throwaway E2E stack;
+                  // production templates and runtime default remain OFF.
+                  PROMO_INVITATIONS_ENABLED: 'true',
                   E2E_DASHBOARD_ENABLED: '1',
                   SESSION_COOKIE_TTL_SECONDS: '604800',
                   NEXT_PUBLIC_LIVEKIT_URL: process.env.E2E_LIVEKIT_URL ?? 'ws://localhost:7880',

--- a/prisma/migrations/20260802113000_promo_invitations/migration.sql
+++ b/prisma/migrations/20260802113000_promo_invitations/migration.sql
@@ -1,0 +1,65 @@
+-- Controlled, session-scoped complimentary invitations. Raw promotion codes
+-- are never stored: only a peppered digest crosses the persistence boundary.
+CREATE TYPE "PromoInvitationStatus" AS ENUM ('ACTIVE', 'DISABLED');
+
+CREATE TABLE "promo_invitations" (
+    "id" UUID NOT NULL,
+    "scheduled_session_id" UUID NOT NULL,
+    "code_digest" CHAR(64) NOT NULL,
+    "label" TEXT NOT NULL,
+    "status" "PromoInvitationStatus" NOT NULL DEFAULT 'ACTIVE',
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "max_redemptions" INTEGER NOT NULL,
+    "redemption_count" INTEGER NOT NULL DEFAULT 0,
+    "issued_by_user_id" UUID NOT NULL,
+    "disabled_at" TIMESTAMP(3),
+    "disabled_by_user_id" UUID,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "promo_invitations_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "promo_invitations_capacity_check" CHECK (
+        "max_redemptions" > 0 AND
+        "redemption_count" >= 0 AND
+        "redemption_count" <= "max_redemptions"
+    ),
+    CONSTRAINT "promo_invitations_disabled_check" CHECK (
+        ("status" = 'ACTIVE' AND "disabled_at" IS NULL) OR
+        ("status" = 'DISABLED' AND "disabled_at" IS NOT NULL)
+    )
+);
+
+CREATE TABLE "promo_redemptions" (
+    "id" UUID NOT NULL,
+    "promo_invitation_id" UUID NOT NULL,
+    "redeemer_digest" CHAR(64) NOT NULL,
+    "ticket_entitlement_id" UUID NOT NULL,
+    "redeemed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "promo_redemptions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "promo_invitations_code_digest_key"
+    ON "promo_invitations"("code_digest");
+CREATE INDEX "promo_invitations_scheduled_session_id_status_expires_at_idx"
+    ON "promo_invitations"("scheduled_session_id", "status", "expires_at");
+CREATE UNIQUE INDEX "promo_redemptions_ticket_entitlement_id_key"
+    ON "promo_redemptions"("ticket_entitlement_id");
+CREATE UNIQUE INDEX "promo_redemptions_promo_invitation_id_redeemer_digest_key"
+    ON "promo_redemptions"("promo_invitation_id", "redeemer_digest");
+
+ALTER TABLE "promo_invitations"
+    ADD CONSTRAINT "promo_invitations_scheduled_session_id_fkey"
+    FOREIGN KEY ("scheduled_session_id") REFERENCES "scheduled_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "promo_invitations"
+    ADD CONSTRAINT "promo_invitations_issued_by_user_id_fkey"
+    FOREIGN KEY ("issued_by_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "promo_invitations"
+    ADD CONSTRAINT "promo_invitations_disabled_by_user_id_fkey"
+    FOREIGN KEY ("disabled_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "promo_redemptions"
+    ADD CONSTRAINT "promo_redemptions_promo_invitation_id_fkey"
+    FOREIGN KEY ("promo_invitation_id") REFERENCES "promo_invitations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "promo_redemptions"
+    ADD CONSTRAINT "promo_redemptions_ticket_entitlement_id_fkey"
+    FOREIGN KEY ("ticket_entitlement_id") REFERENCES "ticket_entitlements"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,11 @@ enum TicketEntitlementState {
   EXPIRED
 }
 
+enum PromoInvitationStatus {
+  ACTIVE
+  DISABLED
+}
+
 enum CommerceProvider {
   TICKET_TAILOR
 }
@@ -77,14 +82,16 @@ model User {
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @updatedAt @map("updated_at")
 
-  facilitatedSessions ScheduledSession[]   @relation("SessionFacilitator")
-  issuedTickets       TicketEntitlement[]  @relation("TicketIssuer")
-  revokedTickets      TicketEntitlement[]  @relation("TicketRevoker")
-  webSessions         WebSession[]         @relation("StaffWebSessions")
-  revokedWebSessions  WebSession[]         @relation("WebSessionRevoker")
-  participations      SessionParticipant[] @relation("StaffParticipation")
-  grantedParticipants SessionParticipant[] @relation("StageGrantActor")
-  auditEntries        AuditLog[]           @relation("AuditActor")
+  facilitatedSessions  ScheduledSession[]   @relation("SessionFacilitator")
+  issuedTickets        TicketEntitlement[]  @relation("TicketIssuer")
+  revokedTickets       TicketEntitlement[]  @relation("TicketRevoker")
+  issuedPromoInvites   PromoInvitation[]    @relation("PromoInvitationIssuer")
+  disabledPromoInvites PromoInvitation[]    @relation("PromoInvitationDisabler")
+  webSessions          WebSession[]         @relation("StaffWebSessions")
+  revokedWebSessions   WebSession[]         @relation("WebSessionRevoker")
+  participations       SessionParticipant[] @relation("StaffParticipation")
+  grantedParticipants  SessionParticipant[] @relation("StageGrantActor")
+  auditEntries         AuditLog[]           @relation("AuditActor")
 
   @@map("users")
 }
@@ -111,6 +118,7 @@ model ScheduledSession {
   tickets              TicketEntitlement[]
   participants         SessionParticipant[]
   commerceEntitlements CommerceEntitlement[]
+  promoInvitations     PromoInvitation[]
 
   @@index([status, scheduledAt])
   @@map("scheduled_sessions")
@@ -139,11 +147,49 @@ model TicketEntitlement {
   webSessions         WebSession[]
   participations      SessionParticipant[]
   commerceEntitlement CommerceEntitlement?
+  promoRedemption     PromoRedemption?
 
   @@index([scheduledSessionId, state])
   @@index([boundEmail])
   @@index([codeLastFour])
   @@map("ticket_entitlements")
+}
+
+model PromoInvitation {
+  id                 String                @id @default(uuid()) @db.Uuid
+  scheduledSessionId String                @map("scheduled_session_id") @db.Uuid
+  scheduledSession   ScheduledSession      @relation(fields: [scheduledSessionId], references: [id], onDelete: Cascade)
+  codeDigest         String                @unique @map("code_digest") @db.Char(64)
+  label              String
+  status             PromoInvitationStatus @default(ACTIVE)
+  expiresAt          DateTime              @map("expires_at")
+  maxRedemptions     Int                   @map("max_redemptions")
+  redemptionCount    Int                   @default(0) @map("redemption_count")
+  issuedByUserId     String                @map("issued_by_user_id") @db.Uuid
+  issuedBy           User                  @relation("PromoInvitationIssuer", fields: [issuedByUserId], references: [id], onDelete: Restrict)
+  disabledAt         DateTime?             @map("disabled_at")
+  disabledByUserId   String?               @map("disabled_by_user_id") @db.Uuid
+  disabledBy         User?                 @relation("PromoInvitationDisabler", fields: [disabledByUserId], references: [id], onDelete: SetNull)
+  createdAt          DateTime              @default(now()) @map("created_at")
+  updatedAt          DateTime              @updatedAt @map("updated_at")
+
+  redemptions PromoRedemption[]
+
+  @@index([scheduledSessionId, status, expiresAt])
+  @@map("promo_invitations")
+}
+
+model PromoRedemption {
+  id                  String            @id @default(uuid()) @db.Uuid
+  promoInvitationId   String            @map("promo_invitation_id") @db.Uuid
+  promoInvitation     PromoInvitation   @relation(fields: [promoInvitationId], references: [id], onDelete: Cascade)
+  redeemerDigest      String            @map("redeemer_digest") @db.Char(64)
+  ticketEntitlementId String            @unique @map("ticket_entitlement_id") @db.Uuid
+  ticketEntitlement   TicketEntitlement @relation(fields: [ticketEntitlementId], references: [id], onDelete: Cascade)
+  redeemedAt          DateTime          @default(now()) @map("redeemed_at")
+
+  @@unique([promoInvitationId, redeemerDigest])
+  @@map("promo_redemptions")
 }
 
 model CommerceEntitlement {

--- a/src/app/api/auth/ticket/__tests__/route.test.ts
+++ b/src/app/api/auth/ticket/__tests__/route.test.ts
@@ -153,7 +153,50 @@ describe('POST /api/auth/ticket', () => {
     afterEach(() => {
         vi.unstubAllEnvs();
         vi.doUnmock('@/lib/db');
+        vi.doUnmock('@/lib/promo-invitation');
         vi.restoreAllMocks();
+    });
+
+    it('keeps short invitation codes disabled by default without revealing whether they exist', async () => {
+        const db = mountDb([]);
+        const { POST } = await importRoute();
+
+        const response = await POST(loginRequest({ code: 'NICO100', email: EMAIL }, '203.0.113.81'));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'That ticket code and email do not match an active ticket.' });
+        expect(db.webSessions).toHaveLength(0);
+    });
+
+    it('returns the ordinary attendee cookie/session response for an enabled promotion', async () => {
+        const redeemPromoInvitation = vi.fn().mockResolvedValue({
+            ok: true,
+            scheduledSessionId: 'session-saturday',
+            entitlementId: 'promo-entitlement-1',
+            codeLastFour: '7XQP',
+            cookieValue: 'promo-cookie-value',
+            replayed: false,
+        });
+        vi.doMock('@/lib/promo-invitation', () => ({
+            isPlausiblePromoCode: (code: string) => code.trim().toUpperCase() === 'NICO100',
+            promoInvitationsEnabled: () => true,
+            redeemPromoInvitation,
+        }));
+        mountDb([]);
+        const { POST } = await importRoute();
+
+        const response = await POST(loginRequest({ code: 'nico100', email: EMAIL }, '203.0.113.82'));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ ok: true, scheduledSessionId: 'session-saturday' });
+        expect(redeemPromoInvitation).toHaveBeenCalledWith('NICO100', EMAIL, NAME);
+        expect(sessionCookieOf(response)).toMatchObject({
+            name: 'hb_session',
+            value: 'promo-cookie-value',
+            httpOnly: true,
+            secure: true,
+            sameSite: 'lax',
+        });
     });
 
     it('binds the ticket on first use and returns the secure hb_session cookie', async () => {

--- a/src/app/api/auth/ticket/route.ts
+++ b/src/app/api/auth/ticket/route.ts
@@ -29,6 +29,11 @@ import {
 } from '@/lib/principal';
 import { authFailureLimiter } from '@/lib/rate-limit';
 import { redactError } from '@/lib/redact';
+import {
+    isPlausiblePromoCode,
+    promoInvitationsEnabled,
+    redeemPromoInvitation,
+} from '@/lib/promo-invitation';
 import { digestTicketCode, normalizeTicketCode } from '@/lib/ticket-code';
 
 /** One message for every rejection. See the module comment. */
@@ -42,7 +47,8 @@ type FailureReason =
     | 'email_mismatch'
     | 'revoked'
     | 'expired'
-    | 'binding_lost';
+    | 'binding_lost'
+    | 'promo_unavailable';
 
 type Attempt =
     | { ok: true; scheduledSessionId: string; entitlementId: string; codeLastFour: string; cookieValue: string }
@@ -76,25 +82,28 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         displayName = '';
     }
 
-    if (code.length < 16 || !isPlausibleEmail(email) || !isValidDisplayName(displayName)) {
+    const promoCandidate = isPlausiblePromoCode(code);
+    if ((!promoCandidate && code.length < 16) || !isPlausibleEmail(email) || !isValidDisplayName(displayName)) {
         return reject(address, 'malformed_request');
-    }
-
-    let codeDigest: string;
-    try {
-        codeDigest = digestTicketCode(code);
-    } catch (error) {
-        // A missing or too-short TICKET_CODE_PEPPER is an outage, not a bad code.
-        // Reporting it as a rejection would send operators hunting for a ticket
-        // problem while every attendee is locked out.
-        console.error(`[auth] ticket login misconfigured: ${redactError(error)}`);
-        return NextResponse.json({ error: 'Login is temporarily unavailable.' }, { status: 500 });
     }
 
     let attempt: Attempt;
     try {
-        attempt = await redeem(codeDigest, email, displayName);
+        if (promoCandidate) {
+            if (!promoInvitationsEnabled()) {
+                return reject(address, 'promo_unavailable');
+            }
+            const promoAttempt = await redeemPromoInvitation(code, email, displayName);
+            attempt = promoAttempt.ok
+                ? promoAttempt
+                : { ok: false, reason: 'promo_unavailable' };
+        } else {
+            const codeDigest = digestTicketCode(code);
+            attempt = await redeem(codeDigest, email, displayName);
+        }
     } catch (error) {
+        // Missing/invalid secret configuration is an outage, never evidence
+        // that a particular ticket or invitation exists.
         console.error(`[auth] ticket login failed: client=${address} ${redactError(error)}`);
         return NextResponse.json({ error: 'Login is temporarily unavailable.' }, { status: 500 });
     }

--- a/src/app/api/ops/admission/__tests__/route.test.ts
+++ b/src/app/api/ops/admission/__tests__/route.test.ts
@@ -55,6 +55,8 @@ const entitlementRow = {
     revocationReason: null,
     createdAt: new Date('2026-07-28T00:00:00Z'),
     scheduledSession: eventRow,
+    commerceEntitlement: null,
+    promoRedemption: null,
 };
 
 function authed(url: string, options: Parameters<typeof createRequest>[1] = {}) {
@@ -169,6 +171,38 @@ describe('/api/ops/admission', () => {
             expect(mockPrisma.ticketEntitlement.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({ where: { codeLastFour: 'AB3F' } }),
             );
+        });
+
+        it('identifies promotional provenance without exposing its code digest', async () => {
+            mockPrisma.ticketEntitlement.findMany.mockResolvedValue([{
+                ...entitlementRow,
+                tier: 'COMP',
+                promoRedemption: {
+                    redeemedAt: new Date('2026-08-02T12:00:00Z'),
+                    promoInvitation: {
+                        id: '50000000-0000-4000-8000-000000000001',
+                        label: 'Guest list',
+                        status: 'ACTIVE',
+                        expiresAt: new Date('2026-08-03T12:00:00Z'),
+                    },
+                },
+            }]);
+            const { GET } = await loadRoute();
+            const { status, body } = await parseResponse(
+                await GET(authed('http://localhost/api/ops/admission?q=buyer@example.com')),
+            );
+
+            expect(status).toBe(200);
+            const [result] = (body as { results: Array<Record<string, unknown>> }).results;
+            expect(result).toMatchObject({
+                tier: 'COMP',
+                promotion: {
+                    campaignId: '50000000-0000-4000-8000-000000000001',
+                    label: 'Guest list',
+                    status: 'ACTIVE',
+                },
+            });
+            expect(JSON.stringify(body)).not.toContain('codeDigest');
         });
 
         it('finds a single entitlement by UUID, 404 when absent', async () => {

--- a/src/app/api/ops/admission/route.ts
+++ b/src/app/api/ops/admission/route.ts
@@ -57,6 +57,15 @@ function serializeEntitlement(entitlement: {
         administrativeState: string;
         mediaStatus: string;
     } | null;
+    promoRedemption: {
+        redeemedAt: Date;
+        promoInvitation: {
+            id: string;
+            label: string;
+            status: string;
+            expiresAt: Date;
+        };
+    } | null;
 }) {
     return {
         id: entitlement.id,
@@ -71,6 +80,15 @@ function serializeEntitlement(entitlement: {
         createdAt: entitlement.createdAt,
         event: entitlement.scheduledSession,
         commerce: entitlement.commerceEntitlement,
+        promotion: entitlement.promoRedemption
+            ? {
+                campaignId: entitlement.promoRedemption.promoInvitation.id,
+                label: entitlement.promoRedemption.promoInvitation.label,
+                status: entitlement.promoRedemption.promoInvitation.status,
+                expiresAt: entitlement.promoRedemption.promoInvitation.expiresAt,
+                redeemedAt: entitlement.promoRedemption.redeemedAt,
+            }
+            : null,
     };
 }
 
@@ -82,6 +100,19 @@ const ENTITLEMENT_INCLUDE = {
             providerState: true,
             administrativeState: true,
             mediaStatus: true,
+        },
+    },
+    promoRedemption: {
+        select: {
+            redeemedAt: true,
+            promoInvitation: {
+                select: {
+                    id: true,
+                    label: true,
+                    status: true,
+                    expiresAt: true,
+                },
+            },
         },
     },
 } as const;

--- a/src/app/api/ops/invitations/[id]/__tests__/route.test.ts
+++ b/src/app/api/ops/invitations/[id]/__tests__/route.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createRequest, mockParams, parseResponse } from '@/__tests__/helpers';
+
+const mocks = vi.hoisted(() => ({
+    resolveStaffSession: vi.fn(),
+    queryRaw: vi.fn(),
+    campaignFindUnique: vi.fn(),
+    campaignUpdate: vi.fn(),
+    redemptionFindMany: vi.fn(),
+    participantFindMany: vi.fn(),
+    participantUpdateMany: vi.fn(),
+    entitlementUpdateMany: vi.fn(),
+    webSessionUpdateMany: vi.fn(),
+    auditCreate: vi.fn(),
+    removeParticipant: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => {
+    const prisma = {
+        $queryRaw: mocks.queryRaw,
+        $transaction: vi.fn(),
+        promoInvitation: {
+            findUnique: mocks.campaignFindUnique,
+            update: mocks.campaignUpdate,
+        },
+        promoRedemption: { findMany: mocks.redemptionFindMany },
+        sessionParticipant: {
+            findMany: mocks.participantFindMany,
+            updateMany: mocks.participantUpdateMany,
+        },
+        ticketEntitlement: { updateMany: mocks.entitlementUpdateMany },
+        webSession: { updateMany: mocks.webSessionUpdateMany },
+        auditLog: { create: mocks.auditCreate },
+    };
+    prisma.$transaction.mockImplementation(
+        async (fn: (tx: typeof prisma) => Promise<unknown>) => fn(prisma),
+    );
+    return { prisma };
+});
+vi.mock('@/lib/ops-auth', () => ({ resolveStaffSession: mocks.resolveStaffSession }));
+vi.mock('@/lib/livekit-server', () => ({
+    bedRoomIdentity: (identity: string) => `bed-${identity}`,
+    getRoomService: () => ({ removeParticipant: mocks.removeParticipant }),
+}));
+
+import { POST } from '../route';
+
+const STAFF = {
+    id: 'operator-1',
+    email: 'operator@example.invalid',
+    name: 'Operator',
+    role: 'OPERATOR',
+};
+const CAMPAIGN = {
+    id: '50000000-0000-4000-8000-000000000001',
+    scheduledSessionId: '10000000-0000-4000-8000-000000000001',
+    disabledAt: null,
+    scheduledSession: { roomName: 'event-stage' },
+};
+
+function disableRequest(body: Record<string, unknown>) {
+    return createRequest('/api/ops/invitations/campaign-1', { method: 'POST', body });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveStaffSession.mockResolvedValue(STAFF);
+    mocks.campaignFindUnique.mockResolvedValue(CAMPAIGN);
+    mocks.campaignUpdate.mockResolvedValue({});
+    mocks.redemptionFindMany.mockResolvedValue([
+        { ticketEntitlementId: 'entitlement-1' },
+        { ticketEntitlementId: 'entitlement-2' },
+    ]);
+    mocks.participantFindMany.mockResolvedValue([
+        { participantIdentity: 'participant-1' },
+    ]);
+    mocks.participantUpdateMany.mockResolvedValue({ count: 1 });
+    mocks.entitlementUpdateMany.mockResolvedValue({ count: 2 });
+    mocks.webSessionUpdateMany.mockResolvedValue({ count: 2 });
+    mocks.auditCreate.mockResolvedValue({});
+    mocks.removeParticipant.mockResolvedValue(undefined);
+});
+
+describe('disable promotion invitation', () => {
+    it('requires staff mutation authority and an explicit derived-access choice', async () => {
+        mocks.resolveStaffSession.mockResolvedValueOnce(null);
+        expect((await POST(disableRequest({}), mockParams({ id: CAMPAIGN.id }))).status).toBe(401);
+
+        mocks.resolveStaffSession.mockResolvedValueOnce({ ...STAFF, role: 'FACILITATOR' });
+        expect((await POST(disableRequest({}), mockParams({ id: CAMPAIGN.id }))).status).toBe(403);
+
+        const ambiguous = await POST(disableRequest({
+            action: 'disable',
+            reason: 'Guest list withdrawn',
+        }), mockParams({ id: CAMPAIGN.id }));
+        expect(ambiguous.status).toBe(400);
+        expect(mocks.campaignUpdate).not.toHaveBeenCalled();
+    });
+
+    it('can stop new redemption while preserving already-issued entitlements', async () => {
+        const { status, body } = await parseResponse(await POST(disableRequest({
+            action: 'disable',
+            reason: 'Guest list closed',
+            revokeDerived: false,
+        }), mockParams({ id: CAMPAIGN.id })));
+
+        expect(status).toBe(200);
+        expect(body).toMatchObject({
+            status: 'DISABLED',
+            revokeDerived: false,
+            revokedEntitlements: 0,
+            mediaCleanupFailed: false,
+        });
+        expect(mocks.redemptionFindMany).not.toHaveBeenCalled();
+        expect(mocks.entitlementUpdateMany).not.toHaveBeenCalled();
+        expect(mocks.removeParticipant).not.toHaveBeenCalled();
+    });
+
+    it('atomically revokes derived access and removes both stage and bed identities', async () => {
+        const { status, body } = await parseResponse(await POST(disableRequest({
+            action: 'disable',
+            reason: 'Controlled invitation revoked',
+            revokeDerived: true,
+        }), mockParams({ id: CAMPAIGN.id })));
+
+        expect(status).toBe(200);
+        expect(body).toMatchObject({ revokedEntitlements: 2, mediaCleanupFailed: false });
+        expect(mocks.entitlementUpdateMany).toHaveBeenCalledOnce();
+        expect(mocks.webSessionUpdateMany).toHaveBeenCalledOnce();
+        expect(mocks.participantFindMany).toHaveBeenCalledWith({
+            where: {
+                scheduledSessionId: CAMPAIGN.scheduledSessionId,
+                ticketEntitlementId: { in: ['entitlement-1', 'entitlement-2'] },
+            },
+            select: { participantIdentity: true },
+        });
+        expect(mocks.participantUpdateMany).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({
+                leftAt: expect.any(Date),
+                publishGrantedAt: null,
+                grantReconcileNeeded: false,
+            }),
+        }));
+        expect(mocks.removeParticipant).toHaveBeenCalledWith('event-stage', 'participant-1');
+        expect(mocks.removeParticipant).toHaveBeenCalledWith('beacon', 'bed-participant-1');
+        expect(mocks.auditCreate).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({
+                action: 'promo.disable',
+                metadata: expect.objectContaining({ revokeDerived: true, revokedEntitlements: 2 }),
+            }),
+        }));
+    });
+
+    it('returns a retryable warning when durable revocation succeeds but media cleanup fails', async () => {
+        mocks.removeParticipant.mockRejectedValueOnce(new Error('LiveKit unavailable'));
+        const { status, body } = await parseResponse(await POST(disableRequest({
+            action: 'disable',
+            reason: 'Controlled invitation revoked',
+            revokeDerived: true,
+        }), mockParams({ id: CAMPAIGN.id })));
+
+        expect(status).toBe(202);
+        expect(body).toMatchObject({ mediaCleanupFailed: true, revokedEntitlements: 2 });
+    });
+});

--- a/src/app/api/ops/invitations/[id]/route.ts
+++ b/src/app/api/ops/invitations/[id]/route.ts
@@ -1,0 +1,152 @@
+import { Prisma } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { prisma } from '@/lib/db';
+import { bedRoomIdentity, getRoomService } from '@/lib/livekit-server';
+import { resolveStaffSession } from '@/lib/ops-auth';
+import { hasStaffCapability } from '@/lib/staff-capabilities';
+
+export const dynamic = 'force-dynamic';
+
+function error(status: number, code: string, message: string) {
+    return NextResponse.json({ error: code, message }, { status });
+}
+
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const staff = await resolveStaffSession(request);
+    if (!staff) return error(401, 'unauthenticated', 'Staff authentication required');
+    if (!hasStaffCapability(staff.role, 'mutate_entitlement')) {
+        return error(403, 'forbidden', 'Your role may not disable invitations');
+    }
+
+    let fields: Record<string, unknown>;
+    try {
+        fields = await request.json() as Record<string, unknown>;
+    } catch {
+        return error(400, 'invalid_request', 'Request body must be JSON');
+    }
+    const reason = typeof fields.reason === 'string' ? fields.reason.trim() : '';
+    const revokeDerived = fields.revokeDerived;
+    if (fields.action !== 'disable' || !reason || typeof revokeDerived !== 'boolean') {
+        return error(400, 'invalid_request', 'Disable requires a non-PII reason and an explicit revokeDerived choice');
+    }
+
+    const { id } = await params;
+    const now = new Date();
+    const result = await prisma.$transaction(async (tx) => {
+        await tx.$queryRaw(
+            Prisma.sql`SELECT "id" FROM "promo_invitations" WHERE "id"::text = ${id} FOR UPDATE`,
+        );
+        const campaign = await tx.promoInvitation.findUnique({
+            where: { id },
+            include: { scheduledSession: { select: { roomName: true } } },
+        });
+        if (!campaign) return null;
+
+        await tx.promoInvitation.update({
+            where: { id },
+            data: {
+                status: 'DISABLED',
+                disabledAt: campaign.disabledAt ?? now,
+                disabledByUserId: staff.id,
+            },
+        });
+
+        let entitlementIds: string[] = [];
+        let participants: Array<{ participantIdentity: string }> = [];
+        if (revokeDerived) {
+            const redemptions = await tx.promoRedemption.findMany({
+                where: { promoInvitationId: id },
+                select: { ticketEntitlementId: true },
+            });
+            entitlementIds = redemptions.map((redemption) => redemption.ticketEntitlementId);
+            participants = entitlementIds.length === 0 ? [] : await tx.sessionParticipant.findMany({
+                where: {
+                    scheduledSessionId: campaign.scheduledSessionId,
+                    ticketEntitlementId: { in: entitlementIds },
+                },
+                select: { participantIdentity: true },
+            });
+            if (entitlementIds.length > 0) {
+                await tx.ticketEntitlement.updateMany({
+                    where: { id: { in: entitlementIds }, state: { not: 'REVOKED' } },
+                    data: {
+                        state: 'REVOKED',
+                        revokedAt: now,
+                        revokedByUserId: staff.id,
+                        revocationReason: reason,
+                    },
+                });
+                await tx.webSession.updateMany({
+                    where: { ticketEntitlementId: { in: entitlementIds }, revokedAt: null },
+                    data: {
+                        revokedAt: now,
+                        revokedByUserId: staff.id,
+                        revocationReason: reason,
+                    },
+                });
+                await tx.sessionParticipant.updateMany({
+                    where: {
+                        scheduledSessionId: campaign.scheduledSessionId,
+                        ticketEntitlementId: { in: entitlementIds },
+                        leftAt: null,
+                    },
+                    data: {
+                        leftAt: now,
+                        publishGrantedAt: null,
+                        publishRevokedAt: now,
+                        grantVersion: { increment: 1 },
+                        grantReconcileNeeded: false,
+                        grantChangedByUserId: staff.id,
+                        grantReason: reason,
+                    },
+                });
+            }
+        }
+
+        await tx.auditLog.create({
+            data: {
+                actorUserId: staff.id,
+                actorRole: staff.role,
+                action: 'promo.disable',
+                targetType: 'SCHEDULED_SESSION',
+                targetId: campaign.scheduledSessionId,
+                reason,
+                metadata: {
+                    promoInvitationId: id,
+                    revokeDerived,
+                    revokedEntitlements: entitlementIds.length,
+                },
+            },
+        });
+        return {
+            roomName: campaign.scheduledSession.roomName,
+            entitlementCount: entitlementIds.length,
+            participants,
+        };
+    });
+
+    if (!result) return error(404, 'not_found', 'No invitation with that ID');
+
+    let mediaCleanupFailed = false;
+    if (revokeDerived && result.participants.length > 0) {
+        const roomService = getRoomService();
+        const bedRoomName = process.env.LIVEKIT_ROOM_NAME || 'beacon';
+        const removals = await Promise.allSettled(result.participants.flatMap(({ participantIdentity }) => [
+            roomService.removeParticipant(result.roomName, participantIdentity),
+            roomService.removeParticipant(bedRoomName, bedRoomIdentity(participantIdentity)),
+        ]));
+        mediaCleanupFailed = removals.some((removal) => removal.status === 'rejected');
+    }
+
+    return NextResponse.json({
+        id,
+        status: 'DISABLED',
+        revokeDerived,
+        revokedEntitlements: result.entitlementCount,
+        mediaCleanupFailed,
+    }, { status: mediaCleanupFailed ? 202 : 200 });
+}

--- a/src/app/api/ops/invitations/__tests__/route.test.ts
+++ b/src/app/api/ops/invitations/__tests__/route.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createRequest, parseResponse } from '@/__tests__/helpers';
+
+const mocks = vi.hoisted(() => ({
+    resolveStaffSession: vi.fn(),
+    queryRaw: vi.fn(),
+    sessionFindUnique: vi.fn(),
+    campaignCreate: vi.fn(),
+    campaignFindMany: vi.fn(),
+    auditCreate: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => {
+    const prisma = {
+        $queryRaw: mocks.queryRaw,
+        $transaction: vi.fn(),
+        scheduledSession: { findUnique: mocks.sessionFindUnique },
+        promoInvitation: {
+            create: mocks.campaignCreate,
+            findMany: mocks.campaignFindMany,
+        },
+        auditLog: { create: mocks.auditCreate },
+    };
+    prisma.$transaction.mockImplementation(
+        async (fn: (tx: typeof prisma) => Promise<unknown>) => fn(prisma),
+    );
+    return { prisma };
+});
+vi.mock('@/lib/ops-auth', () => ({ resolveStaffSession: mocks.resolveStaffSession }));
+
+import { GET, POST } from '../route';
+
+const PEPPER = 'promo-route-test-pepper-at-least-32-characters';
+const ADMIN = {
+    id: 'admin-1',
+    email: 'admin@example.invalid',
+    name: 'Admin',
+    role: 'ADMIN',
+};
+const SESSION = {
+    id: '10000000-0000-4000-8000-000000000001',
+    title: 'Spanish event',
+    language: 'SPANISH',
+    roomName: 'spanish-room',
+    status: 'SCHEDULED',
+    scheduledAt: new Date('2026-08-08T14:30:00.000Z'),
+    attendeeCap: 150,
+};
+const CAMPAIGN = {
+    id: '50000000-0000-4000-8000-000000000001',
+    label: 'Guest list',
+    status: 'ACTIVE',
+    expiresAt: new Date('2026-08-04T12:00:00.000Z'),
+    maxRedemptions: 10,
+    redemptionCount: 0,
+    disabledAt: null,
+    createdAt: new Date('2026-08-02T12:00:00.000Z'),
+    scheduledSession: SESSION,
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.stubEnv('TICKET_CODE_PEPPER', PEPPER);
+    vi.stubEnv('PROMO_INVITATIONS_ENABLED', 'false');
+    vi.setSystemTime(new Date('2026-08-02T12:00:00.000Z'));
+    mocks.resolveStaffSession.mockResolvedValue(ADMIN);
+    mocks.sessionFindUnique.mockResolvedValue(SESSION);
+    mocks.campaignCreate.mockResolvedValue(CAMPAIGN);
+    mocks.campaignFindMany.mockResolvedValue([CAMPAIGN]);
+    mocks.auditCreate.mockResolvedValue({});
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+});
+
+describe('staff promotion invitations', () => {
+    it('denies unauthenticated and incapable staff before reading campaigns', async () => {
+        mocks.resolveStaffSession.mockResolvedValueOnce(null);
+        expect((await GET(createRequest('/api/ops/invitations'))).status).toBe(401);
+
+        mocks.resolveStaffSession.mockResolvedValueOnce({ ...ADMIN, role: 'FACILITATOR' });
+        const response = await POST(createRequest('/api/ops/invitations', {
+            method: 'POST',
+            body: {},
+        }));
+        expect(response.status).toBe(403);
+        expect(mocks.campaignCreate).not.toHaveBeenCalled();
+    });
+
+    it('lists only redacted campaign metadata and reports the global kill switch', async () => {
+        const { status, body } = await parseResponse(await GET(createRequest('/api/ops/invitations')));
+
+        expect(status).toBe(200);
+        expect(body).toMatchObject({
+            redemptionEnabled: false,
+            campaigns: [{ id: CAMPAIGN.id, label: 'Guest list', redemptionCount: 0 }],
+        });
+        expect(JSON.stringify(body)).not.toMatch(/codeDigest|NICO100|admin@example/i);
+    });
+
+    it('creates a session-scoped bounded campaign without persisting or echoing its raw code', async () => {
+        const response = await POST(createRequest('/api/ops/invitations', {
+            method: 'POST',
+            body: {
+                sessionId: SESSION.id,
+                code: 'NICO100',
+                label: 'Guest list',
+                expiresAt: '2026-08-04T12:00:00.000Z',
+                maxRedemptions: 10,
+            },
+        }));
+        const { status, body } = await parseResponse(response);
+
+        expect(status).toBe(201);
+        const data = mocks.campaignCreate.mock.calls[0][0].data;
+        expect(data).toMatchObject({
+            scheduledSessionId: SESSION.id,
+            label: 'Guest list',
+            maxRedemptions: 10,
+            issuedByUserId: ADMIN.id,
+        });
+        expect(data.codeDigest).toMatch(/^[a-f0-9]{64}$/);
+        expect(JSON.stringify(data)).not.toContain('NICO100');
+        expect(JSON.stringify(body)).not.toMatch(/NICO100|codeDigest/);
+        expect(mocks.queryRaw).toHaveBeenCalledOnce();
+        expect(mocks.auditCreate).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ action: 'promo.create' }),
+        }));
+    });
+
+    it('rejects malformed, over-capacity, and long-lived campaigns before mutation', async () => {
+        for (const body of [
+            { sessionId: SESSION.id, code: 'tiny', label: 'Guest list', expiresAt: '2026-08-04T12:00:00.000Z', maxRedemptions: 1 },
+            { sessionId: SESSION.id, code: 'NICO100', label: 'Guest list', expiresAt: '2026-08-04T12:00:00.000Z', maxRedemptions: 151 },
+            { sessionId: SESSION.id, code: 'NICO100', label: 'Guest list', expiresAt: '2026-08-20T12:00:00.000Z', maxRedemptions: 1 },
+        ]) {
+            const response = await POST(createRequest('/api/ops/invitations', { method: 'POST', body }));
+            expect(response.status).toBe(400);
+        }
+        expect(mocks.campaignCreate).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/ops/invitations/route.ts
+++ b/src/app/api/ops/invitations/route.ts
@@ -1,0 +1,165 @@
+import { Prisma } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { prisma } from '@/lib/db';
+import { resolveStaffSession } from '@/lib/ops-auth';
+import {
+    digestPromoCode,
+    isPlausiblePromoCode,
+    MAX_PROMO_LIFETIME_MS,
+    MAX_PROMO_REDEMPTIONS,
+    promoInvitationsEnabled,
+} from '@/lib/promo-invitation';
+import { hasStaffCapability } from '@/lib/staff-capabilities';
+import { ticketExpiresAt } from '@/lib/admission';
+
+export const dynamic = 'force-dynamic';
+
+function error(status: number, code: string, message: string) {
+    return NextResponse.json({ error: code, message }, { status });
+}
+
+const CAMPAIGN_INCLUDE = {
+    scheduledSession: {
+        select: { id: true, title: true, language: true, scheduledAt: true },
+    },
+} as const;
+
+function serializeCampaign(campaign: {
+    id: string;
+    label: string;
+    status: string;
+    expiresAt: Date;
+    maxRedemptions: number;
+    redemptionCount: number;
+    disabledAt: Date | null;
+    createdAt: Date;
+    scheduledSession: { id: string; title: string; language: string; scheduledAt: Date };
+}) {
+    return {
+        id: campaign.id,
+        label: campaign.label,
+        status: campaign.status,
+        expiresAt: campaign.expiresAt,
+        maxRedemptions: campaign.maxRedemptions,
+        redemptionCount: campaign.redemptionCount,
+        disabledAt: campaign.disabledAt,
+        createdAt: campaign.createdAt,
+        event: campaign.scheduledSession,
+    };
+}
+
+export async function GET(request: NextRequest) {
+    const staff = await resolveStaffSession(request);
+    if (!staff) return error(401, 'unauthenticated', 'Staff authentication required');
+    if (!hasStaffCapability(staff.role, 'look_up_admission')) {
+        return error(403, 'forbidden', 'Your role may not view invitations');
+    }
+
+    const campaigns = await prisma.promoInvitation.findMany({
+        include: CAMPAIGN_INCLUDE,
+        orderBy: { createdAt: 'desc' },
+        take: 100,
+    });
+    return NextResponse.json({
+        redemptionEnabled: promoInvitationsEnabled(),
+        campaigns: campaigns.map(serializeCampaign),
+    });
+}
+
+export async function POST(request: NextRequest) {
+    const staff = await resolveStaffSession(request);
+    if (!staff) return error(401, 'unauthenticated', 'Staff authentication required');
+    if (!hasStaffCapability(staff.role, 'issue_comp')) {
+        return error(403, 'forbidden', 'Your role may not create complimentary invitations');
+    }
+
+    let fields: Record<string, unknown>;
+    try {
+        fields = await request.json() as Record<string, unknown>;
+    } catch {
+        return error(400, 'invalid_request', 'Request body must be JSON');
+    }
+    const sessionId = typeof fields.sessionId === 'string' ? fields.sessionId : '';
+    const code = typeof fields.code === 'string' ? fields.code : '';
+    const label = typeof fields.label === 'string' ? fields.label.trim() : '';
+    const expiresAt = typeof fields.expiresAt === 'string' ? new Date(fields.expiresAt) : new Date(Number.NaN);
+    const maxRedemptions = typeof fields.maxRedemptions === 'number' ? fields.maxRedemptions : Number.NaN;
+    const now = new Date();
+
+    if (!sessionId || !isPlausiblePromoCode(code) || label.length < 3 || label.length > 80) {
+        return error(400, 'invalid_request', 'Session, a 6–15 character code, and a 3–80 character label are required');
+    }
+    if (!Number.isSafeInteger(maxRedemptions) || maxRedemptions < 1 || maxRedemptions > MAX_PROMO_REDEMPTIONS) {
+        return error(400, 'invalid_capacity', `Capacity must be between 1 and ${MAX_PROMO_REDEMPTIONS}`);
+    }
+    if (!Number.isFinite(expiresAt.getTime()) || expiresAt <= now || expiresAt.getTime() > now.getTime() + MAX_PROMO_LIFETIME_MS) {
+        return error(400, 'invalid_expiry', 'Invitation expiry must be within the next seven days');
+    }
+
+    let codeDigest: string;
+    try {
+        codeDigest = digestPromoCode(code);
+    } catch {
+        return error(500, 'misconfigured', 'Invitation service is unavailable');
+    }
+
+    try {
+        const campaign = await prisma.$transaction(async (tx) => {
+            await tx.$queryRaw(
+                Prisma.sql`SELECT "id" FROM "scheduled_sessions" WHERE "id"::text = ${sessionId} FOR UPDATE`,
+            );
+            const session = await tx.scheduledSession.findUnique({ where: { id: sessionId } });
+            if (!session) return null;
+            if (!['SCHEDULED', 'LIVE'].includes(session.status)) {
+                throw new Error('SESSION_UNAVAILABLE');
+            }
+            if (expiresAt > ticketExpiresAt(session.scheduledAt, now)) {
+                throw new Error('EXPIRY_AFTER_ACCESS');
+            }
+            const created = await tx.promoInvitation.create({
+                data: {
+                    scheduledSessionId: sessionId,
+                    codeDigest,
+                    label,
+                    expiresAt,
+                    maxRedemptions,
+                    issuedByUserId: staff.id,
+                },
+                include: CAMPAIGN_INCLUDE,
+            });
+            await tx.auditLog.create({
+                data: {
+                    actorUserId: staff.id,
+                    actorRole: staff.role,
+                    action: 'promo.create',
+                    targetType: 'SCHEDULED_SESSION',
+                    targetId: sessionId,
+                    metadata: {
+                        promoInvitationId: created.id,
+                        maxRedemptions,
+                        expiresAt: expiresAt.toISOString(),
+                    },
+                },
+            });
+            return created;
+        });
+
+        if (!campaign) return error(404, 'not_found', 'No scheduled session with that ID');
+        return NextResponse.json({
+            redemptionEnabled: promoInvitationsEnabled(),
+            campaign: serializeCampaign(campaign),
+        }, { status: 201 });
+    } catch (failure) {
+        if (failure instanceof Prisma.PrismaClientKnownRequestError && failure.code === 'P2002') {
+            return error(409, 'code_unavailable', 'Choose a different invitation code');
+        }
+        if (failure instanceof Error && failure.message === 'SESSION_UNAVAILABLE') {
+            return error(409, 'session_unavailable', 'This session no longer accepts invitations');
+        }
+        if (failure instanceof Error && failure.message === 'EXPIRY_AFTER_ACCESS') {
+            return error(400, 'invalid_expiry', 'Invitation cannot outlive event access');
+        }
+        return error(500, 'unavailable', 'Invitation could not be created');
+    }
+}

--- a/src/components/ops/AdmissionConsole.tsx
+++ b/src/components/ops/AdmissionConsole.tsx
@@ -38,6 +38,24 @@ type Entitlement = {
         administrativeState: 'CLEAR' | 'SUSPENDED';
         mediaStatus: string;
     } | null;
+    promotion: {
+        campaignId: string;
+        label: string;
+        status: 'ACTIVE' | 'DISABLED';
+        expiresAt: string;
+        redeemedAt: string;
+    } | null;
+};
+
+type PromoCampaign = {
+    id: string;
+    label: string;
+    status: 'ACTIVE' | 'DISABLED';
+    expiresAt: string;
+    maxRedemptions: number;
+    redemptionCount: number;
+    disabledAt: string | null;
+    event: { id: string; title: string; language: string; scheduledAt: string };
 };
 
 type Props = {
@@ -83,6 +101,14 @@ export default function AdmissionConsole({ role, events }: Props) {
     const [importCsv, setImportCsv] = useState('');
     const [compTier, setCompTier] = useState(canIssueComp ? 'COMP' : 'SUPPORT_OVERRIDE');
     const [compReason, setCompReason] = useState('');
+    const [promoCampaigns, setPromoCampaigns] = useState<PromoCampaign[] | null>(null);
+    const [promoRedemptionEnabled, setPromoRedemptionEnabled] = useState<boolean | null>(null);
+    const [promoCode, setPromoCode] = useState('');
+    const [promoLabel, setPromoLabel] = useState('');
+    const [promoExpiry, setPromoExpiry] = useState('');
+    const [promoCapacity, setPromoCapacity] = useState('1');
+    const [promoReasons, setPromoReasons] = useState<Record<string, string>>({});
+    const [promoRevokeDerived, setPromoRevokeDerived] = useState<Record<string, boolean>>({});
 
     function flash(ok: string | null, err: string | null) {
         setNotice(ok);
@@ -202,6 +228,83 @@ export default function AdmissionConsole({ role, events }: Props) {
         }
     }
 
+    async function loadPromoCampaigns() {
+        setBusy(true);
+        flash(null, null);
+        try {
+            const response = await fetch('/api/ops/invitations');
+            const data = await response.json() as Record<string, unknown>;
+            if (!response.ok) {
+                flash(null, errorMessage(response.status, data));
+                return;
+            }
+            setPromoCampaigns(data.campaigns as PromoCampaign[]);
+            setPromoRedemptionEnabled(Boolean(data.redemptionEnabled));
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function createPromoCampaign() {
+        setBusy(true);
+        flash(null, null);
+        try {
+            const { status, data } = await postJson('/api/ops/invitations', {
+                sessionId: batchEvent,
+                code: promoCode,
+                label: promoLabel,
+                expiresAt: new Date(promoExpiry).toISOString(),
+                maxRedemptions: Number(promoCapacity),
+            });
+            if (status >= 400) {
+                flash(null, errorMessage(status, data));
+                return;
+            }
+            const campaign = data.campaign as PromoCampaign;
+            setPromoCampaigns((current) => [campaign, ...(current ?? [])]);
+            setPromoRedemptionEnabled(Boolean(data.redemptionEnabled));
+            setPromoCode('');
+            setPromoLabel('');
+            flash(
+                data.redemptionEnabled
+                    ? 'Invitation created and ready to redeem.'
+                    : 'Invitation created, but the global redemption switch remains OFF.',
+                null,
+            );
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function disablePromoCampaign(id: string) {
+        setBusy(true);
+        flash(null, null);
+        try {
+            const { status, data } = await postJson(`/api/ops/invitations/${id}`, {
+                action: 'disable',
+                reason: promoReasons[id] ?? '',
+                revokeDerived: promoRevokeDerived[id] ?? false,
+            });
+            if (status >= 400) {
+                flash(null, errorMessage(status, data));
+                return;
+            }
+            setPromoCampaigns((current) => current?.map((campaign) =>
+                campaign.id === id
+                    ? { ...campaign, status: 'DISABLED', disabledAt: new Date().toISOString() }
+                    : campaign,
+            ) ?? null);
+            flash(
+                data.mediaCleanupFailed
+                    ? 'Invitation disabled and access revoked; some live connections need a retry.'
+                    : `Invitation disabled. ${data.revokedEntitlements} derived access grant(s) revoked.`,
+                null,
+            );
+        } finally {
+            setBusy(false);
+        }
+    }
+
     function downloadCsv() {
         if (!oneTimeCsv) return;
         const blob = new Blob([oneTimeCsv], { type: 'text/csv' });
@@ -248,6 +351,13 @@ export default function AdmissionConsole({ role, events }: Props) {
                                         <span>
                                             <strong className="text-[var(--cream)]">Commerce:</strong>{' '}
                                             {item.commerce.providerState} · admin {item.commerce.administrativeState} · media {item.commerce.mediaStatus}
+                                        </span>
+                                    )}
+                                    {item.promotion && (
+                                        <span>
+                                            <strong className="text-[var(--cream)]">Invitation:</strong>{' '}
+                                            {item.promotion.label} · campaign {item.promotion.status} · redeemed{' '}
+                                            {new Date(item.promotion.redeemedAt).toLocaleString()}
                                         </span>
                                     )}
                                 </div>
@@ -408,6 +518,158 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     Issue
                                 </button>
                             </div>
+                        </div>
+                    )}
+                </section>
+            )}
+
+            {(canIssueComp || canMutate) && (
+                <section aria-labelledby="promo-invitations-heading">
+                    <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                            <h2 id="promo-invitations-heading" className="text-lg font-medium text-[var(--cream)]">
+                                Controlled invitations
+                            </h2>
+                            <p className="mt-1 max-w-2xl text-xs leading-5 text-[var(--text-secondary)]">
+                                A short code creates the same session-scoped COMP entitlement as normal admission.
+                                Codes are stored only as digests; capacity, expiry and revocation remain enforced.
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={loadPromoCampaigns}
+                            disabled={busy}
+                            className="event-button event-button--secondary disabled:opacity-50"
+                        >
+                            {promoCampaigns === null ? 'Load invitations' : 'Refresh'}
+                        </button>
+                    </div>
+
+                    {promoRedemptionEnabled !== null && (
+                        <p
+                            role="status"
+                            className={`mb-3 rounded border px-3 py-2 text-sm ${promoRedemptionEnabled
+                                ? 'border-[var(--lime)]/30 bg-[var(--lime)]/10 text-[var(--lime)]'
+                                : 'border-[var(--warning)]/30 bg-[var(--warning)]/10 text-[var(--warning)]'}`}
+                        >
+                            Public redemption is {promoRedemptionEnabled ? 'ON' : 'OFF'}.
+                        </p>
+                    )}
+
+                    {canIssueComp && (
+                        <div className="operational-panel mb-4 space-y-3">
+                            <h3 className="font-medium text-[var(--cream)]">Create bounded invitation</h3>
+                            <div className="grid gap-3 sm:grid-cols-2">
+                                <label className="text-xs text-[var(--text-secondary)]">
+                                    Internal label (never the code)
+                                    <input
+                                        className="event-field mt-1"
+                                        value={promoLabel}
+                                        maxLength={80}
+                                        onChange={(event) => setPromoLabel(event.target.value)}
+                                        placeholder="Guest list — morning ES"
+                                    />
+                                </label>
+                                <label className="text-xs text-[var(--text-secondary)]">
+                                    Human code (6–15 characters)
+                                    <input
+                                        className="event-field mt-1 font-mono uppercase"
+                                        value={promoCode}
+                                        maxLength={15}
+                                        autoComplete="off"
+                                        spellCheck={false}
+                                        onChange={(event) => setPromoCode(event.target.value)}
+                                        placeholder="NICO100"
+                                    />
+                                </label>
+                                <label className="text-xs text-[var(--text-secondary)]">
+                                    Expires (within seven days)
+                                    <input
+                                        className="event-field mt-1"
+                                        type="datetime-local"
+                                        value={promoExpiry}
+                                        onChange={(event) => setPromoExpiry(event.target.value)}
+                                    />
+                                </label>
+                                <label className="text-xs text-[var(--text-secondary)]">
+                                    Redemption capacity
+                                    <input
+                                        className="event-field mt-1"
+                                        type="number"
+                                        min={1}
+                                        max={150}
+                                        value={promoCapacity}
+                                        onChange={(event) => setPromoCapacity(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <button
+                                type="button"
+                                disabled={busy || !batchEvent || !promoLabel.trim() || !promoCode.trim() || !promoExpiry}
+                                onClick={createPromoCampaign}
+                                className="event-button event-button--primary disabled:opacity-50"
+                            >
+                                Create invitation
+                            </button>
+                        </div>
+                    )}
+
+                    {promoCampaigns && (
+                        <div className="space-y-3">
+                            {promoCampaigns.length === 0 && (
+                                <p className="text-sm text-[var(--text-secondary)]">No invitations created.</p>
+                            )}
+                            {promoCampaigns.map((campaign) => (
+                                <article key={campaign.id} className="operational-panel text-sm">
+                                    <div className="flex flex-wrap items-center justify-between gap-2">
+                                        <div>
+                                            <strong className="text-[var(--cream)]">{campaign.label}</strong>
+                                            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                                                {campaign.event.title} · {campaign.redemptionCount}/{campaign.maxRedemptions} redeemed · expires {new Date(campaign.expiresAt).toLocaleString()}
+                                            </p>
+                                        </div>
+                                        <span className="font-mono text-xs text-[var(--gold)]">{campaign.status}</span>
+                                    </div>
+                                    {canMutate && (campaign.status === 'ACTIVE' || campaign.redemptionCount > 0) && (
+                                        <div className="mt-3 space-y-2 border-t border-[var(--border-subtle)] pt-3">
+                                            <input
+                                                className="event-field"
+                                                placeholder="Disable reason (required, no PII)"
+                                                value={promoReasons[campaign.id] ?? ''}
+                                                onChange={(event) => setPromoReasons((current) => ({
+                                                    ...current,
+                                                    [campaign.id]: event.target.value,
+                                                }))}
+                                            />
+                                            <label className="flex min-h-11 items-center gap-2 text-xs text-[var(--text-secondary)]">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={promoRevokeDerived[campaign.id] ?? false}
+                                                    onChange={(event) => setPromoRevokeDerived((current) => ({
+                                                        ...current,
+                                                        [campaign.id]: event.target.checked,
+                                                    }))}
+                                                />
+                                                Also revoke every entitlement already redeemed and disconnect its live media.
+                                            </label>
+                                            <button
+                                                type="button"
+                                                disabled={
+                                                    busy ||
+                                                    !(promoReasons[campaign.id] ?? '').trim() ||
+                                                    (campaign.status === 'DISABLED' && !(promoRevokeDerived[campaign.id] ?? false))
+                                                }
+                                                onClick={() => disablePromoCampaign(campaign.id)}
+                                                className="event-button bg-[var(--danger)] text-white hover:bg-[var(--danger)]/80 disabled:opacity-50"
+                                            >
+                                                {campaign.status === 'ACTIVE'
+                                                    ? 'Disable invitation'
+                                                    : 'Retry revoke / disconnect'}
+                                            </button>
+                                        </div>
+                                    )}
+                                </article>
+                            ))}
                         </div>
                     )}
                 </section>

--- a/src/components/ops/__tests__/AdmissionConsole.test.tsx
+++ b/src/components/ops/__tests__/AdmissionConsole.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import AdmissionConsole from '../AdmissionConsole';
+
+const EVENT = {
+    id: '10000000-0000-4000-8000-000000000001',
+    title: 'Spanish event',
+    language: 'SPANISH',
+    scheduledAt: '2026-08-08T14:30:00.000Z',
+    attendeeCap: 150,
+};
+const CAMPAIGN = {
+    id: '50000000-0000-4000-8000-000000000001',
+    label: 'Guest list',
+    status: 'ACTIVE',
+    expiresAt: '2026-08-04T12:00:00.000Z',
+    maxRedemptions: 10,
+    redemptionCount: 2,
+    disabledAt: null,
+    createdAt: '2026-08-02T12:00:00.000Z',
+    event: EVENT,
+};
+
+afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+});
+
+describe('AdmissionConsole promotion invitations', () => {
+    it('shows promotional provenance in the ordinary entitlement lookup', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                results: [{
+                    id: '70000000-0000-4000-8000-000000000001',
+                    state: 'BOUND',
+                    tier: 'COMP',
+                    codeLastFour: '7XQP',
+                    boundEmail: 'guest@example.invalid',
+                    expiresAt: '2026-08-09T14:30:00.000Z',
+                    revokedAt: null,
+                    revocationReason: null,
+                    event: EVENT,
+                    commerce: null,
+                    promotion: {
+                        campaignId: CAMPAIGN.id,
+                        label: CAMPAIGN.label,
+                        status: CAMPAIGN.status,
+                        expiresAt: CAMPAIGN.expiresAt,
+                        redeemedAt: '2026-08-02T12:00:00.000Z',
+                    },
+                }],
+            }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        render(<AdmissionConsole role="OPERATOR" events={[EVENT]} />);
+
+        await userEvent.type(
+            screen.getByPlaceholderText(/Attendee email/),
+            'guest@example.invalid',
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Look up' }));
+
+        expect(await screen.findByText(/Invitation:/)).toBeInTheDocument();
+        expect(screen.getByText(/Guest list · campaign ACTIVE/)).toBeInTheDocument();
+    });
+
+    it('shows the global kill switch and clears the raw code after bounded creation', async () => {
+        const fetchMock = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => ({
+            ok: true,
+            status: init?.method === 'POST' ? 201 : 200,
+            json: async () => init?.method === 'POST'
+                ? { redemptionEnabled: false, campaign: CAMPAIGN }
+                : { redemptionEnabled: false, campaigns: [] },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(<AdmissionConsole role="FACILITATOR_OP" events={[EVENT]} />);
+
+        await userEvent.click(screen.getByRole('button', { name: 'Load invitations' }));
+        expect(await screen.findByRole('status')).toHaveTextContent('Public redemption is OFF');
+
+        await userEvent.type(screen.getByLabelText(/Internal label/), 'Guest list');
+        const code = screen.getByLabelText(/Human code/);
+        await userEvent.type(code, 'nico100');
+        await userEvent.type(screen.getByLabelText(/Expires/), '2026-08-04T09:00');
+        await userEvent.clear(screen.getByLabelText(/Redemption capacity/));
+        await userEvent.type(screen.getByLabelText(/Redemption capacity/), '10');
+        await userEvent.click(screen.getByRole('button', { name: 'Create invitation' }));
+
+        await waitFor(() => expect(screen.getByText('Guest list')).toBeInTheDocument());
+        expect(code).toHaveValue('');
+        const createCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST');
+        expect(JSON.parse(String(createCall?.[1]?.body))).toMatchObject({
+            sessionId: EVENT.id,
+            code: 'nico100',
+            label: 'Guest list',
+            maxRedemptions: 10,
+        });
+        expect(document.body.textContent).not.toContain('nico100');
+    });
+
+    it('makes preservation versus derived revocation an explicit staff choice', async () => {
+        const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => ({
+            ok: true,
+            status: 200,
+            json: async () => init?.method === 'POST'
+                ? {
+                    id: CAMPAIGN.id,
+                    status: 'DISABLED',
+                    revokeDerived: true,
+                    revokedEntitlements: 2,
+                    mediaCleanupFailed: false,
+                }
+                : { redemptionEnabled: true, campaigns: [CAMPAIGN] },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(<AdmissionConsole role="OPERATOR" events={[EVENT]} />);
+
+        await userEvent.click(screen.getByRole('button', { name: 'Load invitations' }));
+        expect(await screen.findByText('Guest list')).toBeInTheDocument();
+        expect(screen.getByRole('status')).toHaveTextContent('Public redemption is ON');
+
+        await userEvent.type(screen.getByPlaceholderText(/Disable reason/), 'Guest list withdrawn');
+        await userEvent.click(screen.getByRole('checkbox', { name: /Also revoke every entitlement/ }));
+        await userEvent.click(screen.getByRole('button', { name: 'Disable invitation' }));
+
+        await waitFor(() => expect(screen.getByText('DISABLED')).toBeInTheDocument());
+        expect(screen.getByRole('button', { name: 'Retry revoke / disconnect' })).toBeEnabled();
+        const disableCall = fetchMock.mock.calls.find(([url, init]) =>
+            String(url).includes(`/api/ops/invitations/${CAMPAIGN.id}`) && init?.method === 'POST',
+        );
+        expect(JSON.parse(String(disableCall?.[1]?.body))).toEqual({
+            action: 'disable',
+            reason: 'Guest list withdrawn',
+            revokeDerived: true,
+        });
+    });
+});

--- a/src/lib/__tests__/promo-invitation.integration.test.ts
+++ b/src/lib/__tests__/promo-invitation.integration.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { prisma } from '@/lib/db';
+import { principalFromToken } from '@/lib/principal';
+import {
+    digestPromoCode,
+    redeemPromoInvitation,
+} from '@/lib/promo-invitation';
+
+const integration = process.env.COMMERCE_INTEGRATION_TEST === '1' ? describe : describe.skip;
+const PEPPER = 'promo-integration-pepper-at-least-32-characters';
+const NOW = new Date('2026-08-02T12:00:00.000Z');
+const SESSION_ID = '10000000-0000-4000-8000-000000000011';
+const ISSUER_ID = '10000000-0000-4000-8000-000000000099';
+const CAMPAIGN_ID = '50000000-0000-4000-8000-000000000001';
+
+integration('promotion invitation PostgreSQL contract', () => {
+    beforeAll(async () => {
+        const configured = process.env.DATABASE_URL;
+        if (!configured) throw new Error('promotion integration DATABASE_URL is required');
+        const expectedDatabase = new URL(configured).pathname.replace(/^\//, '');
+        const [{ database }] = await prisma.$queryRaw<Array<{ database: string }>>`
+            SELECT current_database() AS "database"
+        `;
+        if (!expectedDatabase.endsWith('_test') || database !== expectedDatabase) {
+            throw new Error('promotion integration cleanup is restricted to the exact configured *_test database');
+        }
+        vi.stubEnv('TICKET_CODE_PEPPER', PEPPER);
+        await prisma.auditLog.deleteMany();
+        await prisma.promoRedemption.deleteMany();
+        await prisma.promoInvitation.deleteMany();
+        await prisma.commerceRequestReceipt.deleteMany();
+        await prisma.commerceEntitlementCommand.deleteMany();
+        await prisma.commerceMediaOutbox.deleteMany();
+        await prisma.commerceEntitlement.deleteMany();
+        await prisma.webSession.deleteMany();
+        await prisma.sessionParticipant.deleteMany();
+        await prisma.ticketEntitlement.deleteMany();
+        await prisma.scheduledSession.deleteMany();
+        await prisma.user.deleteMany();
+        await prisma.user.create({
+            data: {
+                id: ISSUER_ID,
+                email: 'promo-issuer@integration.invalid',
+                name: 'Promotion issuer',
+                role: 'FACILITATOR_OP',
+                passwordDigest: 'not-used',
+            },
+        });
+        await prisma.scheduledSession.create({
+            data: {
+                id: SESSION_ID,
+                title: 'Promotion integration',
+                roomName: 'promo-integration',
+                language: 'SPANISH',
+                scheduledAt: new Date('2026-08-08T14:30:00.000Z'),
+                status: 'LIVE',
+                paidMode: true,
+                attendeeCap: 150,
+                facilitatorId: ISSUER_ID,
+            },
+        });
+        await prisma.promoInvitation.create({
+            data: {
+                id: CAMPAIGN_ID,
+                scheduledSessionId: SESSION_ID,
+                codeDigest: digestPromoCode('NICO100', PEPPER),
+                label: 'Synthetic guest campaign',
+                expiresAt: new Date('2026-08-03T12:00:00.000Z'),
+                maxRedemptions: 1,
+                issuedByUserId: ISSUER_ID,
+            },
+        });
+    });
+
+    afterAll(async () => {
+        vi.unstubAllEnvs();
+        await prisma.$disconnect();
+    });
+
+    it('serializes the last slot, creates a normal entitlement, and never audits raw material', async () => {
+        const [ana, beto] = await Promise.all([
+            redeemPromoInvitation('nico100', 'ana@example.com', 'Ana', NOW),
+            redeemPromoInvitation('NICO100', 'beto@example.com', 'Beto', NOW),
+        ]);
+        const winner = ana.ok ? ana : beto;
+        const loser = ana.ok ? beto : ana;
+
+        expect(winner.ok).toBe(true);
+        expect(loser).toEqual({ ok: false, reason: 'unavailable' });
+        if (!winner.ok) throw new Error('expected one winner');
+
+        await expect(prisma.promoInvitation.findUniqueOrThrow({
+            where: { id: CAMPAIGN_ID },
+        })).resolves.toMatchObject({ redemptionCount: 1, maxRedemptions: 1 });
+        await expect(prisma.ticketEntitlement.findUniqueOrThrow({
+            where: { id: winner.entitlementId },
+            include: { promoRedemption: true, commerceEntitlement: true },
+        })).resolves.toMatchObject({
+            scheduledSessionId: SESSION_ID,
+            tier: 'COMP',
+            state: 'BOUND',
+            promoRedemption: { promoInvitationId: CAMPAIGN_ID },
+            commerceEntitlement: null,
+        });
+        await expect(principalFromToken(winner.cookieValue, NOW)).resolves.toMatchObject({
+            kind: 'attendee',
+            scheduledSessionId: SESSION_ID,
+            entitlementId: winner.entitlementId,
+            tier: 'COMP',
+        });
+
+        const audits = JSON.stringify(await prisma.auditLog.findMany());
+        expect(audits).toContain('promo.redeem');
+        expect(audits).not.toMatch(/nico100|ana@example|beto@example/i);
+    });
+
+    it('replays the winner after campaign expiry/disable but rejects a shared new identity', async () => {
+        const redemption = await prisma.promoRedemption.findFirstOrThrow({
+            include: { ticketEntitlement: true },
+        });
+        await prisma.promoInvitation.update({
+            where: { id: CAMPAIGN_ID },
+            data: { status: 'DISABLED', disabledAt: NOW },
+        });
+
+        const replay = await redeemPromoInvitation(
+            'NICO100',
+            redemption.ticketEntitlement.boundEmail!,
+            'Returning guest',
+            new Date('2026-08-04T12:00:00.000Z'),
+        );
+        expect(replay).toMatchObject({
+            ok: true,
+            entitlementId: redemption.ticketEntitlementId,
+            replayed: true,
+        });
+        await expect(redeemPromoInvitation(
+            'NICO100',
+            'shared@example.com',
+            'Shared code',
+            new Date('2026-08-04T12:00:00.000Z'),
+        )).resolves.toEqual({ ok: false, reason: 'unavailable' });
+        expect(await prisma.ticketEntitlement.count()).toBe(1);
+    });
+});

--- a/src/lib/__tests__/promo-invitation.test.ts
+++ b/src/lib/__tests__/promo-invitation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    digestPromoCode,
+    isPlausiblePromoCode,
+    normalizePromoCode,
+    promoInvitationsEnabled,
+    promoRedeemerDigest,
+} from '../promo-invitation';
+
+const PEPPER = 'promo-test-pepper-with-at-least-32-characters';
+
+describe('promotion invitation primitives', () => {
+    it('normalizes human codes without accepting ambiguous punctuation or unsafe lengths', () => {
+        expect(normalizePromoCode('  nico100 ')).toBe('NICO100');
+        expect(isPlausiblePromoCode('nico100')).toBe(true);
+        expect(isPlausiblePromoCode('A-B-C-D')).toBe(true);
+        expect(isPlausiblePromoCode('tiny')).toBe(false);
+        expect(isPlausiblePromoCode('-nico100')).toBe(false);
+        expect(isPlausiblePromoCode('nico 100')).toBe(false);
+        expect(isPlausiblePromoCode('this-code-is-far-too-long')).toBe(false);
+    });
+
+    it('stores domain-separated deterministic digests, never the raw code or email', () => {
+        const codeDigest = digestPromoCode('nico100', PEPPER);
+        const emailDigest = promoRedeemerDigest(' Ana@Example.COM ', PEPPER);
+
+        expect(codeDigest).toMatch(/^[a-f0-9]{64}$/);
+        expect(emailDigest).toMatch(/^[a-f0-9]{64}$/);
+        expect(codeDigest).not.toBe(emailDigest);
+        expect(codeDigest).toBe(digestPromoCode(' NICO100 ', PEPPER));
+        expect(emailDigest).toBe(promoRedeemerDigest('ana@example.com', PEPPER));
+        expect(`${codeDigest}${emailDigest}`).not.toMatch(/nico|ana|example/i);
+    });
+
+    it('is disabled unless the exact production switch is true', () => {
+        expect(promoInvitationsEnabled()).toBe(false);
+        expect(promoInvitationsEnabled('false')).toBe(false);
+        expect(promoInvitationsEnabled('TRUE')).toBe(false);
+        expect(promoInvitationsEnabled('true')).toBe(true);
+    });
+});

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -44,7 +44,10 @@ export type AdmissionAuditAction =
     | 'ticket.comp_issue'
     | 'ticket.revoke'
     | 'ticket.rebind'
-    | 'ticket.commerce_resume';
+    | 'ticket.commerce_resume'
+    | 'promo.create'
+    | 'promo.disable'
+    | 'promo.redeem';
 
 export type AdmissionAuditTargetType = 'TICKET_ENTITLEMENT' | 'SCHEDULED_SESSION';
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -276,7 +276,7 @@ export const messages: Record<UiLocale, Messages> = {
         ticketLogin: {
             displayName: 'Nombre visible en la sala',
             ticketCode: 'Código de entrada',
-            ticketCodeHint: 'Exactamente como aparece en el correo de tu entrada',
+            ticketCodeHint: 'Exactamente como aparece en tu entrada o invitación',
             email: 'Correo con el que compraste la entrada',
             rejected: 'Ese código y ese correo no coinciden con una entrada activa. Revisá ambos tal como aparecen en el correo de tu entrada.',
             rateLimited: 'Hubo demasiados intentos. Esperá unos minutos y volvé a intentar.',
@@ -500,7 +500,7 @@ export const messages: Record<UiLocale, Messages> = {
         ticketLogin: {
             displayName: 'Name shown in the room',
             ticketCode: 'Ticket code',
-            ticketCodeHint: 'Exactly as it appears in your ticket email',
+            ticketCodeHint: 'Exactly as it appears on your ticket or invitation',
             email: 'Email used to buy the ticket',
             rejected: 'That code and email do not match an active ticket. Check both exactly as they appear in your ticket email.',
             rateLimited: 'Too many attempts. Wait a few minutes and try again.',

--- a/src/lib/promo-invitation.ts
+++ b/src/lib/promo-invitation.ts
@@ -1,0 +1,202 @@
+import { createHmac } from 'node:crypto';
+import { Prisma } from '@prisma/client';
+
+import { batchExceedsCap, generateTicketCode, normalizeEmail, ticketExpiresAt } from '@/lib/admission';
+import { prisma } from '@/lib/db';
+import {
+    newSessionToken,
+    webSessionExpiry,
+} from '@/lib/principal';
+import { ticketCodePepper, ticketCodeStorage } from '@/lib/ticket-code';
+
+export const PROMO_CODE_PATTERN = /^[A-Z0-9](?:[A-Z0-9-]{4,13}[A-Z0-9])$/;
+export const MAX_PROMO_REDEMPTIONS = 150;
+export const MAX_PROMO_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function promoInvitationsEnabled(
+    raw = process.env.PROMO_INVITATIONS_ENABLED,
+): boolean {
+    return raw === 'true';
+}
+
+export function normalizePromoCode(code: string): string {
+    return code.trim().toUpperCase();
+}
+
+export function isPlausiblePromoCode(code: string): boolean {
+    return PROMO_CODE_PATTERN.test(normalizePromoCode(code));
+}
+
+export function digestPromoCode(
+    code: string,
+    pepper = ticketCodePepper(),
+): string {
+    const normalized = normalizePromoCode(code);
+    if (!PROMO_CODE_PATTERN.test(normalized)) {
+        throw new Error('Promotion codes must contain 6–15 letters, digits, or internal hyphens');
+    }
+    return createHmac('sha256', pepper)
+        .update(`promo-invitation:v1:${normalized}`, 'utf8')
+        .digest('hex');
+}
+
+export function promoRedeemerDigest(
+    email: string,
+    pepper = ticketCodePepper(),
+): string {
+    return createHmac('sha256', pepper)
+        .update(`promo-redeemer:v1:${normalizeEmail(email)}`, 'utf8')
+        .digest('hex');
+}
+
+export type PromoRedemptionAttempt =
+    | {
+        ok: true;
+        scheduledSessionId: string;
+        entitlementId: string;
+        codeLastFour: string;
+        cookieValue: string;
+        replayed: boolean;
+    }
+    | { ok: false; reason: 'unavailable' };
+
+/**
+ * Atomically redeem (or replay) one human promotion code.
+ *
+ * The campaign row and the event row are locked before capacity is read. This
+ * shares the same event mutex as paid batches and comps, so the last seat can
+ * only be consumed once. A successful first redemption creates an ordinary
+ * BOUND/COMP TicketEntitlement; every later authorization gate is therefore
+ * identical to a paid ticket. The promotion relation records provenance only.
+ */
+export async function redeemPromoInvitation(
+    code: string,
+    email: string,
+    displayName: string,
+    now = new Date(),
+): Promise<PromoRedemptionAttempt> {
+    const codeDigest = digestPromoCode(code);
+    const redeemerDigest = promoRedeemerDigest(email);
+
+    return prisma.$transaction(async (tx) => {
+        const candidate = await tx.promoInvitation.findUnique({
+            where: { codeDigest },
+            select: { id: true, scheduledSessionId: true },
+        });
+        if (!candidate) return { ok: false, reason: 'unavailable' } as const;
+
+        // Same mutex used by paid/import/comp issuance. Lock the event first,
+        // then the campaign, so every capacity-taking path has one lock order.
+        await tx.$queryRaw(
+            Prisma.sql`SELECT "id" FROM "scheduled_sessions" WHERE "id"::text = ${candidate.scheduledSessionId} FOR UPDATE`,
+        );
+        await tx.$queryRaw(
+            Prisma.sql`SELECT "id" FROM "promo_invitations" WHERE "id"::text = ${candidate.id} FOR UPDATE`,
+        );
+
+        const invitation = await tx.promoInvitation.findUnique({
+            where: { id: candidate.id },
+            include: { scheduledSession: true },
+        });
+        if (!invitation) return { ok: false, reason: 'unavailable' } as const;
+
+        const previous = await tx.promoRedemption.findUnique({
+            where: {
+                promoInvitationId_redeemerDigest: {
+                    promoInvitationId: invitation.id,
+                    redeemerDigest,
+                },
+            },
+            include: { ticketEntitlement: true },
+        });
+
+        let entitlement = previous?.ticketEntitlement ?? null;
+        let replayed = Boolean(previous);
+        if (entitlement) {
+            if (
+                entitlement.state !== 'BOUND' ||
+                entitlement.revokedAt !== null ||
+                entitlement.expiresAt <= now ||
+                entitlement.boundEmail !== normalizeEmail(email)
+            ) {
+                return { ok: false, reason: 'unavailable' } as const;
+            }
+        } else {
+            if (
+                invitation.status !== 'ACTIVE' ||
+                invitation.disabledAt !== null ||
+                invitation.expiresAt <= now ||
+                invitation.redemptionCount >= invitation.maxRedemptions ||
+                !['SCHEDULED', 'LIVE'].includes(invitation.scheduledSession.status)
+            ) {
+                return { ok: false, reason: 'unavailable' } as const;
+            }
+
+            const active = await tx.ticketEntitlement.count({
+                where: {
+                    scheduledSessionId: invitation.scheduledSessionId,
+                    state: { not: 'REVOKED' },
+                },
+            });
+            if (batchExceedsCap(invitation.scheduledSession.attendeeCap, active, 1)) {
+                return { ok: false, reason: 'unavailable' } as const;
+            }
+
+            const internalCredential = generateTicketCode();
+            entitlement = await tx.ticketEntitlement.create({
+                data: {
+                    scheduledSessionId: invitation.scheduledSessionId,
+                    ...ticketCodeStorage(internalCredential),
+                    tier: 'COMP',
+                    state: 'BOUND',
+                    boundEmail: normalizeEmail(email),
+                    boundAt: now,
+                    expiresAt: ticketExpiresAt(invitation.scheduledSession.scheduledAt, now),
+                    issuedByUserId: invitation.issuedByUserId,
+                },
+            });
+            await tx.promoRedemption.create({
+                data: {
+                    promoInvitationId: invitation.id,
+                    redeemerDigest,
+                    ticketEntitlementId: entitlement.id,
+                    redeemedAt: now,
+                },
+            });
+            await tx.promoInvitation.update({
+                where: { id: invitation.id },
+                data: { redemptionCount: { increment: 1 } },
+            });
+            await tx.auditLog.create({
+                data: {
+                    actorUserId: null,
+                    action: 'promo.redeem',
+                    targetType: 'TICKET_ENTITLEMENT',
+                    targetId: entitlement.id,
+                    metadata: { promoInvitationId: invitation.id },
+                },
+            });
+            replayed = false;
+        }
+
+        const issued = newSessionToken();
+        await tx.webSession.create({
+            data: {
+                tokenDigest: issued.database.tokenDigest,
+                displayName,
+                ticketEntitlementId: entitlement.id,
+                expiresAt: webSessionExpiry(now),
+                lastSeenAt: now,
+            },
+        });
+
+        return {
+            ok: true,
+            scheduledSessionId: invitation.scheduledSessionId,
+            entitlementId: entitlement.id,
+            codeLastFour: entitlement.codeLastFour,
+            cookieValue: issued.cookieValue,
+            replayed,
+        } as const;
+    });
+}


### PR DESCRIPTION
Closes #102

## Outcome

Adds session-scoped, bounded promotional invitations that redeem into the existing COMP `TicketEntitlement` and ordinary `WebSession`. This is not a second authentication system or a Ticket Tailor payment claim.

- raw human codes are HMAC-digested and never returned after creation
- campaign expiry and capacity are bounded; event capacity shares the existing admission row lock
- same-email replay is idempotent and creates no extra seat
- disabled/expired/exhausted/unknown codes use the existing generic auth rejection and rate-limit budget
- staff must explicitly choose whether disabling preserves or revokes derived access
- derived revocation invalidates WebSessions and removes both stage and bed identities
- ordinary admission lookup shows promotional provenance without code material
- production defaults to `PROMO_INVITATIONS_ENABLED=false`

No real campaign or `nico100` credential is created. No commerce contract, business rule, or audio path changes.

## Evidence

- 667 unit/component/API tests passed; 7 integration cases are opt-in
- final focused set: 34/34 passed after admission provenance/retry hardening
- PostgreSQL commerce + promotion integration: 7/7 passed, including concurrent last-slot contention
- Chromium + real Postgres + real LiveKit E2E: 1/1 passed (create → redeem → reconnect → replay → revoke → stage/bed removal)
- TypeScript, ESLint, Prisma validate, diff check and production build passed

## Migration and rollout

The migration is additive: `promo_invitations`, `promo_redemptions`, enum, indexes and FKs. Deploy with the flag false. Campaigns may be prepared under staff auth while public redemption remains disabled; enabling redemption is a separate explicit production configuration step.

Rollback application code first and leave the additive tables in place. Already-redeemed rows remain ordinary COMP entitlements. Immediate kill switch: set `PROMO_INVITATIONS_ENABLED=false` and redeploy.

Threat model and rehearsal steps: `docs/architecture/PROMO_INVITATIONS.md`.
