### PR TITLE
Fix tapestry invalidation during in-flight builds

### DIFF
--- a/services/tapestry/src/composite.ts
+++ b/services/tapestry/src/composite.ts
@@ -25,8 +25,12 @@ interface CompositeCacheEntry {
   jpeg: Buffer;
   builtAtMs: number;
   inFlight: Promise<Buffer> | null;
-  /** Set on ingest/sweep; cleared when a rebuild picks up the change. */
-  dirty: boolean;
+  /** Monotonic store revision; every ingest/sweep/arrangement advances it. */
+  revision: number;
+  /** Revision captured by the last successfully completed composite. */
+  builtRevision: number;
+  /** A staff change newer than builtRevision bypasses the ingest rate limit. */
+  urgentRevision: number;
 }
 
 export class TapestryCompositor {
@@ -48,7 +52,9 @@ export class TapestryCompositor {
         jpeg: Buffer.alloc(0),
         builtAtMs: 0,
         inFlight: null,
-        dirty: true,
+        revision: 1,
+        builtRevision: 0,
+        urgentRevision: 0,
       });
     }
   }
@@ -57,12 +63,12 @@ export class TapestryCompositor {
   markDirty(sessionId: string, immediate = false): void {
     const entry = this.cache.get(sessionId);
     if (entry) {
-      entry.dirty = true;
+      entry.revision += 1;
       // Staff actions (arrangement changes) must be visible at once — the
       // rate limit exists to bound ingest-driven rebuild churn, not to make
       // the ops console feel broken.
       if (immediate) {
-        entry.builtAtMs = 0;
+        entry.urgentRevision = entry.revision;
       }
     }
   }
@@ -86,22 +92,31 @@ export class TapestryCompositor {
     if (!entry) {
       return null;
     }
-
-    const now = this.nowMs();
-    const freshEnough =
-      !entry.dirty || now - entry.builtAtMs < this.config.compositeMinIntervalMs;
-    if (entry.jpeg.length > 0 && freshEnough) {
-      return entry.jpeg;
-    }
     if (entry.inFlight) {
       return entry.inFlight;
     }
 
+    const now = this.nowMs();
+    const dirty = entry.builtRevision !== entry.revision;
+    const urgent = entry.urgentRevision > entry.builtRevision;
+    const freshEnough =
+      !dirty || (!urgent && now - entry.builtAtMs < this.config.compositeMinIntervalMs);
+    if (entry.jpeg.length > 0 && freshEnough) {
+      return entry.jpeg;
+    }
+
+    // `build()` snapshots the store synchronously before libvips starts its
+    // asynchronous encoding. Only this captured revision may be marked built:
+    // a later ingest must remain pending when this promise settles.
+    const buildRevision = entry.revision;
     entry.inFlight = this.build(sessionId)
       .then((jpeg) => {
         entry.jpeg = jpeg;
         entry.builtAtMs = this.nowMs();
-        entry.dirty = false;
+        entry.builtRevision = buildRevision;
+        if (entry.urgentRevision <= buildRevision) {
+          entry.urgentRevision = 0;
+        }
         this.compositesBuilt += 1;
         return jpeg;
       })

--- a/services/tapestry/test/composite.test.ts
+++ b/services/tapestry/test/composite.test.ts
@@ -11,6 +11,9 @@ import { test } from "node:test";
 
 import sharp from "sharp";
 
+import { TapestryCompositor } from "../src/composite.js";
+import { TapestryStore } from "../src/store.js";
+
 import {
   SESSION_A,
   getComposite,
@@ -104,6 +107,43 @@ test("composite rebuilds at most once per second and only when frames changed", 
   } finally {
     await service.close();
   }
+});
+
+test("a frame ingested during an in-flight build remains dirty for the next bounded rebuild", async () => {
+  let now = 1_000;
+  const config = testConfig({ compositeMinIntervalMs: 1_000 });
+  const store = new TapestryStore(config.sessionIds, config.maxParticipantsPerSession);
+  const compositor = new TapestryCompositor(config, store, () => now);
+  const red = await makeJpeg(255, 0, 0, config.tileSizePx);
+  const blue = await makeJpeg(0, 0, 255, config.tileSizePx);
+
+  store.ingest(SESSION_A, "p1", red, now);
+  compositor.markDirty(SESSION_A);
+  const firstBuild = compositor.composite(SESSION_A);
+  const concurrentCaller = compositor.composite(SESSION_A);
+
+  // `build()` has already captured the red tile, but libvips is still
+  // encoding asynchronously. This ingest must survive completion bookkeeping.
+  store.ingest(SESSION_A, "p1", blue, now);
+  compositor.markDirty(SESSION_A);
+
+  const [first, concurrent] = await Promise.all([firstBuild, concurrentCaller]);
+  assert.ok(first);
+  assert.strictEqual(concurrent, first, "concurrent callers share one completed buffer");
+  assert.equal(compositor.compositesBuiltCount(), 1);
+  const firstColor = await tileColor(first, 0, 0);
+  assert.ok(firstColor.r > 150 && firstColor.b < 80, "the in-flight snapshot stays coherent");
+
+  const rateLimited = await compositor.composite(SESSION_A);
+  assert.strictEqual(rateLimited, first, "ordinary ingest still respects the rebuild interval");
+  assert.equal(compositor.compositesBuiltCount(), 1);
+
+  now += config.compositeMinIntervalMs;
+  const rebuilt = await compositor.composite(SESSION_A);
+  assert.ok(rebuilt);
+  assert.equal(compositor.compositesBuiltCount(), 2, "the intervening ingest triggers a later build");
+  const rebuiltColor = await tileColor(rebuilt, 0, 0);
+  assert.ok(rebuiltColor.b > 150 && rebuiltColor.r < 80, "the newest frame becomes visible");
 });
 
 test("a stale participant disappears from the composite within 12 seconds", async () => {


### PR DESCRIPTION
Closes #40

## Outcome

A completed composite now records only the monotonic store revision it actually captured. If ingest, expiry, or arrangement changes arrive while libvips is encoding, that newer revision remains pending instead of being overwritten as clean.

- concurrent callers share the one in-flight promise
- normal ingest still respects the once-per-interval rebuild bound
- staff/arrangement invalidation remains urgent and bypasses that bound
- failed builds do not advance the built revision

## Reproduction and evidence

The focused test failed on `main` with `1 !== 2`: an intervening blue frame never triggered the second build after a red snapshot completed. It passes with this change and checks the actual dominant pixel channel of both JPEGs.

- tapestry tests: 23/23 passed, including the 30-second/150-participant soak
- tapestry TypeScript build passed
- diff check passed

No audio, admission, identity, privacy, or public API behavior changes.
