### PR TITLE
fix(deploy): version and roll back tapestry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
 
       - run: npm ci
       - name: Reject high-severity production dependency regressions
-        run: npm audit --omit=dev --audit-level=high
+        run: |
+          npm audit --omit=dev --audit-level=high
+          npm audit --omit=dev --prefix services/tapestry --audit-level=high
+          npm audit --omit=dev --prefix services/playlist-bot --audit-level=high
       - run: npm run lint
       - run: npm run build
         env:
@@ -39,10 +42,12 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
+      - run: npm ci --prefix services/tapestry
       - run: npm run test:coverage
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
           NEXT_PUBLIC_LIVEKIT_URL: https://placeholder.livekit.cloud
+      - run: npm test --prefix services/tapestry
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,13 @@ jobs:
       - name: Verify code and shared contract
         run: |
           npm ci
+          npm ci --prefix services/tapestry
           npm run contract:commerce:verify
           npm test
+          npm test --prefix services/tapestry
+          npm audit --omit=dev --audit-level=high
+          npm audit --omit=dev --prefix services/tapestry --audit-level=high
+          npm audit --omit=dev --prefix services/playlist-bot --audit-level=high
           npx tsc --noEmit
           npm run lint -- --quiet
 
@@ -46,12 +51,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          previous="$(sudo -n docker inspect beacon-app --format '{{.Image}}' 2>/dev/null || true)"
-          if [ -n "$previous" ]; then
-            sudo -n docker tag "$previous" "harmonic-beacon/app:rollback-${GITHUB_RUN_ID}"
-            echo 'available=true' >> "$GITHUB_OUTPUT"
+          previous_app="$(sudo -n docker inspect beacon-app --format '{{.Image}}' 2>/dev/null || true)"
+          if [ -n "$previous_app" ]; then
+            sudo -n docker tag "$previous_app" "harmonic-beacon/app:rollback-${GITHUB_RUN_ID}"
+            echo 'app_available=true' >> "$GITHUB_OUTPUT"
           else
-            echo 'available=false' >> "$GITHUB_OUTPUT"
+            echo 'app_available=false' >> "$GITHUB_OUTPUT"
+          fi
+          previous_tapestry="$(sudo -n docker inspect beacon-tapestry --format '{{.Image}}' 2>/dev/null || true)"
+          if [ -n "$previous_tapestry" ]; then
+            sudo -n docker tag "$previous_tapestry" "harmonic-beacon/tapestry:rollback-${GITHUB_RUN_ID}"
+            echo 'tapestry_available=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'tapestry_available=false' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build commit image
@@ -59,7 +71,7 @@ jobs:
         run: |
           sudo -n env BEACON_IMAGE_TAG="$GITHUB_SHA" docker compose \
             --project-name app --env-file /etc/harmonic-beacon/production.env \
-            build app
+            build app tapestry
 
       - name: Apply additive migrations
         shell: bash
@@ -71,21 +83,23 @@ jobs:
             --project-name app --env-file /etc/harmonic-beacon/production.env \
             run --rm --no-deps app npx prisma migrate status
 
-      - name: Replace app and reconciler
+      - name: Replace app, reconciler and tapestry
         shell: bash
         run: |
           sudo -n env BEACON_IMAGE_TAG="$GITHUB_SHA" docker compose \
             --project-name app --env-file /etc/harmonic-beacon/production.env \
-            up -d --no-deps --force-recreate app commerce-reconciler
+            up -d --no-deps --force-recreate app commerce-reconciler tapestry
 
       - name: Wait for readiness
         shell: bash
         run: |
           set -euo pipefail
-          for attempt in $(seq 1 60); do
+          for _attempt in $(seq 1 60); do
             app_health="$(sudo -n docker inspect beacon-app --format '{{.State.Health.Status}}' 2>/dev/null || true)"
             worker_health="$(sudo -n docker inspect beacon-commerce-reconciler --format '{{.State.Health.Status}}' 2>/dev/null || true)"
+            tapestry_health="$(sudo -n docker inspect beacon-tapestry --format '{{.State.Health.Status}}' 2>/dev/null || true)"
             if [ "$app_health" = healthy ] && [ "$worker_health" = healthy ] && \
+              [ "$tapestry_health" = healthy ] && \
               curl --fail --silent --show-error http://127.0.0.1:3000/api/health/ready >/dev/null; then
               exit 0
             fi
@@ -139,21 +153,53 @@ jobs:
             }
           done
 
-      - name: Roll back immutable app image on failure
-        if: failure() && steps.rollback.outputs.available == 'true'
+      - name: Roll back immutable service images on failure
+        if: ${{ failure() && (steps.rollback.outputs.app_available == 'true' || steps.rollback.outputs.tapestry_available == 'true') }}
         shell: bash
         run: |
           set -euo pipefail
-          sudo -n env BEACON_IMAGE_TAG="rollback-${GITHUB_RUN_ID}" docker compose \
-            --project-name app --env-file /etc/harmonic-beacon/production.env \
-            up -d --no-deps --force-recreate app
-          if sudo -n docker run --rm --entrypoint test \
-            "harmonic-beacon/app:rollback-${GITHUB_RUN_ID}" \
-            -f /app/scripts/commerce-media-worker.ts; then
+          worker_expected=false
+          if [ "${{ steps.rollback.outputs.app_available }}" = true ]; then
             sudo -n env BEACON_IMAGE_TAG="rollback-${GITHUB_RUN_ID}" docker compose \
               --project-name app --env-file /etc/harmonic-beacon/production.env \
-              up -d --no-deps --force-recreate commerce-reconciler
-          else
-            sudo -n docker stop beacon-commerce-reconciler 2>/dev/null || true
+              up -d --no-deps --force-recreate app
+            if sudo -n docker run --rm --entrypoint test \
+              "harmonic-beacon/app:rollback-${GITHUB_RUN_ID}" \
+              -f /app/scripts/commerce-media-worker.ts; then
+              sudo -n env BEACON_IMAGE_TAG="rollback-${GITHUB_RUN_ID}" docker compose \
+                --project-name app --env-file /etc/harmonic-beacon/production.env \
+                up -d --no-deps --force-recreate commerce-reconciler
+              worker_expected=true
+            else
+              sudo -n docker stop beacon-commerce-reconciler 2>/dev/null || true
+            fi
           fi
-          curl --fail --silent --show-error http://127.0.0.1:3000/api/health/ready >/dev/null
+          if [ "${{ steps.rollback.outputs.tapestry_available }}" = true ]; then
+            sudo -n env BEACON_IMAGE_TAG="rollback-${GITHUB_RUN_ID}" docker compose \
+              --project-name app --env-file /etc/harmonic-beacon/production.env \
+              up -d --no-deps --force-recreate tapestry
+          fi
+          for _attempt in $(seq 1 60); do
+            app_ready=true
+            worker_ready=true
+            tapestry_ready=true
+            if [ "${{ steps.rollback.outputs.app_available }}" = true ]; then
+              if [ "$(sudo -n docker inspect beacon-app --format '{{.State.Health.Status}}' 2>/dev/null || true)" != healthy ] || \
+                ! curl --fail --silent --show-error http://127.0.0.1:3000/api/health/ready >/dev/null; then
+                app_ready=false
+              fi
+            fi
+            if [ "$worker_expected" = true ]; then
+              [ "$(sudo -n docker inspect beacon-commerce-reconciler --format '{{.State.Health.Status}}' 2>/dev/null || true)" = healthy ] || worker_ready=false
+            fi
+            if [ "${{ steps.rollback.outputs.tapestry_available }}" = true ]; then
+              [ "$(sudo -n docker inspect beacon-tapestry --format '{{.State.Health.Status}}' 2>/dev/null || true)" = healthy ] || tapestry_ready=false
+            fi
+            if [ "$app_ready" = true ] && [ "$worker_ready" = true ] && [ "$tapestry_ready" = true ]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          sudo -n docker compose --project-name app \
+            --env-file /etc/harmonic-beacon/production.env ps
+          exit 1

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,14 +30,16 @@ A push to `release` runs `.github/workflows/deploy.yml` on the managed host. It:
 
 1. runs contract, unit, type and lint gates;
 2. verifies both root-owned env files and the private network membership;
-3. preserves the currently running app image under an immutable rollback tag;
-4. builds a commit-tagged image;
+3. preserves the currently running app and tapestry images under independent
+   immutable rollback tags;
+4. builds commit-tagged app and tapestry images;
 5. applies additive Prisma migrations and verifies migration status;
-6. replaces only app and commerce reconciler; and
-7. waits for app readiness and reconciler health.
+6. replaces only app, commerce reconciler and tapestry; and
+7. waits for app readiness plus reconciler and tapestry health.
 
-On failure it restores the preserved app image. It never uses `compose down`,
-deletes data or pretends that rebuilding the same tag is a rollback.
+On failure it restores the preserved app and tapestry images independently. It
+never uses `compose down`, deletes data or pretends that rebuilding the same tag
+is a rollback.
 
 ## Manual deploy on mona
 
@@ -48,20 +50,21 @@ use the canonical project name and environment file:
 export BEACON_IMAGE_TAG=<exact-commit-sha>
 sudo -n env BEACON_IMAGE_TAG="$BEACON_IMAGE_TAG" docker compose \
   --project-name app --env-file /etc/harmonic-beacon/production.env \
-  build app
+  build app tapestry
 sudo -n env BEACON_IMAGE_TAG="$BEACON_IMAGE_TAG" docker compose \
   --project-name app --env-file /etc/harmonic-beacon/production.env \
   run --rm --no-deps app npx prisma migrate deploy
 sudo -n env BEACON_IMAGE_TAG="$BEACON_IMAGE_TAG" docker compose \
   --project-name app --env-file /etc/harmonic-beacon/production.env \
-  up -d --no-deps --force-recreate app commerce-reconciler
+  up -d --no-deps --force-recreate app commerce-reconciler tapestry
 ```
 
-Wait for both health checks; do not use a fixed sleep as proof:
+Wait for all three health checks; do not use a fixed sleep as proof:
 
 ```bash
 sudo -n docker inspect beacon-app --format '{{.State.Health.Status}}'
 sudo -n docker inspect beacon-commerce-reconciler --format '{{.State.Health.Status}}'
+sudo -n docker inspect beacon-tapestry --format '{{.State.Health.Status}}'
 curl --fail http://127.0.0.1:3000/api/health/ready
 curl --fail https://live.harmonicbeacon.com/api/health/ready
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,6 +205,7 @@ services:
 
   # ── Tapestry (audience presence grid) ────────────────────────────
   tapestry:
+    image: harmonic-beacon/tapestry:${BEACON_IMAGE_TAG:-latest}
     build:
       context: ./services/tapestry
       dockerfile: Dockerfile

--- a/docs/operations/DEPENDENCY_SECURITY.md
+++ b/docs/operations/DEPENDENCY_SECURITY.md
@@ -23,7 +23,13 @@ baseline it reports one low-severity esbuild issue limited to the Windows
 development server; production runs Linux standalone output and does not expose
 the esbuild development server. Review or remove that exception by 2026-09-01.
 
-Rollback is one commit plus image rebuild: restore `package.json` and
-`package-lock.json`, run `npm ci`, rebuild the standalone image, and redeploy.
-There are no schema, migration, session-cookie or environment changes in this
-dependency update.
+Every independently deployed Node package is audited, not only the repository
+root. The tapestry service is pinned to Sharp 0.35.3 after its prior 0.34 line
+reported a high-severity inherited libvips advisory. CI and release now run
+separate production audits for the root, `services/tapestry` and
+`services/playlist-bot` lockfiles; both services currently report zero findings.
+
+Rollback is one commit plus image rebuild: restore the root and tapestry
+`package.json`/`package-lock.json` pairs, run both clean installs, rebuild the
+standalone and tapestry images, and redeploy. There are no schema, migration,
+session-cookie or environment changes in this dependency update.

--- a/services/tapestry/package-lock.json
+++ b/services/tapestry/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "sharp": "^0.34.3"
+        "sharp": "^0.35.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -491,19 +491,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -513,19 +513,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -539,9 +558,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -555,9 +574,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -571,9 +590,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -587,9 +606,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -603,9 +622,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -619,9 +638,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -635,9 +654,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -651,9 +670,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -667,9 +686,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -683,9 +702,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -695,19 +714,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -717,19 +736,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -739,19 +758,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -761,19 +780,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -783,19 +802,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -805,19 +824,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -827,19 +846,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -849,38 +868,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -890,16 +925,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -909,16 +944,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -928,7 +963,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1023,47 +1058,52 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/tslib": {

--- a/services/tapestry/package.json
+++ b/services/tapestry/package.json
@@ -12,7 +12,7 @@
     "test": "MALLOC_ARENA_MAX=2 tsx --test test/*.test.ts"
   },
   "dependencies": {
-    "sharp": "^0.34.3"
+    "sharp": "^0.35.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const readRepositoryFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8');
+
+describe('production deploy contract', () => {
+  const compose = readRepositoryFile('docker-compose.yml');
+  const ciWorkflow = readRepositoryFile('.github/workflows/ci.yml');
+  const workflow = readRepositoryFile('.github/workflows/deploy.yml');
+
+  it('gives app and tapestry independent commit-tagged images', () => {
+    expect(compose).toContain(
+      'image: harmonic-beacon/app:${BEACON_IMAGE_TAG:-latest}',
+    );
+    expect(compose).toContain(
+      'image: harmonic-beacon/tapestry:${BEACON_IMAGE_TAG:-latest}',
+    );
+  });
+
+  it('builds, replaces and waits for tapestry in every release', () => {
+    expect(workflow).toMatch(/build app tapestry/);
+    expect(workflow).toMatch(
+      /up -d --no-deps --force-recreate app commerce-reconciler tapestry/,
+    );
+    expect(workflow).toContain('tapestry_health=');
+    expect(workflow).toContain('[ "$tapestry_health" = healthy ]');
+  });
+
+  it('preserves and restores app and tapestry independently', () => {
+    expect(workflow).toContain(
+      'harmonic-beacon/app:rollback-${GITHUB_RUN_ID}',
+    );
+    expect(workflow).toContain(
+      'harmonic-beacon/tapestry:rollback-${GITHUB_RUN_ID}',
+    );
+    expect(workflow).toContain(
+      'steps.rollback.outputs.app_available == \'true\'',
+    );
+    expect(workflow).toContain(
+      'steps.rollback.outputs.tapestry_available == \'true\'',
+    );
+    expect(workflow).toContain('worker_expected=true');
+    expect(workflow).toContain('[ "$tapestry_ready" = true ]');
+  });
+
+  it('audits the production dependencies of both deployable packages', () => {
+    for (const contents of [ciWorkflow, workflow]) {
+      expect(contents).toContain('npm audit --omit=dev --audit-level=high');
+      expect(contents).toContain(
+        'npm audit --omit=dev --prefix services/tapestry --audit-level=high',
+      );
+      expect(contents).toContain(
+        'npm audit --omit=dev --prefix services/playlist-bot --audit-level=high',
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes #110\n\n## Outcome\n- Gives tapestry its own immutable commit tag instead of the floating app-tapestry image.\n- Builds and recreates app, reconciler, and tapestry in one release while leaving LiveKit and playlist-bot untouched.\n- Preserves app and tapestry rollback images independently and restores each service from its own prior digest.\n- Requires all three service health checks before release success.\n- Upgrades the tapestry Sharp runtime from 0.34 to 0.35.3 after the service-specific audit exposed a high-severity inherited libvips advisory.\n- Adds separate root and tapestry production audits plus tapestry tests to CI and release gates.\n\n## Verification\n- 673 app tests passed; 7 opt-in integration tests skipped\n- 23 tapestry tests passed, including the 150-participant 30-second soak\n- TypeScript, ESLint, Compose config, YAML parsing, and Actionlint passed\n- root production audit: 0 critical/high/moderate, 1 documented low\n- tapestry production audit: 0 findings\n- production tapestry image built with Sharp 0.35.3\n- container health became healthy\n- real container roundtrip: JPEG ingest 201, composite 200, decoded JPEG 100x100\n\n## Risk and rollback\nThe rollout preserves harmonic-beacon/app:rollback-RUN_ID and harmonic-beacon/tapestry:rollback-RUN_ID independently before replacement. A failure restores each available prior image and verifies app readiness. No database rollback is required.\n\nNo LiveKit, playlist-bot, codec, gain, buffer, sample-rate, or other audio path is changed.