### PR TITLE
fix(deploy): pin releases to the mona runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - mona

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,14 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, mona]
     steps:
+      - name: Verify deploy runner identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(hostname -s)" = mona
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,6 +41,22 @@ On failure it restores the preserved app and tapestry images independently. It
 never uses `compose down`, deletes data or pretends that rebuilding the same tag
 is a rollback.
 
+### Runner isolation
+
+The deploy job requires both the standard `self-hosted` label and the dedicated
+`mona` label, then verifies that `hostname -s` is exactly `mona` before checkout
+or any privileged command. Never register mona as an unrestricted generic
+self-hosted runner: pull-request workflows also use self-hosted capacity, and
+unreviewed PR code must not execute on the production host.
+
+An organization administrator must place the mona runner in a runner group that
+is restricted to this repository and the `Deploy` workflow. Keep it offline
+until that restriction exists. The sudoers policy must allow only the explicit
+Docker, stat and file-read commands used by the workflow, without a general root
+shell. If the dedicated runner is unavailable, use the manual deploy below over
+the separately controlled SSH path; a generic runner is never an acceptable
+fallback.
+
 ## Manual deploy on mona
 
 From `/opt/beacon/app`, preserve the untracked production compose override and

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -28,6 +28,12 @@ describe('production deploy contract', () => {
     expect(workflow).toContain('[ "$tapestry_health" = healthy ]');
   });
 
+  it('can only schedule production deploys on the verified mona runner', () => {
+    expect(workflow).toContain('runs-on: [self-hosted, mona]');
+    expect(workflow).toContain('test "$(hostname -s)" = mona');
+    expect(workflow).not.toMatch(/runs-on:\s+self-hosted\s*$/m);
+  });
+
   it('preserves and restores app and tapestry independently', () => {
     expect(workflow).toContain(
       'harmonic-beacon/app:rollback-${GITHUB_RUN_ID}',


### PR DESCRIPTION
Refs #112\n\n## Outcome\n- Requires the dedicated mona label in addition to self-hosted for production deploys.\n- Fails closed unless hostname -s is exactly mona before checkout or privileged work.\n- Documents the required workflow-restricted runner group and narrow sudo policy.\n- Keeps the tested manual SSH runbook as the fallback; a generic organization runner is never accepted.\n- Adds the custom label to Actionlint configuration and a regression test for runner targeting.\n\n## Incident evidence\nRelease run 30748384641 selected yupanki-pve under the former generic selector and failed at its first sudo prerequisite. No production container was touched by that run. The same reviewed release was then deployed manually to mona with rollback tags, migration status, health, boundary and functional tapestry evidence.\n\n## Verification\n- 674 app tests passed; 7 opt-in integration tests skipped\n- TypeScript and ESLint passed\n- Actionlint passed with the declared custom runner label\n- deployment contract test asserts both label and hostname fail-closed checks\n\n## Remaining admin prerequisite\nThis PR intentionally does not install a generic runner on mona. An organization admin must create a runner group restricted to this repository and the Deploy workflow, then register/label the host as mona with a narrow sudoers policy. Issue #112 should remain open until a dry run and a complete automated deploy prove that external setup.\n\nNo application, database, LiveKit, playlist-bot or audio behavior changes.