### PR TITLE
test(e2e): prove consecutive facilitator-op lifecycles

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -14,7 +14,7 @@ deterministic fixtures, no production credentials or participant data.
 | `tests/visual.spec.ts` | stack | screenshot baselines at the same four widths |
 | `tests/media-continuity.spec.ts` | stack + LiveKit | the four media invariants in desktop Chromium, Android/Chrome emulation and iPhone/WebKit emulation |
 | `tests/stage-invitation.spec.ts` | stack + LiveKit | two-browser hand → decline/invite → fresh connection stays pending → accept → return journey |
-| `tests/whole-system.spec.ts` | stack + LiveKit | two consecutive waiting → doors → hand → invite → decline/accept → return → terminate lifecycles, plus one-identity `FACILITATOR_OP` admission/health/reconciliation |
+| `tests/whole-system.spec.ts` | stack + LiveKit | two consecutive ES → EN waiting → doors → hand → invite → decline/accept → return → terminate lifecycles, selected-event health, plus one-identity `FACILITATOR_OP` admission/reconciliation |
 | `src/app/session/[id]/__tests__/media-continuity.test.tsx` | nothing | same invariants in Vitest/jsdom (`npm test`) |
 
 Suites that need the stack skip with a precise reason when it is missing —

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -14,6 +14,7 @@ deterministic fixtures, no production credentials or participant data.
 | `tests/visual.spec.ts` | stack | screenshot baselines at the same four widths |
 | `tests/media-continuity.spec.ts` | stack + LiveKit | the four media invariants in desktop Chromium, Android/Chrome emulation and iPhone/WebKit emulation |
 | `tests/stage-invitation.spec.ts` | stack + LiveKit | two-browser hand → decline/invite → fresh connection stays pending → accept → return journey |
+| `tests/whole-system.spec.ts` | stack + LiveKit | two consecutive waiting → doors → hand → invite → decline/accept → return → terminate lifecycles, plus one-identity `FACILITATOR_OP` admission/health/reconciliation |
 | `src/app/session/[id]/__tests__/media-continuity.test.tsx` | nothing | same invariants in Vitest/jsdom (`npm test`) |
 
 Suites that need the stack skip with a precise reason when it is missing —

--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -24,6 +24,12 @@ export function requireDirectDb(testInfo: TestInfo): string {
 
 export type FixtureSessionStatus = 'SCHEDULED' | 'LIVE';
 
+type FixtureSessionLifecycle = {
+    status: 'SCHEDULED' | 'LIVE' | 'ENDED' | 'CANCELLED';
+    started_at: Date | null;
+    ended_at: Date | null;
+};
+
 /**
  * Flip a fixture session's status for the duration of `run`, restoring the
  * original status afterwards even when the callback throws.
@@ -51,6 +57,82 @@ export async function withSessionStatus<T>(
                 'SCHEDULED',
                 sessionId,
             ]);
+        }
+    } finally {
+        await client.end();
+    }
+}
+
+/**
+ * Exercise a complete doors-open/doors-closed journey from a known baseline,
+ * then put the shared fixture back exactly as it was. Unlike
+ * `withSessionStatus`, this also preserves the lifecycle timestamps mutated
+ * by the product's real transition endpoint.
+ */
+export async function withResetSessionLifecycle<T>(
+    databaseUrl: string,
+    sessionId: string,
+    run: () => Promise<T>,
+): Promise<T> {
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        const { rows } = await client.query<FixtureSessionLifecycle>(
+            'select status, started_at, ended_at from scheduled_sessions where id = $1',
+            [sessionId],
+        );
+        const original = rows[0];
+        if (!original) {
+            throw new Error(`fixture session ${sessionId} not found`);
+        }
+
+        await client.query(
+            "update scheduled_sessions set status = 'SCHEDULED', started_at = null, ended_at = null where id = $1",
+            [sessionId],
+        );
+        try {
+            return await run();
+        } finally {
+            await client.query(
+                'update scheduled_sessions set status = $1, started_at = $2, ended_at = $3 where id = $4',
+                [original.status, original.started_at, original.ended_at, sessionId],
+            );
+        }
+    } finally {
+        await client.end();
+    }
+}
+
+type FixtureStaffSnapshot = {
+    name: string;
+    role: 'FACILITATOR' | 'FACILITATOR_OP' | 'OPERATOR' | 'ADMIN';
+    disabled_at: Date | null;
+};
+
+/** Preserve the shared facilitator row while the E2E dashboard upgrades it to FACILITATOR_OP. */
+export async function withPreservedFixtureStaff<T>(
+    databaseUrl: string,
+    email: string,
+    run: () => Promise<T>,
+): Promise<T> {
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        const { rows } = await client.query<FixtureStaffSnapshot>(
+            'select name, role, disabled_at from users where email = $1',
+            [email],
+        );
+        const original = rows[0];
+        if (!original) {
+            throw new Error(`fixture staff ${email} not found`);
+        }
+        try {
+            return await run();
+        } finally {
+            await client.query(
+                'update users set name = $1, role = $2, disabled_at = $3 where email = $4',
+                [original.name, original.role, original.disabled_at, email],
+            );
         }
     } finally {
         await client.end();

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -25,6 +25,8 @@ export const TICKETS = {
     esBound: { code: 'TEST-TEST-TEST-TESD', email: 'asistente@altermundi.net' },
     /** REVOKED — login must fail with the generic error. */
     esRevoked: 'TEST-TEST-TEST-TESE',
+    /** ISSUED for the English fixture; reserved for the second lifecycle E2E. */
+    enIssuedB: 'TEST-TEST-TEST-TENB',
 } as const;
 
 /** All fixture staff accounts share the documented password `test`. */

--- a/e2e/tests/whole-system.spec.ts
+++ b/e2e/tests/whole-system.spec.ts
@@ -1,13 +1,13 @@
 import type { Page } from '@playwright/test';
 
-import { loginViaDashboard } from '../fixtures/auth';
+import { loginAttendeeWithTicket, loginViaDashboard } from '../fixtures/auth';
 import {
     requireDirectDb,
     withPreservedFixtureStaff,
     withResetSessionLifecycle,
 } from '../fixtures/db';
 import { expect, stackTest } from '../fixtures/stack';
-import { ROUTES, SESSION_ES, STAFF } from '../fixtures/test-data';
+import { ROUTES, SESSION_EN, SESSION_ES, STAFF, TICKETS } from '../fixtures/test-data';
 
 async function closeCockpitDrawer(staff: Page): Promise<void> {
     const drawer = staff.getByRole('dialog');
@@ -36,21 +36,27 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
 
     try {
         await withPreservedFixtureStaff(db, STAFF.facilitator.email, async () => {
-            for (const [index, invitationDecision] of ['decline', 'accept'].entries()) {
-                await withResetSessionLifecycle(db, SESSION_ES.id, async () => {
+            const rehearsals = [
+                { session: SESSION_ES, invitationDecision: 'decline' },
+                { session: SESSION_EN, invitationDecision: 'accept' },
+            ] as const;
+
+            for (const [index, { session, invitationDecision }] of rehearsals.entries()) {
+                await withResetSessionLifecycle(db, session.id, async () => {
                     if (!staffLoggedIn) {
                         await loginViaDashboard(
                             staff,
                             'FACILITATOR_OP',
                             'Lifecycle Conductor',
-                            ROUTES.opsSession(SESSION_ES.id),
+                            ROUTES.opsSession(session.id),
                         );
                         staffLoggedIn = true;
                     } else {
-                        await staff.goto(ROUTES.opsSession(SESSION_ES.id));
+                        await staff.goto(ROUTES.opsSession(session.id));
                     }
 
                     await expect(staff.getByTestId('conductor-cockpit')).toBeVisible();
+                    await expect(staff.getByRole('heading', { name: session.title })).toBeVisible();
                     await expect(staff.getByText('Lifecycle Conductor').first()).toBeVisible();
                     await expect(staff.getByText(
                         /Facilitación y operaciones|Facilitator and operations/i,
@@ -62,14 +68,23 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
                     const attendeeName = `Lifecycle Attendee ${index + 1}`;
 
                     try {
-                        await loginViaDashboard(
-                            attendee,
-                            'ATTENDEE',
-                            attendeeName,
-                            ROUTES.session(SESSION_ES.id),
-                        );
+                        if (session.id === SESSION_ES.id) {
+                            await loginViaDashboard(
+                                attendee,
+                                'ATTENDEE',
+                                attendeeName,
+                                ROUTES.session(session.id),
+                            );
+                        } else {
+                            await loginAttendeeWithTicket(attendee, {
+                                name: attendeeName,
+                                email: 'lifecycle-attendee-2@e2e.altermundi.net',
+                                code: TICKETS.enIssuedB,
+                            });
+                            await attendee.waitForURL(`**${ROUTES.session(session.id)}`);
+                        }
                         await expect(attendee.getByText(
-                            /doors are still closed|puertas todavía están cerradas/i,
+                            /doors are (?:still closed|not open yet)|puertas todavía están cerradas/i,
                         )).toBeVisible({ timeout: 10_000 });
 
                         await staff.locator('[data-signal="door"]').click();
@@ -95,18 +110,23 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
                         const admission = staff.getByRole('dialog');
                         await admission.getByPlaceholder(
                             'Attendee email, code last four, or entitlement ID',
-                        ).fill('TESD');
+                        ).fill(session.id === SESSION_ES.id ? 'TESD' : 'TEND');
                         await admission.getByRole('button', { name: 'Look up' }).click();
                         await expect(admission.getByText('Last four:')).toBeVisible();
-                        await expect(admission.getByText('TESD', { exact: true })).toBeVisible();
+                        await expect(admission.getByText(
+                            session.id === SESSION_ES.id ? 'TESD' : 'TEND',
+                            { exact: true },
+                        )).toBeVisible();
                         await closeCockpitDrawer(staff);
 
                         await staff.locator('[data-signal="health"]').click();
                         const health = staff.getByRole('dialog');
                         await health.getByRole('button', { name: 'Refresh now' }).click();
-                        await expect(health.locator('p').filter({
+                        const healthSummary = health.locator('p').filter({
                             hasText: /Watching session.*signed in as FACILITATOR_OP/i,
-                        })).toBeVisible({ timeout: 15_000 });
+                        });
+                        await expect(healthSummary).toBeVisible({ timeout: 15_000 });
+                        await expect(healthSummary).toContainText(session.title);
                         await closeCockpitDrawer(staff);
 
                         await staff.locator('[data-signal="hands"]').click();

--- a/e2e/tests/whole-system.spec.ts
+++ b/e2e/tests/whole-system.spec.ts
@@ -1,0 +1,173 @@
+import type { Page } from '@playwright/test';
+
+import { loginViaDashboard } from '../fixtures/auth';
+import {
+    requireDirectDb,
+    withPreservedFixtureStaff,
+    withResetSessionLifecycle,
+} from '../fixtures/db';
+import { expect, stackTest } from '../fixtures/stack';
+import { ROUTES, SESSION_ES, STAFF } from '../fixtures/test-data';
+
+async function closeCockpitDrawer(staff: Page): Promise<void> {
+    const drawer = staff.getByRole('dialog');
+    await drawer.getByRole('button', {
+        name: /Return to the live room|Volver a la sala en vivo/i,
+    }).click();
+    await expect(drawer).toBeHidden();
+}
+
+/**
+ * Phase-B acceptance for #69.
+ *
+ * One FACILITATOR_OP identity runs two complete, consecutive rehearsals:
+ * waiting room → doors → room → hand → invitation → decline/accept → return
+ * → terminate. The same login also performs the real admission lookup,
+ * health refresh and LiveKit reconciliation actions from the cockpit.
+ */
+stackTest('FACILITATOR_OP completes two consecutive event lifecycles without switching identity', async ({
+    browser,
+}, testInfo) => {
+    stackTest.slow();
+    const db = requireDirectDb(testInfo);
+    const staffContext = await browser.newContext();
+    const staff = await staffContext.newPage();
+    let staffLoggedIn = false;
+
+    try {
+        await withPreservedFixtureStaff(db, STAFF.facilitator.email, async () => {
+            for (const [index, invitationDecision] of ['decline', 'accept'].entries()) {
+                await withResetSessionLifecycle(db, SESSION_ES.id, async () => {
+                    if (!staffLoggedIn) {
+                        await loginViaDashboard(
+                            staff,
+                            'FACILITATOR_OP',
+                            'Lifecycle Conductor',
+                            ROUTES.opsSession(SESSION_ES.id),
+                        );
+                        staffLoggedIn = true;
+                    } else {
+                        await staff.goto(ROUTES.opsSession(SESSION_ES.id));
+                    }
+
+                    await expect(staff.getByTestId('conductor-cockpit')).toBeVisible();
+                    await expect(staff.getByText('Lifecycle Conductor').first()).toBeVisible();
+                    await expect(staff.getByText(
+                        /Facilitación y operaciones|Facilitator and operations/i,
+                    ).first())
+                        .toBeVisible();
+
+                    const attendeeContext = await browser.newContext();
+                    const attendee = await attendeeContext.newPage();
+                    const attendeeName = `Lifecycle Attendee ${index + 1}`;
+
+                    try {
+                        await loginViaDashboard(
+                            attendee,
+                            'ATTENDEE',
+                            attendeeName,
+                            ROUTES.session(SESSION_ES.id),
+                        );
+                        await expect(attendee.getByText(
+                            /doors are still closed|puertas todavía están cerradas/i,
+                        )).toBeVisible({ timeout: 10_000 });
+
+                        await staff.locator('[data-signal="door"]').click();
+                        const doors = staff.getByRole('dialog');
+                        const reason = doors.getByLabel(/Operational reason/i);
+                        if (await reason.isVisible()) {
+                            await reason.fill(`E2E lifecycle ${index + 1}`);
+                        }
+                        await doors.getByRole('button', { name: 'Open doors' }).click();
+                        await expect(doors.getByRole('status')).toContainText('Doors are open');
+                        await closeCockpitDrawer(staff);
+
+                        await expect(attendee.getByTestId('connection-state')).toHaveAttribute(
+                            'data-state',
+                            'connected',
+                            { timeout: 25_000 },
+                        );
+
+                        // The composite role uses global operational tools in
+                        // the same authenticated cockpit, without a mode or
+                        // account switch.
+                        await staff.locator('[data-tool="admission"]').click();
+                        const admission = staff.getByRole('dialog');
+                        await admission.getByPlaceholder(
+                            'Attendee email, code last four, or entitlement ID',
+                        ).fill('TESD');
+                        await admission.getByRole('button', { name: 'Look up' }).click();
+                        await expect(admission.getByText('Last four:')).toBeVisible();
+                        await expect(admission.getByText('TESD', { exact: true })).toBeVisible();
+                        await closeCockpitDrawer(staff);
+
+                        await staff.locator('[data-signal="health"]').click();
+                        const health = staff.getByRole('dialog');
+                        await health.getByRole('button', { name: 'Refresh now' }).click();
+                        await expect(health.locator('p').filter({
+                            hasText: /Watching session.*signed in as FACILITATOR_OP/i,
+                        })).toBeVisible({ timeout: 15_000 });
+                        await closeCockpitDrawer(staff);
+
+                        await staff.locator('[data-signal="hands"]').click();
+                        const scene = staff.getByRole('dialog');
+                        await scene.getByRole('button', { name: 'Reconcile grants' }).click();
+                        await expect(scene.getByRole('status')).toContainText('Reconciliation finished');
+
+                        await attendee.getByRole('button', {
+                            name: /Raise hand|Levantar la mano/i,
+                        }).click();
+                        const queueRow = scene.locator('li').filter({ hasText: attendeeName });
+                        await expect(queueRow.getByRole('button', { name: 'Give floor' })).toBeEnabled({
+                            timeout: 10_000,
+                        });
+                        await queueRow.getByRole('button', { name: 'Give floor' }).click();
+
+                        const invitation = attendee.getByRole('dialog', {
+                            name: /invited into the scene|invitan a entrar en escena/i,
+                        });
+                        await expect(invitation).toBeVisible({ timeout: 10_000 });
+
+                        if (invitationDecision === 'decline') {
+                            await invitation.getByRole('button', { name: /Not now|Ahora no/i }).click();
+                            await expect(attendee.getByRole('button', {
+                                name: /Raise hand|Levantar la mano/i,
+                            })).toBeVisible({ timeout: 10_000 });
+                        } else {
+                            await invitation.getByRole('button', {
+                                name: /Accept and join|Aceptar y entrar/i,
+                            }).click();
+                            await expect(attendee.getByRole('button', {
+                                name: /Turn camera off|Apagar (?:la )?cámara/i,
+                            })).toBeVisible({ timeout: 15_000 });
+                            const stageRow = scene.locator('li').filter({ hasText: attendeeName });
+                            await expect(stageRow.getByRole('button', { name: 'Take floor' })).toBeVisible({
+                                timeout: 10_000,
+                            });
+                            await stageRow.getByRole('button', { name: 'Take floor' }).click();
+                            await expect(attendee.getByRole('button', {
+                                name: /Turn camera off|Apagar (?:la )?cámara/i,
+                            })).toHaveCount(0, { timeout: 10_000 });
+                        }
+
+                        await closeCockpitDrawer(staff);
+                        await staff.locator('[data-signal="door"]').click();
+                        const closePanel = staff.getByRole('dialog');
+                        await closePanel.getByRole('button', { name: 'Close event' }).click();
+                        await closePanel.getByRole('button', {
+                            name: 'End & disconnect everyone',
+                        }).click();
+                        await expect(closePanel.getByRole('status')).toContainText('Event ended now');
+                        await expect(attendee.getByRole('heading', {
+                            name: /Session ended|La sesión terminó/i,
+                        })).toBeVisible({ timeout: 15_000 });
+                    } finally {
+                        await attendeeContext.close();
+                    }
+                });
+            }
+        });
+    } finally {
+        await staffContext.close();
+    }
+});


### PR DESCRIPTION
Refs #69 and #65

## Outcome
- Adds one real-browser Phase-B acceptance journey with one persistent `FACILITATOR_OP` identity.
- Runs two distinct consecutive event lifecycles, Spanish then English: waiting room → doors open → join → hand → invitation → decline/accept → return → terminate.
- Proves selected-event health follows each event, including the ES → EN handoff.
- Exercises admission lookup, health refresh and LiveKit grant reconciliation from the same authenticated cockpit.
- Preserves and restores shared fixture lifecycle timestamps and the facilitator row, including on failure.
- Documents the new gate in the E2E matrix.

## Safety
- Synthetic local fixtures only; the database guard still accepts only loopback `beacon_test`.
- No production credentials, PII or imagery.
- No application or audio path changes: codec, bitrate, sample rate, buffer, gain, crossfader and room lifecycle are untouched.

## Local evidence
- 673 Vitest passed; 7 opt-in integration tests skipped.
- TypeScript and ESLint passed.
- Focused real Postgres + LiveKit acceptance: 3/3 (existing termination, invitation/reload, and new consecutive lifecycle).
- New ES → EN lifecycle alone: 1/1, both cycles in 20.9 seconds.
- Production build completed through the Playwright managed server.

## Remaining issue boundary
The physical-device items in #69 stay open: real iPhone Safari, Android Chrome, Firefox/Chrome hardware media, background/foreground, degraded network, partial device permissions and the separately guarded acoustic evaluation in #93. Emulation and automation do not claim to replace those checks.
