### PR TITLE
feat(i18n): localize lifecycle and stage operations

### DIFF
--- a/e2e/tests/hand-queue-thumbnails.spec.ts
+++ b/e2e/tests/hand-queue-thumbnails.spec.ts
@@ -75,16 +75,16 @@ stackTest('private hand thumbnails remain bounded, accessible and actionable at 
     await page.locator('[data-signal="hands"]').click();
     const drawer = page.getByRole('dialog');
 
-    await expect(drawer.getByText('No hands raised.')).toBeVisible();
+    await expect(drawer.getByText(/No hands raised|No hay manos levantadas/i)).toBeVisible();
 
     participants = [handFixture(0)];
     const firstRow = drawer.locator('li').filter({ hasText: 'Queue Person 1' });
     await expect(firstRow.getByRole('img', {
-        name: 'Recent tapestry snapshot of Queue Person 1',
+        name: /Recent tapestry snapshot of Queue Person 1|Imagen reciente del tapiz de Queue Person 1/i,
     })).toBeVisible({ timeout: 10_000 });
 
-    const firstGiveFloor = firstRow.getByRole('button', { name: 'Give floor' });
-    const firstRemoveHand = firstRow.getByRole('button', { name: 'Remove hand' });
+    const firstGiveFloor = firstRow.getByRole('button', { name: /Give floor|Dar la palabra/i });
+    const firstRemoveHand = firstRow.getByRole('button', { name: /Remove hand|Quitar mano/i });
     await firstGiveFloor.focus();
     await page.keyboard.press('Tab');
     await expect(firstRemoveHand).toBeFocused();
@@ -95,9 +95,9 @@ stackTest('private hand thumbnails remain bounded, accessible and actionable at 
         timeout: 10_000,
     });
     expect(snapshotRequests - requestsBeforeFifty).toBeLessThanOrEqual(2);
-    await expect(drawer.getByRole('button', { name: 'Give floor' })).toHaveCount(50);
-    await expect(drawer.getByRole('button', { name: 'Remove hand' })).toHaveCount(50);
-    await expect(drawer.getByRole('img', { name: /Recent tapestry snapshot/ })).toHaveCount(25);
-    await expect(drawer.getByRole('img', { name: /no current tapestry snapshot/ })).toHaveCount(25);
+    await expect(drawer.getByRole('button', { name: /Give floor|Dar la palabra/i })).toHaveCount(50);
+    await expect(drawer.getByRole('button', { name: /Remove hand|Quitar mano/i })).toHaveCount(50);
+    await expect(drawer.getByRole('img', { name: /Recent tapestry snapshot|Imagen reciente del tapiz/i })).toHaveCount(25);
+    await expect(drawer.getByRole('img', { name: /no current tapestry snapshot|sin imagen actual del tapiz/i })).toHaveCount(25);
     expect(tileRequests.size).toBeLessThanOrEqual(25);
 });

--- a/e2e/tests/session-termination.spec.ts
+++ b/e2e/tests/session-termination.spec.ts
@@ -46,16 +46,16 @@ stackTest('ending an event immediately disconnects every selected-session client
             );
 
             await operator.locator('[data-signal="door"]').click();
-            await operator.getByRole('button', { name: 'Close event' }).click();
+            await operator.getByRole('button', { name: /Close event|Cerrar evento/i }).click();
             await expect(operator.getByRole('alertdialog')).toContainText(
-                'Other events and the Beacon source stay online',
+                /Other events and the Beacon source stay online|Los demás eventos y la fuente del Beacon siguen en línea/i,
             );
             await operator.getByRole('button', {
-                name: 'End & disconnect everyone',
+                name: /End & disconnect everyone|Finalizar y desconectar/i,
             }).click();
 
             await expect(operator.getByRole('status')).toContainText(
-                /Disconnected [1-9]\d* Stage and [1-9]\d* Beacon connections/,
+                /Disconnected [1-9]\d* Stage and [1-9]\d* Beacon connections|Se desconectaron [1-9]\d* conexiones de Escena y [1-9]\d* del Beacon/i,
             );
             await expect(attendee.getByRole('heading', {
                 name: /Session ended|La sesión terminó/i,

--- a/e2e/tests/stage-invitation.spec.ts
+++ b/e2e/tests/stage-invitation.spec.ts
@@ -46,10 +46,10 @@ stackTest('a fresh connection stays invited until the attendee accepts the stage
             const raiseHand = attendee.getByRole('button', { name: /Raise hand|Levantar la mano/i });
             await raiseHand.click();
             const queueRow = drawer.locator('li').filter({ hasText: 'Journey Attendee' });
-            await expect(queueRow.getByRole('button', { name: 'Give floor' })).toBeEnabled({
+            await expect(queueRow.getByRole('button', { name: /Give floor|Dar la palabra/i })).toBeEnabled({
                 timeout: 10_000,
             });
-            await queueRow.getByRole('button', { name: 'Give floor' }).click();
+            await queueRow.getByRole('button', { name: /Give floor|Dar la palabra/i }).click();
 
             const invitation = attendee.getByRole('dialog', {
                 name: /invited into the scene|invitan a entrar en escena/i,
@@ -62,17 +62,17 @@ stackTest('a fresh connection stays invited until the attendee accepts the stage
             await expect(raiseHand).toBeVisible({ timeout: 10_000 });
 
             await raiseHand.click();
-            await expect(queueRow.getByRole('button', { name: 'Give floor' })).toBeEnabled({
+            await expect(queueRow.getByRole('button', { name: /Give floor|Dar la palabra/i })).toBeEnabled({
                 timeout: 10_000,
             });
-            await queueRow.getByRole('button', { name: 'Give floor' }).click();
+            await queueRow.getByRole('button', { name: /Give floor|Dar la palabra/i }).click();
             await expect(invitation).toBeVisible({ timeout: 10_000 });
 
             const pendingRow = drawer.locator('li').filter({ hasText: 'Journey Attendee' });
-            await expect(pendingRow.getByRole('button', { name: 'Cancel invitation' })).toBeVisible({
+            await expect(pendingRow.getByRole('button', { name: /Cancel invitation|Cancelar invitación/i })).toBeVisible({
                 timeout: 10_000,
             });
-            await expect(pendingRow.getByRole('button', { name: 'Take floor' })).toHaveCount(0);
+            await expect(pendingRow.getByRole('button', { name: /Take floor|Quitar la palabra/i })).toHaveCount(0);
 
             await attendee.reload();
             await expect(attendee.getByTestId('connection-state')).toHaveAttribute(
@@ -81,10 +81,10 @@ stackTest('a fresh connection stays invited until the attendee accepts the stage
                 { timeout: 20_000 },
             );
             await expect(invitation).toBeVisible({ timeout: 10_000 });
-            await expect(pendingRow.getByRole('button', { name: 'Cancel invitation' })).toBeVisible({
+            await expect(pendingRow.getByRole('button', { name: /Cancel invitation|Cancelar invitación/i })).toBeVisible({
                 timeout: 10_000,
             });
-            await expect(pendingRow.getByRole('button', { name: 'Take floor' })).toHaveCount(0);
+            await expect(pendingRow.getByRole('button', { name: /Take floor|Quitar la palabra/i })).toHaveCount(0);
 
             await invitation.getByRole('button', { name: /Accept and join|Aceptar y entrar/i }).click();
 
@@ -113,10 +113,10 @@ stackTest('a fresh connection stays invited until the attendee accepts the stage
             );
 
             const stageRow = drawer.locator('li').filter({ hasText: 'Journey Attendee' });
-            await expect(stageRow.getByRole('button', { name: 'Take floor' })).toBeVisible({
+            await expect(stageRow.getByRole('button', { name: /Take floor|Quitar la palabra/i })).toBeVisible({
                 timeout: 10_000,
             });
-            await stageRow.getByRole('button', { name: 'Take floor' }).click();
+            await stageRow.getByRole('button', { name: /Take floor|Quitar la palabra/i }).click();
             await expect(
                 attendee.getByRole('button', { name: /Turn camera off|Apagar (?:la )?cámara/i }),
             ).toHaveCount(0, { timeout: 10_000 });

--- a/e2e/tests/whole-system.spec.ts
+++ b/e2e/tests/whole-system.spec.ts
@@ -89,12 +89,12 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
 
                         await staff.locator('[data-signal="door"]').click();
                         const doors = staff.getByRole('dialog');
-                        const reason = doors.getByLabel(/Operational reason/i);
+                        const reason = doors.getByLabel(/Operational reason|Motivo operativo/i);
                         if (await reason.isVisible()) {
                             await reason.fill(`E2E lifecycle ${index + 1}`);
                         }
-                        await doors.getByRole('button', { name: 'Open doors' }).click();
-                        await expect(doors.getByRole('status')).toContainText('Doors are open');
+                        await doors.getByRole('button', { name: /Open doors|Abrir puertas/i }).click();
+                        await expect(doors.getByRole('status')).toContainText(/Doors are open|Las puertas están abiertas/i);
                         await closeCockpitDrawer(staff);
 
                         await expect(attendee.getByTestId('connection-state')).toHaveAttribute(
@@ -131,17 +131,19 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
 
                         await staff.locator('[data-signal="hands"]').click();
                         const scene = staff.getByRole('dialog');
-                        await scene.getByRole('button', { name: 'Reconcile grants' }).click();
-                        await expect(scene.getByRole('status')).toContainText('Reconciliation finished');
+                        await scene.getByRole('button', { name: /Reconcile grants|Reconciliar permisos/i }).click();
+                        await expect(scene.getByRole('status')).toContainText(
+                            /Reconciliation finished|Reconciliación terminada/i,
+                        );
 
                         await attendee.getByRole('button', {
                             name: /Raise hand|Levantar la mano/i,
                         }).click();
                         const queueRow = scene.locator('li').filter({ hasText: attendeeName });
-                        await expect(queueRow.getByRole('button', { name: 'Give floor' })).toBeEnabled({
+                        await expect(queueRow.getByRole('button', { name: /Give floor|Dar la palabra/i })).toBeEnabled({
                             timeout: 10_000,
                         });
-                        await queueRow.getByRole('button', { name: 'Give floor' }).click();
+                        await queueRow.getByRole('button', { name: /Give floor|Dar la palabra/i }).click();
 
                         const invitation = attendee.getByRole('dialog', {
                             name: /invited into the scene|invitan a entrar en escena/i,
@@ -161,10 +163,10 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
                                 name: /Turn camera off|Apagar (?:la )?cámara/i,
                             })).toBeVisible({ timeout: 15_000 });
                             const stageRow = scene.locator('li').filter({ hasText: attendeeName });
-                            await expect(stageRow.getByRole('button', { name: 'Take floor' })).toBeVisible({
+                            await expect(stageRow.getByRole('button', { name: /Take floor|Quitar la palabra/i })).toBeVisible({
                                 timeout: 10_000,
                             });
-                            await stageRow.getByRole('button', { name: 'Take floor' }).click();
+                            await stageRow.getByRole('button', { name: /Take floor|Quitar la palabra/i }).click();
                             await expect(attendee.getByRole('button', {
                                 name: /Turn camera off|Apagar (?:la )?cámara/i,
                             })).toHaveCount(0, { timeout: 10_000 });
@@ -173,11 +175,11 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
                         await closeCockpitDrawer(staff);
                         await staff.locator('[data-signal="door"]').click();
                         const closePanel = staff.getByRole('dialog');
-                        await closePanel.getByRole('button', { name: 'Close event' }).click();
+                        await closePanel.getByRole('button', { name: /Close event|Cerrar evento/i }).click();
                         await closePanel.getByRole('button', {
-                            name: 'End & disconnect everyone',
+                            name: /End & disconnect everyone|Finalizar y desconectar/i,
                         }).click();
-                        await expect(closePanel.getByRole('status')).toContainText('Event ended now');
+                        await expect(closePanel.getByRole('status')).toContainText(/Event ended now|Evento finalizado/i);
                         await expect(attendee.getByRole('heading', {
                             name: /Session ended|La sesión terminó/i,
                         })).toBeVisible({ timeout: 15_000 });

--- a/src/app/ops/events/[id]/page.tsx
+++ b/src/app/ops/events/[id]/page.tsx
@@ -100,6 +100,8 @@ export default async function EventPage({
                 }]}
                 copy={copy.cockpit}
                 lifecycleCopy={copy.lifecycle}
+                spotlightCopy={copy.spotlight}
+                staffRoleLabels={messages[locale].staffRoles}
             />
         </section>
     );

--- a/src/app/ops/events/[id]/page.tsx
+++ b/src/app/ops/events/[id]/page.tsx
@@ -90,6 +90,7 @@ export default async function EventPage({
                     scheduledAt: scheduledSession.scheduledAt.toISOString(),
                 }}
                 role={staff.role}
+                locale={locale}
                 admissionEvents={[{
                     id: scheduledSession.id,
                     title: scheduledSession.title,
@@ -98,6 +99,7 @@ export default async function EventPage({
                     attendeeCap: scheduledSession.attendeeCap,
                 }]}
                 copy={copy.cockpit}
+                lifecycleCopy={copy.lifecycle}
             />
         </section>
     );

--- a/src/components/ops/ConductorCockpit.tsx
+++ b/src/components/ops/ConductorCockpit.tsx
@@ -36,6 +36,8 @@ type Props = {
     admissionEvents: AdmissionEvent[];
     copy: Messages['ops']['cockpit'];
     lifecycleCopy: Messages['ops']['lifecycle'];
+    spotlightCopy: Messages['ops']['spotlight'];
+    staffRoleLabels: Messages['staffRoles'];
 };
 
 const EMPTY_STAGE: SpotlightSummary = {
@@ -60,6 +62,8 @@ export default function ConductorCockpit({
     admissionEvents,
     copy,
     lifecycleCopy,
+    spotlightCopy,
+    staffRoleLabels,
 }: Props) {
     const [drawer, setDrawer] = useState<Drawer | null>(null);
     const [status, setStatus] = useState<EventStatus>(session.status);
@@ -300,6 +304,8 @@ export default function ConductorCockpit({
                         <SpotlightConsole
                             sessionId={session.id}
                             role={role}
+                            copy={spotlightCopy}
+                            staffRoles={staffRoleLabels}
                             onSummary={onStageSummary}
                         />
                     </div>

--- a/src/components/ops/ConductorCockpit.tsx
+++ b/src/components/ops/ConductorCockpit.tsx
@@ -5,6 +5,7 @@ import type { StaffRole } from '@prisma/client';
 
 import OpsHealthClient from '@/app/ops/health/OpsHealthClient';
 import type { Messages } from '@/lib/i18n';
+import type { UiLocale } from '@/lib/i18n';
 import type { HealthLevel } from '@/lib/ops-health';
 
 import AdmissionConsole from './AdmissionConsole';
@@ -31,8 +32,10 @@ type Props = {
         scheduledAt: string;
     };
     role: StaffRole;
+    locale: UiLocale;
     admissionEvents: AdmissionEvent[];
     copy: Messages['ops']['cockpit'];
+    lifecycleCopy: Messages['ops']['lifecycle'];
 };
 
 const EMPTY_STAGE: SpotlightSummary = {
@@ -50,7 +53,14 @@ const HEALTH_DOT: Record<HealthLevel, string> = {
     red: 'bg-[var(--danger)]',
 };
 
-export default function ConductorCockpit({ session, role, admissionEvents, copy }: Props) {
+export default function ConductorCockpit({
+    session,
+    role,
+    locale,
+    admissionEvents,
+    copy,
+    lifecycleCopy,
+}: Props) {
     const [drawer, setDrawer] = useState<Drawer | null>(null);
     const [status, setStatus] = useState<EventStatus>(session.status);
     const [stage, setStage] = useState<SpotlightSummary>(EMPTY_STAGE);
@@ -280,6 +290,8 @@ export default function ConductorCockpit({ session, role, admissionEvents, copy 
                             initialStatus={session.status}
                             scheduledAt={session.scheduledAt}
                             role={role}
+                            locale={locale}
+                            copy={lifecycleCopy}
                             observedStatus={status}
                             onStatusChange={setStatus}
                         />

--- a/src/components/ops/SessionLifecycleControl.tsx
+++ b/src/components/ops/SessionLifecycleControl.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import type { StaffRole } from '@prisma/client';
+import type { Messages, UiLocale } from '@/lib/i18n';
 
 type Props = {
     sessionId: string;
     initialStatus: 'SCHEDULED' | 'LIVE' | 'ENDED' | 'CANCELLED';
     scheduledAt: string;
     role: StaffRole;
+    locale: UiLocale;
+    copy: Messages['ops']['lifecycle'];
     observedStatus?: 'SCHEDULED' | 'LIVE' | 'ENDED' | 'CANCELLED';
     onStatusChange?: (status: 'SCHEDULED' | 'LIVE' | 'ENDED' | 'CANCELLED') => void;
 };
@@ -20,6 +23,8 @@ export default function SessionLifecycleControl({
     initialStatus,
     scheduledAt,
     role,
+    locale,
+    copy,
     observedStatus,
     onStatusChange,
 }: Props) {
@@ -50,6 +55,12 @@ export default function SessionLifecycleControl({
     }, [scheduledAt, nowMs]);
     const canOverrideWindow = role === 'ADMIN' || role === 'FACILITATOR_OP';
 
+    function connectionOutcome(template: string, stage: number, beacon: number): string {
+        return template
+            .replace('{stage}', String(stage))
+            .replace('{beacon}', String(beacon));
+    }
+
     async function transition(targetStatus: 'LIVE' | 'ENDED' | 'CANCELLED') {
         setBusy(true);
         setError(null);
@@ -74,7 +85,7 @@ export default function SessionLifecycleControl({
                 };
             };
             if (!response.ok) {
-                throw new Error(data.message || `Status change failed (HTTP ${response.status})`);
+                throw new Error(`${copy.statusChangeFailed} (HTTP ${response.status})`);
             }
             const nextStatus = (data.status as typeof status) || targetStatus;
             setStatus(nextStatus);
@@ -83,18 +94,21 @@ export default function SessionLifecycleControl({
             setReason('');
             if (targetStatus === 'LIVE') {
                 setNotice(data.changed === false
-                    ? 'Doors were already open.'
-                    : 'Doors are open. Attendees are entering now.');
+                    ? copy.doorsAlreadyOpen
+                    : copy.doorsOpened);
             } else if (data.termination?.complete) {
-                const outcome = targetStatus === 'CANCELLED' ? 'cancelled' : 'ended';
                 setNotice(
-                    `Event ${outcome} now. Disconnected ${data.termination.stageDisconnected} Stage and ${data.termination.bedDisconnected} Beacon connections.`,
+                    connectionOutcome(
+                        targetStatus === 'CANCELLED' ? copy.eventCancelled : copy.eventEnded,
+                        data.termination.stageDisconnected,
+                        data.termination.bedDisconnected,
+                    ),
                 );
             } else {
-                setError('Event closed, but an immediate media disconnect was incomplete. Use “Disconnect remaining clients” to retry.');
+                setError(copy.disconnectIncomplete);
             }
         } catch (failure) {
-            setError(failure instanceof Error ? failure.message : 'Status change failed');
+            setError(failure instanceof Error ? failure.message : copy.statusChangeFailed);
         } finally {
             setBusy(false);
         }
@@ -105,11 +119,11 @@ export default function SessionLifecycleControl({
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                     <h2 id="event-lifecycle-heading" className="font-semibold text-[var(--cream)]">
-                        Event doors
+                        {copy.heading}
                     </h2>
                     <p className="text-xs text-[var(--text-secondary)]">
-                        Status: <strong>{status}</strong> · scheduled{' '}
-                        {new Date(scheduledAt).toLocaleString()}
+                        {copy.status}: <strong>{copy.statuses[status]}</strong> · {copy.scheduled}{' '}
+                        {new Date(scheduledAt).toLocaleString(locale === 'es' ? 'es-AR' : 'en-GB')}
                     </p>
                 </div>
                 {status === 'SCHEDULED' ? (
@@ -121,7 +135,7 @@ export default function SessionLifecycleControl({
                         onClick={() => void transition('LIVE')}
                         className="event-button event-button--primary"
                     >
-                        {busy ? 'Opening…' : 'Open doors'}
+                        {busy ? copy.opening : copy.openDoors}
                     </button>
                 ) : status === 'LIVE' ? (
                     <button
@@ -130,12 +144,12 @@ export default function SessionLifecycleControl({
                         onClick={() => setConfirmClose(true)}
                         className="event-button event-button--secondary"
                     >
-                        Close event
+                        {copy.closeEvent}
                     </button>
                 ) : (
                     <div className="flex flex-wrap items-center gap-2">
                         <span className="rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-muted)]">
-                            {status === 'ENDED' ? 'Event closed' : 'Event cancelled'}
+                            {copy.statuses[status]}
                         </span>
                         {status === 'ENDED' || canOverrideWindow ? (
                             <button
@@ -144,7 +158,7 @@ export default function SessionLifecycleControl({
                                 onClick={() => setConfirmClose(true)}
                                 className="event-button event-button--secondary"
                             >
-                                Disconnect remaining clients
+                                {copy.disconnectRemaining}
                             </button>
                         ) : null}
                     </div>
@@ -155,12 +169,12 @@ export default function SessionLifecycleControl({
                 <div className="mt-3 space-y-2">
                     <p className="text-xs text-[var(--warning)]">
                         {canOverrideWindow
-                            ? 'This is outside the normal opening window. An audit reason is required.'
-                            : 'Doors can open from 10 minutes before until 60 minutes after the scheduled start.'}
+                            ? copy.outsideWindowOverride
+                            : copy.outsideWindowRestricted}
                     </p>
                     {canOverrideWindow ? (
                         <label className="block text-xs text-[var(--text-secondary)]">
-                            Operational reason (do not include attendee details)
+                            {copy.reasonLabel}
                             <input
                                 value={reason}
                                 maxLength={240}
@@ -174,9 +188,9 @@ export default function SessionLifecycleControl({
 
             {confirmClose ? (
                 <div role="alertdialog" aria-labelledby="close-event-heading" className="mt-3 rounded border border-[var(--warning)]/40 bg-[var(--warning)]/10 p-3">
-                    <h3 id="close-event-heading" className="font-medium text-[var(--cream)]">End this experience for everyone?</h3>
+                    <h3 id="close-event-heading" className="font-medium text-[var(--cream)]">{copy.confirmHeading}</h3>
                     <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                        New entries stop first. Then every Stage connection and this event&apos;s Beacon listeners are disconnected immediately. Other events and the Beacon source stay online.
+                        {copy.confirmBody}
                     </p>
                     <div className="mt-3 flex gap-2">
                         <button
@@ -185,7 +199,7 @@ export default function SessionLifecycleControl({
                             onClick={() => void transition(status === 'CANCELLED' ? 'CANCELLED' : 'ENDED')}
                             className="event-button event-button--primary"
                         >
-                            {busy ? 'Disconnecting…' : 'End & disconnect everyone'}
+                            {busy ? copy.disconnecting : copy.endAndDisconnect}
                         </button>
                         <button
                             type="button"
@@ -193,7 +207,7 @@ export default function SessionLifecycleControl({
                             onClick={() => setConfirmClose(false)}
                             className="event-button event-button--secondary"
                         >
-                            Keep open
+                            {copy.keepOpen}
                         </button>
                     </div>
                 </div>

--- a/src/components/ops/SpotlightConsole.tsx
+++ b/src/components/ops/SpotlightConsole.tsx
@@ -15,6 +15,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { StaffRole } from '@prisma/client';
 import { effectiveStageState, type EffectiveStageState } from '@/lib/stage-presence';
+import type { Messages } from '@/lib/i18n';
 
 const POLL_INTERVAL_MS = 2_000;
 
@@ -88,6 +89,8 @@ type ActionError = {
 type Props = {
     sessionId: string;
     role: StaffRole;
+    copy: Messages['ops']['spotlight'];
+    staffRoles: Messages['staffRoles'];
     onSummary?: (summary: SpotlightSummary) => void;
 };
 
@@ -114,11 +117,22 @@ async function postStage(
     return { status: response.status, data };
 }
 
-function describeActionError(status: number, data: Record<string, unknown>): ActionError {
+function fill(template: string, values: Record<string, string | number>): string {
+    return Object.entries(values).reduce(
+        (result, [key, value]) => result.replaceAll(`{${key}}`, String(value)),
+        template,
+    );
+}
+
+function describeActionError(
+    status: number,
+    data: Record<string, unknown>,
+    copy: Messages['ops']['spotlight'],
+): ActionError {
     const code = typeof data.error === 'string' ? data.error : 'request_failed';
     const message = typeof data.message === 'string'
         ? data.message
-        : `Request failed (HTTP ${status})`;
+        : fill(copy.requestFailed, { status });
     return {
         code,
         message,
@@ -137,23 +151,35 @@ function formatQueueAge(raisedAt: string, nowMs: number): string {
         : `${seconds}s`;
 }
 
-function connectionBadge(participant: ConsoleParticipant): string {
+function connectionBadge(
+    participant: ConsoleParticipant,
+    copy: Messages['ops']['spotlight'],
+): string {
     if (participant.connected === null) {
-        return 'live state unknown';
+        return copy.liveUnknown;
     }
-    return participant.connected ? 'connected' : 'left';
+    return participant.connected ? copy.connected : copy.disconnected;
 }
 
-function mediaSummary(participant: ConsoleParticipant): string {
+function mediaSummary(
+    participant: ConsoleParticipant,
+    copy: Messages['ops']['spotlight'],
+): string {
     if (participant.connected !== true) {
         return '—';
     }
     if (participant.media.length === 0) {
-        return 'no tracks published';
+        return copy.noTracks;
     }
     return participant.media
-        .map((track) => `${track.source.toLowerCase()} ${track.muted ? 'muted' : 'live'}`)
+        .map((track) => `${track.source.toLowerCase()} ${track.muted ? copy.muted : copy.trackLive}`)
         .join(' · ');
+}
+
+function roleLabel(role: string | null, labels: Messages['staffRoles']): string | null {
+    return role && role in labels
+        ? labels[role as keyof Messages['staffRoles']]
+        : role;
 }
 
 function participantLabel(participant: ConsoleParticipant): string {
@@ -167,10 +193,12 @@ function HandThumbnail({
     displayName,
     src,
     freshForSeconds,
+    copy,
 }: {
     displayName: string;
     src: string | null;
     freshForSeconds: number;
+    copy: Messages['ops']['spotlight'];
 }) {
     const [failedSrc, setFailedSrc] = useState<string | null>(null);
     const showImage = Boolean(src) && failedSrc !== src;
@@ -183,7 +211,7 @@ function HandThumbnail({
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
                     src={src!}
-                    alt={`Recent tapestry snapshot of ${displayName}`}
+                    alt={fill(copy.recentSnapshotAlt, { name: displayName })}
                     width={48}
                     height={48}
                     loading="lazy"
@@ -194,20 +222,20 @@ function HandThumbnail({
             ) : (
                 <span
                     role="img"
-                    aria-label={`${displayName}: no current tapestry snapshot`}
+                    aria-label={fill(copy.noSnapshotAlt, { name: displayName })}
                     className="flex h-12 w-12 items-center justify-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-alt)] text-lg text-[var(--text-muted)]"
                 >
                     ◌
                 </span>
             )}
             <span className="text-center text-[9px] leading-tight text-[var(--text-muted)]" aria-hidden="true">
-                {showImage ? `≤${freshForSeconds}s` : 'no image'}
+                {showImage ? `≤${freshForSeconds}s` : copy.noImage}
             </span>
         </div>
     );
 }
 
-export default function SpotlightConsole({ sessionId, role, onSummary }: Props) {
+export default function SpotlightConsole({ sessionId, role, copy, staffRoles, onSummary }: Props) {
     const [snapshot, setSnapshot] = useState<ParticipantsSnapshot | null>(null);
     const [pollError, setPollError] = useState<string | null>(null);
     const [actionError, setActionError] = useState<ActionError | null>(null);
@@ -250,11 +278,11 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
         } catch (error) {
             if (mounted.current) {
                 setPollError(
-                    error instanceof Error ? error.message : 'Polling failed',
+                    error instanceof Error ? error.message : copy.requestFailed,
                 );
             }
         }
-    }, [sessionId, onSummary]);
+    }, [sessionId, onSummary, copy.requestFailed]);
 
     useEffect(() => {
         mounted.current = true;
@@ -277,7 +305,7 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
         try {
             const { status, data } = await postStage(sessionId, body);
             if (status >= 400) {
-                setActionError(describeActionError(status, data));
+                setActionError(describeActionError(status, data, copy));
                 return false;
             }
             setNotice(okMessage);
@@ -285,7 +313,7 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
         } catch {
             setActionError({
                 code: 'request_failed',
-                message: 'The stage endpoint could not be reached',
+                message: copy.endpointUnavailable,
             });
             return false;
         } finally {
@@ -298,7 +326,7 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
         if (participant.connected !== true) {
             setActionError({
                 code: 'participant_not_connected',
-                message: 'This participant is not connected. Wait for them to rejoin or remove the stale hand.',
+                message: copy.participantDisconnected,
             });
             return;
         }
@@ -306,7 +334,7 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
         const promoted = await runAction(
             `promote:${participant.id}`,
             { action: 'promote', participantId: participant.id, reason: 'Hand queue' },
-            `${label} has the floor`,
+            fill(copy.hasFloor, { name: label }),
         );
         if (!promoted) {
             return;
@@ -314,7 +342,7 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
         await runAction(
             `lower:${participant.id}`,
             { action: 'lower_hand', participantId: participant.id, reason: 'Promoted to stage' },
-            `${label} has the floor`,
+            fill(copy.hasFloor, { name: label }),
         );
     }
 
@@ -322,21 +350,21 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
         runAction(
             `promote:${participant.id}`,
             { action: 'promote', participantId: participant.id, reason: 'Invited from audience' },
-            `${participantLabel(participant)} was invited to the stage`,
+            fill(copy.invitedNotice, { name: participantLabel(participant) }),
         );
 
     const takeFloor = (participant: ConsoleParticipant) =>
         runAction(
             `demote:${participant.id}`,
             { action: 'demote', participantId: participant.id, reason: 'Operator took the floor' },
-            `${participantLabel(participant)} was taken off the stage`,
+            fill(copy.removedNotice, { name: participantLabel(participant) }),
         );
 
     const removeHand = (participant: ConsoleParticipant) =>
         runAction(
             `lower:${participant.id}`,
             { action: 'lower_hand', participantId: participant.id, reason: 'Removed from hand queue' },
-            `${participantLabel(participant)}'s hand was lowered`,
+            fill(copy.handLoweredNotice, { name: participantLabel(participant) }),
         );
 
     const muteTrack = (participant: ConsoleParticipant, track: LiveTrack) =>
@@ -348,14 +376,14 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                 trackSid: track.trackSid,
                 muted: true,
             },
-            `${track.source.toLowerCase()} muted; the participant can re-enable it`,
+            fill(copy.trackMutedNotice, { track: track.source.toLowerCase() }),
         );
 
     const reconcile = () =>
         runAction(
             'reconcile',
             { action: 'reconcile' },
-            'Reconciliation finished',
+            copy.reconciliationFinished,
         );
 
     const all = snapshot?.participants ?? [];
@@ -377,27 +405,32 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
             {/* Status banners */}
             {pollError ? (
                 <div role="alert" className="rounded border border-[var(--danger)]/40 bg-[var(--danger)]/10 px-4 py-2 text-sm text-[var(--danger)]">
-                    Polling failed ({pollError}) — showing the last known state. Retrying every {POLL_INTERVAL_MS / 1000}s.
+                    {fill(copy.pollingFailed, {
+                        error: pollError,
+                        seconds: POLL_INTERVAL_MS / 1000,
+                    })}
                 </div>
             ) : null}
             {snapshot && !snapshot.liveStateAvailable ? (
                 <div role="alert" className="rounded border border-[var(--warning)]/40 bg-[var(--warning)]/10 px-4 py-2 text-sm text-[var(--warning)]">
-                    LiveKit live state unavailable — connection and media are unknown. Durable grants and the hand queue are still current.
+                    {copy.liveStateUnavailable}
                 </div>
             ) : null}
             {reconcilePending.length > 0 ? (
                 <div role="alert" className="rounded border border-[var(--warning)]/40 bg-[var(--warning)]/10 px-4 py-2 text-sm text-[var(--warning)]">
-                    {reconcilePending.length} participant{reconcilePending.length !== 1 ? 's' : ''} need{reconcilePending.length === 1 ? 's' : ''} reconciliation — the durable grant and LiveKit disagree.
+                    {reconcilePending.length === 1
+                        ? copy.reconciliationOne
+                        : fill(copy.reconciliationMany, { count: reconcilePending.length })}
                 </div>
             ) : null}
             {actionError ? (
                 <div role="alert" className="rounded border border-[var(--danger)]/40 bg-[var(--danger)]/10 px-4 py-2 text-sm text-[var(--danger)]">
                     {actionError.code === 'stage_full'
-                        ? `Stage is full — this hand stays #${actionError.queuePosition ?? '?'} in the queue. Take a floor first.`
+                        ? fill(copy.stageFull, { position: actionError.queuePosition ?? '?' })
                         : actionError.code === 'participant_not_connected'
                           ? actionError.message
                         : actionError.code === 'livekit_failed' && actionError.reconcileNeeded
-                          ? `${actionError.message}. The durable grant was revoked; press Reconcile to retry the LiveKit update.`
+                          ? fill(copy.livekitFailure, { message: actionError.message })
                           : `${actionError.message} (${actionError.code})`}
                 </div>
             ) : null}
@@ -409,11 +442,17 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
 
             <div className="flex items-center justify-between text-sm">
                 <span className="text-[var(--text-secondary)]">
-                    Stage: {snapshot ? `${snapshot.activePublishers}/${snapshot.maxPublishers}` : '…'} publishing
+                    {fill(copy.stageSummary, {
+                        active: snapshot?.activePublishers ?? '…',
+                        max: snapshot?.maxPublishers ?? '…',
+                    })}
                     {snapshot?.grantedPublishers !== undefined
-                        ? ` · ${snapshot.grantedPublishers}/${snapshot.maxPublishers} slots reserved`
+                        ? ` · ${fill(copy.slotsReserved, {
+                            granted: snapshot.grantedPublishers,
+                            max: snapshot.maxPublishers,
+                        })}`
                         : ''} ·{' '}
-                    {queue.length} hand{queue.length !== 1 ? 's' : ''} raised
+                    {fill(copy.handsRaised, { count: queue.length })}
                 </span>
                 <button
                     type="button"
@@ -421,19 +460,18 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                     disabled={busyKey === 'reconcile'}
                     className="min-h-11 rounded border border-[var(--border-subtle)] px-3 py-2 text-xs hover:bg-white/5 disabled:opacity-50"
                 >
-                    Reconcile grants
+                    {copy.reconcile}
                 </button>
             </div>
 
             {/* Hand queue comes first so a facilitator never has to hunt below the stage. */}
             <div>
-                <h2 className="mb-1 text-lg font-semibold text-[var(--cream)]">Hand queue</h2>
+                <h2 className="mb-1 text-lg font-semibold text-[var(--cream)]">{copy.handQueue}</h2>
                 <p className="mb-2 text-xs text-[var(--text-muted)]">
-                    Raised hands appear here automatically. Give floor moves a connected person to the stage; Remove hand clears the request.
-                    {' '}Snapshots are private, refresh together and disappear after {thumbnailFreshForSeconds}s without a new consented frame.
+                    {fill(copy.handQueueHelp, { seconds: thumbnailFreshForSeconds })}
                 </p>
                 {queue.length === 0 ? (
-                    <p className="text-sm text-[var(--text-secondary)]">No hands raised.</p>
+                    <p className="text-sm text-[var(--text-secondary)]">{copy.noHands}</p>
                 ) : (
                     <ul className="space-y-2">
                         {queue.map((participant) => (
@@ -443,14 +481,15 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                         displayName={participant.displayName}
                                         src={participant.thumbnailUrl ?? null}
                                         freshForSeconds={thumbnailFreshForSeconds}
+                                        copy={copy}
                                     />
                                     <div className="min-w-0">
                                         <span className="font-medium text-[var(--cream)]">#{participant.queuePosition} — {participantLabel(participant)}</span>
                                         <div className="text-xs text-[var(--text-secondary)]">
-                                            waiting {participant.raisedAt ? formatQueueAge(participant.raisedAt, nowMs) : '…'}
-                                            {' · '}{connectionBadge(participant)}
-                                            {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()} quality` : ''}
-                                            {participant.reconcileNeeded ? ' · reconcile needed' : ''}
+                                            {copy.waiting} {participant.raisedAt ? formatQueueAge(participant.raisedAt, nowMs) : '…'}
+                                            {' · '}{connectionBadge(participant, copy)}
+                                            {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()} ${copy.quality}` : ''}
+                                            {participant.reconcileNeeded ? ` · ${copy.reconcileNeeded}` : ''}
                                         </div>
                                     </div>
                                 </div>
@@ -459,10 +498,10 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                         type="button"
                                         disabled={busyKey !== null || participant.connected !== true}
                                         onClick={() => void giveFloor(participant)}
-                                        title={participant.connected === true ? undefined : 'Participant must be connected before joining the stage'}
+                                        title={participant.connected === true ? undefined : copy.mustReconnect}
                                     className="min-h-11 rounded border border-[var(--lime)] px-3 py-2 text-xs text-[var(--lime)] hover:bg-[var(--lime)]/10 disabled:opacity-50"
                                     >
-                                        {participant.connected === true ? 'Give floor' : 'Waiting for reconnect'}
+                                        {participant.connected === true ? copy.giveFloor : copy.waitingForReconnect}
                                     </button>
                                     <button
                                         type="button"
@@ -470,7 +509,7 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                         onClick={() => void removeHand(participant)}
                                         className="min-h-11 rounded border border-[var(--border-subtle)] px-3 py-2 text-xs hover:bg-white/5 disabled:opacity-50"
                                     >
-                                        Remove hand
+                                        {copy.removeHand}
                                     </button>
                                 </div>
                             </li>
@@ -480,9 +519,9 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
             </div>
 
             <div>
-                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">Invited / reconnecting</h2>
+                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">{copy.invitedHeading}</h2>
                 {invited.length === 0 ? (
-                    <p className="text-sm text-[var(--text-secondary)]">No pending stage invitations.</p>
+                    <p className="text-sm text-[var(--text-secondary)]">{copy.noInvitations}</p>
                 ) : (
                     <ul className="space-y-2">
                         {invited.map((participant) => (
@@ -491,18 +530,18 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                     <span className="font-medium text-[var(--cream)]">{participantLabel(participant)}</span>
                                     <div className="text-xs text-[var(--text-secondary)]">
                                         {participant.stageState === 'RECONNECTING'
-                                            ? 'Disconnected — invitation will be shown again after re-entry'
+                                            ? copy.inviteAfterReentry
                                             : participant.stageState === 'UNKNOWN'
-                                              ? 'Live state unknown — grant retained'
-                                              : 'Connected — waiting for acceptance and media'}
+                                              ? copy.unknownGrant
+                                              : copy.awaitingAcceptance}
                                     </div>
                                 </div>
                                 {!participant.isAssignedFacilitator ? (
                                     <button type="button" disabled={busyKey !== null} onClick={() => void takeFloor(participant)} className="min-h-11 rounded border border-[var(--danger)] px-3 py-2 text-xs text-[var(--danger)] hover:bg-[var(--danger)]/10 disabled:opacity-50">
-                                        Cancel invitation
+                                        {copy.cancelInvitation}
                                     </button>
                                 ) : (
-                                    <span className="text-xs font-medium text-[var(--text-muted)]">Reserved facilitator slot</span>
+                                    <span className="text-xs font-medium text-[var(--text-muted)]">{copy.reservedFacilitator}</span>
                                 )}
                             </li>
                         ))}
@@ -512,9 +551,9 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
 
             {/* Stage */}
             <div>
-                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">On stage</h2>
+                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">{copy.onStage}</h2>
                 {onStage.length === 0 ? (
-                    <p className="text-sm text-[var(--text-secondary)]">Nobody has the floor yet.</p>
+                    <p className="text-sm text-[var(--text-secondary)]">{copy.nobodyOnStage}</p>
                 ) : (
                     <ul className="space-y-2">
                         {onStage.map((participant) => (
@@ -523,19 +562,21 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                     <div className="min-w-0">
                                         <span className="font-medium text-[var(--cream)]">{participantLabel(participant)}</span>
                                         {participant.staffRole ? (
-                                            <span className="ml-2 text-[10px] uppercase text-[var(--text-muted)]">{participant.staffRole}</span>
+                                            <span className="ml-2 text-[10px] uppercase text-[var(--text-muted)]">{roleLabel(participant.staffRole, staffRoles)}</span>
                                         ) : null}
                                         <div className="text-xs text-[var(--text-secondary)]">
-                                            {connectionBadge(participant)}
-                                            {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()} quality` : ''}
-                                            {' · '}{mediaSummary(participant)}
-                                            {participant.reconcileNeeded ? ' · reconcile needed' : ''}
+                                            {connectionBadge(participant, copy)}
+                                            {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()} ${copy.quality}` : ''}
+                                            {' · '}{mediaSummary(participant, copy)}
+                                            {participant.reconcileNeeded ? ` · ${copy.reconcileNeeded}` : ''}
                                         </div>
                                     </div>
                                     <div className="flex shrink-0 flex-wrap items-center gap-2">
                                         {participant.media.map((track) => track.muted ? (
                                             <span key={track.trackSid} className="text-xs text-[var(--text-muted)]">
-                                                Participant must re-enable {track.source.toLowerCase()}
+                                                {fill(copy.participantMustEnable, {
+                                                    track: track.source.toLowerCase(),
+                                                })}
                                             </span>
                                         ) : (
                                             <button
@@ -545,7 +586,9 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                                 onClick={() => void muteTrack(participant, track)}
                                                 className="min-h-11 rounded border border-[var(--border-subtle)] px-3 py-2 text-xs hover:bg-white/5 disabled:opacity-50"
                                             >
-                                                Mute {track.source.toLowerCase()}
+                                                {fill(copy.muteTrack, {
+                                                    track: track.source.toLowerCase(),
+                                                })}
                                             </button>
                                         ))}
                                         {!participant.isAssignedFacilitator ? (
@@ -555,11 +598,11 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                                 onClick={() => void takeFloor(participant)}
                                                 className="min-h-11 rounded border border-[var(--danger)] px-3 py-2 text-xs text-[var(--danger)] hover:bg-[var(--danger)]/10 disabled:opacity-50"
                                             >
-                                                Take floor
+                                                {copy.takeFloor}
                                             </button>
                                         ) : (
                                             <span className="text-xs font-medium text-[var(--text-muted)]">
-                                                Reserved facilitator slot
+                                                {copy.reservedFacilitator}
                                             </span>
                                         )}
                                     </div>
@@ -572,9 +615,11 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
 
             {/* Audience */}
             <div>
-                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">Audience ({audience.length})</h2>
+                <h2 className="mb-2 text-lg font-semibold text-[var(--cream)]">
+                    {fill(copy.audience, { count: audience.length })}
+                </h2>
                 {audience.length === 0 ? (
-                    <p className="text-sm text-[var(--text-secondary)]">No other participants.</p>
+                    <p className="text-sm text-[var(--text-secondary)]">{copy.noAudience}</p>
                 ) : (
                     <ul className="space-y-1 text-sm">
                         {audience.map((participant) => (
@@ -582,12 +627,12 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                 <span className="text-[var(--cream)]">
                                     {participantLabel(participant)}
                                     {participant.staffRole ? (
-                                        <span className="ml-2 text-[10px] uppercase text-[var(--text-muted)]">{participant.staffRole}</span>
+                                        <span className="ml-2 text-[10px] uppercase text-[var(--text-muted)]">{roleLabel(participant.staffRole, staffRoles)}</span>
                                     ) : null}
                                 </span>
                                 <span className="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
                                     <span>
-                                        {connectionBadge(participant)}
+                                        {connectionBadge(participant, copy)}
                                         {participant.connectionQuality ? ` · ${participant.connectionQuality.toLowerCase()}` : ''}
                                     </span>
                                     {participant.connected === true ? (
@@ -597,7 +642,7 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
                                             onClick={() => void inviteToStage(participant)}
                                             className="min-h-11 rounded border border-[var(--lime)] px-3 py-2 text-xs text-[var(--lime)] hover:bg-[var(--lime)]/10 disabled:opacity-50"
                                         >
-                                            Invite to stage
+                                            {copy.inviteToStage}
                                         </button>
                                     ) : null}
                                 </span>
@@ -608,7 +653,10 @@ export default function SpotlightConsole({ sessionId, role, onSummary }: Props) 
             </div>
 
             <p className="text-xs text-[var(--text-muted)]">
-                Signed in as {role}. Queue refreshes every {POLL_INTERVAL_MS / 1000}s; durable grants are the authority.
+                {fill(copy.footer, {
+                    role: staffRoles[role],
+                    seconds: POLL_INTERVAL_MS / 1000,
+                })}
             </p>
         </section>
     );

--- a/src/components/ops/__tests__/ConductorCockpit.test.tsx
+++ b/src/components/ops/__tests__/ConductorCockpit.test.tsx
@@ -52,8 +52,10 @@ const props = {
         scheduledAt: '2026-08-01T18:00:00.000Z',
     },
     role: 'FACILITATOR_OP' as const,
+    locale: 'en' as const,
     admissionEvents: [],
     copy: messages.en.ops.cockpit,
+    lifecycleCopy: messages.en.ops.lifecycle,
 };
 
 afterEach(() => {

--- a/src/components/ops/__tests__/ConductorCockpit.test.tsx
+++ b/src/components/ops/__tests__/ConductorCockpit.test.tsx
@@ -56,6 +56,8 @@ const props = {
     admissionEvents: [],
     copy: messages.en.ops.cockpit,
     lifecycleCopy: messages.en.ops.lifecycle,
+    spotlightCopy: messages.en.ops.spotlight,
+    staffRoleLabels: messages.en.staffRoles,
 };
 
 afterEach(() => {

--- a/src/components/ops/__tests__/SessionLifecycleControl.test.tsx
+++ b/src/components/ops/__tests__/SessionLifecycleControl.test.tsx
@@ -2,7 +2,10 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { messages } from '@/lib/i18n';
 import SessionLifecycleControl from '../SessionLifecycleControl';
+
+const localized = { locale: 'en' as const, copy: messages.en.ops.lifecycle };
 
 describe('SessionLifecycleControl', () => {
     beforeEach(() => {
@@ -21,6 +24,7 @@ describe('SessionLifecycleControl', () => {
 
     it('opens doors with one glanceable action', async () => {
         render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="SCHEDULED"
             scheduledAt="2026-08-01T18:00:00Z"
@@ -34,6 +38,24 @@ describe('SessionLifecycleControl', () => {
         );
     });
 
+    it('renders the complete lifecycle control in Spanish from the typed dictionary', async () => {
+        render(<SessionLifecycleControl
+            locale="es"
+            copy={messages.es.ops.lifecycle}
+            sessionId="event-1"
+            initialStatus="SCHEDULED"
+            scheduledAt="2026-08-01T18:00:00Z"
+            role="FACILITATOR"
+        />);
+
+        expect(screen.getByRole('heading', { name: 'Puertas del evento' })).toBeInTheDocument();
+        expect(screen.getByText(/Estado:/)).toHaveTextContent('Próximo');
+        fireEvent.click(screen.getByRole('button', { name: 'Abrir puertas' }));
+        expect(await screen.findByText(
+            'Las puertas están abiertas. Las personas ya pueden entrar.',
+        )).toBeInTheDocument();
+    });
+
     it('requires explicit confirmation before closing', async () => {
         vi.mocked(fetch).mockResolvedValue({
             ok: true,
@@ -44,6 +66,7 @@ describe('SessionLifecycleControl', () => {
             }),
         } as Response);
         render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="LIVE"
             scheduledAt="2026-08-01T18:00:00Z"
@@ -67,6 +90,7 @@ describe('SessionLifecycleControl', () => {
             }),
         } as Response);
         render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="ENDED"
             scheduledAt="2026-08-01T18:00:00Z"
@@ -93,6 +117,7 @@ describe('SessionLifecycleControl', () => {
             }),
         } as Response);
         render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="CANCELLED"
             scheduledAt="2026-08-01T18:00:00Z"
@@ -111,6 +136,7 @@ describe('SessionLifecycleControl', () => {
 
     it('does not offer an unauthorized cancellation retry to an operator', () => {
         render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="CANCELLED"
             scheduledAt="2026-08-01T18:00:00Z"
@@ -122,6 +148,7 @@ describe('SessionLifecycleControl', () => {
 
     it('blocks non-admin staff outside the opening window', () => {
         render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="SCHEDULED"
             scheduledAt="2026-08-02T18:00:00Z"
@@ -133,6 +160,7 @@ describe('SessionLifecycleControl', () => {
 
     it('lets an admin provide an audited override reason', () => {
         render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="SCHEDULED"
             scheduledAt="2026-08-02T18:00:00Z"
@@ -148,6 +176,7 @@ describe('SessionLifecycleControl', () => {
 
     it('lets FACILITATOR_OP provide the same audited override reason', () => {
         render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="SCHEDULED"
             scheduledAt="2026-08-02T18:00:00Z"
@@ -161,6 +190,7 @@ describe('SessionLifecycleControl', () => {
 
     it('adopts status observed by another operator without a reload', async () => {
         const { rerender } = render(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="SCHEDULED"
             observedStatus="SCHEDULED"
@@ -170,6 +200,7 @@ describe('SessionLifecycleControl', () => {
         expect(screen.getByRole('button', { name: 'Open doors' })).toBeInTheDocument();
 
         rerender(<SessionLifecycleControl
+            {...localized}
             sessionId="event-1"
             initialStatus="SCHEDULED"
             observedStatus="LIVE"

--- a/src/components/ops/__tests__/SpotlightConsole.test.tsx
+++ b/src/components/ops/__tests__/SpotlightConsole.test.tsx
@@ -1,9 +1,23 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import SpotlightConsole from '../SpotlightConsole';
+import { messages } from '@/lib/i18n';
+import SpotlightConsoleImpl from '../SpotlightConsole';
+
+type SpotlightConsoleProps = Omit<ComponentProps<typeof SpotlightConsoleImpl>, 'copy' | 'staffRoles'>;
+
+function SpotlightConsole(props: SpotlightConsoleProps) {
+    return (
+        <SpotlightConsoleImpl
+            {...props}
+            copy={messages.en.ops.spotlight}
+            staffRoles={messages.en.staffRoles}
+        />
+    );
+}
 
 type Participant = Record<string, unknown>;
 
@@ -108,6 +122,30 @@ describe('SpotlightConsole', () => {
         expect(screen.getByText(/left/)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Take floor' })).toBeInTheDocument();
         expect(screen.getAllByRole('button', { name: 'Give floor' })).toHaveLength(2);
+    });
+
+    it('renders the stage workflow and staff role in Spanish', async () => {
+        vi.stubGlobal('fetch', mockFetch(snapshot([
+            attendee('raised', {
+                displayName: 'Alguien',
+                raisedAt: '2026-08-01T15:10:00.000Z',
+                queuePosition: 1,
+            }),
+        ], { activePublishers: 0 })));
+
+        render(
+            <SpotlightConsoleImpl
+                sessionId="event-1"
+                role="FACILITATOR_OP"
+                copy={messages.es.ops.spotlight}
+                staffRoles={messages.es.staffRoles}
+            />,
+        );
+
+        expect(await screen.findByRole('heading', { name: 'Fila de manos' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Dar la palabra' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Quitar mano' })).toBeInTheDocument();
+        expect(screen.getByText(/Sesión de Facilitación y operaciones/)).toBeInTheDocument();
     });
 
     it('shows a recent private snapshot, uses one neutral fallback, and recovers from image failure', async () => {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -242,6 +242,62 @@ export type Messages = {
             disconnectIncomplete: string;
             statusChangeFailed: string;
         };
+        spotlight: {
+            pollingFailed: string;
+            liveStateUnavailable: string;
+            reconciliationOne: string;
+            reconciliationMany: string;
+            requestFailed: string;
+            endpointUnavailable: string;
+            participantDisconnected: string;
+            hasFloor: string;
+            invitedNotice: string;
+            removedNotice: string;
+            handLoweredNotice: string;
+            trackMutedNotice: string;
+            reconciliationFinished: string;
+            stageFull: string;
+            livekitFailure: string;
+            stageSummary: string;
+            slotsReserved: string;
+            handsRaised: string;
+            reconcile: string;
+            handQueue: string;
+            handQueueHelp: string;
+            noHands: string;
+            waiting: string;
+            connected: string;
+            disconnected: string;
+            liveUnknown: string;
+            quality: string;
+            reconcileNeeded: string;
+            giveFloor: string;
+            waitingForReconnect: string;
+            removeHand: string;
+            mustReconnect: string;
+            invitedHeading: string;
+            noInvitations: string;
+            inviteAfterReentry: string;
+            unknownGrant: string;
+            awaitingAcceptance: string;
+            cancelInvitation: string;
+            reservedFacilitator: string;
+            onStage: string;
+            nobodyOnStage: string;
+            noTracks: string;
+            muted: string;
+            trackLive: string;
+            participantMustEnable: string;
+            muteTrack: string;
+            takeFloor: string;
+            audience: string;
+            noAudience: string;
+            inviteToStage: string;
+            recentSnapshotAlt: string;
+            noSnapshotAlt: string;
+            noImage: string;
+            footer: string;
+        };
         cockpit: {
             roomTitle: string;
             roomHint: string;
@@ -497,6 +553,62 @@ export const messages: Record<UiLocale, Messages> = {
                 disconnectIncomplete: 'El evento se cerró, pero quedaron conexiones activas. Usá “Desconectar conexiones restantes” para volver a intentarlo.',
                 statusChangeFailed: 'No se pudo cambiar el estado del evento',
             },
+            spotlight: {
+                pollingFailed: 'No se pudo actualizar ({error}). Se muestra el último estado conocido y se vuelve a intentar cada {seconds}s.',
+                liveStateUnavailable: 'LiveKit no está respondiendo: no se puede confirmar presencia ni medios. Las invitaciones y la fila de manos guardadas siguen vigentes.',
+                reconciliationOne: '1 persona necesita reconciliación: el permiso guardado y LiveKit no coinciden.',
+                reconciliationMany: '{count} personas necesitan reconciliación: los permisos guardados y LiveKit no coinciden.',
+                requestFailed: 'La acción no se pudo completar (HTTP {status})',
+                endpointUnavailable: 'No se pudo contactar el control de escena',
+                participantDisconnected: 'Esta persona no está conectada. Esperá su regreso o quitá la mano de la fila.',
+                hasFloor: '{name} tiene la palabra',
+                invitedNotice: '{name} recibió una invitación a la escena',
+                removedNotice: '{name} volvió al público',
+                handLoweredNotice: 'Se bajó la mano de {name}',
+                trackMutedNotice: 'Se silenció {track}; la persona puede volver a activarlo',
+                reconciliationFinished: 'Reconciliación terminada',
+                stageFull: 'La escena está completa. Esta mano conserva el puesto #{position}; liberá un lugar primero.',
+                livekitFailure: '{message}. Se revocó el permiso guardado; usá Reconciliar para volver a intentar en LiveKit.',
+                stageSummary: 'Escena: {active}/{max} publicando',
+                slotsReserved: '{granted}/{max} lugares reservados',
+                handsRaised: '{count} manos levantadas',
+                reconcile: 'Reconciliar permisos',
+                handQueue: 'Fila de manos',
+                handQueueHelp: 'Las manos aparecen automáticamente. Dar la palabra invita a una persona conectada; Quitar mano limpia la solicitud. Las miniaturas son privadas, se actualizan juntas y desaparecen después de {seconds}s sin una nueva imagen consentida.',
+                noHands: 'No hay manos levantadas.',
+                waiting: 'espera',
+                connected: 'conectada',
+                disconnected: 'salió',
+                liveUnknown: 'presencia desconocida',
+                quality: 'calidad',
+                reconcileNeeded: 'requiere reconciliación',
+                giveFloor: 'Dar la palabra',
+                waitingForReconnect: 'Esperando reconexión',
+                removeHand: 'Quitar mano',
+                mustReconnect: 'La persona debe estar conectada antes de entrar en escena',
+                invitedHeading: 'Invitadas / reconectando',
+                noInvitations: 'No hay invitaciones pendientes.',
+                inviteAfterReentry: 'Desconectada: la invitación volverá a mostrarse cuando regrese',
+                unknownGrant: 'Estado en vivo desconocido: la invitación sigue vigente',
+                awaitingAcceptance: 'Conectada: esperando aceptación y medios',
+                cancelInvitation: 'Cancelar invitación',
+                reservedFacilitator: 'Lugar reservado para facilitación',
+                onStage: 'En escena',
+                nobodyOnStage: 'Todavía nadie tiene la palabra.',
+                noTracks: 'sin medios publicados',
+                muted: 'silenciado',
+                trackLive: 'activo',
+                participantMustEnable: 'La persona debe volver a activar {track}',
+                muteTrack: 'Silenciar {track}',
+                takeFloor: 'Quitar la palabra',
+                audience: 'Público ({count})',
+                noAudience: 'No hay otras personas.',
+                inviteToStage: 'Invitar a la escena',
+                recentSnapshotAlt: 'Imagen reciente del tapiz de {name}',
+                noSnapshotAlt: '{name}: sin imagen actual del tapiz',
+                noImage: 'sin imagen',
+                footer: 'Sesión de {role}. La fila se actualiza cada {seconds}s; los permisos guardados son la referencia.',
+            },
             cockpit: {
                 roomTitle: 'Sala en vivo',
                 roomHint: 'La escena permanece conectada mientras abrís las herramientas.',
@@ -749,6 +861,62 @@ export const messages: Record<UiLocale, Messages> = {
                 eventCancelled: 'Event cancelled now. Disconnected {stage} Stage and {beacon} Beacon connections.',
                 disconnectIncomplete: 'Event closed, but an immediate media disconnect was incomplete. Use “Disconnect remaining clients” to retry.',
                 statusChangeFailed: 'Status change failed',
+            },
+            spotlight: {
+                pollingFailed: 'Update failed ({error}). Showing the last known state and retrying every {seconds}s.',
+                liveStateUnavailable: 'LiveKit live state unavailable — connection and media are unknown. Durable grants and the hand queue are still current.',
+                reconciliationOne: '1 participant needs reconciliation: the saved grant and LiveKit disagree.',
+                reconciliationMany: '{count} participants need reconciliation: the saved grants and LiveKit disagree.',
+                requestFailed: 'The action could not be completed (HTTP {status})',
+                endpointUnavailable: 'The stage control could not be reached',
+                participantDisconnected: 'This participant is not connected. Wait for them to rejoin or remove the stale hand.',
+                hasFloor: '{name} has the floor',
+                invitedNotice: '{name} was invited to the stage',
+                removedNotice: '{name} returned to the audience',
+                handLoweredNotice: '{name}’s hand was lowered',
+                trackMutedNotice: '{track} muted; the participant can re-enable it',
+                reconciliationFinished: 'Reconciliation finished',
+                stageFull: 'Stage is full — this hand stays #{position} in the queue. Take a floor first.',
+                livekitFailure: '{message}. The durable grant was revoked; press Reconcile to retry the LiveKit update.',
+                stageSummary: 'Stage: {active}/{max} publishing',
+                slotsReserved: '{granted}/{max} slots reserved',
+                handsRaised: '{count} hands raised',
+                reconcile: 'Reconcile grants',
+                handQueue: 'Hand queue',
+                handQueueHelp: 'Raised hands appear automatically. Give floor invites a connected person; Remove hand clears the request. Snapshots are private, refresh together and disappear after {seconds}s without a new consented frame.',
+                noHands: 'No hands raised.',
+                waiting: 'waiting',
+                connected: 'connected',
+                disconnected: 'left',
+                liveUnknown: 'live state unknown',
+                quality: 'quality',
+                reconcileNeeded: 'reconcile needed',
+                giveFloor: 'Give floor',
+                waitingForReconnect: 'Waiting for reconnect',
+                removeHand: 'Remove hand',
+                mustReconnect: 'Participant must be connected before joining the stage',
+                invitedHeading: 'Invited / reconnecting',
+                noInvitations: 'No pending stage invitations.',
+                inviteAfterReentry: 'Disconnected — invitation will be shown again',
+                unknownGrant: 'Live state unknown: the invitation remains active',
+                awaitingAcceptance: 'Connected: waiting for acceptance and media',
+                cancelInvitation: 'Cancel invitation',
+                reservedFacilitator: 'Reserved facilitator slot',
+                onStage: 'On stage',
+                nobodyOnStage: 'Nobody has the floor yet.',
+                noTracks: 'no tracks published',
+                muted: 'muted',
+                trackLive: 'live',
+                participantMustEnable: 'Participant must re-enable {track}',
+                muteTrack: 'Mute {track}',
+                takeFloor: 'Take floor',
+                audience: 'Audience ({count})',
+                noAudience: 'No other participants.',
+                inviteToStage: 'Invite to stage',
+                recentSnapshotAlt: 'Recent tapestry snapshot of {name}',
+                noSnapshotAlt: '{name}: no current tapestry snapshot',
+                noImage: 'no image',
+                footer: 'Signed in as {role}. Queue refreshes every {seconds}s; saved grants are authoritative.',
             },
             cockpit: {
                 roomTitle: 'Live room',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -218,6 +218,30 @@ export type Messages = {
         unavailableTitle: string;
         unavailableBody: string;
         recover: string;
+        lifecycle: {
+            heading: string;
+            status: string;
+            scheduled: string;
+            statuses: Record<'SCHEDULED' | 'LIVE' | 'ENDED' | 'CANCELLED', string>;
+            opening: string;
+            openDoors: string;
+            closeEvent: string;
+            disconnectRemaining: string;
+            outsideWindowOverride: string;
+            outsideWindowRestricted: string;
+            reasonLabel: string;
+            confirmHeading: string;
+            confirmBody: string;
+            disconnecting: string;
+            endAndDisconnect: string;
+            keepOpen: string;
+            doorsAlreadyOpen: string;
+            doorsOpened: string;
+            eventEnded: string;
+            eventCancelled: string;
+            disconnectIncomplete: string;
+            statusChangeFailed: string;
+        };
         cockpit: {
             roomTitle: string;
             roomHint: string;
@@ -444,6 +468,35 @@ export const messages: Record<UiLocale, Messages> = {
             unavailableTitle: 'Este evento no está disponible',
             unavailableBody: 'El enlace puede estar vencido o pertenecer a otro equipo. No se mostraron datos del evento.',
             recover: 'Volver a tus eventos',
+            lifecycle: {
+                heading: 'Puertas del evento',
+                status: 'Estado',
+                scheduled: 'programado para',
+                statuses: {
+                    SCHEDULED: 'Próximo',
+                    LIVE: 'En vivo',
+                    ENDED: 'Finalizado',
+                    CANCELLED: 'Cancelado',
+                },
+                opening: 'Abriendo…',
+                openDoors: 'Abrir puertas',
+                closeEvent: 'Cerrar evento',
+                disconnectRemaining: 'Desconectar conexiones restantes',
+                outsideWindowOverride: 'Estás fuera del horario normal de apertura. Hace falta dejar un motivo de auditoría.',
+                outsideWindowRestricted: 'Las puertas se pueden abrir desde 10 minutos antes hasta 60 minutos después del horario programado.',
+                reasonLabel: 'Motivo operativo (sin datos de participantes)',
+                confirmHeading: '¿Finalizar esta experiencia para todas las personas?',
+                confirmBody: 'Primero se detienen los nuevos ingresos. Luego se desconectan de inmediato la Escena y quienes escuchan el Beacon de este evento. Los demás eventos y la fuente del Beacon siguen en línea.',
+                disconnecting: 'Desconectando…',
+                endAndDisconnect: 'Finalizar y desconectar a todas las personas',
+                keepOpen: 'Mantener abierto',
+                doorsAlreadyOpen: 'Las puertas ya estaban abiertas.',
+                doorsOpened: 'Las puertas están abiertas. Las personas ya pueden entrar.',
+                eventEnded: 'Evento finalizado. Se desconectaron {stage} conexiones de Escena y {beacon} del Beacon.',
+                eventCancelled: 'Evento cancelado. Se desconectaron {stage} conexiones de Escena y {beacon} del Beacon.',
+                disconnectIncomplete: 'El evento se cerró, pero quedaron conexiones activas. Usá “Desconectar conexiones restantes” para volver a intentarlo.',
+                statusChangeFailed: 'No se pudo cambiar el estado del evento',
+            },
             cockpit: {
                 roomTitle: 'Sala en vivo',
                 roomHint: 'La escena permanece conectada mientras abrís las herramientas.',
@@ -668,6 +721,35 @@ export const messages: Record<UiLocale, Messages> = {
             unavailableTitle: 'This event is unavailable',
             unavailableBody: 'The link may be stale or belong to another team. No event details were disclosed.',
             recover: 'Return to your events',
+            lifecycle: {
+                heading: 'Event doors',
+                status: 'Status',
+                scheduled: 'scheduled',
+                statuses: {
+                    SCHEDULED: 'Upcoming',
+                    LIVE: 'Live',
+                    ENDED: 'Ended',
+                    CANCELLED: 'Cancelled',
+                },
+                opening: 'Opening…',
+                openDoors: 'Open doors',
+                closeEvent: 'Close event',
+                disconnectRemaining: 'Disconnect remaining clients',
+                outsideWindowOverride: 'This is outside the normal opening window. An audit reason is required.',
+                outsideWindowRestricted: 'Doors can open from 10 minutes before until 60 minutes after the scheduled start.',
+                reasonLabel: 'Operational reason (do not include attendee details)',
+                confirmHeading: 'End this experience for everyone?',
+                confirmBody: 'New entries stop first. Then every Stage connection and this event’s Beacon listeners are disconnected immediately. Other events and the Beacon source stay online.',
+                disconnecting: 'Disconnecting…',
+                endAndDisconnect: 'End & disconnect everyone',
+                keepOpen: 'Keep open',
+                doorsAlreadyOpen: 'Doors were already open.',
+                doorsOpened: 'Doors are open. Attendees are entering now.',
+                eventEnded: 'Event ended now. Disconnected {stage} Stage and {beacon} Beacon connections.',
+                eventCancelled: 'Event cancelled now. Disconnected {stage} Stage and {beacon} Beacon connections.',
+                disconnectIncomplete: 'Event closed, but an immediate media disconnect was incomplete. Use “Disconnect remaining clients” to retry.',
+                statusChangeFailed: 'Status change failed',
+            },
             cockpit: {
                 roomTitle: 'Live room',
                 roomHint: 'The scene stays connected while you open tools.',


### PR DESCRIPTION
Refs #65 and #68

## Outcome
- Localizes event lifecycle controls, confirmations, status feedback and time formatting in typed ES/EN dictionaries.
- Localizes the complete Spotlight workflow: hand queue, invitations, reconciliation, stage, media status, audience and staff role labels.
- Preserves the already validated English operational wording and adds direct Spanish component coverage.
- Makes the real-browser acceptance selectors explicitly bilingual across lifecycle, invitation, tapestry and consecutive ES to EN journeys.

## Evidence
- 676 Vitest tests passed; 7 opt-in integration tests skipped.
- TypeScript, ESLint and production build passed.
- Real local PostgreSQL + LiveKit acceptance passed 3/3: termination, invitation/reload/camera switch, and consecutive ES to EN FACILITATOR_OP lifecycles.

## Safety
- No audio paths, codec, bitrate, sample rate, buffer, gain, crossfader or room lifecycle logic changed.
- No database schema, production data or credentials changed.
- Rollback is a revert of this PR.