### PR TITLE
feat(i18n): localize operational support surfaces

### DIFF
--- a/e2e/tests/promo-invitation.spec.ts
+++ b/e2e/tests/promo-invitation.spec.ts
@@ -103,17 +103,17 @@ stackTest('controlled invitation becomes normal access, replays, then revokes an
 
             try {
                 await loginViaDashboard(staff, 'ADMIN', 'Invitation Admin', ROUTES.opsAdmission);
-                await staff.getByRole('button', { name: 'Load invitations' }).click();
-                await expect(staff.getByRole('status')).toContainText('Public redemption is ON');
-                await staff.getByLabel(/Internal label/).fill(CAMPAIGN_LABEL);
-                await staff.getByLabel(/Human code/).fill(PROMO_CODE);
-                await staff.getByLabel(/Expires/).fill(
+                await staff.getByRole('button', { name: /Load invitations|Cargar invitaciones/i }).click();
+                await expect(staff.getByRole('status')).toContainText(/Public redemption is ON|El canje público está ACTIVADO/i);
+                await staff.getByLabel(/Internal label|Etiqueta interna/i).fill(CAMPAIGN_LABEL);
+                await staff.getByLabel(/Human code|Código para personas/i).fill(PROMO_CODE);
+                await staff.getByLabel(/Expires|Vence/i).fill(
                     localDateTimeInput(new Date(Date.now() + 6 * 60 * 60 * 1000)),
                 );
-                await staff.getByLabel(/Redemption capacity/).fill('1');
-                await staff.getByRole('button', { name: 'Create invitation' }).click();
+                await staff.getByLabel(/Redemption capacity|Cupo de canjes/i).fill('1');
+                await staff.getByRole('button', { name: /Create invitation|Crear invitación/i }).click();
                 const campaign = staff.locator('article').filter({ hasText: CAMPAIGN_LABEL });
-                await expect(campaign).toContainText('0/1 redeemed');
+                await expect(campaign).toContainText(/0\/1 redeemed|0\/1 canjeadas/i);
 
                 await loginAttendeeWithTicket(firstGuest, {
                     name: 'Promotion Guest',
@@ -149,13 +149,13 @@ stackTest('controlled invitation becomes normal access, replays, then revokes an
                 );
                 const participantIdentity = await participantIdentityForCampaign(databaseUrl);
 
-                await staff.getByRole('button', { name: 'Refresh' }).click();
-                await expect(campaign).toContainText('1/1 redeemed');
-                await campaign.getByPlaceholder(/Disable reason/).fill('Synthetic campaign complete');
-                await campaign.getByRole('checkbox', { name: /Also revoke every entitlement/ }).check();
-                await campaign.getByRole('button', { name: 'Disable invitation' }).click();
-                await expect(campaign).toContainText('DISABLED');
-                await expect(staff.getByText(/1 derived access grant\(s\) revoked/)).toBeVisible();
+                await staff.getByRole('button', { name: /Refresh|Actualizar/i }).click();
+                await expect(campaign).toContainText(/1\/1 redeemed|1\/1 canjeadas/i);
+                await campaign.getByPlaceholder(/Disable reason|Motivo de desactivación/i).fill('Synthetic campaign complete');
+                await campaign.getByRole('checkbox', { name: /Also revoke every entitlement|Revocar también todos los accesos/i }).check();
+                await campaign.getByRole('button', { name: /Disable invitation|Desactivar invitación/i }).click();
+                await expect(campaign).toContainText(/Disabled|Desactivada/i);
+                await expect(staff.getByText(/1 derived access grant\(s\) revoked|Se revocaron 1 accesos derivados/i)).toBeVisible();
 
                 await expect.poll(async () => {
                     const response = await returningGuest.request.get(

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -120,11 +120,11 @@ stackTest.describe('fixture stack', () => {
         page,
     }) => {
         await loginViaDashboard(page, 'OPERATOR', 'E2E Operator', ROUTES.opsAdmission);
-        await expect(page.getByRole('heading', { name: /admission/i })).toBeVisible();
+        await expect(page.getByRole('heading', { name: /Admission support|Soporte de entradas/i })).toBeVisible();
     });
 
     stackTest('admin dashboard login reaches ops health', async ({ page }) => {
         await loginViaDashboard(page, 'ADMIN', 'E2E Admin', ROUTES.opsHealth);
-        await expect(page.getByRole('heading', { name: /health/i })).toBeVisible();
+        await expect(page.getByRole('heading', { name: /Event health|Salud del evento/i })).toBeVisible();
     });
 });

--- a/e2e/tests/whole-system.spec.ts
+++ b/e2e/tests/whole-system.spec.ts
@@ -109,10 +109,10 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
                         await staff.locator('[data-tool="admission"]').click();
                         const admission = staff.getByRole('dialog');
                         await admission.getByPlaceholder(
-                            'Attendee email, code last four, or entitlement ID',
+                            /Attendee email, code last four, or entitlement ID|Email, últimos cuatro caracteres del código o ID de acceso/i,
                         ).fill(session.id === SESSION_ES.id ? 'TESD' : 'TEND');
-                        await admission.getByRole('button', { name: 'Look up' }).click();
-                        await expect(admission.getByText('Last four:')).toBeVisible();
+                        await admission.getByRole('button', { name: /Look up|Buscar/i }).click();
+                        await expect(admission.getByText(/Last four:|Últimos cuatro:/i)).toBeVisible();
                         await expect(admission.getByText(
                             session.id === SESSION_ES.id ? 'TESD' : 'TEND',
                             { exact: true },

--- a/e2e/tests/whole-system.spec.ts
+++ b/e2e/tests/whole-system.spec.ts
@@ -121,9 +121,9 @@ stackTest('FACILITATOR_OP completes two consecutive event lifecycles without swi
 
                         await staff.locator('[data-signal="health"]').click();
                         const health = staff.getByRole('dialog');
-                        await health.getByRole('button', { name: 'Refresh now' }).click();
+                        await health.getByRole('button', { name: /Refresh now|Actualizar ahora/i }).click();
                         const healthSummary = health.locator('p').filter({
-                            hasText: /Watching session.*signed in as FACILITATOR_OP/i,
+                            hasText: /Watching session.*Facilitator and operations|Observando la sesión.*Facilitación y operaciones/i,
                         });
                         await expect(healthSummary).toBeVisible({ timeout: 15_000 });
                         await expect(healthSummary).toContainText(session.title);

--- a/src/app/ops/admission/page.tsx
+++ b/src/app/ops/admission/page.tsx
@@ -12,6 +12,8 @@ import { redirect } from 'next/navigation';
 
 import AdmissionConsole from '@/components/ops/AdmissionConsole';
 import { prisma } from '@/lib/db';
+import { messages } from '@/lib/i18n';
+import { requestLocale } from '@/lib/i18n-server';
 import { resolveStaffByToken } from '@/lib/ops-auth';
 import { SESSION_COOKIE_NAME } from '@/lib/session-auth';
 
@@ -28,15 +30,22 @@ export default async function AdmissionPage() {
         orderBy: { scheduledAt: 'asc' },
         select: { id: true, title: true, language: true, scheduledAt: true, attendeeCap: true },
     });
+    const locale = await requestLocale();
+    const copy = messages[locale].ops.admissionPanel;
+    const pageIntro = copy.pageIntro
+        .replace('{name}', staff.name)
+        .replace('{role}', messages[locale].staffRoles[staff.role]);
 
     return (
         <main className="mx-auto max-w-4xl px-4 py-8">
-            <h1 className="mb-1 text-2xl font-semibold">Admission support</h1>
+            <h1 className="mb-1 text-2xl font-semibold">{copy.pageTitle}</h1>
             <p className="mb-6 text-sm text-[var(--text-secondary)]">
-                Signed in as {staff.name} ({staff.role}). Every mutation requires a non-PII reason and is audited.
+                {pageIntro}
             </p>
             <AdmissionConsole
                 role={staff.role}
+                locale={locale}
+                copy={copy}
                 events={events.map((event) => ({
                     id: event.id,
                     title: event.title,

--- a/src/app/ops/events/[id]/page.tsx
+++ b/src/app/ops/events/[id]/page.tsx
@@ -103,6 +103,7 @@ export default async function EventPage({
                 spotlightCopy={copy.spotlight}
                 healthCopy={copy.healthPanel}
                 admissionCopy={copy.admissionPanel}
+                tapestryCopy={copy.tapestryArrange}
                 staffRoleLabels={messages[locale].staffRoles}
             />
         </section>

--- a/src/app/ops/events/[id]/page.tsx
+++ b/src/app/ops/events/[id]/page.tsx
@@ -102,6 +102,7 @@ export default async function EventPage({
                 lifecycleCopy={copy.lifecycle}
                 spotlightCopy={copy.spotlight}
                 healthCopy={copy.healthPanel}
+                admissionCopy={copy.admissionPanel}
                 staffRoleLabels={messages[locale].staffRoles}
             />
         </section>

--- a/src/app/ops/events/[id]/page.tsx
+++ b/src/app/ops/events/[id]/page.tsx
@@ -101,6 +101,7 @@ export default async function EventPage({
                 copy={copy.cockpit}
                 lifecycleCopy={copy.lifecycle}
                 spotlightCopy={copy.spotlight}
+                healthCopy={copy.healthPanel}
                 staffRoleLabels={messages[locale].staffRoles}
             />
         </section>

--- a/src/app/ops/health/OpsHealthClient.tsx
+++ b/src/app/ops/health/OpsHealthClient.tsx
@@ -12,7 +12,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { StaffRole } from '@prisma/client';
 
-import type { Messages, UiLocale } from '@/lib/i18n';
+import { messages, type Messages, type UiLocale } from '@/lib/i18n';
 import type { HealthLevel, OperatorHealthReport, SubsystemCheck } from '@/lib/ops-health';
 import ThumbnailTapestry from '@/components/session/ThumbnailTapestry';
 
@@ -182,7 +182,13 @@ export default function OpsHealthClient({
                 </ul>
             ) : null}
 
-            {report?.session ? <ThumbnailTapestry sessionId={report.session.id} staffOnly /> : null}
+            {report?.session ? (
+                <ThumbnailTapestry
+                    sessionId={report.session.id}
+                    staffOnly
+                    labels={messages[locale].tapestry}
+                />
+            ) : null}
 
             <div className="flex items-center justify-between text-xs text-[var(--text-secondary)]">
                 <span>

--- a/src/app/ops/health/OpsHealthClient.tsx
+++ b/src/app/ops/health/OpsHealthClient.tsx
@@ -10,19 +10,21 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { StaffRole } from '@prisma/client';
 
+import type { Messages, UiLocale } from '@/lib/i18n';
 import type { HealthLevel, OperatorHealthReport, SubsystemCheck } from '@/lib/ops-health';
 import ThumbnailTapestry from '@/components/session/ThumbnailTapestry';
 
 const POLL_INTERVAL_MS = 10_000;
 
-const CHECK_LABELS: Array<{ key: keyof OperatorHealthReport['checks']; label: string }> = [
-    { key: 'postgres', label: 'PostgreSQL' },
-    { key: 'livekit', label: 'LiveKit API' },
-    { key: 'stageRoom', label: 'Stage room' },
-    { key: 'publisherGrants', label: 'Publisher grants' },
-    { key: 'bedPublisher', label: 'Bed publisher (playlist bot)' },
-    { key: 'tapestry', label: 'Tapestry (cuttable)' },
+const CHECK_KEYS: Array<keyof OperatorHealthReport['checks']> = [
+    'postgres',
+    'livekit',
+    'stageRoom',
+    'publisherGrants',
+    'bedPublisher',
+    'tapestry',
 ];
 
 const LEVEL_STYLES: Record<HealthLevel, { banner: string; dot: string; text: string }> = {
@@ -43,13 +45,22 @@ const LEVEL_STYLES: Record<HealthLevel, { banner: string; dot: string; text: str
     },
 };
 
-const LEVEL_HEADLINES: Record<HealthLevel, string> = {
-    green: 'GREEN — all subsystems nominal',
-    yellow: 'YELLOW — degraded, cuttable subsystem failing',
-    red: 'RED — launch-blocking subsystem failing',
-};
+function fill(template: string, values: Record<string, string | number>): string {
+    return Object.entries(values).reduce(
+        (result, [key, value]) => result.replaceAll(`{${key}}`, String(value)),
+        template,
+    );
+}
 
-function CheckRow({ label, check }: { label: string; check: SubsystemCheck }) {
+function CheckRow({
+    label,
+    check,
+    copy,
+}: {
+    label: string;
+    check: SubsystemCheck;
+    copy: Messages['ops']['healthPanel'];
+}) {
     const styles = LEVEL_STYLES[check.status];
     return (
         <li className="flex items-start gap-3 rounded border border-[var(--border-subtle)] px-4 py-3">
@@ -61,7 +72,7 @@ function CheckRow({ label, check }: { label: string; check: SubsystemCheck }) {
                 <div className="flex items-baseline justify-between gap-3">
                     <span className="font-medium text-[var(--cream)]">{label}</span>
                     <span className={`text-xs font-semibold uppercase ${styles.text}`}>
-                        {check.status}
+                        {copy.levels[check.status]}
                     </span>
                 </div>
                 <p className="text-sm text-[var(--text-secondary)]">{check.detail}</p>
@@ -81,10 +92,16 @@ function CheckRow({ label, check }: { label: string; check: SubsystemCheck }) {
 export default function OpsHealthClient({
     role,
     sessionId,
+    locale,
+    copy,
+    staffRoles,
     onLevelChange,
 }: {
-    role: string;
+    role: StaffRole;
     sessionId?: string;
+    locale: UiLocale;
+    copy: Messages['ops']['healthPanel'];
+    staffRoles: Messages['staffRoles'];
     onLevelChange?: (level: HealthLevel) => void;
 }) {
     const [report, setReport] = useState<OperatorHealthReport | null>(null);
@@ -99,7 +116,7 @@ export default function OpsHealthClient({
                 : '/api/ops/health';
             const response = await fetch(endpoint, { cache: 'no-store' });
             if (!response.ok) {
-                throw new Error(`Endpoint answered HTTP ${response.status}`);
+                throw new Error(fill(copy.endpointHttp, { status: response.status }));
             }
             const body = (await response.json()) as OperatorHealthReport;
             if (mounted.current) {
@@ -110,7 +127,7 @@ export default function OpsHealthClient({
         } catch (error) {
             if (mounted.current) {
                 setEndpointError(
-                    error instanceof Error ? error.message : 'Health endpoint unreachable',
+                    error instanceof Error ? error.message : copy.endpointUnavailable,
                 );
                 onLevelChange?.('red');
             }
@@ -119,7 +136,7 @@ export default function OpsHealthClient({
                 setLoading(false);
             }
         }
-    }, [sessionId, onLevelChange]);
+    }, [sessionId, onLevelChange, copy.endpointHttp, copy.endpointUnavailable]);
 
     useEffect(() => {
         mounted.current = true;
@@ -138,29 +155,29 @@ export default function OpsHealthClient({
         <section className="space-y-4" aria-live="polite">
             <div className={`rounded-lg border px-4 py-3 font-semibold ${styles.banner}`}>
                 {endpointError
-                    ? `RED — health endpoint unreachable: ${endpointError}`
+                    ? fill(copy.endpointAlarm, { error: endpointError })
                     : report
-                      ? LEVEL_HEADLINES[report.status]
+                      ? copy.headlines[report.status]
                       : loading
-                        ? 'Checking subsystems…'
-                        : 'YELLOW — no report yet'}
+                        ? copy.checking
+                        : copy.noReport}
             </div>
 
             {report?.session ? (
                 <p className="text-sm text-[var(--text-secondary)]">
-                    Watching session <span className="font-medium text-[var(--cream)]">{report.session.title}</span>{' '}
-                    ({report.session.status}) — signed in as {role}.
+                    {copy.watchingSession} <span className="font-medium text-[var(--cream)]">{report.session.title}</span>{' '}
+                    ({copy.sessionStatuses[report.session.status]}) — {copy.signedInAs} {staffRoles[role]}.
                 </p>
             ) : (
                 <p className="text-sm text-[var(--text-secondary)]">
-                    No live or scheduled session is being watched — signed in as {role}.
+                    {copy.noSession} — {copy.signedInAs} {staffRoles[role]}.
                 </p>
             )}
 
             {report ? (
                 <ul className="space-y-2">
-                    {CHECK_LABELS.map(({ key, label }) => (
-                        <CheckRow key={key} label={label} check={report.checks[key]} />
+                    {CHECK_KEYS.map((key) => (
+                        <CheckRow key={key} label={copy.checks[key]} check={report.checks[key]} copy={copy} />
                     ))}
                 </ul>
             ) : null}
@@ -170,15 +187,15 @@ export default function OpsHealthClient({
             <div className="flex items-center justify-between text-xs text-[var(--text-secondary)]">
                 <span>
                     {report
-                        ? `Last checked ${new Date(report.checkedAt).toLocaleTimeString()} — refreshes every ${POLL_INTERVAL_MS / 1000}s`
-                        : 'Waiting for the first report…'}
+                        ? `${copy.lastChecked} ${new Date(report.checkedAt).toLocaleTimeString(locale === 'es' ? 'es-AR' : 'en-GB')} — ${fill(copy.refreshesEvery, { seconds: POLL_INTERVAL_MS / 1000 })}`
+                        : copy.waitingFirstReport}
                 </span>
                 <button
                     type="button"
                     onClick={() => void refresh()}
                     className="min-h-11 rounded border border-[var(--border-subtle)] px-3 py-2 text-xs hover:bg-white/5"
                 >
-                    Refresh now
+                    {copy.refreshNow}
                 </button>
             </div>
         </section>

--- a/src/app/ops/health/__tests__/OpsHealthClient.test.tsx
+++ b/src/app/ops/health/__tests__/OpsHealthClient.test.tsx
@@ -4,8 +4,15 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { OperatorHealthReport } from '@/lib/ops-health';
+import { messages } from '@/lib/i18n';
 
 import OpsHealthClient from '../OpsHealthClient';
+
+const englishProps = {
+    locale: 'en' as const,
+    copy: messages.en.ops.healthPanel,
+    staffRoles: messages.en.staffRoles,
+};
 
 function makeReport(overrides: Partial<OperatorHealthReport> = {}): OperatorHealthReport {
     return {
@@ -42,7 +49,7 @@ describe('OpsHealthClient', () => {
     });
 
     it('renders the green board with every subsystem row', async () => {
-        render(<OpsHealthClient role="OPERATOR" />);
+        render(<OpsHealthClient role="OPERATOR" {...englishProps} />);
 
         await waitFor(() => {
             expect(screen.getByText(/GREEN — all subsystems nominal/)).toBeInTheDocument();
@@ -71,7 +78,7 @@ describe('OpsHealthClient', () => {
         });
         vi.stubGlobal('fetch', mockFetchWith(report));
 
-        render(<OpsHealthClient role="ADMIN" />);
+        render(<OpsHealthClient role="ADMIN" {...englishProps} />);
 
         await waitFor(() => {
             expect(screen.getByText(/RED — launch-blocking subsystem failing/)).toBeInTheDocument();
@@ -94,17 +101,35 @@ describe('OpsHealthClient', () => {
         });
         vi.stubGlobal('fetch', mockFetchWith(report));
 
-        render(<OpsHealthClient role="OPERATOR" />);
+        render(<OpsHealthClient role="OPERATOR" {...englishProps} />);
 
         await waitFor(() => {
             expect(screen.getByText(/YELLOW — degraded/)).toBeInTheDocument();
         });
     });
 
+    it('renders the selected session, levels, role and refresh action in Spanish', async () => {
+        render(
+            <OpsHealthClient
+                role="FACILITATOR_OP"
+                locale="es"
+                copy={messages.es.ops.healthPanel}
+                staffRoles={messages.es.staffRoles}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(/VERDE — todos los subsistemas/)).toBeInTheDocument();
+        });
+        expect(screen.getByText('Sala de Escena')).toBeInTheDocument();
+        expect(screen.getByText(/identidad activa: Facilitación y operaciones/)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Actualizar ahora' })).toBeInTheDocument();
+    });
+
     it('treats an unreachable endpoint as its own red alarm', async () => {
         vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('NetworkError')));
 
-        render(<OpsHealthClient role="OPERATOR" />);
+        render(<OpsHealthClient role="OPERATOR" {...englishProps} />);
 
         await waitFor(() => {
             expect(screen.getByText(/health endpoint unreachable/)).toBeInTheDocument();
@@ -115,7 +140,7 @@ describe('OpsHealthClient', () => {
         const fetchMock = mockFetchWith(makeReport());
         vi.stubGlobal('fetch', fetchMock);
 
-        render(<OpsHealthClient role="OPERATOR" />);
+        render(<OpsHealthClient role="OPERATOR" {...englishProps} />);
         await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
         await userEvent.click(screen.getByRole('button', { name: 'Refresh now' }));

--- a/src/app/ops/health/page.tsx
+++ b/src/app/ops/health/page.tsx
@@ -10,6 +10,8 @@
 import { redirect } from 'next/navigation';
 
 import { currentPrincipal } from '@/lib/auth';
+import { messages } from '@/lib/i18n';
+import { requestLocale } from '@/lib/i18n-server';
 
 import OpsHealthClient from './OpsHealthClient';
 
@@ -28,14 +30,15 @@ export default async function OpsHealthPage({
     const sessionId = typeof requestedSessionId === 'string'
         ? requestedSessionId
         : undefined;
+    const locale = await requestLocale();
+    const copy = messages[locale].ops.healthPanel;
 
     return (
         <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-10">
             <header className="space-y-1">
-                <h1 className="text-2xl font-bold">Event health</h1>
+                <h1 className="text-2xl font-bold">{copy.pageTitle}</h1>
                 <p className="text-sm text-[var(--text-secondary)]">
-                    Live subsystem board for the weekend sessions. Red means launch-blocking;
-                    yellow means cuttable. Failure playbooks are in{' '}
+                    {copy.pageIntro}{' '}
                     <code>docs/ops/WEEKEND_EVENT_RUNBOOK.md</code>.
                 </p>
             </header>
@@ -43,6 +46,9 @@ export default async function OpsHealthPage({
             <OpsHealthClient
                 role={principal.role}
                 sessionId={sessionId}
+                locale={locale}
+                copy={copy}
+                staffRoles={messages[locale].staffRoles}
             />
         </main>
     );

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -247,6 +247,20 @@ function renderPage(locale: UiLocale = 'en') {
 }
 
 describe('SessionRoomPage - event entry', () => {
+    it('keeps backend details private and explains an entry check failure in the selected language', async () => {
+        vi.mocked(global.fetch).mockResolvedValue({
+            ok: false,
+            status: 503,
+            json: async () => ({ error: 'database connection refused at internal-host:5432' }),
+        } as Response);
+
+        renderPage('es');
+
+        expect(await screen.findByText('No se pudo comprobar el ingreso')).toBeInTheDocument();
+        expect(screen.queryByText(/internal-host/)).toBeNull();
+        expect(screen.getByRole('button', { name: 'Intentar de nuevo' })).toBeInTheDocument();
+    });
+
     it('shows a truthful waiting room and mints no LiveKit token before doors open', async () => {
         vi.mocked(global.fetch).mockImplementation((url: string | URL | Request) => {
             if (String(url).includes('/entry')) {
@@ -995,7 +1009,8 @@ describe('SessionRoomPage - initial connection failure', () => {
         });
 
         renderPage();
-        expect(await screen.findByText('Room is temporarily unavailable')).toBeInTheDocument();
+        expect(await screen.findByText('We could not enter the room. Your access is still confirmed; try again.')).toBeInTheDocument();
+        expect(screen.queryByText('Room is temporarily unavailable')).toBeNull();
 
         fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
         expect(screen.getByText('Connecting')).toBeInTheDocument();

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -179,7 +179,7 @@ function SessionRoom() {
     const [sessionInfo, setSessionInfo] = useState<SessionInfo | null>(null);
     const [isConnected, setIsConnected] = useState(false);
     const [isConnecting, setIsConnecting] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+    const [connectionError, setConnectionError] = useState(false);
     const [canPublish, setCanPublish] = useState(false);
     const [principalKind, setPrincipalKind] = useState<"ticket" | "staff">("ticket");
     const [isMicOn, setIsMicOn] = useState(false);
@@ -354,7 +354,7 @@ function SessionRoom() {
         setDisconnectState(null);
         setIsConnected(false);
         setIsConnecting(true);
-        setError(null);
+        setConnectionError(false);
         setAudioActivationError(null);
         setRetryToken((t) => t + 1);
     }, []);
@@ -609,7 +609,7 @@ function SessionRoom() {
                 setIsConnected(true);
                 setIsConnecting(false);
                 setDisconnectState(null);
-                setError(null);
+                setConnectionError(false);
                 autoReconnectAttemptRef.current = 0;
                 if (autoReconnectTimerRef.current) {
                     clearTimeout(autoReconnectTimerRef.current);
@@ -643,7 +643,8 @@ function SessionRoom() {
                     if (autoReconnectAttemptRef.current > 0) {
                         scheduleAutoReconnect();
                     } else {
-                        setError(e instanceof Error ? e.message : "Failed to connect");
+                        console.error("Failed to connect to the stage room:", redactErrorDetail(e));
+                        setConnectionError(true);
                         setIsConnecting(false);
                     }
                 }
@@ -836,14 +837,14 @@ function SessionRoom() {
     }
 
     // Error state
-    if (error) {
+    if (connectionError) {
         return (
             <main className="event-shell">
                 <div className="relative z-10 flex min-h-screen items-center justify-center px-4">
                     <div className="event-card w-full max-w-sm text-center">
                         <div className="terminal-state__icon text-[var(--danger)]">&#9888;</div>
                         <h2 className="terminal-state__title">{copy.session.connectionErrorHeading}</h2>
-                        <p className="terminal-state__body">{error}</p>
+                        <p className="terminal-state__body">{copy.session.connectionUnavailable}</p>
                         <div className="mt-4 flex flex-col gap-2">
                             <button onClick={rejoin} className="event-button event-button--primary w-full">
                                 {copy.session.tryAgain}
@@ -1293,7 +1294,8 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
                 }
             } catch (failure) {
                 if (!cancelled) {
-                    setEntryError(failure instanceof Error ? failure.message : copy.session.entryUnavailable);
+                    console.error('Failed to confirm event entry:', redactErrorDetail(failure));
+                    setEntryError(copy.session.entryUnavailable);
                 }
             } finally {
                 inFlight = false;

--- a/src/components/ops/AdmissionConsole.tsx
+++ b/src/components/ops/AdmissionConsole.tsx
@@ -12,6 +12,7 @@
 import { useState, type FormEvent } from 'react';
 import type { StaffRole } from '@prisma/client';
 
+import type { Messages, UiLocale } from '@/lib/i18n';
 import { hasStaffCapability } from '@/lib/staff-capabilities';
 
 type EventOption = {
@@ -61,6 +62,8 @@ type PromoCampaign = {
 type Props = {
     role: StaffRole;
     events: EventOption[];
+    locale: UiLocale;
+    copy: Messages['ops']['admissionPanel'];
 };
 
 async function postJson(url: string, body: unknown): Promise<{ status: number; data: Record<string, unknown> }> {
@@ -73,12 +76,23 @@ async function postJson(url: string, body: unknown): Promise<{ status: number; d
     return { status: response.status, data };
 }
 
-function errorMessage(status: number, data: Record<string, unknown>): string {
-    const detail = typeof data.message === 'string' ? data.message : 'Unexpected error';
+function fill(template: string, values: Record<string, string | number>): string {
+    return Object.entries(values).reduce(
+        (result, [key, value]) => result.replaceAll(`{${key}}`, String(value)),
+        template,
+    );
+}
+
+function errorMessage(
+    status: number,
+    data: Record<string, unknown>,
+    copy: Messages['ops']['admissionPanel'],
+): string {
+    const detail = typeof data.message === 'string' ? data.message : copy.unexpectedError;
     return `${detail} (HTTP ${status})`;
 }
 
-export default function AdmissionConsole({ role, events }: Props) {
+export default function AdmissionConsole({ role, events, locale, copy }: Props) {
     const canMutate = hasStaffCapability(role, 'mutate_entitlement');
     const canBatch = hasStaffCapability(role, 'manage_ticket_batches');
     const canIssueComp = hasStaffCapability(role, 'issue_comp');
@@ -123,12 +137,12 @@ export default function AdmissionConsole({ role, events }: Props) {
             const response = await fetch(`/api/ops/admission?q=${encodeURIComponent(query)}`);
             const data = await response.json();
             if (!response.ok) {
-                flash(null, errorMessage(response.status, data));
+                flash(null, errorMessage(response.status, data, copy));
                 setResults(null);
             } else {
                 setResults(data.results as Entitlement[]);
                 if ((data.results as Entitlement[]).length === 0) {
-                    flash('No matching entitlements.', null);
+                    flash(copy.notices.noMatches, null);
                 }
             }
         } finally {
@@ -146,14 +160,14 @@ export default function AdmissionConsole({ role, events }: Props) {
                 ...(email !== undefined ? { email } : {}),
             });
             if (status >= 400) {
-                flash(null, errorMessage(status, data));
+                flash(null, errorMessage(status, data, copy));
             } else {
                 flash(
                     action === 'revoke'
-                        ? 'Access suspended or revoked.'
+                        ? copy.notices.accessRevoked
                         : action === 'resume'
-                            ? 'Administrative suspension cleared.'
-                            : 'Binding updated.',
+                            ? copy.notices.suspensionCleared
+                            : copy.notices.bindingUpdated,
                     null,
                 );
                 setResults((current) =>
@@ -193,12 +207,15 @@ export default function AdmissionConsole({ role, events }: Props) {
                 : { action, sessionId: batchEvent, tier: batchTier, csv: importCsv };
             const { status, data } = await postJson('/api/ops/admission', body);
             if (status >= 400) {
-                flash(null, errorMessage(status, data));
+                flash(null, errorMessage(status, data, copy));
             } else if (action === 'generate') {
                 setOneTimeCsv(data.csv as string);
-                flash('Batch generated. Copy or download the CSV now — it is shown only once.', null);
+                flash(copy.notices.batchGenerated, null);
             } else {
-                flash(`Import complete: ${data.created} created, ${data.skipped} skipped (already existed).`, null);
+                flash(fill(copy.notices.importComplete, {
+                    created: String(data.created),
+                    skipped: String(data.skipped),
+                }), null);
             }
         } finally {
             setBusy(false);
@@ -217,11 +234,11 @@ export default function AdmissionConsole({ role, events }: Props) {
                 reason: compReason,
             });
             if (status >= 400) {
-                flash(null, errorMessage(status, data));
+                flash(null, errorMessage(status, data, copy));
             } else {
                 setOneTimeCsv(data.csv as string);
                 setCompReason('');
-                flash('Comp/override issued. Copy or download the CSV now — it is shown only once.', null);
+                flash(copy.notices.compIssued, null);
             }
         } finally {
             setBusy(false);
@@ -235,7 +252,7 @@ export default function AdmissionConsole({ role, events }: Props) {
             const response = await fetch('/api/ops/invitations');
             const data = await response.json() as Record<string, unknown>;
             if (!response.ok) {
-                flash(null, errorMessage(response.status, data));
+                flash(null, errorMessage(response.status, data, copy));
                 return;
             }
             setPromoCampaigns(data.campaigns as PromoCampaign[]);
@@ -257,7 +274,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                 maxRedemptions: Number(promoCapacity),
             });
             if (status >= 400) {
-                flash(null, errorMessage(status, data));
+                flash(null, errorMessage(status, data, copy));
                 return;
             }
             const campaign = data.campaign as PromoCampaign;
@@ -267,8 +284,8 @@ export default function AdmissionConsole({ role, events }: Props) {
             setPromoLabel('');
             flash(
                 data.redemptionEnabled
-                    ? 'Invitation created and ready to redeem.'
-                    : 'Invitation created, but the global redemption switch remains OFF.',
+                    ? copy.notices.invitationReady
+                    : copy.notices.invitationSwitchOff,
                 null,
             );
         } finally {
@@ -286,7 +303,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                 revokeDerived: promoRevokeDerived[id] ?? false,
             });
             if (status >= 400) {
-                flash(null, errorMessage(status, data));
+                flash(null, errorMessage(status, data, copy));
                 return;
             }
             setPromoCampaigns((current) => current?.map((campaign) =>
@@ -296,8 +313,10 @@ export default function AdmissionConsole({ role, events }: Props) {
             ) ?? null);
             flash(
                 data.mediaCleanupFailed
-                    ? 'Invitation disabled and access revoked; some live connections need a retry.'
-                    : `Invitation disabled. ${data.revokedEntitlements} derived access grant(s) revoked.`,
+                    ? copy.notices.invitationCleanupFailed
+                    : fill(copy.notices.invitationDisabled, {
+                        count: String(data.revokedEntitlements),
+                    }),
                 null,
             );
         } finally {
@@ -319,11 +338,11 @@ export default function AdmissionConsole({ role, events }: Props) {
     return (
         <div className="space-y-10">
             <section>
-                <h2 className="mb-2 text-lg font-medium text-[var(--cream)]">Ticket lookup</h2>
+                <h2 className="mb-2 text-lg font-medium text-[var(--cream)]">{copy.lookup.heading}</h2>
                 <form onSubmit={runLookup} className="flex gap-2">
                     <input
                         className="event-field flex-1"
-                        placeholder="Attendee email, code last four, or entitlement ID"
+                        placeholder={copy.lookup.placeholder}
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}
                     />
@@ -332,7 +351,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                         disabled={busy || !query.trim()}
                         className="event-button event-button--primary"
                     >
-                        Look up
+                        {copy.lookup.action}
                     </button>
                 </form>
 
@@ -341,30 +360,30 @@ export default function AdmissionConsole({ role, events }: Props) {
                         {results.map((item) => (
                             <div key={item.id} className="operational-panel text-sm">
                                 <div className="flex flex-wrap gap-x-6 gap-y-1">
-                                    <span><strong className="text-[var(--cream)]">State:</strong> {item.state}</span>
-                                    <span><strong className="text-[var(--cream)]">Tier:</strong> {item.tier}</span>
-                                    <span><strong className="text-[var(--cream)]">Last four:</strong> <span className="font-mono">{item.codeLastFour}</span></span>
-                                    <span><strong className="text-[var(--cream)]">Bound email:</strong> {item.boundEmail ?? '—'}</span>
-                                    <span><strong className="text-[var(--cream)]">Event:</strong> {item.event.title}</span>
-                                    <span><strong className="text-[var(--cream)]">Expires:</strong> {new Date(item.expiresAt).toLocaleString()}</span>
+                                    <span><strong className="text-[var(--cream)]">{copy.labels.state}</strong> {copy.values[item.state as keyof typeof copy.values] ?? item.state}</span>
+                                    <span><strong className="text-[var(--cream)]">{copy.labels.tier}</strong> {copy.tiers[item.tier as keyof typeof copy.tiers] ?? item.tier}</span>
+                                    <span><strong className="text-[var(--cream)]">{copy.labels.lastFour}</strong> <span className="font-mono">{item.codeLastFour}</span></span>
+                                    <span><strong className="text-[var(--cream)]">{copy.labels.boundEmail}</strong> {item.boundEmail ?? '—'}</span>
+                                    <span><strong className="text-[var(--cream)]">{copy.labels.event}</strong> {item.event.title}</span>
+                                    <span><strong className="text-[var(--cream)]">{copy.labels.expires}</strong> {new Date(item.expiresAt).toLocaleString(locale === 'es' ? 'es-AR' : 'en-GB')}</span>
                                     {item.commerce && (
                                         <span>
-                                            <strong className="text-[var(--cream)]">Commerce:</strong>{' '}
-                                            {item.commerce.providerState} · admin {item.commerce.administrativeState} · media {item.commerce.mediaStatus}
+                                            <strong className="text-[var(--cream)]">{copy.labels.commerce}</strong>{' '}
+                                            {copy.values[item.commerce.providerState]} · {copy.labels.admin} {copy.values[item.commerce.administrativeState]} · {copy.labels.media} {copy.values[item.commerce.mediaStatus as keyof typeof copy.values] ?? item.commerce.mediaStatus}
                                         </span>
                                     )}
                                     {item.promotion && (
                                         <span>
-                                            <strong className="text-[var(--cream)]">Invitation:</strong>{' '}
-                                            {item.promotion.label} · campaign {item.promotion.status} · redeemed{' '}
-                                            {new Date(item.promotion.redeemedAt).toLocaleString()}
+                                            <strong className="text-[var(--cream)]">{copy.labels.invitation}</strong>{' '}
+                                            {item.promotion.label} · {copy.labels.campaign} {copy.values[item.promotion.status]} · {copy.labels.redeemed}{' '}
+                                            {new Date(item.promotion.redeemedAt).toLocaleString(locale === 'es' ? 'es-AR' : 'en-GB')}
                                         </span>
                                     )}
                                 </div>
                                 <div className="mt-1 font-mono text-[10px] text-[var(--text-muted)]">ID: {item.id}</div>
                                 {item.revokedAt && (
                                     <div className="mt-1 text-xs text-[var(--danger)]">
-                                        Revoked {new Date(item.revokedAt).toLocaleString()} — {item.revocationReason}
+                                        {copy.labels.revoked} {new Date(item.revokedAt).toLocaleString(locale === 'es' ? 'es-AR' : 'en-GB')} — {item.revocationReason}
                                     </div>
                                 )}
 
@@ -372,7 +391,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[var(--border-subtle)] pt-3">
                                         <input
                                             className="event-field min-w-56 flex-1"
-                                            placeholder="Reason (required, no PII)"
+                                            placeholder={copy.actions.reason}
                                             value={reasons[item.id] ?? ''}
                                             onChange={(event) =>
                                                 setReasons((current) => ({ ...current, [item.id]: event.target.value }))
@@ -382,7 +401,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                             <>
                                                 <input
                                                     className="event-field min-w-56 flex-1"
-                                                    placeholder="New email (optional rebind)"
+                                                    placeholder={copy.actions.newEmail}
                                                     value={emails[item.id] ?? ''}
                                                     onChange={(event) =>
                                                         setEmails((current) => ({ ...current, [item.id]: event.target.value }))
@@ -394,7 +413,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                                     onClick={() => runEntitlementAction(item.id, 'rebind', emails[item.id] ?? '')}
                                                     className="event-button event-button--secondary disabled:opacity-50"
                                                 >
-                                                    {(emails[item.id] ?? '').trim() ? 'Rebind to email' : 'Clear binding'}
+                                                    {(emails[item.id] ?? '').trim() ? copy.actions.rebind : copy.actions.clearBinding}
                                                 </button>
                                             </>
                                         )}
@@ -405,7 +424,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                                 onClick={() => runEntitlementAction(item.id, 'resume')}
                                                 className="event-button event-button--primary disabled:opacity-50"
                                             >
-                                                Resume access
+                                                {copy.actions.resume}
                                             </button>
                                         ) : (
                                             <button
@@ -414,7 +433,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                                 onClick={() => runEntitlementAction(item.id, 'revoke')}
                                                 className="event-button bg-[var(--danger)] text-white hover:bg-[var(--danger)]/80 disabled:opacity-50"
                                             >
-                                                {item.commerce ? 'Suspend access' : 'Revoke'}
+                                                {item.commerce ? copy.actions.suspend : copy.actions.revoke}
                                             </button>
                                         )}
                                     </div>
@@ -427,17 +446,17 @@ export default function AdmissionConsole({ role, events }: Props) {
 
             {(canBatch || canMutate) && (
                 <section>
-                    <h2 className="mb-2 text-lg font-medium text-[var(--cream)]">Issue tickets</h2>
+                    <h2 className="mb-2 text-lg font-medium text-[var(--cream)]">{copy.tickets.heading}</h2>
                     <div className="mb-3 flex flex-wrap gap-2">
                         <select
                             className="event-field"
-                            aria-label="Event"
+                            aria-label={copy.tickets.eventLabel}
                             value={batchEvent}
                             onChange={(event) => setBatchEvent(event.target.value)}
                         >
                             {events.map((event) => (
                                 <option key={event.id} value={event.id}>
-                                    {event.title} ({event.language}, cap {event.attendeeCap})
+                                    {event.title} ({event.language === 'SPANISH' ? 'ES' : 'EN'}, {copy.labels.cap} {event.attendeeCap})
                                 </option>
                             ))}
                         </select>
@@ -445,16 +464,16 @@ export default function AdmissionConsole({ role, events }: Props) {
 
                     {canBatch && (
                         <div className="operational-panel mb-6 space-y-3">
-                            <h3 className="font-medium text-[var(--cream)]">Batch (ADMIN)</h3>
+                            <h3 className="font-medium text-[var(--cream)]">{copy.tickets.batchHeading}</h3>
                             <div className="flex flex-wrap items-center gap-2">
                                 <select
                                     className="event-field"
-                                    aria-label="Ticket tier"
+                                    aria-label={copy.tickets.tierLabel}
                                     value={batchTier}
                                     onChange={(event) => setBatchTier(event.target.value)}
                                 >
-                                    <option value="GLOBAL_NORTH">Global North ($50)</option>
-                                    <option value="GLOBAL_SOUTH">Global South ($20)</option>
+                                    <option value="GLOBAL_NORTH">{copy.tickets.globalNorth}</option>
+                                    <option value="GLOBAL_SOUTH">{copy.tickets.globalSouth}</option>
                                 </select>
                                 <input
                                     className="event-field w-24"
@@ -470,12 +489,12 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     onClick={() => runBatch('generate')}
                                     className="event-button event-button--primary disabled:opacity-50"
                                 >
-                                    Generate batch
+                                    {copy.tickets.generate}
                                 </button>
                             </div>
                             <textarea
                                 className="event-field h-24 font-mono text-xs"
-                                placeholder="Paste platform CSV to import (code column, header optional)"
+                                placeholder={copy.tickets.importPlaceholder}
                                 value={importCsv}
                                 onChange={(event) => setImportCsv(event.target.value)}
                             />
@@ -485,27 +504,27 @@ export default function AdmissionConsole({ role, events }: Props) {
                                 onClick={() => runBatch('import')}
                                 className="event-button event-button--secondary disabled:opacity-50"
                             >
-                                Import CSV (idempotent)
+                                {copy.tickets.importAction}
                             </button>
                         </div>
                     )}
 
                     {canMutate && (
                         <div className="operational-panel space-y-3">
-                            <h3 className="font-medium text-[var(--cream)]">Comp / support override</h3>
+                            <h3 className="font-medium text-[var(--cream)]">{copy.tickets.overrideHeading}</h3>
                             <div className="flex flex-wrap items-center gap-2">
                                 <select
                                     className="event-field"
-                                    aria-label="Override tier"
+                                    aria-label={copy.tickets.overrideTier}
                                     value={compTier}
                                     onChange={(event) => setCompTier(event.target.value)}
                                 >
-                                    {canIssueComp && <option value="COMP">Comp</option>}
-                                    <option value="SUPPORT_OVERRIDE">Support override</option>
+                                    {canIssueComp && <option value="COMP">{copy.tickets.comp}</option>}
+                                    <option value="SUPPORT_OVERRIDE">{copy.tickets.supportOverride}</option>
                                 </select>
                                 <input
                                     className="event-field min-w-56 flex-1"
-                                    placeholder="Reason (required, no PII — e.g. support case reference)"
+                                    placeholder={copy.tickets.overrideReason}
                                     value={compReason}
                                     onChange={(event) => setCompReason(event.target.value)}
                                 />
@@ -515,7 +534,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     onClick={runComp}
                                     className="event-button event-button--primary disabled:opacity-50"
                                 >
-                                    Issue
+                                    {copy.tickets.issue}
                                 </button>
                             </div>
                         </div>
@@ -528,11 +547,10 @@ export default function AdmissionConsole({ role, events }: Props) {
                     <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
                         <div>
                             <h2 id="promo-invitations-heading" className="text-lg font-medium text-[var(--cream)]">
-                                Controlled invitations
+                                {copy.invitations.heading}
                             </h2>
                             <p className="mt-1 max-w-2xl text-xs leading-5 text-[var(--text-secondary)]">
-                                A short code creates the same session-scoped COMP entitlement as normal admission.
-                                Codes are stored only as digests; capacity, expiry and revocation remain enforced.
+                                {copy.invitations.help}
                             </p>
                         </div>
                         <button
@@ -541,7 +559,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                             disabled={busy}
                             className="event-button event-button--secondary disabled:opacity-50"
                         >
-                            {promoCampaigns === null ? 'Load invitations' : 'Refresh'}
+                            {promoCampaigns === null ? copy.invitations.load : copy.invitations.refresh}
                         </button>
                     </div>
 
@@ -552,26 +570,28 @@ export default function AdmissionConsole({ role, events }: Props) {
                                 ? 'border-[var(--lime)]/30 bg-[var(--lime)]/10 text-[var(--lime)]'
                                 : 'border-[var(--warning)]/30 bg-[var(--warning)]/10 text-[var(--warning)]'}`}
                         >
-                            Public redemption is {promoRedemptionEnabled ? 'ON' : 'OFF'}.
+                            {fill(copy.invitations.redemptionStatus, {
+                                status: promoRedemptionEnabled ? copy.invitations.on : copy.invitations.off,
+                            })}
                         </p>
                     )}
 
                     {canIssueComp && (
                         <div className="operational-panel mb-4 space-y-3">
-                            <h3 className="font-medium text-[var(--cream)]">Create bounded invitation</h3>
+                            <h3 className="font-medium text-[var(--cream)]">{copy.invitations.createHeading}</h3>
                             <div className="grid gap-3 sm:grid-cols-2">
                                 <label className="text-xs text-[var(--text-secondary)]">
-                                    Internal label (never the code)
+                                    {copy.invitations.internalLabel}
                                     <input
                                         className="event-field mt-1"
                                         value={promoLabel}
                                         maxLength={80}
                                         onChange={(event) => setPromoLabel(event.target.value)}
-                                        placeholder="Guest list — morning ES"
+                                        placeholder={copy.invitations.internalPlaceholder}
                                     />
                                 </label>
                                 <label className="text-xs text-[var(--text-secondary)]">
-                                    Human code (6–15 characters)
+                                    {copy.invitations.humanCode}
                                     <input
                                         className="event-field mt-1 font-mono uppercase"
                                         value={promoCode}
@@ -583,7 +603,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     />
                                 </label>
                                 <label className="text-xs text-[var(--text-secondary)]">
-                                    Expires (within seven days)
+                                    {copy.invitations.expiresWithin}
                                     <input
                                         className="event-field mt-1"
                                         type="datetime-local"
@@ -592,7 +612,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                     />
                                 </label>
                                 <label className="text-xs text-[var(--text-secondary)]">
-                                    Redemption capacity
+                                    {copy.invitations.capacity}
                                     <input
                                         className="event-field mt-1"
                                         type="number"
@@ -609,7 +629,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                 onClick={createPromoCampaign}
                                 className="event-button event-button--primary disabled:opacity-50"
                             >
-                                Create invitation
+                                {copy.invitations.create}
                             </button>
                         </div>
                     )}
@@ -617,7 +637,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                     {promoCampaigns && (
                         <div className="space-y-3">
                             {promoCampaigns.length === 0 && (
-                                <p className="text-sm text-[var(--text-secondary)]">No invitations created.</p>
+                                <p className="text-sm text-[var(--text-secondary)]">{copy.invitations.none}</p>
                             )}
                             {promoCampaigns.map((campaign) => (
                                 <article key={campaign.id} className="operational-panel text-sm">
@@ -625,16 +645,19 @@ export default function AdmissionConsole({ role, events }: Props) {
                                         <div>
                                             <strong className="text-[var(--cream)]">{campaign.label}</strong>
                                             <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                                                {campaign.event.title} · {campaign.redemptionCount}/{campaign.maxRedemptions} redeemed · expires {new Date(campaign.expiresAt).toLocaleString()}
+                                                {campaign.event.title} · {fill(copy.invitations.redeemedCount, {
+                                                    count: campaign.redemptionCount,
+                                                    max: campaign.maxRedemptions,
+                                                })} · {copy.invitations.expires} {new Date(campaign.expiresAt).toLocaleString(locale === 'es' ? 'es-AR' : 'en-GB')}
                                             </p>
                                         </div>
-                                        <span className="font-mono text-xs text-[var(--gold)]">{campaign.status}</span>
+                                        <span className="font-mono text-xs text-[var(--gold)]">{copy.values[campaign.status]}</span>
                                     </div>
                                     {canMutate && (campaign.status === 'ACTIVE' || campaign.redemptionCount > 0) && (
                                         <div className="mt-3 space-y-2 border-t border-[var(--border-subtle)] pt-3">
                                             <input
                                                 className="event-field"
-                                                placeholder="Disable reason (required, no PII)"
+                                                placeholder={copy.invitations.disableReason}
                                                 value={promoReasons[campaign.id] ?? ''}
                                                 onChange={(event) => setPromoReasons((current) => ({
                                                     ...current,
@@ -650,7 +673,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                                                         [campaign.id]: event.target.checked,
                                                     }))}
                                                 />
-                                                Also revoke every entitlement already redeemed and disconnect its live media.
+                                                {copy.invitations.revokeDerived}
                                             </label>
                                             <button
                                                 type="button"
@@ -663,8 +686,8 @@ export default function AdmissionConsole({ role, events }: Props) {
                                                 className="event-button bg-[var(--danger)] text-white hover:bg-[var(--danger)]/80 disabled:opacity-50"
                                             >
                                                 {campaign.status === 'ACTIVE'
-                                                    ? 'Disable invitation'
-                                                    : 'Retry revoke / disconnect'}
+                                                    ? copy.invitations.disable
+                                                    : copy.invitations.retryDisconnect}
                                             </button>
                                         </div>
                                     )}
@@ -680,10 +703,9 @@ export default function AdmissionConsole({ role, events }: Props) {
 
             {oneTimeCsv && (
                 <section className="rounded border-2 border-[var(--warning)] p-3">
-                    <h3 className="mb-1 font-medium text-[var(--warning)]">One-time code export</h3>
+                    <h3 className="mb-1 font-medium text-[var(--warning)]">{copy.export.heading}</h3>
                     <p className="mb-2 text-sm text-[var(--warning)]">
-                        These plaintext codes are shown once and are never stored by the app. Save the CSV
-                        under ops control now; do not commit it or paste it into tickets/chat.
+                        {copy.export.warning}
                     </p>
                     <textarea
                         readOnly
@@ -696,7 +718,7 @@ export default function AdmissionConsole({ role, events }: Props) {
                         onClick={downloadCsv}
                         className="event-button mt-2 bg-[var(--warning)] text-[var(--ink)] hover:bg-[var(--warning)]/80"
                     >
-                        Download CSV
+                        {copy.export.download}
                     </button>
                 </section>
             )}

--- a/src/components/ops/ConductorCockpit.tsx
+++ b/src/components/ops/ConductorCockpit.tsx
@@ -37,6 +37,7 @@ type Props = {
     copy: Messages['ops']['cockpit'];
     lifecycleCopy: Messages['ops']['lifecycle'];
     spotlightCopy: Messages['ops']['spotlight'];
+    healthCopy: Messages['ops']['healthPanel'];
     staffRoleLabels: Messages['staffRoles'];
 };
 
@@ -63,6 +64,7 @@ export default function ConductorCockpit({
     copy,
     lifecycleCopy,
     spotlightCopy,
+    healthCopy,
     staffRoleLabels,
 }: Props) {
     const [drawer, setDrawer] = useState<Drawer | null>(null);
@@ -319,6 +321,9 @@ export default function ConductorCockpit({
                         <OpsHealthClient
                             role={role}
                             sessionId={session.id}
+                            locale={locale}
+                            copy={healthCopy}
+                            staffRoles={staffRoleLabels}
                             onLevelChange={onHealthChange}
                         />
                     </div>

--- a/src/components/ops/ConductorCockpit.tsx
+++ b/src/components/ops/ConductorCockpit.tsx
@@ -38,6 +38,7 @@ type Props = {
     lifecycleCopy: Messages['ops']['lifecycle'];
     spotlightCopy: Messages['ops']['spotlight'];
     healthCopy: Messages['ops']['healthPanel'];
+    admissionCopy: Messages['ops']['admissionPanel'];
     staffRoleLabels: Messages['staffRoles'];
 };
 
@@ -65,6 +66,7 @@ export default function ConductorCockpit({
     lifecycleCopy,
     spotlightCopy,
     healthCopy,
+    admissionCopy,
     staffRoleLabels,
 }: Props) {
     const [drawer, setDrawer] = useState<Drawer | null>(null);
@@ -315,7 +317,12 @@ export default function ConductorCockpit({
                         <TapestryArrange sessionId={session.id} />
                     </div>
                     <div hidden={drawer !== 'admission'}>
-                        <AdmissionConsole role={role} events={admissionEvents} />
+                        <AdmissionConsole
+                            role={role}
+                            events={admissionEvents}
+                            locale={locale}
+                            copy={admissionCopy}
+                        />
                     </div>
                     <div hidden={drawer !== 'health'}>
                         <OpsHealthClient

--- a/src/components/ops/ConductorCockpit.tsx
+++ b/src/components/ops/ConductorCockpit.tsx
@@ -39,6 +39,7 @@ type Props = {
     spotlightCopy: Messages['ops']['spotlight'];
     healthCopy: Messages['ops']['healthPanel'];
     admissionCopy: Messages['ops']['admissionPanel'];
+    tapestryCopy: Messages['ops']['tapestryArrange'];
     staffRoleLabels: Messages['staffRoles'];
 };
 
@@ -67,6 +68,7 @@ export default function ConductorCockpit({
     spotlightCopy,
     healthCopy,
     admissionCopy,
+    tapestryCopy,
     staffRoleLabels,
 }: Props) {
     const [drawer, setDrawer] = useState<Drawer | null>(null);
@@ -314,7 +316,7 @@ export default function ConductorCockpit({
                         />
                     </div>
                     <div hidden={drawer !== 'tapestry'}>
-                        <TapestryArrange sessionId={session.id} />
+                        <TapestryArrange sessionId={session.id} copy={tapestryCopy} />
                     </div>
                     <div hidden={drawer !== 'admission'}>
                         <AdmissionConsole

--- a/src/components/ops/TapestryArrange.tsx
+++ b/src/components/ops/TapestryArrange.tsx
@@ -10,12 +10,20 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Messages } from '@/lib/i18n';
 
 const REFRESH_INTERVAL_MS = 5_000;
 
-type Props = { sessionId: string };
+type Props = {
+    sessionId: string;
+    copy: Messages['ops']['tapestryArrange'];
+};
 
-export default function TapestryArrange({ sessionId }: Props) {
+function fill(template: string, index: number): string {
+    return template.replace('{index}', String(index));
+}
+
+export default function TapestryArrange({ sessionId, copy }: Props) {
     const [order, setOrder] = useState<string[]>([]);
     const [dirty, setDirty] = useState(false);
     const [saving, setSaving] = useState(false);
@@ -80,9 +88,9 @@ export default function TapestryArrange({ sessionId }: Props) {
                 throw new Error(`HTTP ${response.status}`);
             }
             setDirty(false);
-            setMessage('Arrangement saved');
+            setMessage(copy.saved);
         } catch {
-            setMessage('Could not save the arrangement — try again');
+            setMessage(copy.saveFailed);
         } finally {
             setSaving(false);
         }
@@ -92,7 +100,7 @@ export default function TapestryArrange({ sessionId }: Props) {
         <section className="mt-8 rounded-lg border border-[var(--border-subtle)] p-4" aria-live="polite">
             <div className="mb-3 flex items-center justify-between gap-3">
                 <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-                    Tapestry arrangement
+                    {copy.heading}
                 </h2>
                 <button
                     type="button"
@@ -100,12 +108,12 @@ export default function TapestryArrange({ sessionId }: Props) {
                     disabled={!dirty || saving}
                     className="min-h-11 rounded border border-[var(--gold)] px-3 py-2 text-xs text-[var(--gold)] disabled:opacity-40"
                 >
-                    {saving ? 'Saving…' : dirty ? 'Save arrangement' : 'Saved'}
+                    {saving ? copy.saving : dirty ? copy.save : copy.saved}
                 </button>
             </div>
             {order.length === 0 ? (
                 <p className="text-xs text-[var(--text-muted)]">
-                    No attendee snapshots yet — tiles appear here as cameras join.
+                    {copy.empty}
                 </p>
             ) : (
                 <ol className="flex flex-wrap gap-3">
@@ -115,7 +123,7 @@ export default function TapestryArrange({ sessionId }: Props) {
                             {/* eslint-disable-next-line @next/next/no-img-element */}
                             <img
                                 src={`/api/ops/sessions/${sessionId}/tapestry/tiles/${encodeURIComponent(pid)}?t=${refreshTick}`}
-                                alt={`Tapestry tile ${index + 1}`}
+                                alt={fill(copy.tileAlt, index + 1)}
                                 width={72}
                                 height={72}
                                 className="rounded border border-[var(--border-subtle)]"
@@ -123,7 +131,7 @@ export default function TapestryArrange({ sessionId }: Props) {
                             <div className="flex gap-1">
                                 <button
                                     type="button"
-                                    aria-label={`Move tile ${index + 1} left`}
+                                    aria-label={fill(copy.moveLeft, index + 1)}
                                     onClick={() => move(index, -1)}
                                     disabled={index === 0}
                                     className="min-h-11 min-w-11 rounded border border-[var(--border-subtle)] px-2 text-xs disabled:opacity-30"
@@ -132,7 +140,7 @@ export default function TapestryArrange({ sessionId }: Props) {
                                 </button>
                                 <button
                                     type="button"
-                                    aria-label={`Move tile ${index + 1} right`}
+                                    aria-label={fill(copy.moveRight, index + 1)}
                                     onClick={() => move(index, 1)}
                                     disabled={index === order.length - 1}
                                     className="min-h-11 min-w-11 rounded border border-[var(--border-subtle)] px-2 text-xs disabled:opacity-30"

--- a/src/components/ops/__tests__/AdmissionConsole.test.tsx
+++ b/src/components/ops/__tests__/AdmissionConsole.test.tsx
@@ -3,7 +3,15 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import AdmissionConsole from '../AdmissionConsole';
+import type { ComponentProps } from 'react';
+import { messages } from '@/lib/i18n';
+import AdmissionConsoleImpl from '../AdmissionConsole';
+
+type AdmissionProps = Omit<ComponentProps<typeof AdmissionConsoleImpl>, 'locale' | 'copy'>;
+
+function AdmissionConsole(props: AdmissionProps) {
+    return <AdmissionConsoleImpl {...props} locale="en" copy={messages.en.ops.admissionPanel} />;
+}
 
 const EVENT = {
     id: '10000000-0000-4000-8000-000000000001',
@@ -30,6 +38,23 @@ afterEach(() => {
 });
 
 describe('AdmissionConsole promotion invitations', () => {
+    it('renders admission, ticket and invitation controls in Spanish', () => {
+        render(
+            <AdmissionConsoleImpl
+                role="FACILITATOR_OP"
+                events={[EVENT]}
+                locale="es"
+                copy={messages.es.ops.admissionPanel}
+            />,
+        );
+
+        expect(screen.getByRole('heading', { name: 'Buscar entrada' })).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/Email, últimos cuatro/)).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Emitir entradas' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Invitaciones controladas' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Cargar invitaciones' })).toBeInTheDocument();
+    });
+
     it('shows promotional provenance in the ordinary entitlement lookup', async () => {
         const fetchMock = vi.fn().mockResolvedValue({
             ok: true,
@@ -66,7 +91,7 @@ describe('AdmissionConsole promotion invitations', () => {
         await userEvent.click(screen.getByRole('button', { name: 'Look up' }));
 
         expect(await screen.findByText(/Invitation:/)).toBeInTheDocument();
-        expect(screen.getByText(/Guest list · campaign ACTIVE/)).toBeInTheDocument();
+        expect(screen.getByText(/Guest list · campaign Active/)).toBeInTheDocument();
     });
 
     it('shows the global kill switch and clears the raw code after bounded creation', async () => {
@@ -128,7 +153,7 @@ describe('AdmissionConsole promotion invitations', () => {
         await userEvent.click(screen.getByRole('checkbox', { name: /Also revoke every entitlement/ }));
         await userEvent.click(screen.getByRole('button', { name: 'Disable invitation' }));
 
-        await waitFor(() => expect(screen.getByText('DISABLED')).toBeInTheDocument());
+        await waitFor(() => expect(screen.getByText('Disabled')).toBeInTheDocument());
         expect(screen.getByRole('button', { name: 'Retry revoke / disconnect' })).toBeEnabled();
         const disableCall = fetchMock.mock.calls.find(([url, init]) =>
             String(url).includes(`/api/ops/invitations/${CAMPAIGN.id}`) && init?.method === 'POST',

--- a/src/components/ops/__tests__/ConductorCockpit.test.tsx
+++ b/src/components/ops/__tests__/ConductorCockpit.test.tsx
@@ -59,6 +59,7 @@ const props = {
     spotlightCopy: messages.en.ops.spotlight,
     healthCopy: messages.en.ops.healthPanel,
     admissionCopy: messages.en.ops.admissionPanel,
+    tapestryCopy: messages.en.ops.tapestryArrange,
     staffRoleLabels: messages.en.staffRoles,
 };
 

--- a/src/components/ops/__tests__/ConductorCockpit.test.tsx
+++ b/src/components/ops/__tests__/ConductorCockpit.test.tsx
@@ -57,6 +57,7 @@ const props = {
     copy: messages.en.ops.cockpit,
     lifecycleCopy: messages.en.ops.lifecycle,
     spotlightCopy: messages.en.ops.spotlight,
+    healthCopy: messages.en.ops.healthPanel,
     staffRoleLabels: messages.en.staffRoles,
 };
 

--- a/src/components/ops/__tests__/ConductorCockpit.test.tsx
+++ b/src/components/ops/__tests__/ConductorCockpit.test.tsx
@@ -58,6 +58,7 @@ const props = {
     lifecycleCopy: messages.en.ops.lifecycle,
     spotlightCopy: messages.en.ops.spotlight,
     healthCopy: messages.en.ops.healthPanel,
+    admissionCopy: messages.en.ops.admissionPanel,
     staffRoleLabels: messages.en.staffRoles,
 };
 

--- a/src/components/ops/__tests__/TapestryArrange.test.tsx
+++ b/src/components/ops/__tests__/TapestryArrange.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { messages } from '@/lib/i18n';
+import TapestryArrange from '../TapestryArrange';
+
+afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+});
+
+describe('TapestryArrange', () => {
+    it('renders and saves an arrangement in Spanish', async () => {
+        const fetchMock = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => ({
+            ok: true,
+            status: 200,
+            json: async () => init?.method === 'PUT' ? {} : { participants: ['one', 'two'] },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(
+            <TapestryArrange
+                sessionId="event-1"
+                copy={messages.es.ops.tapestryArrange}
+            />,
+        );
+
+        expect(await screen.findByAltText('Tesela 1 del tapiz')).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', { name: 'Mover tesela 1 a la derecha' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Guardar orden' }));
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledWith(
+                '/api/ops/sessions/event-1/tapestry',
+                expect.objectContaining({ method: 'PUT' }),
+            );
+        });
+        expect(screen.getAllByText('Guardado')).toHaveLength(2);
+    });
+});

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -2,22 +2,24 @@
 
 import { useEffect, useState } from 'react';
 import { useLocale } from '@/context/LocaleContext';
-import { messages, type Messages } from '@/lib/i18n';
+import type { Messages } from '@/lib/i18n';
 
-type Props = { sessionId: string; staffOnly?: boolean };
+type Props = {
+    sessionId: string;
+    staffOnly?: boolean;
+    labels?: Messages['tapestry'];
+};
 
-export default function ThumbnailTapestry({ sessionId, staffOnly = false }: Props) {
-    if (staffOnly) {
-        // The ops board is intentionally outside this attendee-localization
-        // slice. Preserve its existing English labels and standalone tests.
-        return <ThumbnailTapestryView sessionId={sessionId} staffOnly labels={messages.en.tapestry} />;
+export default function ThumbnailTapestry({ sessionId, staffOnly = false, labels }: Props) {
+    if (labels) {
+        return <ThumbnailTapestryView sessionId={sessionId} staffOnly={staffOnly} labels={labels} />;
     }
-    return <LocalizedThumbnailTapestry sessionId={sessionId} />;
+    return <LocalizedThumbnailTapestry sessionId={sessionId} staffOnly={staffOnly} />;
 }
 
-function LocalizedThumbnailTapestry({ sessionId }: { sessionId: string }) {
+function LocalizedThumbnailTapestry({ sessionId, staffOnly = false }: Props) {
     const { copy } = useLocale();
-    return <ThumbnailTapestryView sessionId={sessionId} staffOnly={false} labels={copy.tapestry} />;
+    return <ThumbnailTapestryView sessionId={sessionId} staffOnly={staffOnly} labels={copy.tapestry} />;
 }
 
 function ThumbnailTapestryView({

--- a/src/components/session/__tests__/ThumbnailTapestry.test.tsx
+++ b/src/components/session/__tests__/ThumbnailTapestry.test.tsx
@@ -6,8 +6,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import ThumbnailTapestry from '../ThumbnailTapestry';
 import { LocaleProvider } from '@/context/LocaleContext';
 
-function render(ui: ReactNode) {
-    return rtlRender(ui, { wrapper: ({ children }) => <LocaleProvider initialLocale="en">{children}</LocaleProvider> });
+function render(ui: ReactNode, initialLocale: 'es' | 'en' = 'en') {
+    return rtlRender(ui, { wrapper: ({ children }) => <LocaleProvider initialLocale={initialLocale}>{children}</LocaleProvider> });
 }
 
 afterEach(() => cleanup());
@@ -20,5 +20,16 @@ describe('ThumbnailTapestry', () => {
         render(<ThumbnailTapestry sessionId="session-1" />);
         await waitFor(() => expect(fetch).toHaveBeenCalled());
         expect(vi.mocked(fetch).mock.calls[0][1]?.credentials).toBe('omit');
+    });
+
+    it('uses the selected staff locale while preserving authenticated loading', async () => {
+        global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+
+        const view = render(<ThumbnailTapestry sessionId="session-1" staffOnly />, 'es');
+
+        expect(view.getByRole('region', { name: 'Tapiz' })).toBeInTheDocument();
+        expect(view.getByText('Esperando imágenes.')).toBeInTheDocument();
+        await waitFor(() => expect(fetch).toHaveBeenCalled());
+        expect(vi.mocked(fetch).mock.calls[0][1]?.credentials).toBe('same-origin');
     });
 });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -413,6 +413,17 @@ export type Messages = {
             values: Record<'ISSUED' | 'BOUND' | 'REVOKED' | 'EXPIRED' | 'ACTIVE' | 'DISABLED' | 'CLEAR' | 'SUSPENDED' | 'NOT_REQUIRED' | 'RECONCILIATION_REQUIRED' | 'DISCONNECTED', string>;
             tiers: Record<'GLOBAL_NORTH' | 'GLOBAL_SOUTH' | 'COMP' | 'SUPPORT_OVERRIDE', string>;
         };
+        tapestryArrange: {
+            heading: string;
+            saving: string;
+            save: string;
+            saved: string;
+            saveFailed: string;
+            empty: string;
+            tileAlt: string;
+            moveLeft: string;
+            moveRight: string;
+        };
         cockpit: {
             roomTitle: string;
             roomHint: string;
@@ -872,6 +883,17 @@ export const messages: Record<UiLocale, Messages> = {
                     SUPPORT_OVERRIDE: 'Excepción de soporte',
                 },
             },
+            tapestryArrange: {
+                heading: 'Orden del tapiz',
+                saving: 'Guardando…',
+                save: 'Guardar orden',
+                saved: 'Guardado',
+                saveFailed: 'No se pudo guardar el orden. Volvé a intentarlo.',
+                empty: 'Todavía no hay imágenes: las teselas aparecen cuando se suman cámaras.',
+                tileAlt: 'Tesela {index} del tapiz',
+                moveLeft: 'Mover tesela {index} a la izquierda',
+                moveRight: 'Mover tesela {index} a la derecha',
+            },
             cockpit: {
                 roomTitle: 'Sala en vivo',
                 roomHint: 'La escena permanece conectada mientras abrís las herramientas.',
@@ -1328,6 +1350,17 @@ export const messages: Record<UiLocale, Messages> = {
                     COMP: 'Comp',
                     SUPPORT_OVERRIDE: 'Support override',
                 },
+            },
+            tapestryArrange: {
+                heading: 'Tapestry arrangement',
+                saving: 'Saving…',
+                save: 'Save arrangement',
+                saved: 'Saved',
+                saveFailed: 'Could not save the arrangement — try again',
+                empty: 'No attendee snapshots yet — tiles appear here as cameras join.',
+                tileAlt: 'Tapestry tile {index}',
+                moveLeft: 'Move tile {index} left',
+                moveRight: 'Move tile {index} right',
             },
             cockpit: {
                 roomTitle: 'Live room',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -298,6 +298,26 @@ export type Messages = {
             noImage: string;
             footer: string;
         };
+        healthPanel: {
+            pageTitle: string;
+            pageIntro: string;
+            headlines: Record<'green' | 'yellow' | 'red', string>;
+            levels: Record<'green' | 'yellow' | 'red', string>;
+            sessionStatuses: Record<'SCHEDULED' | 'LIVE' | 'ENDED' | 'CANCELLED', string>;
+            checks: Record<'postgres' | 'livekit' | 'stageRoom' | 'publisherGrants' | 'bedPublisher' | 'tapestry', string>;
+            endpointHttp: string;
+            endpointUnavailable: string;
+            endpointAlarm: string;
+            checking: string;
+            noReport: string;
+            watchingSession: string;
+            signedInAs: string;
+            noSession: string;
+            lastChecked: string;
+            refreshesEvery: string;
+            waitingFirstReport: string;
+            refreshNow: string;
+        };
         cockpit: {
             roomTitle: string;
             roomHint: string;
@@ -609,6 +629,42 @@ export const messages: Record<UiLocale, Messages> = {
                 noImage: 'sin imagen',
                 footer: 'Sesión de {role}. La fila se actualiza cada {seconds}s; los permisos guardados son la referencia.',
             },
+            healthPanel: {
+                pageTitle: 'Salud del evento',
+                pageIntro: 'Estado en vivo de los subsistemas del evento. Rojo impide abrir; amarillo indica un componente prescindible. Los procedimientos ante fallas están en',
+                headlines: {
+                    green: 'VERDE — todos los subsistemas funcionan normalmente',
+                    yellow: 'AMARILLO — hay una falla degradada y prescindible',
+                    red: 'ROJO — hay una falla que impide abrir el evento',
+                },
+                levels: { green: 'verde', yellow: 'amarillo', red: 'rojo' },
+                sessionStatuses: {
+                    SCHEDULED: 'Próximo',
+                    LIVE: 'En vivo',
+                    ENDED: 'Finalizado',
+                    CANCELLED: 'Cancelado',
+                },
+                checks: {
+                    postgres: 'PostgreSQL',
+                    livekit: 'API de LiveKit',
+                    stageRoom: 'Sala de Escena',
+                    publisherGrants: 'Permisos de publicación',
+                    bedPublisher: 'Fuente del Beacon (playlist bot)',
+                    tapestry: 'Tapiz (prescindible)',
+                },
+                endpointHttp: 'El endpoint respondió HTTP {status}',
+                endpointUnavailable: 'No se pudo contactar el endpoint de salud',
+                endpointAlarm: 'ROJO — no se puede consultar la salud: {error}',
+                checking: 'Comprobando subsistemas…',
+                noReport: 'AMARILLO — todavía no hay informe',
+                watchingSession: 'Observando la sesión',
+                signedInAs: 'identidad activa:',
+                noSession: 'No se está observando ninguna sesión programada o en vivo',
+                lastChecked: 'Última comprobación',
+                refreshesEvery: 'se actualiza cada {seconds}s',
+                waitingFirstReport: 'Esperando el primer informe…',
+                refreshNow: 'Actualizar ahora',
+            },
             cockpit: {
                 roomTitle: 'Sala en vivo',
                 roomHint: 'La escena permanece conectada mientras abrís las herramientas.',
@@ -917,6 +973,42 @@ export const messages: Record<UiLocale, Messages> = {
                 noSnapshotAlt: '{name}: no current tapestry snapshot',
                 noImage: 'no image',
                 footer: 'Signed in as {role}. Queue refreshes every {seconds}s; saved grants are authoritative.',
+            },
+            healthPanel: {
+                pageTitle: 'Event health',
+                pageIntro: 'Live subsystem board for the event. Red means launch-blocking; yellow means cuttable. Failure playbooks are in',
+                headlines: {
+                    green: 'GREEN — all subsystems nominal',
+                    yellow: 'YELLOW — degraded, cuttable subsystem failing',
+                    red: 'RED — launch-blocking subsystem failing',
+                },
+                levels: { green: 'green', yellow: 'yellow', red: 'red' },
+                sessionStatuses: {
+                    SCHEDULED: 'Upcoming',
+                    LIVE: 'Live',
+                    ENDED: 'Ended',
+                    CANCELLED: 'Cancelled',
+                },
+                checks: {
+                    postgres: 'PostgreSQL',
+                    livekit: 'LiveKit API',
+                    stageRoom: 'Stage room',
+                    publisherGrants: 'Publisher grants',
+                    bedPublisher: 'Bed publisher (playlist bot)',
+                    tapestry: 'Tapestry (cuttable)',
+                },
+                endpointHttp: 'Endpoint answered HTTP {status}',
+                endpointUnavailable: 'Health endpoint unreachable',
+                endpointAlarm: 'RED — health endpoint unreachable: {error}',
+                checking: 'Checking subsystems…',
+                noReport: 'YELLOW — no report yet',
+                watchingSession: 'Watching session',
+                signedInAs: 'signed in as',
+                noSession: 'No live or scheduled session is being watched',
+                lastChecked: 'Last checked',
+                refreshesEvery: 'refreshes every {seconds}s',
+                waitingFirstReport: 'Waiting for the first report…',
+                refreshNow: 'Refresh now',
             },
             cockpit: {
                 roomTitle: 'Live room',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -88,6 +88,7 @@ export type Messages = {
         connectingHeading: string;
         connectingBody: string;
         connectionErrorHeading: string;
+        connectionUnavailable: string;
         tryAgain: string;
         backToSessions: string;
         endedHeading: string;
@@ -515,6 +516,7 @@ export const messages: Record<UiLocale, Messages> = {
             connectingHeading: 'Conectando',
             connectingBody: 'Entrando al campo armónico…',
             connectionErrorHeading: 'Error de conexión',
+            connectionUnavailable: 'No pudimos entrar a la sala. Tu acceso sigue confirmado; intentá de nuevo.',
             tryAgain: 'Intentar de nuevo',
             backToSessions: 'Volver a las sesiones',
             endedHeading: 'La sesión terminó',
@@ -983,6 +985,7 @@ export const messages: Record<UiLocale, Messages> = {
             connectingHeading: 'Connecting',
             connectingBody: 'Entering the Harmonic field…',
             connectionErrorHeading: 'Connection error',
+            connectionUnavailable: 'We could not enter the room. Your access is still confirmed; try again.',
             tryAgain: 'Try again',
             backToSessions: 'Back to sessions',
             endedHeading: 'Session ended',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -318,6 +318,101 @@ export type Messages = {
             waitingFirstReport: string;
             refreshNow: string;
         };
+        admissionPanel: {
+            pageTitle: string;
+            pageIntro: string;
+            unexpectedError: string;
+            notices: {
+                noMatches: string;
+                accessRevoked: string;
+                suspensionCleared: string;
+                bindingUpdated: string;
+                batchGenerated: string;
+                importComplete: string;
+                compIssued: string;
+                invitationReady: string;
+                invitationSwitchOff: string;
+                invitationCleanupFailed: string;
+                invitationDisabled: string;
+            };
+            lookup: {
+                heading: string;
+                placeholder: string;
+                action: string;
+            };
+            labels: {
+                state: string;
+                tier: string;
+                lastFour: string;
+                boundEmail: string;
+                event: string;
+                expires: string;
+                commerce: string;
+                admin: string;
+                media: string;
+                invitation: string;
+                campaign: string;
+                redeemed: string;
+                revoked: string;
+                cap: string;
+            };
+            actions: {
+                reason: string;
+                newEmail: string;
+                rebind: string;
+                clearBinding: string;
+                resume: string;
+                suspend: string;
+                revoke: string;
+            };
+            tickets: {
+                heading: string;
+                eventLabel: string;
+                batchHeading: string;
+                tierLabel: string;
+                globalNorth: string;
+                globalSouth: string;
+                generate: string;
+                importPlaceholder: string;
+                importAction: string;
+                overrideHeading: string;
+                overrideTier: string;
+                comp: string;
+                supportOverride: string;
+                overrideReason: string;
+                issue: string;
+            };
+            invitations: {
+                heading: string;
+                help: string;
+                load: string;
+                refresh: string;
+                redemptionStatus: string;
+                on: string;
+                off: string;
+                createHeading: string;
+                internalLabel: string;
+                internalPlaceholder: string;
+                humanCode: string;
+                expiresWithin: string;
+                capacity: string;
+                create: string;
+                none: string;
+                redeemedCount: string;
+                expires: string;
+                disableReason: string;
+                revokeDerived: string;
+                disable: string;
+                retryDisconnect: string;
+            };
+            export: {
+                heading: string;
+                warning: string;
+                download: string;
+            };
+            values: Record<'ISSUED' | 'BOUND' | 'REVOKED' | 'EXPIRED' | 'ACTIVE' | 'DISABLED' | 'CLEAR' | 'SUSPENDED' | 'NOT_REQUIRED' | 'RECONCILIATION_REQUIRED' | 'DISCONNECTED', string>;
+            tiers: Record<'GLOBAL_NORTH' | 'GLOBAL_SOUTH' | 'COMP' | 'SUPPORT_OVERRIDE', string>;
+        };
         cockpit: {
             roomTitle: string;
             roomHint: string;
@@ -665,6 +760,118 @@ export const messages: Record<UiLocale, Messages> = {
                 waitingFirstReport: 'Esperando el primer informe…',
                 refreshNow: 'Actualizar ahora',
             },
+            admissionPanel: {
+                pageTitle: 'Soporte de entradas',
+                pageIntro: 'Sesión de {name} ({role}). Toda modificación exige un motivo sin datos personales y queda auditada.',
+                unexpectedError: 'Error inesperado',
+                notices: {
+                    noMatches: 'No se encontraron accesos.',
+                    accessRevoked: 'El acceso fue suspendido o revocado.',
+                    suspensionCleared: 'Se levantó la suspensión administrativa.',
+                    bindingUpdated: 'Se actualizó la vinculación.',
+                    batchGenerated: 'Lote generado. Copiá o descargá el CSV ahora: se muestra una sola vez.',
+                    importComplete: 'Importación terminada: {created} creados, {skipped} omitidos porque ya existían.',
+                    compIssued: 'Cortesía o excepción emitida. Copiá o descargá el CSV ahora: se muestra una sola vez.',
+                    invitationReady: 'Invitación creada y lista para usar.',
+                    invitationSwitchOff: 'Invitación creada, pero el canje público global sigue DESACTIVADO.',
+                    invitationCleanupFailed: 'Invitación desactivada y accesos revocados; algunas conexiones en vivo requieren otro intento.',
+                    invitationDisabled: 'Invitación desactivada. Se revocaron {count} accesos derivados.',
+                },
+                lookup: {
+                    heading: 'Buscar entrada',
+                    placeholder: 'Email, últimos cuatro caracteres del código o ID de acceso',
+                    action: 'Buscar',
+                },
+                labels: {
+                    state: 'Estado:',
+                    tier: 'Tipo:',
+                    lastFour: 'Últimos cuatro:',
+                    boundEmail: 'Email vinculado:',
+                    event: 'Evento:',
+                    expires: 'Vence:',
+                    commerce: 'Comercio:',
+                    admin: 'administración',
+                    media: 'medios',
+                    invitation: 'Invitación:',
+                    campaign: 'campaña',
+                    redeemed: 'canjeada',
+                    revoked: 'Revocada',
+                    cap: 'cupo',
+                },
+                actions: {
+                    reason: 'Motivo (obligatorio, sin datos personales)',
+                    newEmail: 'Nuevo email (opcional)',
+                    rebind: 'Vincular al email',
+                    clearBinding: 'Quitar vinculación',
+                    resume: 'Reactivar acceso',
+                    suspend: 'Suspender acceso',
+                    revoke: 'Revocar',
+                },
+                tickets: {
+                    heading: 'Emitir entradas',
+                    eventLabel: 'Evento',
+                    batchHeading: 'Lote (ADMIN)',
+                    tierLabel: 'Tipo de entrada',
+                    globalNorth: 'Norte Global (USD 50)',
+                    globalSouth: 'Sur Global (USD 20)',
+                    generate: 'Generar lote',
+                    importPlaceholder: 'Pegá el CSV de la plataforma (columna code; encabezado opcional)',
+                    importAction: 'Importar CSV (idempotente)',
+                    overrideHeading: 'Cortesía / excepción de soporte',
+                    overrideTier: 'Tipo de excepción',
+                    comp: 'Cortesía',
+                    supportOverride: 'Excepción de soporte',
+                    overrideReason: 'Motivo (obligatorio, sin datos personales; por ejemplo, referencia del caso)',
+                    issue: 'Emitir',
+                },
+                invitations: {
+                    heading: 'Invitaciones controladas',
+                    help: 'Un código breve genera el mismo acceso de cortesía, limitado a esta sesión, que una entrada normal. Sólo se guarda su huella; se controlan cupo, vencimiento y revocación.',
+                    load: 'Cargar invitaciones',
+                    refresh: 'Actualizar',
+                    redemptionStatus: 'El canje público está {status}.',
+                    on: 'ACTIVADO',
+                    off: 'DESACTIVADO',
+                    createHeading: 'Crear invitación limitada',
+                    internalLabel: 'Etiqueta interna (nunca el código)',
+                    internalPlaceholder: 'Lista de invitados — mañana ES',
+                    humanCode: 'Código para personas (6–15 caracteres)',
+                    expiresWithin: 'Vence (dentro de siete días)',
+                    capacity: 'Cupo de canjes',
+                    create: 'Crear invitación',
+                    none: 'No hay invitaciones creadas.',
+                    redeemedCount: '{count}/{max} canjeadas',
+                    expires: 'vence',
+                    disableReason: 'Motivo de desactivación (obligatorio, sin datos personales)',
+                    revokeDerived: 'Revocar también todos los accesos ya canjeados y desconectar sus medios en vivo.',
+                    disable: 'Desactivar invitación',
+                    retryDisconnect: 'Reintentar revocación / desconexión',
+                },
+                export: {
+                    heading: 'Exportación única de códigos',
+                    warning: 'Estos códigos se muestran una sola vez y la aplicación nunca los guarda en texto plano. Guardá ahora el CSV bajo control operativo; no lo subas al repositorio ni lo pegues en issues o chats.',
+                    download: 'Descargar CSV',
+                },
+                values: {
+                    ISSUED: 'Emitida',
+                    BOUND: 'Vinculada',
+                    REVOKED: 'Revocada',
+                    EXPIRED: 'Vencida',
+                    ACTIVE: 'Activa',
+                    DISABLED: 'Desactivada',
+                    CLEAR: 'Sin suspensión',
+                    SUSPENDED: 'Suspendida',
+                    NOT_REQUIRED: 'No requerido',
+                    RECONCILIATION_REQUIRED: 'Requiere reconciliación',
+                    DISCONNECTED: 'Desconectado',
+                },
+                tiers: {
+                    GLOBAL_NORTH: 'Norte Global',
+                    GLOBAL_SOUTH: 'Sur Global',
+                    COMP: 'Cortesía',
+                    SUPPORT_OVERRIDE: 'Excepción de soporte',
+                },
+            },
             cockpit: {
                 roomTitle: 'Sala en vivo',
                 roomHint: 'La escena permanece conectada mientras abrís las herramientas.',
@@ -1009,6 +1216,118 @@ export const messages: Record<UiLocale, Messages> = {
                 refreshesEvery: 'refreshes every {seconds}s',
                 waitingFirstReport: 'Waiting for the first report…',
                 refreshNow: 'Refresh now',
+            },
+            admissionPanel: {
+                pageTitle: 'Admission support',
+                pageIntro: 'Signed in as {name} ({role}). Every mutation requires a non-PII reason and is audited.',
+                unexpectedError: 'Unexpected error',
+                notices: {
+                    noMatches: 'No matching entitlements.',
+                    accessRevoked: 'Access suspended or revoked.',
+                    suspensionCleared: 'Administrative suspension cleared.',
+                    bindingUpdated: 'Binding updated.',
+                    batchGenerated: 'Batch generated. Copy or download the CSV now — it is shown only once.',
+                    importComplete: 'Import complete: {created} created, {skipped} skipped (already existed).',
+                    compIssued: 'Comp/override issued. Copy or download the CSV now — it is shown only once.',
+                    invitationReady: 'Invitation created and ready to redeem.',
+                    invitationSwitchOff: 'Invitation created, but the global redemption switch remains OFF.',
+                    invitationCleanupFailed: 'Invitation disabled and access revoked; some live connections need a retry.',
+                    invitationDisabled: 'Invitation disabled. {count} derived access grant(s) revoked.',
+                },
+                lookup: {
+                    heading: 'Ticket lookup',
+                    placeholder: 'Attendee email, code last four, or entitlement ID',
+                    action: 'Look up',
+                },
+                labels: {
+                    state: 'State:',
+                    tier: 'Tier:',
+                    lastFour: 'Last four:',
+                    boundEmail: 'Bound email:',
+                    event: 'Event:',
+                    expires: 'Expires:',
+                    commerce: 'Commerce:',
+                    admin: 'admin',
+                    media: 'media',
+                    invitation: 'Invitation:',
+                    campaign: 'campaign',
+                    redeemed: 'redeemed',
+                    revoked: 'Revoked',
+                    cap: 'cap',
+                },
+                actions: {
+                    reason: 'Reason (required, no PII)',
+                    newEmail: 'New email (optional rebind)',
+                    rebind: 'Rebind to email',
+                    clearBinding: 'Clear binding',
+                    resume: 'Resume access',
+                    suspend: 'Suspend access',
+                    revoke: 'Revoke',
+                },
+                tickets: {
+                    heading: 'Issue tickets',
+                    eventLabel: 'Event',
+                    batchHeading: 'Batch (ADMIN)',
+                    tierLabel: 'Ticket tier',
+                    globalNorth: 'Global North ($50)',
+                    globalSouth: 'Global South ($20)',
+                    generate: 'Generate batch',
+                    importPlaceholder: 'Paste platform CSV to import (code column, header optional)',
+                    importAction: 'Import CSV (idempotent)',
+                    overrideHeading: 'Comp / support override',
+                    overrideTier: 'Override tier',
+                    comp: 'Comp',
+                    supportOverride: 'Support override',
+                    overrideReason: 'Reason (required, no PII — e.g. support case reference)',
+                    issue: 'Issue',
+                },
+                invitations: {
+                    heading: 'Controlled invitations',
+                    help: 'A short code creates the same session-scoped COMP entitlement as normal admission. Codes are stored only as digests; capacity, expiry and revocation remain enforced.',
+                    load: 'Load invitations',
+                    refresh: 'Refresh',
+                    redemptionStatus: 'Public redemption is {status}.',
+                    on: 'ON',
+                    off: 'OFF',
+                    createHeading: 'Create bounded invitation',
+                    internalLabel: 'Internal label (never the code)',
+                    internalPlaceholder: 'Guest list — morning ES',
+                    humanCode: 'Human code (6–15 characters)',
+                    expiresWithin: 'Expires (within seven days)',
+                    capacity: 'Redemption capacity',
+                    create: 'Create invitation',
+                    none: 'No invitations created.',
+                    redeemedCount: '{count}/{max} redeemed',
+                    expires: 'expires',
+                    disableReason: 'Disable reason (required, no PII)',
+                    revokeDerived: 'Also revoke every entitlement already redeemed and disconnect its live media.',
+                    disable: 'Disable invitation',
+                    retryDisconnect: 'Retry revoke / disconnect',
+                },
+                export: {
+                    heading: 'One-time code export',
+                    warning: 'These plaintext codes are shown once and are never stored by the app. Save the CSV under ops control now; do not commit it or paste it into tickets/chat.',
+                    download: 'Download CSV',
+                },
+                values: {
+                    ISSUED: 'Issued',
+                    BOUND: 'Bound',
+                    REVOKED: 'Revoked',
+                    EXPIRED: 'Expired',
+                    ACTIVE: 'Active',
+                    DISABLED: 'Disabled',
+                    CLEAR: 'Clear',
+                    SUSPENDED: 'Suspended',
+                    NOT_REQUIRED: 'Not required',
+                    RECONCILIATION_REQUIRED: 'Reconciliation required',
+                    DISCONNECTED: 'Disconnected',
+                },
+                tiers: {
+                    GLOBAL_NORTH: 'Global North',
+                    GLOBAL_SOUTH: 'Global South',
+                    COMP: 'Comp',
+                    SUPPORT_OVERRIDE: 'Support override',
+                },
             },
             cockpit: {
                 roomTitle: 'Live room',


### PR DESCRIPTION
Refs #68

## Outcome
- Localizes Health status, severity, session context, role, cadence and controls through typed ES/EN copy.
- Localizes admission lookup, comp tickets, controlled invitations, state labels, actions and operator feedback.
- Localizes tapestry arrangement, reordering, empty state, accessibility labels and save feedback.
- Keeps technical backend details intact where operators need exact diagnostics.
- Updates the two-event real-browser journey with bilingual selectors.

## Evidence
- 679 Vitest tests passed; 7 opt-in integration tests skipped.
- TypeScript, ESLint and production build passed after rebasing onto main.
- Real local PostgreSQL + LiveKit FACILITATOR_OP journey passed 1/1 across consecutive ES and EN event lifecycles.
- `git diff --check` clean.

## Safety
- No audio paths, codec, bitrate, sample rate, buffer, gain, crossfader or room lifecycle behavior changed.
- No database schema, production data or credentials changed.
- Rollback is a revert of this PR.

## Remaining issue-level gate
The broader #68 fluent-human ES/EN review and repository-wide supporting-surface audit remain explicit before closing the card.