### PR TITLE
Free audited invitation and long WAV playlist source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,5 +92,7 @@ MAX_UPLOAD_SIZE_MB=100
 # ===================
 # Identity shown in LiveKit room (frontend detects non-beacon01 as PLAYLIST mode)
 BOT_IDENTITY=playlist-bot
-# Path to recorded beacon .ogg files (bind-mounted in Docker)
+# Path to recorded Beacon audio files (bind-mounted in Docker)
 BEACON_RECORDS_PATH=/data/beacon-records
+# Optional exact .wav or .ogg source. When set, playlist-bot publishes only it.
+BEACON_PLAYLIST_FILE=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,6 +177,7 @@ services:
       - LIVEKIT_ROOM_NAME=${LIVEKIT_ROOM_NAME:-beacon}
       - BOT_IDENTITY=playlist-bot
       - BEACON_RECORDS_PATH=/data/beacon-records
+      - BEACON_PLAYLIST_FILE=${BEACON_PLAYLIST_FILE:-}
     volumes:
       - /mnt/beacon-data/beacon-records:/data/beacon-records:ro
     networks:

--- a/scripts/weekend-stabilize.ts
+++ b/scripts/weekend-stabilize.ts
@@ -170,7 +170,7 @@ function printDryRun(snapshot: StabilizationSnapshot, digest: string): void {
         changes: EVENT_CONTRACTS.map((contract) => ({
             event: contract.key,
             id: contract.id,
-            desiredStatus: contract.isTest ? 'CANCELLED' : 'SCHEDULED',
+            desiredStatus: contract.desiredStatus,
             desiredScheduledAt: contract.scheduledAt,
             current: snapshot.sessions.find((session) => session.id === contract.id),
         })),
@@ -183,8 +183,11 @@ function sessionNeedsUpdate(
     session: StabilizationSessionSnapshot,
     contract: (typeof EVENT_CONTRACTS)[number],
 ): boolean {
+    if (session.title !== contract.title || session.paidMode !== contract.paidMode) return true;
     if (session.scheduledAt !== contract.scheduledAt) return true;
-    if (contract.isTest) return session.status !== 'CANCELLED' || session.endedAt === null;
+    if (contract.desiredStatus === 'CANCELLED') {
+        return session.status !== 'CANCELLED' || session.endedAt === null;
+    }
     return session.status !== 'SCHEDULED' || session.startedAt !== null || session.endedAt !== null;
 }
 

--- a/services/playlist-bot/src/index.ts
+++ b/services/playlist-bot/src/index.ts
@@ -11,8 +11,7 @@ import {
 } from '@livekit/rtc-node';
 import { AccessToken } from 'livekit-server-sdk';
 import { spawn, execSync } from 'node:child_process';
-import { readdirSync, existsSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
 import { hasAvailableBeaconAudio } from './beaconAvailability.js';
 import {
   BYTES_PER_FRAME,
@@ -25,6 +24,7 @@ import {
   SAMPLE_RATE,
   SAMPLES_PER_CHANNEL,
 } from './audioFormat.js';
+import { resolvePlaylist } from './playlist.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -36,6 +36,7 @@ const LIVEKIT_API_SECRET = process.env.LIVEKIT_API_SECRET || '';
 const ROOM_NAME = process.env.LIVEKIT_ROOM_NAME || 'beacon';
 const BOT_IDENTITY = process.env.BOT_IDENTITY || 'playlist-bot';
 const RECORDS_PATH = process.env.BEACON_RECORDS_PATH || '/data/beacon-records';
+const PLAYLIST_FILE = process.env.BEACON_PLAYLIST_FILE;
 const BEACON_IDENTITY = 'beacon01';
 
 const FRAME_DURATION_MS = 20;
@@ -84,17 +85,9 @@ async function createBotToken(): Promise<string> {
 // ---------------------------------------------------------------------------
 
 function scanPlaylist(): string[] {
-  if (!existsSync(RECORDS_PATH)) {
-    log('WARN', `Records path does not exist: ${RECORDS_PATH}`);
-    return [];
-  }
+  const files = resolvePlaylist(RECORDS_PATH, PLAYLIST_FILE);
 
-  const files = readdirSync(RECORDS_PATH)
-    .filter((f) => f.endsWith('.ogg'))
-    .sort()
-    .map((f) => join(RECORDS_PATH, f));
-
-  log('INFO', `Playlist scanned: ${files.length} file(s)`);
+  log('INFO', `Playlist scanned: ${files.length} file(s)${PLAYLIST_FILE ? ' (explicit source)' : ''}`);
   return files;
 }
 
@@ -393,7 +386,7 @@ class PlaylistBot {
       const playlist = scanPlaylist();
 
       if (playlist.length === 0) {
-        log('WARN', 'No .ogg files found, waiting...');
+        log('WARN', 'No supported audio source found, waiting...');
         await sleep(RESCAN_INTERVAL_MS);
         continue;
       }

--- a/services/playlist-bot/src/playlist.ts
+++ b/services/playlist-bot/src/playlist.ts
@@ -1,0 +1,26 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { extname, isAbsolute, join, resolve } from 'node:path';
+
+const SUPPORTED_EXTENSIONS = new Set(['.ogg', '.wav']);
+
+function supportedAudioFile(path: string): boolean {
+  return SUPPORTED_EXTENSIONS.has(extname(path).toLowerCase());
+}
+
+/** Resolve an explicit production source, or scan the records directory. */
+export function resolvePlaylist(recordsPath: string, configuredFile?: string): string[] {
+  if (!existsSync(recordsPath)) return [];
+
+  const selected = configuredFile?.trim();
+  if (selected) {
+    const selectedPath = resolve(isAbsolute(selected) ? selected : join(recordsPath, selected));
+    const recordsRoot = `${resolve(recordsPath)}/`;
+    if (!selectedPath.startsWith(recordsRoot) || !supportedAudioFile(selectedPath)) return [];
+    return existsSync(selectedPath) ? [selectedPath] : [];
+  }
+
+  return readdirSync(recordsPath)
+    .filter(supportedAudioFile)
+    .sort()
+    .map((file) => join(recordsPath, file));
+}

--- a/services/playlist-bot/test/playlist.test.ts
+++ b/services/playlist-bot/test/playlist.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { resolvePlaylist } from '../src/playlist.js';
+
+test('selects one configured WAV instead of mixing it with the rollback OGG', () => {
+  const records = mkdtempSync(join(tmpdir(), 'beacon-playlist-'));
+  const wav = join(records, 'luz_de_manana_long.wav');
+  writeFileSync(wav, 'wav');
+  writeFileSync(join(records, 'luz_de_manana.ogg'), 'ogg');
+
+  assert.deepEqual(resolvePlaylist(records, wav), [wav]);
+});
+
+test('scans supported stereo source containers deterministically when no source is configured', () => {
+  const records = mkdtempSync(join(tmpdir(), 'beacon-playlist-'));
+  writeFileSync(join(records, 'b.wav'), 'wav');
+  writeFileSync(join(records, 'a.ogg'), 'ogg');
+  writeFileSync(join(records, 'notes.txt'), 'ignore');
+
+  assert.deepEqual(resolvePlaylist(records), [
+    join(records, 'a.ogg'),
+    join(records, 'b.wav'),
+  ]);
+});
+
+test('fails closed for a missing, unsupported or out-of-directory configured source', () => {
+  const records = mkdtempSync(join(tmpdir(), 'beacon-playlist-'));
+  writeFileSync(join(records, 'notes.txt'), 'ignore');
+
+  assert.deepEqual(resolvePlaylist(records, 'missing.wav'), []);
+  assert.deepEqual(resolvePlaylist(records, 'notes.txt'), []);
+  assert.deepEqual(resolvePlaylist(records, '../outside.wav'), []);
+});

--- a/src/app/api/auth/ticket/__tests__/route.test.ts
+++ b/src/app/api/auth/ticket/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
 
 import { createRequest, parseResponse } from '@/__tests__/helpers';
 import { digestSessionToken } from '@/lib/session-auth';
@@ -133,6 +134,23 @@ function loginRequest(body: unknown, address = CLIENT) {
     });
 }
 
+function invitationRequest(overrides: Record<string, string> = {}, address = CLIENT) {
+    return new NextRequest('https://live.harmonicbeacon.com/api/auth/ticket', {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+            'x-forwarded-for': address,
+        },
+        body: new URLSearchParams({
+            name: NAME,
+            email: EMAIL,
+            code: 'NICO100',
+            termsAccepted: 'accepted',
+            ...overrides,
+        }),
+    });
+}
+
 async function importRoute() {
     return import('../route');
 }
@@ -197,6 +215,64 @@ describe('POST /api/auth/ticket', () => {
             secure: true,
             sameSite: 'lax',
         });
+    });
+
+    it('redeems the public invitation form, audits terms, sets the cookie and redirects to its event', async () => {
+        const redeemPromoInvitation = vi.fn().mockResolvedValue({
+            ok: true,
+            scheduledSessionId: '10000000-0000-4000-8000-000000000001',
+            entitlementId: 'promo-entitlement-1',
+            codeLastFour: '7XQP',
+            cookieValue: 'promo-cookie-value',
+            replayed: false,
+        });
+        vi.doMock('@/lib/promo-invitation', () => ({
+            isPlausiblePromoCode: (code: string) => code === 'NICO100',
+            promoInvitationsEnabled: () => true,
+            redeemPromoInvitation,
+        }));
+        mountDb([]);
+        const { POST } = await importRoute();
+
+        const response = await POST(invitationRequest());
+
+        expect(response.status).toBe(303);
+        expect(response.headers.get('location')).toBe(
+            'https://live.harmonicbeacon.com/session/10000000-0000-4000-8000-000000000001',
+        );
+        expect(redeemPromoInvitation).toHaveBeenCalledWith(
+            'NICO100',
+            EMAIL,
+            NAME,
+            expect.any(Date),
+            { version: 'personal-invitation-v2', acceptedAt: expect.any(Date) },
+        );
+        expect(sessionCookieOf(response)).toMatchObject({
+            value: 'promo-cookie-value',
+            httpOnly: true,
+            secure: true,
+            sameSite: 'lax',
+        });
+    });
+
+    it('returns malformed invitation forms to the landing without reflecting PII', async () => {
+        mountDb([]);
+        const { POST } = await importRoute();
+
+        const malformed: Array<Record<string, string>> = [
+            { name: '' },
+            { email: 'not-an-email' },
+            { termsAccepted: '' },
+            { code: CODE },
+        ];
+        for (const [index, overrides] of malformed.entries()) {
+            const response = await POST(invitationRequest(overrides, `198.51.100.${30 + index}`));
+            expect(response.status).toBe(303);
+            expect(response.headers.get('location')).toBe(
+                'https://harmonicbeacon.com/invitacion/?entry_error=invalid',
+            );
+            expect(response.headers.get('location')).not.toContain(EMAIL);
+        }
     });
 
     it('binds the ticket on first use and returns the secure hb_session cookie', async () => {

--- a/src/app/api/auth/ticket/route.ts
+++ b/src/app/api/auth/ticket/route.ts
@@ -40,6 +40,8 @@ import { digestTicketCode, normalizeTicketCode } from '@/lib/ticket-code';
 const GENERIC_REJECTION = 'That ticket code and email do not match an active ticket.';
 const RATE_LIMITED = 'Too many attempts. Please wait and try again.';
 const MALFORMED_REQUEST = 'A display name, ticket code and email address are required.';
+const INVITATION_TERMS_VERSION = 'personal-invitation-v2';
+const INVITATION_RETURN_URL = 'https://harmonicbeacon.com/invitacion/';
 
 type FailureReason =
     | 'malformed_request'
@@ -56,11 +58,15 @@ type Attempt =
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     const address = clientAddress(request.headers);
+    const isInvitationForm = request.headers.get('content-type')
+        ?.toLowerCase()
+        .includes('application/x-www-form-urlencoded') ?? false;
 
     if (authFailureLimiter.isLimited(address)) {
         // Nothing about the attempt is examined once the budget is gone, so a
         // limited client learns nothing by continuing to guess.
         console.warn(`[auth] ticket login rate limited: client=${address}`);
+        if (isInvitationForm) return invitationFailure('limited');
         return NextResponse.json({ error: RATE_LIMITED }, {
             status: 429,
             headers: { 'Retry-After': String(authFailureLimiter.retryAfterSeconds(address)) },
@@ -70,12 +76,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     let code: string;
     let email: string;
     let displayName: string;
+    let acceptedInvitationTerms = false;
     try {
-        const body = (await request.json()) as unknown;
-        const fields = (body ?? {}) as Record<string, unknown>;
+        const fields = isInvitationForm
+            ? Object.fromEntries(await request.formData())
+            : ((await request.json()) as Record<string, unknown> | null) ?? {};
         code = typeof fields.code === 'string' ? normalizeTicketCode(fields.code) : '';
         email = typeof fields.email === 'string' ? normalizeLoginEmail(fields.email) : '';
         displayName = typeof fields.name === 'string' ? normalizeDisplayName(fields.name) : '';
+        acceptedInvitationTerms = fields.termsAccepted === 'accepted';
     } catch {
         code = '';
         email = '';
@@ -83,17 +92,31 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     const promoCandidate = isPlausiblePromoCode(code);
-    if ((!promoCandidate && code.length < 16) || !isPlausibleEmail(email) || !isValidDisplayName(displayName)) {
-        return reject(address, 'malformed_request');
+    if (
+        (!promoCandidate && code.length < 16) ||
+        !isPlausibleEmail(email) ||
+        !isValidDisplayName(displayName) ||
+        (isInvitationForm && (!promoCandidate || !acceptedInvitationTerms))
+    ) {
+        return reject(address, 'malformed_request', isInvitationForm);
     }
 
     let attempt: Attempt;
     try {
         if (promoCandidate) {
             if (!promoInvitationsEnabled()) {
-                return reject(address, 'promo_unavailable');
+                return reject(address, 'promo_unavailable', isInvitationForm);
             }
-            const promoAttempt = await redeemPromoInvitation(code, email, displayName);
+            const now = new Date();
+            const promoAttempt = isInvitationForm
+                ? await redeemPromoInvitation(
+                    code,
+                    email,
+                    displayName,
+                    now,
+                    { version: INVITATION_TERMS_VERSION, acceptedAt: now },
+                )
+                : await redeemPromoInvitation(code, email, displayName);
             attempt = promoAttempt.ok
                 ? promoAttempt
                 : { ok: false, reason: 'promo_unavailable' };
@@ -105,11 +128,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         // Missing/invalid secret configuration is an outage, never evidence
         // that a particular ticket or invitation exists.
         console.error(`[auth] ticket login failed: client=${address} ${redactError(error)}`);
+        if (isInvitationForm) return invitationFailure('unavailable');
         return NextResponse.json({ error: 'Login is temporarily unavailable.' }, { status: 500 });
     }
 
     if (!attempt.ok) {
-        return reject(address, attempt.reason);
+        return reject(address, attempt.reason, isInvitationForm);
     }
 
     // Ticket id and last four are the admission-support handles the roadmap
@@ -118,20 +142,32 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         `[auth] ticket session issued: entitlement=${attempt.entitlementId} last4=${attempt.codeLastFour} client=${address}`,
     );
 
-    const response = NextResponse.json({ ok: true, scheduledSessionId: attempt.scheduledSessionId });
+    const response = isInvitationForm
+        ? NextResponse.redirect(
+            new URL(`/session/${attempt.scheduledSessionId}`, request.url),
+            { status: 303 },
+        )
+        : NextResponse.json({ ok: true, scheduledSessionId: attempt.scheduledSessionId });
     response.cookies.set(sessionCookie(attempt.cookieValue));
     return response;
 }
 
-function reject(address: string, reason: FailureReason): NextResponse {
+function reject(address: string, reason: FailureReason, invitationForm = false): NextResponse {
     authFailureLimiter.recordFailure(address);
     // `reason` is a fixed enum: useful to an operator reading container logs,
     // and free of the code, the email, and any hint of which exists.
     console.warn(`[auth] ticket login rejected: reason=${reason} client=${address}`);
+    if (invitationForm) return invitationFailure(reason === 'malformed_request' ? 'invalid' : 'unavailable');
     return NextResponse.json(
         { error: reason === 'malformed_request' ? MALFORMED_REQUEST : GENERIC_REJECTION },
         { status: reason === 'malformed_request' ? 400 : 401 },
     );
+}
+
+function invitationFailure(reason: 'invalid' | 'limited' | 'unavailable'): NextResponse {
+    const returnUrl = new URL(INVITATION_RETURN_URL);
+    returnUrl.searchParams.set('entry_error', reason);
+    return NextResponse.redirect(returnUrl, { status: 303 });
 }
 
 /**

--- a/src/lib/__tests__/event-stabilization.test.ts
+++ b/src/lib/__tests__/event-stabilization.test.ts
@@ -22,7 +22,7 @@ function validSnapshot(): StabilizationSnapshot {
             endedAt: null,
             status: contract.acceptedStatuses[0],
             isTest: contract.isTest,
-            paidMode: true,
+            paidMode: contract.paidMode,
             attendeeCap: 150,
             maxPublishers: 6,
             facilitatorId: 'facilitator-id',
@@ -82,18 +82,26 @@ describe('event stabilization safety contract', () => {
         expect(() => validateStabilizationSnapshot(moved)).toThrow(/unexpected scheduledAt/);
     });
 
-    it('refuses execution at and after the ten-minute doors boundary', () => {
-        expect(() => assertStabilizationWindow(new Date('2026-08-08T14:19:59.999Z'))).not.toThrow();
-        expect(() => assertStabilizationWindow(new Date('2026-08-08T14:20:00.000Z'))).toThrow(/Refusing/);
+    it('refuses execution at and after the free-event doors boundary', () => {
+        expect(() => assertStabilizationWindow(new Date('2026-08-02T16:49:59.999Z'))).not.toThrow();
+        expect(() => assertStabilizationWindow(new Date('2026-08-02T16:50:00.000Z'))).toThrow(/Refusing/);
     });
 
-    it('pins both production sessions to August 8 and derives the deadline from that release', () => {
+    it('pins the combined free event and retires the unused English session', () => {
         const [spanish, english] = EVENT_CONTRACTS;
 
-        expect(EVENT_STABILIZATION_DEADLINE.toISOString()).toBe('2026-08-08T14:20:00.000Z');
+        expect(EVENT_STABILIZATION_DEADLINE.toISOString()).toBe('2026-08-02T16:50:00.000Z');
         expect(desiredSessionState(spanish, new Date()).scheduledAt.toISOString())
-            .toBe('2026-08-08T14:30:00.000Z');
+            .toBe('2026-08-02T17:00:00.000Z');
+        expect(desiredSessionState(spanish, new Date())).toMatchObject({
+            status: 'SCHEDULED',
+            paidMode: false,
+        });
         expect(desiredSessionState(english, new Date()).scheduledAt.toISOString())
             .toBe('2026-08-08T20:00:00.000Z');
+        expect(desiredSessionState(english, new Date())).toMatchObject({
+            status: 'CANCELLED',
+            paidMode: false,
+        });
     });
 });

--- a/src/lib/__tests__/promo-invitation.integration.test.ts
+++ b/src/lib/__tests__/promo-invitation.integration.test.ts
@@ -129,6 +129,10 @@ integration('promotion invitation PostgreSQL contract', () => {
             redemption.ticketEntitlement.boundEmail!,
             'Returning guest',
             new Date('2026-08-04T12:00:00.000Z'),
+            {
+                version: 'personal-invitation-v2',
+                acceptedAt: new Date('2026-08-04T12:00:00.000Z'),
+            },
         );
         expect(replay).toMatchObject({
             ok: true,
@@ -142,5 +146,17 @@ integration('promotion invitation PostgreSQL contract', () => {
             new Date('2026-08-04T12:00:00.000Z'),
         )).resolves.toEqual({ ok: false, reason: 'unavailable' });
         expect(await prisma.ticketEntitlement.count()).toBe(1);
+        await expect(prisma.auditLog.findFirst({
+            where: {
+                action: 'invitation.terms.accept',
+                targetId: redemption.ticketEntitlementId,
+            },
+        })).resolves.toMatchObject({
+            metadata: {
+                promoInvitationId: CAMPAIGN_ID,
+                termsVersion: 'personal-invitation-v2',
+                acceptedAt: '2026-08-04T12:00:00.000Z',
+            },
+        });
     });
 });

--- a/src/lib/event-stabilization.ts
+++ b/src/lib/event-stabilization.ts
@@ -6,7 +6,7 @@ import type {
     TicketEntitlementState,
 } from '@prisma/client';
 
-export const EVENT_STABILIZATION_DEADLINE = new Date('2026-08-08T14:20:00.000Z');
+export const EVENT_STABILIZATION_DEADLINE = new Date('2026-08-02T16:50:00.000Z');
 
 export type EventContract = {
     id: string;
@@ -15,6 +15,8 @@ export type EventContract = {
     roomName: string;
     language: SessionLanguage;
     isTest: boolean;
+    paidMode: boolean;
+    desiredStatus: Extract<ScheduledSessionStatus, 'SCHEDULED' | 'CANCELLED'>;
     scheduledAt: string;
     acceptedScheduledAt: readonly string[];
     acceptedStatuses: readonly ScheduledSessionStatus[];
@@ -24,16 +26,19 @@ export const EVENT_CONTRACTS: readonly EventContract[] = [
     {
         id: '10000000-0000-4000-8000-000000000001',
         key: 'real-es',
-        title: 'Sesión Harmonic Beacon — Español',
+        title: 'Harmonic Beacon — Encuentro abierto ES/EN',
         roomName: 'weekend-session-1',
         language: 'SPANISH',
         isTest: false,
-        scheduledAt: '2026-08-08T14:30:00.000Z',
+        scheduledAt: '2026-08-02T17:00:00.000Z',
         acceptedScheduledAt: [
             '2026-08-01T14:30:00.000Z',
+            '2026-08-02T17:00:00.000Z',
             '2026-08-08T14:30:00.000Z',
         ],
         acceptedStatuses: ['SCHEDULED', 'LIVE'],
+        paidMode: false,
+        desiredStatus: 'SCHEDULED',
     },
     {
         id: '10000000-0000-4000-8000-000000000002',
@@ -48,7 +53,9 @@ export const EVENT_CONTRACTS: readonly EventContract[] = [
             '2026-08-01T20:00:00.000Z',
             '2026-08-08T20:00:00.000Z',
         ],
-        acceptedStatuses: ['SCHEDULED', 'LIVE'],
+        acceptedStatuses: ['CANCELLED'],
+        paidMode: false,
+        desiredStatus: 'CANCELLED',
     },
     {
         id: '10000000-0000-4000-8000-000000000101',
@@ -63,6 +70,8 @@ export const EVENT_CONTRACTS: readonly EventContract[] = [
             '2026-08-08T14:30:00.000Z',
         ],
         acceptedStatuses: ['SCHEDULED', 'LIVE', 'CANCELLED'],
+        paidMode: true,
+        desiredStatus: 'CANCELLED',
     },
     {
         id: '10000000-0000-4000-8000-000000000102',
@@ -78,6 +87,8 @@ export const EVENT_CONTRACTS: readonly EventContract[] = [
             '2026-08-08T20:00:00.000Z',
         ],
         acceptedStatuses: ['SCHEDULED', 'LIVE', 'CANCELLED'],
+        paidMode: true,
+        desiredStatus: 'CANCELLED',
     },
 ] as const;
 
@@ -125,7 +136,7 @@ export function validateStabilizationSnapshot(snapshot: StabilizationSnapshot): 
             ['roomName', session.roomName, contract.roomName],
             ['language', session.language, contract.language],
             ['isTest', session.isTest, contract.isTest],
-            ['paidMode', session.paidMode, true],
+            ['paidMode', session.paidMode, contract.paidMode],
             ['attendeeCap', session.attendeeCap, 150],
             ['maxPublishers', session.maxPublishers, 6],
         ];
@@ -173,15 +184,19 @@ export function assertStabilizationWindow(now: Date): void {
 }
 
 export function desiredSessionState(contract: EventContract, now: Date) {
-    return contract.isTest
+    return contract.desiredStatus === 'CANCELLED'
         ? {
             status: 'CANCELLED' as const,
             scheduledAt: new Date(contract.scheduledAt),
+            title: contract.title,
+            paidMode: contract.paidMode,
             endedAt: now,
         }
         : {
             status: 'SCHEDULED' as const,
             scheduledAt: new Date(contract.scheduledAt),
+            title: contract.title,
+            paidMode: contract.paidMode,
             startedAt: null,
             endedAt: null,
         };

--- a/src/lib/promo-invitation.ts
+++ b/src/lib/promo-invitation.ts
@@ -60,6 +60,11 @@ export type PromoRedemptionAttempt =
     }
     | { ok: false; reason: 'unavailable' };
 
+export type PromoTermsAcceptance = {
+    version: string;
+    acceptedAt: Date;
+};
+
 /**
  * Atomically redeem (or replay) one human promotion code.
  *
@@ -74,6 +79,7 @@ export async function redeemPromoInvitation(
     email: string,
     displayName: string,
     now = new Date(),
+    termsAcceptance?: PromoTermsAcceptance,
 ): Promise<PromoRedemptionAttempt> {
     const codeDigest = digestPromoCode(code);
     const redeemerDigest = promoRedeemerDigest(email);
@@ -189,6 +195,22 @@ export async function redeemPromoInvitation(
                 lastSeenAt: now,
             },
         });
+
+        if (termsAcceptance) {
+            await tx.auditLog.create({
+                data: {
+                    actorUserId: null,
+                    action: 'invitation.terms.accept',
+                    targetType: 'TICKET_ENTITLEMENT',
+                    targetId: entitlement.id,
+                    metadata: {
+                        promoInvitationId: invitation.id,
+                        termsVersion: termsAcceptance.version,
+                        acceptedAt: termsAcceptance.acceptedAt.toISOString(),
+                    },
+                },
+            });
+        }
 
         return {
             ok: true,


### PR DESCRIPTION
## Summary
- accept the public invitation form through the existing secure promo entitlement path
- audit terms acceptance without logging attendee PII
- pin today's combined free session and cancel the unused EN session contract
- select one explicit WAV/OGG playlist source without mixing rollback assets

## Evidence
- 686 tests passed, 7 integration tests skipped by default
- TypeScript and ESLint passed
- production build passed
- playlist-bot: 9 tests and build passed

## Rollback
Revert this PR, set BEACON_PLAYLIST_FILE back to /data/beacon-records/luz_de_manana.ogg, and disable the NICO100 campaign.