### PR TITLE
Preserve paid-mode invariant for free event

### DIFF
--- a/src/lib/__tests__/event-stabilization.test.ts
+++ b/src/lib/__tests__/event-stabilization.test.ts
@@ -95,13 +95,13 @@ describe('event stabilization safety contract', () => {
             .toBe('2026-08-02T17:00:00.000Z');
         expect(desiredSessionState(spanish, new Date())).toMatchObject({
             status: 'SCHEDULED',
-            paidMode: false,
+            paidMode: true,
         });
         expect(desiredSessionState(english, new Date()).scheduledAt.toISOString())
             .toBe('2026-08-08T20:00:00.000Z');
         expect(desiredSessionState(english, new Date())).toMatchObject({
             status: 'CANCELLED',
-            paidMode: false,
+            paidMode: true,
         });
     });
 });

--- a/src/lib/event-stabilization.ts
+++ b/src/lib/event-stabilization.ts
@@ -37,7 +37,9 @@ export const EVENT_CONTRACTS: readonly EventContract[] = [
             '2026-08-08T14:30:00.000Z',
         ],
         acceptedStatuses: ['SCHEDULED', 'LIVE'],
-        paidMode: false,
+        // Historical weekend rows are constrained to paid_mode=true. Free
+        // admission is represented by the COMP promotion entitlement itself.
+        paidMode: true,
         desiredStatus: 'SCHEDULED',
     },
     {
@@ -54,7 +56,7 @@ export const EVENT_CONTRACTS: readonly EventContract[] = [
             '2026-08-08T20:00:00.000Z',
         ],
         acceptedStatuses: ['CANCELLED'],
-        paidMode: false,
+        paidMode: true,
         desiredStatus: 'CANCELLED',
     },
     {


### PR DESCRIPTION
The historical weekend rows enforce paid_mode=true at the database level. Free access remains represented by COMP promotion entitlements. This aligns the stabilization contract with the successful production transaction.