### PR TITLE
Keep invitation redirect on public origin

### DIFF
--- a/src/app/api/auth/ticket/__tests__/route.test.ts
+++ b/src/app/api/auth/ticket/__tests__/route.test.ts
@@ -135,7 +135,9 @@ function loginRequest(body: unknown, address = CLIENT) {
 }
 
 function invitationRequest(overrides: Record<string, string> = {}, address = CLIENT) {
-    return new NextRequest('https://live.harmonicbeacon.com/api/auth/ticket', {
+    // Production reverse-proxy requests reach Next.js with this internal
+    // origin; redirects must never expose it to the attendee.
+    return new NextRequest('http://0.0.0.0:3000/api/auth/ticket', {
         method: 'POST',
         headers: {
             'content-type': 'application/x-www-form-urlencoded',

--- a/src/app/api/auth/ticket/route.ts
+++ b/src/app/api/auth/ticket/route.ts
@@ -42,6 +42,7 @@ const RATE_LIMITED = 'Too many attempts. Please wait and try again.';
 const MALFORMED_REQUEST = 'A display name, ticket code and email address are required.';
 const INVITATION_TERMS_VERSION = 'personal-invitation-v2';
 const INVITATION_RETURN_URL = 'https://harmonicbeacon.com/invitacion/';
+const PUBLIC_APP_ORIGIN = 'https://live.harmonicbeacon.com';
 
 type FailureReason =
     | 'malformed_request'
@@ -144,7 +145,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const response = isInvitationForm
         ? NextResponse.redirect(
-            new URL(`/session/${attempt.scheduledSessionId}`, request.url),
+            new URL(`/session/${attempt.scheduledSessionId}`, PUBLIC_APP_ORIGIN),
             { status: 303 },
         )
         : NextResponse.json({ ok: true, scheduledSessionId: attempt.scheduledSessionId });


### PR DESCRIPTION
Production smoke found the reverse proxy exposes Next.js as 0.0.0.0:3000 in request.url. Pin the form redirect to live.harmonicbeacon.com and cover the internal-origin request.