### PR TITLE
Add clean August 8 paid sessions

### DIFF
--- a/prisma/migrations/20260804100000_hmp_august_8_paid_sessions/migration.sql
+++ b/prisma/migrations/20260804100000_hmp_august_8_paid_sessions/migration.sql
@@ -27,10 +27,28 @@ SELECT
     true,
     150,
     6,
-    "facilitator_id",
-    CURRENT_TIMESTAMP
-FROM "scheduled_sessions"
-WHERE "id" = '10000000-0000-4000-8000-000000000001'::uuid;
+    COALESCE(
+        (
+            SELECT "facilitator_id"
+            FROM "scheduled_sessions"
+            WHERE "id" = '10000000-0000-4000-8000-000000000001'::uuid
+        ),
+        (
+            SELECT "facilitator_id"
+            FROM "scheduled_sessions"
+            WHERE "language" = 'SPANISH'::"SessionLanguage"
+            ORDER BY "is_test" ASC, "scheduled_at" DESC
+            LIMIT 1
+        ),
+        (
+            SELECT "id"
+            FROM "users"
+            WHERE "role" = 'FACILITATOR'::"StaffRole" AND "disabled_at" IS NULL
+            ORDER BY "created_at" ASC
+            LIMIT 1
+        )
+    ),
+    CURRENT_TIMESTAMP;
 
 INSERT INTO "scheduled_sessions" (
     "id",
@@ -59,10 +77,28 @@ SELECT
     true,
     150,
     6,
-    "facilitator_id",
-    CURRENT_TIMESTAMP
-FROM "scheduled_sessions"
-WHERE "id" = '10000000-0000-4000-8000-000000000002'::uuid;
+    COALESCE(
+        (
+            SELECT "facilitator_id"
+            FROM "scheduled_sessions"
+            WHERE "id" = '10000000-0000-4000-8000-000000000002'::uuid
+        ),
+        (
+            SELECT "facilitator_id"
+            FROM "scheduled_sessions"
+            WHERE "language" = 'ENGLISH'::"SessionLanguage"
+            ORDER BY "is_test" ASC, "scheduled_at" DESC
+            LIMIT 1
+        ),
+        (
+            SELECT "id"
+            FROM "users"
+            WHERE "role" = 'FACILITATOR'::"StaffRole" AND "disabled_at" IS NULL
+            ORDER BY "created_at" ASC
+            LIMIT 1
+        )
+    ),
+    CURRENT_TIMESTAMP;
 
 DO $$
 BEGIN

--- a/prisma/migrations/20260804100000_hmp_august_8_paid_sessions/migration.sql
+++ b/prisma/migrations/20260804100000_hmp_august_8_paid_sessions/migration.sql
@@ -1,0 +1,79 @@
+-- New paid sessions for 2026-08-08. The August 2 production rows retain
+-- participants, grants and web sessions, so they must remain historical.
+INSERT INTO "scheduled_sessions" (
+    "id",
+    "title",
+    "description",
+    "room_name",
+    "language",
+    "scheduled_at",
+    "status",
+    "is_test",
+    "paid_mode",
+    "attendee_cap",
+    "max_publishers",
+    "facilitator_id",
+    "updated_at"
+)
+SELECT
+    '20000000-0000-4000-8000-202608080001'::uuid,
+    'Harmonic Myth Projection — Español — 8 de agosto',
+    'Sesión virtual en español · 08:30 Costa Rica',
+    'hmp-2026-08-08-es',
+    'SPANISH'::"SessionLanguage",
+    '2026-08-08 14:30:00'::timestamp,
+    'SCHEDULED'::"ScheduledSessionStatus",
+    false,
+    true,
+    150,
+    6,
+    "facilitator_id",
+    CURRENT_TIMESTAMP
+FROM "scheduled_sessions"
+WHERE "id" = '10000000-0000-4000-8000-000000000001'::uuid;
+
+INSERT INTO "scheduled_sessions" (
+    "id",
+    "title",
+    "description",
+    "room_name",
+    "language",
+    "scheduled_at",
+    "status",
+    "is_test",
+    "paid_mode",
+    "attendee_cap",
+    "max_publishers",
+    "facilitator_id",
+    "updated_at"
+)
+SELECT
+    '20000000-0000-4000-8000-202608080002'::uuid,
+    'Harmonic Myth Projection — English — August 8',
+    'Virtual English session · 14:00 Costa Rica',
+    'hmp-2026-08-08-en',
+    'ENGLISH'::"SessionLanguage",
+    '2026-08-08 20:00:00'::timestamp,
+    'SCHEDULED'::"ScheduledSessionStatus",
+    false,
+    true,
+    150,
+    6,
+    "facilitator_id",
+    CURRENT_TIMESTAMP
+FROM "scheduled_sessions"
+WHERE "id" = '10000000-0000-4000-8000-000000000002'::uuid;
+
+DO $$
+BEGIN
+    IF (
+        SELECT count(*)
+        FROM "scheduled_sessions"
+        WHERE "id" IN (
+            '20000000-0000-4000-8000-202608080001'::uuid,
+            '20000000-0000-4000-8000-202608080002'::uuid
+        )
+    ) <> 2 THEN
+        RAISE EXCEPTION 'August 8 production sessions could not be created';
+    END IF;
+END $$;

--- a/prisma/migrations/20260804100000_hmp_august_8_paid_sessions/migration.sql
+++ b/prisma/migrations/20260804100000_hmp_august_8_paid_sessions/migration.sql
@@ -27,28 +27,10 @@ SELECT
     true,
     150,
     6,
-    COALESCE(
-        (
-            SELECT "facilitator_id"
-            FROM "scheduled_sessions"
-            WHERE "id" = '10000000-0000-4000-8000-000000000001'::uuid
-        ),
-        (
-            SELECT "facilitator_id"
-            FROM "scheduled_sessions"
-            WHERE "language" = 'SPANISH'::"SessionLanguage"
-            ORDER BY "is_test" ASC, "scheduled_at" DESC
-            LIMIT 1
-        ),
-        (
-            SELECT "id"
-            FROM "users"
-            WHERE "role" = 'FACILITATOR'::"StaffRole" AND "disabled_at" IS NULL
-            ORDER BY "created_at" ASC
-            LIMIT 1
-        )
-    ),
-    CURRENT_TIMESTAMP;
+    "facilitator_id",
+    CURRENT_TIMESTAMP
+FROM "scheduled_sessions"
+WHERE "id" = '10000000-0000-4000-8000-000000000001'::uuid;
 
 INSERT INTO "scheduled_sessions" (
     "id",
@@ -77,39 +59,34 @@ SELECT
     true,
     150,
     6,
-    COALESCE(
-        (
-            SELECT "facilitator_id"
-            FROM "scheduled_sessions"
-            WHERE "id" = '10000000-0000-4000-8000-000000000002'::uuid
-        ),
-        (
-            SELECT "facilitator_id"
-            FROM "scheduled_sessions"
-            WHERE "language" = 'ENGLISH'::"SessionLanguage"
-            ORDER BY "is_test" ASC, "scheduled_at" DESC
-            LIMIT 1
-        ),
-        (
-            SELECT "id"
-            FROM "users"
-            WHERE "role" = 'FACILITATOR'::"StaffRole" AND "disabled_at" IS NULL
-            ORDER BY "created_at" ASC
-            LIMIT 1
-        )
-    ),
-    CURRENT_TIMESTAMP;
+    "facilitator_id",
+    CURRENT_TIMESTAMP
+FROM "scheduled_sessions"
+WHERE "id" = '10000000-0000-4000-8000-000000000002'::uuid;
 
 DO $$
+DECLARE
+    historical_source_count integer;
+    target_count integer;
 BEGIN
-    IF (
-        SELECT count(*)
-        FROM "scheduled_sessions"
-        WHERE "id" IN (
+    SELECT count(*) INTO historical_source_count
+    FROM "scheduled_sessions"
+    WHERE "id" IN (
+        '10000000-0000-4000-8000-000000000001'::uuid,
+        '10000000-0000-4000-8000-000000000002'::uuid
+    );
+
+    SELECT count(*) INTO target_count
+    FROM "scheduled_sessions"
+    WHERE "id" IN (
             '20000000-0000-4000-8000-202608080001'::uuid,
             '20000000-0000-4000-8000-202608080002'::uuid
-        )
-    ) <> 2 THEN
+    );
+
+    IF historical_source_count NOT IN (0, 2) THEN
+        RAISE EXCEPTION 'August 8 historical session source is incomplete';
+    END IF;
+    IF target_count <> historical_source_count THEN
         RAISE EXCEPTION 'August 8 production sessions could not be created';
     END IF;
 END $$;

--- a/src/lib/__tests__/seed-contract.test.ts
+++ b/src/lib/__tests__/seed-contract.test.ts
@@ -155,6 +155,8 @@ describe('weekend seed contract', () => {
         expect(migration).toContain("'2026-08-08 14:30:00'::timestamp");
         expect(migration).toContain("'2026-08-08 20:00:00'::timestamp");
         expect(migration).toContain("'SCHEDULED'::\"ScheduledSessionStatus\"");
+        expect(migration).toContain("'FACILITATOR'::\"StaffRole\"");
+        expect(migration).toContain('ORDER BY "is_test" ASC, "scheduled_at" DESC');
         expect(migration).not.toMatch(/UPDATE\s+"scheduled_sessions"/i);
     });
 });

--- a/src/lib/__tests__/seed-contract.test.ts
+++ b/src/lib/__tests__/seed-contract.test.ts
@@ -155,8 +155,8 @@ describe('weekend seed contract', () => {
         expect(migration).toContain("'2026-08-08 14:30:00'::timestamp");
         expect(migration).toContain("'2026-08-08 20:00:00'::timestamp");
         expect(migration).toContain("'SCHEDULED'::\"ScheduledSessionStatus\"");
-        expect(migration).toContain("'FACILITATOR'::\"StaffRole\"");
-        expect(migration).toContain('ORDER BY "is_test" ASC, "scheduled_at" DESC');
+        expect(migration).toContain('historical_source_count NOT IN (0, 2)');
+        expect(migration).toContain('target_count <> historical_source_count');
         expect(migration).not.toMatch(/UPDATE\s+"scheduled_sessions"/i);
     });
 });

--- a/src/lib/__tests__/seed-contract.test.ts
+++ b/src/lib/__tests__/seed-contract.test.ts
@@ -140,4 +140,21 @@ describe('weekend seed contract', () => {
         expect(migration).toContain('10000000-0000-4000-8000-000000000102');
         expect(migration).not.toMatch(/(?:lower\s*\()?"?title"?\)?\s+(?:like|ilike)/i);
     });
+
+    it('creates fresh paid sessions for August 8 without repurposing historical rows', () => {
+        const migration = readFileSync(
+            new URL(
+                '../../../prisma/migrations/20260804100000_hmp_august_8_paid_sessions/migration.sql',
+                import.meta.url,
+            ),
+            'utf8',
+        );
+
+        expect(migration).toContain('20000000-0000-4000-8000-202608080001');
+        expect(migration).toContain('20000000-0000-4000-8000-202608080002');
+        expect(migration).toContain("'2026-08-08 14:30:00'::timestamp");
+        expect(migration).toContain("'2026-08-08 20:00:00'::timestamp");
+        expect(migration).toContain("'SCHEDULED'::\"ScheduledSessionStatus\"");
+        expect(migration).not.toMatch(/UPDATE\s+"scheduled_sessions"/i);
+    });
 });


### PR DESCRIPTION
Creates two new SCHEDULED production sessions for the August 8 Spanish and English events instead of repurposing August 2 rows that retain participants, grants, tickets, and web sessions. Includes a migration assertion and regression coverage. Full suite: 688 passed, 7 skipped; lint and production build passed.