### PR TITLE
feat(deploy): expose and verify release provenance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,15 @@ jobs:
       - name: Build commit image
         shell: bash
         run: |
-          sudo -n env BEACON_IMAGE_TAG="$GITHUB_SHA" docker compose \
+          build_time="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          database_schema_version="$(find prisma/migrations -mindepth 1 -maxdepth 1 \
+            -type d -printf '%f\n' | sort | tail -1)"
+          test -n "$database_schema_version"
+          sudo -n env BEACON_IMAGE_TAG="$GITHUB_SHA" \
+            BEACON_GIT_SHA="$GITHUB_SHA" \
+            BEACON_BUILD_TIME="$build_time" \
+            BEACON_DATABASE_SCHEMA_VERSION="$database_schema_version" \
+            docker compose \
             --project-name app --env-file /etc/harmonic-beacon/production.env \
             build app tapestry
 
@@ -115,6 +123,34 @@ jobs:
             --env-file /etc/harmonic-beacon/production.env ps
           sudo -n docker logs --tail 100 beacon-app || true
           sudo -n docker logs --tail 100 beacon-commerce-reconciler || true
+          exit 1
+
+      - name: Verify deployed revision publicly
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_revision() {
+            local url="$1"
+            local body
+            body="$(curl --fail --silent --show-error "$url")"
+            HEALTH_BODY="$body" EXPECTED_GIT_SHA="$GITHUB_SHA" node -e '
+              const health = JSON.parse(process.env.HEALTH_BODY || "null");
+              if (health?.schemaVersion !== "health.response.v2") process.exit(1);
+              if (health?.gitSha !== process.env.EXPECTED_GIT_SHA) process.exit(1);
+              if (typeof health?.buildTime !== "string") process.exit(1);
+              if (health?.databaseSchemaVersion === "unknown") process.exit(1);
+              if (health?.contractVersions?.commerceEntitlement !== "commerce-entitlement.v1") process.exit(1);
+            '
+          }
+
+          verify_revision http://127.0.0.1:3000/api/health
+          for _attempt in $(seq 1 30); do
+            if verify_revision https://live.harmonicbeacon.com/api/health; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Public health never served expected revision $GITHUB_SHA" >&2
           exit 1
 
       - name: Verify private boundary and secret isolation

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,14 @@ FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
+ARG BEACON_GIT_SHA=unknown
+ARG BEACON_BUILD_TIME=unknown
+ARG BEACON_DATABASE_SCHEMA_VERSION=unknown
+
+ENV BEACON_GIT_SHA=$BEACON_GIT_SHA \
+    BEACON_BUILD_TIME=$BEACON_BUILD_TIME \
+    BEACON_DATABASE_SCHEMA_VERSION=$BEACON_DATABASE_SCHEMA_VERSION
+
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs && \
     apk add --no-cache curl ffmpeg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       context: .
       args:
         - NEXT_PUBLIC_LIVEKIT_URL=${NEXT_PUBLIC_LIVEKIT_URL:-wss://live.harmonicbeacon.com}
+        - BEACON_GIT_SHA=${BEACON_GIT_SHA:-unknown}
+        - BEACON_BUILD_TIME=${BEACON_BUILD_TIME:-unknown}
+        - BEACON_DATABASE_SCHEMA_VERSION=${BEACON_DATABASE_SCHEMA_VERSION:-unknown}
     container_name: beacon-app
     restart: unless-stopped
     env_file:

--- a/src/app/api/health/__tests__/route.test.ts
+++ b/src/app/api/health/__tests__/route.test.ts
@@ -4,9 +4,13 @@ import { parseResponse } from '@/__tests__/helpers';
 describe('GET /api/health', () => {
     beforeEach(() => {
         vi.resetModules();
+        vi.unstubAllEnvs();
     });
 
-    it('returns 200 with status, uptime, and version without querying the database', async () => {
+    it('returns release provenance without querying the database', async () => {
+        vi.stubEnv('BEACON_GIT_SHA', 'a'.repeat(40));
+        vi.stubEnv('BEACON_BUILD_TIME', '2026-08-04T18:30:00Z');
+        vi.stubEnv('BEACON_DATABASE_SCHEMA_VERSION', '20260804100000_hmp_august_8_paid_sessions');
         const queryRaw = vi.fn();
         const mockPrisma = { $queryRaw: queryRaw };
 
@@ -20,10 +24,41 @@ describe('GET /api/health', () => {
         const { status, body } = await parseResponse(response);
 
         expect(status).toBe(200);
-        const data = body as { status: string; uptime: number; version: string };
+        const data = body as {
+            schemaVersion: string;
+            status: string;
+            uptime: number;
+            version: string;
+            gitSha: string;
+            buildTime: string;
+            databaseSchemaVersion: string;
+            contractVersions: { commerceEntitlement: string };
+        };
+        expect(data.schemaVersion).toBe('health.response.v2');
         expect(data.status).toBe('ok');
         expect(typeof data.uptime).toBe('number');
         expect(typeof data.version).toBe('string');
+        expect(data.gitSha).toBe('a'.repeat(40));
+        expect(data.buildTime).toBe('2026-08-04T18:30:00Z');
+        expect(data.databaseSchemaVersion).toBe('20260804100000_hmp_august_8_paid_sessions');
+        expect(data.contractVersions).toEqual({ commerceEntitlement: 'commerce-entitlement.v1' });
+        expect(response.headers.get('Cache-Control')).toBe('no-store');
         expect(queryRaw).not.toHaveBeenCalled();
+    });
+
+    it('fails closed to unknown provenance when build arguments are malformed', async () => {
+        vi.stubEnv('BEACON_GIT_SHA', 'release-latest');
+        vi.stubEnv('BEACON_BUILD_TIME', 'today');
+        vi.stubEnv('BEACON_DATABASE_SCHEMA_VERSION', '../migrations');
+
+        const { GET } = await import('../route');
+        const response = await GET();
+        const { body } = await parseResponse(response);
+
+        expect(body).toEqual(expect.objectContaining({
+            gitSha: 'unknown',
+            buildTime: null,
+            databaseSchemaVersion: 'unknown',
+        }));
     });
 });

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import packageJson from '../../../../package.json';
+import { buildProvenance, HEALTH_SCHEMA_VERSION } from '@/lib/build-provenance';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,9 +12,14 @@ export const dynamic = 'force-dynamic';
  * process, so it must stay green even when the database is unreachable.
  */
 export async function GET() {
-    return NextResponse.json({
-        status: 'ok',
-        uptime: process.uptime(),
-        version: packageJson.version,
-    });
+    return NextResponse.json(
+        {
+            schemaVersion: HEALTH_SCHEMA_VERSION,
+            status: 'ok',
+            uptime: process.uptime(),
+            version: packageJson.version,
+            ...buildProvenance(process.env),
+        },
+        { headers: { 'Cache-Control': 'no-store' } },
+    );
 }

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -28,6 +28,18 @@ describe('production deploy contract', () => {
     expect(workflow).toContain('[ "$tapestry_health" = healthy ]');
   });
 
+  it('embeds and verifies the exact release provenance before success', () => {
+    expect(compose).toContain('BEACON_GIT_SHA=${BEACON_GIT_SHA:-unknown}');
+    expect(compose).toContain('BEACON_BUILD_TIME=${BEACON_BUILD_TIME:-unknown}');
+    expect(compose).toContain(
+      'BEACON_DATABASE_SCHEMA_VERSION=${BEACON_DATABASE_SCHEMA_VERSION:-unknown}',
+    );
+    expect(workflow).toContain('BEACON_GIT_SHA="$GITHUB_SHA"');
+    expect(workflow).toContain('EXPECTED_GIT_SHA="$GITHUB_SHA"');
+    expect(workflow).toContain('health?.gitSha !== process.env.EXPECTED_GIT_SHA');
+    expect(workflow).toContain('https://live.harmonicbeacon.com/api/health');
+  });
+
   it('can only schedule production deploys on the verified mona runner', () => {
     expect(workflow).toContain('runs-on: [self-hosted, mona]');
     expect(workflow).toContain('test "$(hostname -s)" = mona');

--- a/src/lib/build-provenance.ts
+++ b/src/lib/build-provenance.ts
@@ -1,0 +1,38 @@
+export const HEALTH_SCHEMA_VERSION = 'health.response.v2';
+export const COMMERCE_ENTITLEMENT_CONTRACT_VERSION = 'commerce-entitlement.v1';
+
+type Environment = Record<string, string | undefined>;
+
+const FULL_GIT_SHA = /^[0-9a-f]{40}$/;
+const UTC_BUILD_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+const DATABASE_SCHEMA_VERSION = /^\d{14}_[a-z0-9_]+$/;
+
+export type BuildProvenance = {
+    gitSha: string;
+    buildTime: string | null;
+    databaseSchemaVersion: string;
+    contractVersions: {
+        commerceEntitlement: typeof COMMERCE_ENTITLEMENT_CONTRACT_VERSION;
+    };
+};
+
+/**
+ * Expose only validated, non-sensitive build metadata. Missing local build
+ * arguments remain explicit instead of pretending to identify a release.
+ */
+export function buildProvenance(environment: Environment): BuildProvenance {
+    const gitSha = environment.BEACON_GIT_SHA?.toLowerCase() ?? '';
+    const buildTime = environment.BEACON_BUILD_TIME ?? '';
+    const databaseSchemaVersion = environment.BEACON_DATABASE_SCHEMA_VERSION ?? '';
+
+    return {
+        gitSha: FULL_GIT_SHA.test(gitSha) ? gitSha : 'unknown',
+        buildTime: UTC_BUILD_TIME.test(buildTime) ? buildTime : null,
+        databaseSchemaVersion: DATABASE_SCHEMA_VERSION.test(databaseSchemaVersion)
+            ? databaseSchemaVersion
+            : 'unknown',
+        contractVersions: {
+            commerceEntitlement: COMMERCE_ENTITLEMENT_CONTRACT_VERSION,
+        },
+    };
+}


### PR DESCRIPTION
## Outcome

Makes every deployed Beacon revision externally identifiable and makes the production workflow fail and roll back when the public hostname serves a stale or unknown revision.

Progresses #124 without touching registration or payment behavior.

## Contract

`GET /api/health` now returns validated, non-sensitive release metadata:

- `schemaVersion: health.response.v2`
- exact 40-character `gitSha`
- UTC `buildTime`
- latest Prisma `databaseSchemaVersion`
- `contractVersions.commerceEntitlement: commerce-entitlement.v1`

Malformed or absent local build values fail closed to `unknown` / `null`, and the response is `no-store`. The liveness route still performs no database query.

The release workflow embeds those values in the immutable image, verifies the exact SHA locally and through `https://live.harmonicbeacon.com/api/health`, retries the public edge for 60 seconds, and triggers the existing immutable-image rollback if the expected revision never appears.

## Verification

- 690 tests passed; 7 integration tests skipped by their existing opt-in gates
- TypeScript passed
- ESLint `--quiet` passed
- production build passed
- `git diff --check` passed

## Safety / boundaries

- No database query or migration is introduced by the health endpoint.
- No PII, credential, secret, registration state, payment state, or participant data is exposed.
- No deployment is performed by this PR.
- The cross-repo synthetic registration/access smoke remains explicitly open in #124.