### PR TITLE
test(roles): cover browser capability matrix

### DIFF
--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -176,3 +176,41 @@ export async function withPreservedFixtureStaff<T>(
         await client.end();
     }
 }
+
+/**
+ * Temporarily change one synthetic staff identity's role, preserving the row.
+ *
+ * This lets the browser matrix exercise an unassigned facilitator and an
+ * unassigned FACILITATOR_OP without adding production-only impersonation
+ * behavior to the E2E dashboard route.
+ */
+export async function withFixtureStaffRole<T>(
+    databaseUrl: string,
+    email: string,
+    role: FixtureStaffSnapshot['role'],
+    run: () => Promise<T>,
+): Promise<T> {
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        const { rows } = await client.query<FixtureStaffSnapshot>(
+            'select name, role, disabled_at from users where email = $1',
+            [email],
+        );
+        const original = rows[0];
+        if (!original) {
+            throw new Error(`fixture staff ${email} not found`);
+        }
+        await client.query('update users set role = $1 where email = $2', [role, email]);
+        try {
+            return await run();
+        } finally {
+            await client.query(
+                'update users set name = $1, role = $2, disabled_at = $3 where email = $4',
+                [original.name, original.role, original.disabled_at, email],
+            );
+        }
+    } finally {
+        await client.end();
+    }
+}

--- a/e2e/tests/role-capabilities.spec.ts
+++ b/e2e/tests/role-capabilities.spec.ts
@@ -1,0 +1,230 @@
+import type { Browser, Page } from '@playwright/test';
+
+import {
+    loginAttendeeWithTicket,
+    loginViaDashboard,
+    type DashboardRole,
+} from '../fixtures/auth';
+import {
+    requireDirectDb,
+    withFixtureStaffRole,
+    withPreservedFixtureStaff,
+    withSessionStatus,
+} from '../fixtures/db';
+import { expect, stackTest } from '../fixtures/stack';
+import { ROUTES, SESSION_EN, SESSION_ES, STAFF, TICKETS } from '../fixtures/test-data';
+
+type StaffDashboardRole = Exclude<DashboardRole, 'ATTENDEE'>;
+type UiLocale = 'es' | 'en';
+
+const ROLE_COPY: Record<UiLocale, Record<StaffDashboardRole, {
+    label: string;
+    description: string;
+}>> = {
+    es: {
+        FACILITATOR: {
+            label: 'Facilitador/a',
+            description: 'Conduce y publica únicamente en los eventos que tiene asignados. Puede consultar entradas y estado técnico, pero no administrar accesos.',
+        },
+        FACILITATOR_OP: {
+            label: 'Facilitación y operaciones',
+            description: 'Opera todos los eventos. Sólo en su evento asignado actúa como facilitación y puede publicar; fuera de él conserva acceso operativo sin publicación.',
+        },
+        OPERATOR: {
+            label: 'Operaciones',
+            description: 'Opera todos los eventos y resuelve admisión y accesos. No publica cámara o micrófono como facilitación.',
+        },
+        ADMIN: {
+            label: 'Administración',
+            description: 'Administra el sistema, los eventos y los accesos globalmente. No publica cámara o micrófono como facilitación.',
+        },
+    },
+    en: {
+        FACILITATOR: {
+            label: 'Facilitator',
+            description: 'Conducts and publishes only in assigned events. Can inspect admission and system health, but cannot administer access.',
+        },
+        FACILITATOR_OP: {
+            label: 'Facilitator and operations',
+            description: 'Operates every event. Acts as facilitator and may publish only in the assigned event; elsewhere retains operational access without publication.',
+        },
+        OPERATOR: {
+            label: 'Operations',
+            description: 'Operates every event and supports admission and access. Does not publish camera or microphone as facilitator.',
+        },
+        ADMIN: {
+            label: 'Administration',
+            description: 'Administers the system, events, and access globally. Does not publish camera or microphone as facilitator.',
+        },
+    },
+};
+
+const ROLE_NAMES: Record<StaffDashboardRole, string> = {
+    FACILITATOR: 'E2E Fede',
+    FACILITATOR_OP: 'E2E Conductor',
+    OPERATOR: 'E2E Support',
+    ADMIN: 'E2E Steward',
+};
+
+async function setLocale(page: Page, locale: UiLocale): Promise<void> {
+    await page.goto('/');
+    await page.context().addCookies([{
+        name: 'hb_locale',
+        value: locale,
+        url: new URL(page.url()).origin,
+    }]);
+}
+
+async function withPage<T>(browser: Browser, run: (page: Page) => Promise<T>): Promise<T> {
+    const context = await browser.newContext();
+    try {
+        return await run(await context.newPage());
+    } finally {
+        await context.close();
+    }
+}
+
+async function expectStaffIdentity(
+    page: Page,
+    role: StaffDashboardRole,
+    name: string,
+    locale: UiLocale,
+): Promise<void> {
+    const copy = ROLE_COPY[locale][role];
+    const identity = page.locator('nav details');
+    await expect(identity.locator('summary')).toContainText(name);
+    await expect(identity.locator('summary')).toContainText(copy.label);
+    await identity.locator('summary').click();
+    await expect(identity).toContainText(copy.description);
+    await expect(page.locator('body')).not.toContainText(role);
+
+    for (const label of locale === 'es'
+        ? ['Eventos', 'Estado técnico', 'Entradas']
+        : ['Events', 'System health', 'Admission']) {
+        await expect(page.getByRole('link', { name: label, exact: true })).toBeVisible();
+    }
+}
+
+stackTest.describe('role capability contract', () => {
+    stackTest('presents every staff role and its assigned-event authority in ES and EN', async ({
+        browser,
+    }, testInfo) => {
+        stackTest.slow();
+        const db = requireDirectDb(testInfo);
+        const roles = [
+            ['FACILITATOR', true],
+            ['FACILITATOR_OP', true],
+            ['OPERATOR', false],
+            ['ADMIN', false],
+        ] as const;
+
+        await withPreservedFixtureStaff(db, STAFF.facilitator.email, async () => {
+            for (const locale of ['es', 'en'] as const) {
+                for (const [role, publishesInitially] of roles) {
+                    await withPage(browser, async (page) => {
+                        const name = `${ROLE_NAMES[role]} ${locale.toUpperCase()}`;
+                        await setLocale(page, locale);
+                        await loginViaDashboard(page, role, name, ROUTES.opsEvents);
+                        await expect(page.locator('html')).toHaveAttribute('lang', locale);
+                        await expectStaffIdentity(page, role, name, locale);
+
+                        const entry = await page.request.get(
+                            `/api/scheduled-sessions/${SESSION_ES.id}/entry`,
+                        );
+                        expect(entry.status()).toBe(200);
+
+                        const token = await page.request.get(
+                            `/api/scheduled-sessions/${SESSION_ES.id}/token`,
+                        );
+                        expect(token.status()).toBe(200);
+                        expect(await token.json()).toMatchObject({
+                            role,
+                            isAssignedFacilitator: publishesInitially,
+                            canPublish: publishesInitially,
+                            principalKind: 'staff',
+                        });
+                    });
+                }
+            }
+        });
+    });
+
+    stackTest('keeps an unassigned facilitator out while FACILITATOR_OP operates subscribe-only', async ({
+        browser,
+    }, testInfo) => {
+        const db = requireDirectDb(testInfo);
+        const syntheticOperatorEmail = 'e2e-operator@altermundi.net';
+
+        for (const role of ['FACILITATOR', 'FACILITATOR_OP'] as const) {
+            await withPage(browser, async (page) => {
+                await loginViaDashboard(page, 'OPERATOR', 'E2E Unassigned Staff', ROUTES.opsEvents);
+                await withFixtureStaffRole(db, syntheticOperatorEmail, role, async () => {
+                    const entry = await page.request.get(
+                        `/api/scheduled-sessions/${SESSION_EN.id}/entry`,
+                    );
+                    expect(entry.status()).toBe(role === 'FACILITATOR' ? 403 : 200);
+
+                    const token = await page.request.get(
+                        `/api/scheduled-sessions/${SESSION_EN.id}/token`,
+                    );
+                    if (role === 'FACILITATOR') {
+                        expect(token.status()).toBe(403);
+                        await page.goto(ROUTES.opsSession(SESSION_EN.id));
+                        await expect(page.getByRole('heading', {
+                            name: /This event is unavailable|Este evento no está disponible/i,
+                        })).toBeVisible();
+                    } else {
+                        expect(token.status()).toBe(200);
+                        expect(await token.json()).toMatchObject({
+                            role: 'FACILITATOR_OP',
+                            isAssignedFacilitator: false,
+                            canPublish: false,
+                            principalKind: 'staff',
+                        });
+                    }
+                });
+            });
+        }
+    });
+
+    stackTest('explains attendee control and consent in both event languages', async ({
+        browser,
+    }, testInfo) => {
+        stackTest.slow();
+        const db = requireDirectDb(testInfo);
+        const cases = [
+            {
+                session: SESSION_ES,
+                credentials: {
+                    name: 'E2E Attendee ES',
+                    email: 'e2e.attendee@altermundi.net',
+                    code: TICKETS.esIssuedA,
+                },
+                capability: 'Participante · tu cámara y micrófono quedan bajo tu control; sólo entrás en escena después de aceptar una invitación.',
+            },
+            {
+                session: SESSION_EN,
+                credentials: {
+                    name: 'E2E Attendee EN',
+                    email: 'lifecycle-attendee-2@e2e.altermundi.net',
+                    code: TICKETS.enIssuedB,
+                },
+                capability: 'Participant · your camera and microphone stay under your control; you enter the stage only after accepting an invitation.',
+            },
+        ] as const;
+
+        for (const { session, credentials, capability } of cases) {
+            await withSessionStatus(db, session.id, 'LIVE', async () => {
+                await withPage(browser, async (page) => {
+                    await loginAttendeeWithTicket(page, credentials);
+                    await page.waitForURL(`**${ROUTES.session(session.id)}`);
+                    await expect(page.getByTestId('viewer-identity')).toContainText(credentials.name, {
+                        timeout: 30_000,
+                    });
+                    await expect(page.getByTestId('viewer-role-guidance')).toHaveText(capability);
+                    await expect(page.getByTestId('viewer-identity')).not.toContainText('ATTENDEE');
+                });
+            });
+        }
+    });
+});

--- a/src/app/api/ops/health/__tests__/route.test.ts
+++ b/src/app/api/ops/health/__tests__/route.test.ts
@@ -125,4 +125,19 @@ describe('GET /api/ops/health', () => {
         expect(status).toBe(403);
         expect(collectOperatorHealth).not.toHaveBeenCalled();
     });
+
+    it('lets FACILITATOR_OP inspect an unassigned event through the central event policy', async () => {
+        requireStaffCapability.mockResolvedValue([
+            { kind: 'staff', webSessionId: 'ws-1', userId: 'facilitator-op-2', role: 'FACILITATOR_OP' },
+            null,
+        ]);
+
+        const { GET } = await import('../route');
+        const { status } = await parseResponse(await GET(
+            createRequest('/api/ops/health?sessionId=session-1'),
+        ));
+
+        expect(status).toBe(200);
+        expect(collectOperatorHealth).toHaveBeenCalledWith({ selected: true });
+    });
 });

--- a/src/app/api/ops/health/route.ts
+++ b/src/app/api/ops/health/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireStaffCapability } from '@/lib/auth';
 import { prisma } from '@/lib/db';
 import { collectOperatorHealth, productionDeps } from '@/lib/ops-health';
+import { eventStaffPolicy } from '@/lib/staff-capabilities';
 
 export const dynamic = 'force-dynamic';
 
@@ -37,7 +38,10 @@ export async function GET(request: NextRequest) {
         if (!session) {
             return NextResponse.json({ error: 'Session not found' }, { status: 404 });
         }
-        if (staff.role === 'FACILITATOR' && session.facilitatorId !== staff.userId) {
+        if (!eventStaffPolicy(
+            staff.role,
+            session.facilitatorId === staff.userId,
+        ).canOperateEvent) {
             return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 });
         }
         if (session.status !== 'SCHEDULED' && session.status !== 'LIVE') {


### PR DESCRIPTION
## Summary

Completes the automated role/capability evidence that remained open in #66 without touching the UI surfaces reserved for Annie.

- exercises all five public/staff roles in the browser;
- checks staff identity, human-readable capability guidance, navigation, and initial Stage authority in ES and EN;
- proves an unassigned FACILITATOR is denied without event disclosure;
- proves an unassigned FACILITATOR_OP retains operational access but receives subscribe-only Stage authority;
- checks attendee identity and camera/microphone consent guidance in both event languages;
- changes the selected-session Health guard from a literal FACILITATOR comparison to the shared eventStaffPolicy;
- adds a restoring synthetic-DB helper so no production impersonation behavior is introduced.

This intentionally does not close #66: the final non-technical human comprehension review remains.

## Verification

- focused unit policy/Health tests: 23 passed
- browser matrix against local PostgreSQL + LiveKit: 3 passed
- full unit suite: 697 passed, 7 opt-in integration tests skipped
- TypeScript: green
- ESLint: green
- production build: green (run by the Playwright web-server gate)
- git diff --check: green

## Risk and rollback

Low risk. The only runtime change replaces a narrower literal role check with the already-shipped central event policy, preserving FACILITATOR denial and global-role access. Everything else is test infrastructure and an E2E spec.

No audio, UI, tapestry, chat, payment, schema, fixture baseline, production configuration, or deployment changes. Rollback is a single revert of this commit.

Refs #66
Refs #69