### PR TITLE
TAP-02 — Tapestry operativo con manos, nombres y presencia (#129)

### DIFF
--- a/docs/design/STAGE_GRAMMAR.md
+++ b/docs/design/STAGE_GRAMMAR.md
@@ -332,10 +332,21 @@ composite, the capture lifecycle, or any media path.
 - On the public room surface, connected raised hands are named in plain text
   near the tapestry via `GET /api/scheduled-sessions/[id]/tapestry/hands`,
   gated by the room entitlement check. The sidecar names only waiting hands
-  that remain connected — no tile positions, camera state, presence or
+  that remain connected — no camera state, presence of anyone else, or
   thumbnails — so the collective JPEG stays anonymous and the sidecar cannot
   become a participant directory. A LiveKit outage names nobody rather than
   guessing presence.
+- Each named hand also carries its cell in the composite grid, so the room
+  draws the name over the person's own tile (the Zoom/Meet reading of the
+  issue). The internal service captures the grid layout synchronously with
+  every composite build and exposes it at `GET
+  /tapestry/sessions/:id/layout` alongside the `x-tapestry-revision` header
+  on `composite.jpg` — building on the monotonic build revision introduced
+  for #40 in PR #108. The room only draws the overlay when the sidecar's
+  layout revision equals the composite's revision; a disagreement omits the
+  overlay rather than placing a name over the wrong person. The overlay is
+  `aria-hidden` and pointer-free: the plain names line remains the
+  accessible and touch/keyboard equivalent.
 
 ## 7. Motion and interaction
 

--- a/docs/design/STAGE_GRAMMAR.md
+++ b/docs/design/STAGE_GRAMMAR.md
@@ -330,10 +330,19 @@ composite, the capture lifecycle, or any media path.
   image requests. An accessible plain-text list carries the complete state
   of every person, so mouse, touch, keyboard and screen readers all reach
   the same facts. The composite bytes refresh every poll while the semantic
-  layer re-renders only when its content revision changes; overlays draw
-  only when the manifest's layout revision equals the composite's
-  `x-tapestry-revision`, and each poll aborts and supersedes the previous
-  one so a slow earlier response can never overwrite fresher state.
+  layer re-renders only when its content revision OR its layout revision
+  changes, and each poll aborts and supersedes the previous one so a slow
+  earlier response can never overwrite fresher state.
+- Composite and layout are snapshots correlated by build revision: the
+  client reads the composite first and the manifest immediately after, and
+  publishes image + annotations only as one accepted cycle's state. A frame
+  landing between the two reads produces a revision mismatch, which is never
+  rendered as an overlay — the pair is retried immediately, strictly bounded
+  (at most 3 attempts per cycle, independent of participant count), and if
+  the mismatch persists the safe fallback shows image and list without
+  overlays until the next cycle reconverges. Hiding temporarily is safe;
+  converging is mandatory, and the accessible list always keeps the freshest
+  accepted semantics.
 - Naming consent (product canon, confirmed by Annie on 2026-08-04): raising
   a hand IS the consent to be named publicly, with exactly this scope — the
   name shows only inside the same session, only while the hand stays raised
@@ -356,9 +365,14 @@ composite, the capture lifecycle, or any media path.
   every composite build and exposes it at `GET
   /tapestry/sessions/:id/layout` alongside the `x-tapestry-revision` header
   on `composite.jpg` — building on the monotonic build revision introduced
-  for #40 in PR #108. The room only draws the overlay when the sidecar's
-  layout revision equals the composite's revision; a disagreement omits the
-  overlay rather than placing a name over the wrong person. The overlay is
+  for #40 in PR #108. A single polling coordinator reads the composite and
+  the sidecar as one correlated unit and publishes image, names and layout
+  only from the same accepted cycle: the room only draws the overlay when
+  the sidecar's layout revision equals the composite's revision, a mismatch
+  is retried immediately with a strict bound and otherwise omits the
+  overlay, and the accessible names line always reflects the freshest
+  accepted sidecar state — lowering a hand or leaving retires the name with
+  priority, without waiting for any correlation. The overlay is
   `aria-hidden` and pointer-free: the plain names line remains the
   accessible and touch/keyboard equivalent.
 

--- a/docs/design/STAGE_GRAMMAR.md
+++ b/docs/design/STAGE_GRAMMAR.md
@@ -304,6 +304,39 @@ snapshot. It adds no capture, camera, LiveKit publication, or image stream.
 - Public-disabled mode renders no broken collective image and makes no claim
   that audience presence is visible.
 
+### 6.4 Operational tapestry layer (TAP-02, issue #129)
+
+Shipped separately from the public grammar above. The operational layer is a
+staff-only reading of the tapestry; it changes nothing about the public
+composite, the capture lifecycle, or any media path.
+
+- `GET /api/ops/sessions/[id]/tapestry/manifest` returns one bounded document
+  per poll: tile id (opaque), display position, authorized name, hand and
+  queue position, presence (`connected` / `reconnecting` / `left` /
+  `unknown`), camera (`on` / `off` / `unknown`) and an epoch-versioned
+  thumbnail proxy URL per tile, plus the waiting-hand summary including hands
+  with no tile. Three lookups total (database, LiveKit list, internal
+  tapestry list); there is no per-tile request and no N+1 at 150
+  participants. The response is `private, no-store`; names and identities
+  never appear in logs.
+- Authorization matches the other ops tapestry routes: a staff session plus
+  the event-scoped `canOperateEvent` policy. Attendees, staff of other
+  events, and anonymous callers receive the same refusals as the sibling
+  routes.
+- The conductor cockpit tapestry drawer renders the manifest as the
+  operational view above the existing arrangement tool. Every tile carries
+  its full state in an accessible name; the hand badge is labelled text, not
+  color alone; hover, touch, keyboard and screen readers all reach the same
+  detail. A tile without a current consented frame falls back to a quiet
+  deterministic color field that never discloses why the image is absent.
+- On the public room surface, connected raised hands are named in plain text
+  near the tapestry via `GET /api/scheduled-sessions/[id]/tapestry/hands`,
+  gated by the room entitlement check. The sidecar names only waiting hands
+  that remain connected — no tile positions, camera state, presence or
+  thumbnails — so the collective JPEG stays anonymous and the sidecar cannot
+  become a participant directory. A LiveKit outage names nobody rather than
+  guessing presence.
+
 ## 7. Motion and interaction
 
 Motion is an orientation aid, never ambience.

--- a/docs/design/STAGE_GRAMMAR.md
+++ b/docs/design/STAGE_GRAMMAR.md
@@ -311,24 +311,38 @@ staff-only reading of the tapestry; it changes nothing about the public
 composite, the capture lifecycle, or any media path.
 
 - `GET /api/ops/sessions/[id]/tapestry/manifest` returns one bounded document
-  per poll: tile id (opaque), display position, authorized name, hand and
-  queue position, presence (`connected` / `reconnecting` / `left` /
-  `unknown`), camera (`on` / `off` / `unknown`) and an epoch-versioned
-  thumbnail proxy URL per tile, plus the waiting-hand summary including hands
-  with no tile. Three lookups total (database, LiveKit list, internal
-  tapestry list); there is no per-tile request and no N+1 at 150
-  participants. The response is `private, no-store`; names and identities
-  never appear in logs.
+  per poll: tile id (opaque), grid cell (column/row), authorized name, hand
+  and queue position, presence (`connected` / `reconnecting` / `left` /
+  `unknown`), camera (`on` / `off` / `unknown`) and the build-time layout
+  metadata, plus the waiting-hand summary including hands with no tile.
+  Three lookups total (database, LiveKit list, internal layout read); there
+  is no per-tile request and no N+1 at 150 participants. The response is
+  `private, no-store`; names and identities never appear in logs.
 - Authorization matches the other ops tapestry routes: a staff session plus
   the event-scoped `canOperateEvent` policy. Attendees, staff of other
   events, and anonymous callers receive the same refusals as the sibling
   routes.
-- The conductor cockpit tapestry drawer renders the manifest as the
-  operational view above the existing arrangement tool. Every tile carries
-  its full state in an accessible name; the hand badge is labelled text, not
-  color alone; hover, touch, keyboard and screen readers all reach the same
-  detail. A tile without a current consented frame falls back to a quiet
-  deterministic color field that never discloses why the image is absent.
+- The conductor cockpit tapestry drawer renders the operational view above
+  the existing arrangement tool with O(1) visual transport: ONE shared
+  composite image per poll — the same JPEG the service already builds —
+  annotated by semantic overlays (name tag, hand badge, camera-off marker,
+  presence dimming) positioned from the build-time layout, never per-tile
+  image requests. An accessible plain-text list carries the complete state
+  of every person, so mouse, touch, keyboard and screen readers all reach
+  the same facts. The composite bytes refresh every poll while the semantic
+  layer re-renders only when its content revision changes; overlays draw
+  only when the manifest's layout revision equals the composite's
+  `x-tapestry-revision`, and each poll aborts and supersedes the previous
+  one so a slow earlier response can never overwrite fresher state.
+- Naming consent (product canon, confirmed by Annie on 2026-08-04): raising
+  a hand IS the consent to be named publicly, with exactly this scope — the
+  name shows only inside the same session, only while the hand stays raised
+  and the person connected, only over that person's tapestry cell; lowering
+  the hand or disconnecting removes the public name; it never authorizes
+  publishing email, internal id, LiveKit identity, camera, presence,
+  individual thumbnail or history, and it never turns the tapestry into a
+  permanent directory; staff keep their authorized operational view. The
+  hand control explains this scope next to the raise/lower button in ES/EN.
 - On the public room surface, connected raised hands are named in plain text
   near the tapestry via `GET /api/scheduled-sessions/[id]/tapestry/hands`,
   gated by the room entitlement check. The sidecar names only waiting hands

--- a/e2e/tests/ops-tapestry-requests.spec.ts
+++ b/e2e/tests/ops-tapestry-requests.spec.ts
@@ -52,6 +52,7 @@ function manifestFor(count: number) {
 stackTest('operational tapestry stays O(1) at 0/1/50/150 participants', async ({ page }) => {
     stackTest.slow();
     let count = 0;
+    let mismatched = false;
     const counters = { manifest: 0, composite: 0, tiles: 0 };
 
     page.on('request', (request) => {
@@ -68,10 +69,12 @@ stackTest('operational tapestry stays O(1) at 0/1/50/150 participants', async ({
         await route.fulfill({ json: manifestFor(count) });
     });
     await page.route(`**/api/tapestry/${SESSION_ES.id}**`, async (route) => {
+        // Simulated continuous ingest: the composite reports a build newer
+        // than the manifest's layout, forcing bounded correlation retries.
         await route.fulfill({
             body: Buffer.from('R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', 'base64'),
             contentType: 'image/gif',
-            headers: { 'x-tapestry-revision': '7' },
+            headers: { 'x-tapestry-revision': mismatched ? '8' : '7' },
         });
     });
     await page.route(`**/api/ops/sessions/${SESSION_ES.id}/tapestry/tiles/**`, async (route) => {
@@ -125,5 +128,33 @@ stackTest('operational tapestry stays O(1) at 0/1/50/150 participants', async ({
         if (n > 0) {
             await expect(section.getByRole('listitem')).toHaveCount(n);
         }
+        if (n === 1) {
+            // Correlated pair: the semantic overlay draws over the cell.
+            await expect(section.locator('[aria-hidden="true"]')).toBeVisible();
+        }
     }
+
+    // Continuous-ingest mismatch: the composite reports a build the manifest
+    // layout has not caught up with. Retries stay strictly bounded per cycle,
+    // overlays hide, the accessible list keeps telling the truth.
+    count = 1;
+    mismatched = true;
+    await expect(section.getByRole('listitem')).toHaveCount(1);
+    await expect(section.locator('[aria-hidden="true"]')).toHaveCount(0, { timeout: 10_000 });
+    const beforeMismatch = { ...counters };
+    await page.waitForTimeout(7_000);
+    const mismatchSpent = {
+        manifest: counters.manifest - beforeMismatch.manifest,
+        composite: counters.composite - beforeMismatch.composite,
+        tiles: counters.tiles - beforeMismatch.tiles,
+    };
+    // ~3 cycles × at most 3 attempts: an explicit ceiling, no storm, and
+    // still completely independent of the participant count.
+    expect(mismatchSpent.manifest, 'manifest requests under mismatch').toBeLessThanOrEqual(12);
+    expect(mismatchSpent.composite, 'composite requests under mismatch').toBeLessThanOrEqual(12);
+    expect(mismatchSpent.tiles, 'per-tile requests under mismatch').toBe(0);
+
+    // Correlation returns: the overlay reconverges over the right cell.
+    mismatched = false;
+    await expect(section.locator('[aria-hidden="true"]')).toBeVisible({ timeout: 10_000 });
 });

--- a/e2e/tests/ops-tapestry-requests.spec.ts
+++ b/e2e/tests/ops-tapestry-requests.spec.ts
@@ -1,0 +1,119 @@
+import { expect, stackTest } from '../fixtures/stack';
+import { loginViaDashboard } from '../fixtures/auth';
+import { ROUTES, SESSION_ES } from '../fixtures/test-data';
+
+/**
+ * TAP-02 request measurement (issue #129, PR #145): the operational tapestry
+ * must stay O(1) — one manifest JSON + one composite image per poll cycle —
+ * regardless of participant count. Measured in a real browser against the
+ * real cockpit, with 0, 1, 50 and 150 manifest entries. The hand-queue spec
+ * covers the same discipline for the spotlight drawer.
+ */
+
+type ManifestEntry = {
+    tileId: string;
+    displayName: string;
+    handRaised: boolean;
+    queuePosition: number | null;
+    presence: 'connected';
+    camera: 'on';
+    column: number;
+    row: number;
+};
+
+function manifestFor(count: number) {
+    const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
+    const rows = Math.max(1, Math.ceil(count / columns));
+    const entries: ManifestEntry[] = Array.from({ length: count }, (_, i) => ({
+        tileId: `tp-${i + 1}`,
+        displayName: `Tapestry Person ${i + 1}`,
+        handRaised: i === 0,
+        queuePosition: i === 0 ? 1 : null,
+        presence: 'connected',
+        camera: 'on',
+        column: i % columns,
+        row: Math.floor(i / columns),
+    }));
+    return {
+        sessionId: SESSION_ES.id,
+        revision: 'measurement-rev',
+        liveStateAvailable: true,
+        layout: { revision: 7, columns, rows, tileSizePx: 100 },
+        tileFreshForSeconds: 10,
+        entries,
+        waitingHands: count > 0
+            ? [{ displayName: 'Tapestry Person 1', queuePosition: 1, tileId: 'tp-1' }]
+            : [],
+    };
+}
+
+stackTest('operational tapestry stays O(1) at 0/1/50/150 participants', async ({ page }) => {
+    stackTest.slow();
+    let count = 0;
+    const counters = { manifest: 0, composite: 0, tiles: 0 };
+
+    page.on('request', (request) => {
+        // Only the main frame's cockpit counts; the room iframe has its own
+        // optional composite poll covered by its own contract.
+        if (request.frame() !== page.mainFrame()) return;
+        const url = request.url();
+        if (url.includes(`/api/ops/sessions/${SESSION_ES.id}/tapestry/manifest`)) counters.manifest += 1;
+        else if (url.includes(`/api/ops/sessions/${SESSION_ES.id}/tapestry/tiles/`)) counters.tiles += 1;
+        else if (url.includes(`/api/tapestry/${SESSION_ES.id}`)) counters.composite += 1;
+    });
+
+    await page.route(`**/api/ops/sessions/${SESSION_ES.id}/tapestry/manifest`, async (route) => {
+        await route.fulfill({ json: manifestFor(count) });
+    });
+    await page.route(`**/api/tapestry/${SESSION_ES.id}`, async (route) => {
+        await route.fulfill({
+            body: Buffer.from('R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', 'base64'),
+            contentType: 'image/gif',
+            headers: { 'x-tapestry-revision': '7' },
+        });
+    });
+    await page.route(`**/api/ops/sessions/${SESSION_ES.id}/tapestry/tiles/**`, async (route) => {
+        await route.fulfill({ status: 404 });
+    });
+
+    await loginViaDashboard(page, 'OPERATOR', 'Tapestry Measure Op', ROUTES.opsSession(SESSION_ES.id));
+
+    // Drawer closed: the operational tapestry spends nothing at all.
+    await page.waitForTimeout(7_000);
+    expect(counters).toEqual({ manifest: 0, composite: 0, tiles: 0 });
+
+    await page.locator('[data-tool="tapestry"]').click();
+    const drawer = page.getByRole('dialog');
+    const section = drawer.getByRole('region', { name: /Operational tapestry|Tapiz operativo/i });
+    await expect(section).toBeVisible();
+
+    for (const n of [0, 1, 50, 150]) {
+        count = n;
+        const before = { ...counters };
+        if (n > 0) {
+            await expect(section.getByText(`Tapestry Person ${n}`, { exact: true })).toBeVisible({
+                timeout: 10_000,
+            });
+        } else {
+            await expect(section.getByText(/No tiles yet|Todavía no hay teselas/i)).toBeVisible({
+                timeout: 10_000,
+            });
+        }
+        // Two more full poll cycles (3s each) beyond the first render.
+        await page.waitForTimeout(7_000);
+        const spent = {
+            manifest: counters.manifest - before.manifest,
+            composite: counters.composite - before.composite,
+            tiles: counters.tiles - before.tiles,
+        };
+        // ~3 cycles in the window: strictly bounded, independent of N.
+        expect(spent.manifest, `manifest requests at ${n} participants`).toBeLessThanOrEqual(4);
+        expect(spent.composite, `composite requests at ${n} participants`).toBeLessThanOrEqual(4);
+        expect(spent.tiles, `per-tile requests at ${n} participants`).toBe(0);
+        // Exactly one image carries the whole room.
+        await expect(section.getByRole('img')).toHaveCount(1);
+        if (n > 0) {
+            await expect(section.getByRole('listitem')).toHaveCount(n);
+        }
+    }
+});

--- a/e2e/tests/ops-tapestry-requests.spec.ts
+++ b/e2e/tests/ops-tapestry-requests.spec.ts
@@ -61,13 +61,13 @@ stackTest('operational tapestry stays O(1) at 0/1/50/150 participants', async ({
         const url = request.url();
         if (url.includes(`/api/ops/sessions/${SESSION_ES.id}/tapestry/manifest`)) counters.manifest += 1;
         else if (url.includes(`/api/ops/sessions/${SESSION_ES.id}/tapestry/tiles/`)) counters.tiles += 1;
-        else if (url.includes(`/api/tapestry/${SESSION_ES.id}`)) counters.composite += 1;
+        else if (url.includes(`/api/tapestry/${SESSION_ES.id}?view=ops-tapestry`)) counters.composite += 1;
     });
 
     await page.route(`**/api/ops/sessions/${SESSION_ES.id}/tapestry/manifest`, async (route) => {
         await route.fulfill({ json: manifestFor(count) });
     });
-    await page.route(`**/api/tapestry/${SESSION_ES.id}`, async (route) => {
+    await page.route(`**/api/tapestry/${SESSION_ES.id}**`, async (route) => {
         await route.fulfill({
             body: Buffer.from('R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', 'base64'),
             contentType: 'image/gif',

--- a/e2e/tests/ops-tapestry-requests.spec.ts
+++ b/e2e/tests/ops-tapestry-requests.spec.ts
@@ -99,9 +99,11 @@ stackTest('operational tapestry stays O(1) at 0/1/50/150 participants', async ({
         count = n;
         const before = { ...counters };
         if (n > 0) {
-            await expect(section.getByText(`Tapestry Person ${n}`, { exact: true })).toBeVisible({
-                timeout: 10_000,
-            });
+            // The name appears in the aria-hidden overlay AND the accessible
+            // list; assert on the list, the semantic surface.
+            await expect(
+                section.getByRole('listitem').getByText(`Tapestry Person ${n}`, { exact: true }),
+            ).toBeVisible({ timeout: 10_000 });
         } else {
             await expect(section.getByText(/No tiles yet|Todavía no hay teselas/i)).toBeVisible({
                 timeout: 10_000,

--- a/e2e/tests/ops-tapestry-requests.spec.ts
+++ b/e2e/tests/ops-tapestry-requests.spec.ts
@@ -36,7 +36,9 @@ function manifestFor(count: number) {
     }));
     return {
         sessionId: SESSION_ES.id,
-        revision: 'measurement-rev',
+        // The revision must change with the payload, like the real builder:
+        // the cockpit re-renders annotations only on revision change.
+        revision: `measurement-rev-${count}`,
         liveStateAvailable: true,
         layout: { revision: 7, columns, rows, tileSizePx: 100 },
         tileFreshForSeconds: 10,
@@ -74,6 +76,12 @@ stackTest('operational tapestry stays O(1) at 0/1/50/150 participants', async ({
     });
     await page.route(`**/api/ops/sessions/${SESSION_ES.id}/tapestry/tiles/**`, async (route) => {
         await route.fulfill({ status: 404 });
+    });
+    // The measurement is the cockpit's OpsTapestry; the room iframe has its
+    // own optional composite poll (covered by its own contract) and would
+    // only add noise here, so its document is stubbed out.
+    await page.route(`**/session/${SESSION_ES.id}?surface=cockpit`, async (route) => {
+        await route.fulfill({ contentType: 'text/html', body: '<html><body>room stub</body></html>' });
     });
 
     await loginViaDashboard(page, 'OPERATOR', 'Tapestry Measure Op', ROUTES.opsSession(SESSION_ES.id));

--- a/services/tapestry/src/composite.ts
+++ b/services/tapestry/src/composite.ts
@@ -31,6 +31,28 @@ interface CompositeCacheEntry {
   builtRevision: number;
   /** A staff change newer than builtRevision bypasses the ingest rate limit. */
   urgentRevision: number;
+  /** Grid layout captured by the same build as `jpeg`; they always agree. */
+  builtLayout: BuiltCompositeLayout | null;
+}
+
+/** Grid position of one tile in the built composite. */
+export interface BuiltCompositeCell {
+  id: string;
+  column: number;
+  row: number;
+}
+
+/**
+ * Layout of the last built composite, captured synchronously with the same
+ * participant snapshot as the JPEG itself. Consumers overlay names or markers
+ * only when this layout's revision matches the served composite's revision,
+ * so a name can never land on the wrong person.
+ */
+export interface BuiltCompositeLayout {
+  columns: number;
+  rows: number;
+  tileSizePx: number;
+  cells: BuiltCompositeCell[];
 }
 
 export class TapestryCompositor {
@@ -55,6 +77,7 @@ export class TapestryCompositor {
         revision: 1,
         builtRevision: 0,
         urgentRevision: 0,
+        builtLayout: null,
       });
     }
   }
@@ -110,10 +133,11 @@ export class TapestryCompositor {
     // a later ingest must remain pending when this promise settles.
     const buildRevision = entry.revision;
     entry.inFlight = this.build(sessionId)
-      .then((jpeg) => {
+      .then(({ jpeg, layout }) => {
         entry.jpeg = jpeg;
         entry.builtAtMs = this.nowMs();
         entry.builtRevision = buildRevision;
+        entry.builtLayout = layout;
         if (entry.urgentRevision <= buildRevision) {
           entry.urgentRevision = 0;
         }
@@ -126,7 +150,30 @@ export class TapestryCompositor {
     return entry.inFlight;
   }
 
-  private async build(sessionId: string): Promise<Buffer> {
+  /**
+   * Revision of the composite bytes a `composite()` call last resolved to,
+   * or null when the session is unknown or never built. Read after awaiting
+   * `composite()` — together they identify exactly the served image.
+   */
+  builtRevisionOf(sessionId: string): number | null {
+    const entry = this.cache.get(sessionId);
+    if (!entry || entry.builtLayout === null) {
+      return null;
+    }
+    return entry.builtRevision;
+  }
+
+  /**
+   * Grid layout captured by the same build as the currently served
+   * composite, or null when the session is unknown or never built. Pair it
+   * with `builtRevisionOf`: an overlay is only truthful when the layout and
+   * the served JPEG carry the same revision.
+   */
+  builtCompositeLayout(sessionId: string): BuiltCompositeLayout | null {
+    return this.cache.get(sessionId)?.builtLayout ?? null;
+  }
+
+  private async build(sessionId: string): Promise<{ jpeg: Buffer; layout: BuiltCompositeLayout }> {
     // Display order = staff arrangement first, then first-seen (store.orderedActive).
     const participants = this.store.orderedActive(
       sessionId,
@@ -137,13 +184,23 @@ export class TapestryCompositor {
     // Dynamic grid: never larger than the active set needs (1x1 when empty).
     const columns = Math.max(1, Math.min(this.config.gridColumns, participants.length));
     const rows = Math.max(1, Math.ceil(participants.length / columns));
+    const layout: BuiltCompositeLayout = {
+      columns,
+      rows,
+      tileSizePx: tile,
+      cells: participants.map(({ id }, index) => ({
+        id,
+        column: index % columns,
+        row: Math.floor(index / columns),
+      })),
+    };
     const inputs = participants.map(({ participant }, index) => ({
       input: participant.tile,
       left: (index % columns) * tile,
       top: Math.floor(index / columns) * tile,
     }));
 
-    return sharp({
+    const jpeg = await sharp({
       create: {
         width: columns * tile,
         height: rows * tile,
@@ -154,6 +211,7 @@ export class TapestryCompositor {
       .composite(inputs)
       .jpeg({ quality: this.config.compositeJpegQuality })
       .toBuffer();
+    return { jpeg, layout };
   }
 }
 

--- a/services/tapestry/src/composite.ts
+++ b/services/tapestry/src/composite.ts
@@ -21,18 +21,30 @@ import type { TapestryStore } from "./store.js";
 sharp.concurrency(1);
 sharp.cache({ memory: 16, files: 0, items: 20 });
 
+/**
+ * Immutable result of one completed composite build: the JPEG bytes, the
+ * store revision they were built from, and the grid layout captured from the
+ * same synchronous participant snapshot. The three values always travel
+ * together, so a response can never mix bytes from one build with the
+ * revision or layout of another.
+ */
+export interface CompositeSnapshot {
+  bytes: Buffer;
+  revision: number;
+  layout: BuiltCompositeLayout;
+}
+
 interface CompositeCacheEntry {
-  jpeg: Buffer;
+  /** Latest completed build; replaced wholesale, never mutated in place. */
+  snapshot: CompositeSnapshot | null;
   builtAtMs: number;
-  inFlight: Promise<Buffer> | null;
+  inFlight: Promise<CompositeSnapshot> | null;
   /** Monotonic store revision; every ingest/sweep/arrangement advances it. */
   revision: number;
   /** Revision captured by the last successfully completed composite. */
   builtRevision: number;
   /** A staff change newer than builtRevision bypasses the ingest rate limit. */
   urgentRevision: number;
-  /** Grid layout captured by the same build as `jpeg`; they always agree. */
-  builtLayout: BuiltCompositeLayout | null;
 }
 
 /** Grid position of one tile in the built composite. */
@@ -71,13 +83,12 @@ export class TapestryCompositor {
     this.gridHeightPx = rows * config.tileSizePx;
     for (const sessionId of config.sessionIds) {
       this.cache.set(sessionId, {
-        jpeg: Buffer.alloc(0),
+        snapshot: null,
         builtAtMs: 0,
         inFlight: null,
         revision: 1,
         builtRevision: 0,
         urgentRevision: 0,
-        builtLayout: null,
       });
     }
   }
@@ -105,12 +116,13 @@ export class TapestryCompositor {
   }
 
   /**
-   * Return the current composite JPEG for a session. Serves the cached image
-   * when it is fresh enough or nothing changed; otherwise rebuilds, at most
-   * once per compositeMinIntervalMs per session. Concurrent callers share one
-   * in-flight rebuild.
+   * Return the latest composite snapshot for a session. Serves the cached
+   * snapshot when it is fresh enough or nothing changed; otherwise rebuilds,
+   * at most once per compositeMinIntervalMs per session. Concurrent callers
+   * share one in-flight rebuild. The returned snapshot is immutable: bytes,
+   * revision and layout always describe the same completed build.
    */
-  async composite(sessionId: string): Promise<Buffer | null> {
+  async composite(sessionId: string): Promise<CompositeSnapshot | null> {
     const entry = this.cache.get(sessionId);
     if (!entry) {
       return null;
@@ -124,8 +136,8 @@ export class TapestryCompositor {
     const urgent = entry.urgentRevision > entry.builtRevision;
     const freshEnough =
       !dirty || (!urgent && now - entry.builtAtMs < this.config.compositeMinIntervalMs);
-    if (entry.jpeg.length > 0 && freshEnough) {
-      return entry.jpeg;
+    if (entry.snapshot && freshEnough) {
+      return entry.snapshot;
     }
 
     // `build()` snapshots the store synchronously before libvips starts its
@@ -134,15 +146,19 @@ export class TapestryCompositor {
     const buildRevision = entry.revision;
     entry.inFlight = this.build(sessionId)
       .then(({ jpeg, layout }) => {
-        entry.jpeg = jpeg;
+        const snapshot: CompositeSnapshot = {
+          bytes: jpeg,
+          revision: buildRevision,
+          layout,
+        };
+        entry.snapshot = snapshot;
         entry.builtAtMs = this.nowMs();
         entry.builtRevision = buildRevision;
-        entry.builtLayout = layout;
         if (entry.urgentRevision <= buildRevision) {
           entry.urgentRevision = 0;
         }
         this.compositesBuilt += 1;
-        return jpeg;
+        return snapshot;
       })
       .finally(() => {
         entry.inFlight = null;
@@ -151,26 +167,22 @@ export class TapestryCompositor {
   }
 
   /**
-   * Revision of the composite bytes a `composite()` call last resolved to,
-   * or null when the session is unknown or never built. Read after awaiting
-   * `composite()` — together they identify exactly the served image.
+   * Revision of the latest completed build, or null when the session is
+   * unknown or never built. Part of the snapshot triple — responses should
+   * normally read it from the `composite()` result itself.
    */
   builtRevisionOf(sessionId: string): number | null {
-    const entry = this.cache.get(sessionId);
-    if (!entry || entry.builtLayout === null) {
-      return null;
-    }
-    return entry.builtRevision;
+    return this.cache.get(sessionId)?.snapshot?.revision ?? null;
   }
 
   /**
-   * Grid layout captured by the same build as the currently served
-   * composite, or null when the session is unknown or never built. Pair it
-   * with `builtRevisionOf`: an overlay is only truthful when the layout and
-   * the served JPEG carry the same revision.
+   * Grid layout of the latest completed build, or null when the session is
+   * unknown or never built. Pair it with the revision from the same build:
+   * an overlay is only truthful when the layout and the served JPEG carry
+   * the same revision.
    */
   builtCompositeLayout(sessionId: string): BuiltCompositeLayout | null {
-    return this.cache.get(sessionId)?.builtLayout ?? null;
+    return this.cache.get(sessionId)?.snapshot?.layout ?? null;
   }
 
   private async build(sessionId: string): Promise<{ jpeg: Buffer; layout: BuiltCompositeLayout }> {

--- a/services/tapestry/src/server.ts
+++ b/services/tapestry/src/server.ts
@@ -215,7 +215,9 @@ export function createTapestryServer(config: TapestryConfig): TapestryServer {
       sendJson(res, 404, { error: "layout_unavailable" });
       return;
     }
-    sendJson(res, 200, { revision, ...layout });
+    // frameTtlMs rides along so consumers can state snapshot freshness
+    // without a second internal endpoint.
+    sendJson(res, 200, { revision, frameTtlMs: config.frameTtlMs, ...layout });
   }
 
   function handleHealth(res: ServerResponse): void {

--- a/services/tapestry/src/server.ts
+++ b/services/tapestry/src/server.ts
@@ -4,9 +4,13 @@
  *   POST /tapestry/sessions/:sessionId/participants/:participantId/frame
  *        Authenticated JPEG ingest (raw image/jpeg body, size-capped).
  *   GET  /tapestry/sessions/:sessionId/composite.jpg
- *        Authenticated composite JPEG.
+ *        Authenticated composite JPEG, with the build revision in
+ *        `x-tapestry-revision` so overlays can match their layout to it.
  *   GET  /tapestry/sessions/:sessionId/participants
  *        Authenticated list of active participant ids in display order.
+ *   GET  /tapestry/sessions/:sessionId/layout
+ *        Authenticated grid layout (revision, columns, rows, tile size and
+ *        per-tile cells) captured by the same build as the served composite.
  *   PUT  /tapestry/sessions/:sessionId/order
  *        Authenticated staff arrangement: JSON {"order": string[]}.
  *   GET  /tapestry/sessions/:sessionId/participants/:participantId/frame.jpg
@@ -31,6 +35,7 @@ const FRAME_ROUTE =
   /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/participants\/([A-Za-z0-9_-]{1,128})\/frame$/;
 const COMPOSITE_ROUTE = /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/composite\.jpg$/;
 const PARTICIPANTS_ROUTE = /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/participants$/;
+const LAYOUT_ROUTE = /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/layout$/;
 const ORDER_ROUTE = /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/order$/;
 const TILE_ROUTE =
   /^\/tapestry\/sessions\/([A-Za-z0-9_-]{1,128})\/participants\/([A-Za-z0-9_-]{1,128})\/frame\.jpg$/;
@@ -174,14 +179,41 @@ export function createTapestryServer(config: TapestryConfig): TapestryServer {
       sendJson(res, 404, { error: "unknown_session" });
       return;
     }
+    const revision = compositor.builtRevisionOf(sessionId);
     res.writeHead(200, {
       "content-type": "image/jpeg",
       "content-length": jpeg.length,
       // Downstream caching policy (2s shared TTL, staff-only variant) is set
       // by the Next.js proxy; the internal service itself asks not to be cached.
       "cache-control": "no-store",
+      // Names the exact build these bytes came from; overlay consumers must
+      // only draw over a composite whose revision matches their layout.
+      ...(revision === null ? {} : { "x-tapestry-revision": String(revision) }),
     });
     res.end(jpeg);
+  }
+
+  async function handleLayout(
+    req: IncomingMessage,
+    res: ServerResponse,
+    sessionId: string,
+  ): Promise<void> {
+    if (!secretMatches(req.headers[INTERNAL_SECRET_HEADER] as string | undefined, config.internalSecret)) {
+      sendJson(res, 401, { error: "unauthorized" });
+      return;
+    }
+    if (!store.hasSession(sessionId)) {
+      sendJson(res, 404, { error: "unknown_session" });
+      return;
+    }
+    const layout = compositor.builtCompositeLayout(sessionId);
+    const revision = compositor.builtRevisionOf(sessionId);
+    if (!layout || revision === null) {
+      // No composite has been built yet: there is truthfully nothing to overlay.
+      sendJson(res, 404, { error: "layout_unavailable" });
+      return;
+    }
+    sendJson(res, 200, { revision, ...layout });
   }
 
   function handleHealth(res: ServerResponse): void {
@@ -315,6 +347,11 @@ export function createTapestryServer(config: TapestryConfig): TapestryServer {
       }
       if (req.method === "GET" && participantsMatch) {
         await handleParticipants(req, res, participantsMatch[1]);
+        return;
+      }
+      const layoutMatch = url.pathname.match(LAYOUT_ROUTE);
+      if (req.method === "GET" && layoutMatch) {
+        await handleLayout(req, res, layoutMatch[1]);
         return;
       }
       if (req.method === "PUT" && orderMatch) {

--- a/services/tapestry/src/server.ts
+++ b/services/tapestry/src/server.ts
@@ -174,23 +174,25 @@ export function createTapestryServer(config: TapestryConfig): TapestryServer {
       sendJson(res, 401, { error: "unauthorized" });
       return;
     }
-    const jpeg = await compositor.composite(sessionId);
-    if (!jpeg) {
+    // One immutable snapshot per response: bytes, revision and layout all
+    // belong to the same completed build, even if a newer build finishes
+    // while this response is in flight.
+    const snapshot = await compositor.composite(sessionId);
+    if (!snapshot) {
       sendJson(res, 404, { error: "unknown_session" });
       return;
     }
-    const revision = compositor.builtRevisionOf(sessionId);
     res.writeHead(200, {
       "content-type": "image/jpeg",
-      "content-length": jpeg.length,
+      "content-length": snapshot.bytes.length,
       // Downstream caching policy (2s shared TTL, staff-only variant) is set
       // by the Next.js proxy; the internal service itself asks not to be cached.
       "cache-control": "no-store",
       // Names the exact build these bytes came from; overlay consumers must
       // only draw over a composite whose revision matches their layout.
-      ...(revision === null ? {} : { "x-tapestry-revision": String(revision) }),
+      "x-tapestry-revision": String(snapshot.revision),
     });
-    res.end(jpeg);
+    res.end(snapshot.bytes);
   }
 
   async function handleLayout(

--- a/services/tapestry/test/composite.test.ts
+++ b/services/tapestry/test/composite.test.ts
@@ -129,9 +129,9 @@ test("a frame ingested during an in-flight build remains dirty for the next boun
 
   const [first, concurrent] = await Promise.all([firstBuild, concurrentCaller]);
   assert.ok(first);
-  assert.strictEqual(concurrent, first, "concurrent callers share one completed buffer");
+  assert.strictEqual(concurrent, first, "concurrent callers share one completed snapshot");
   assert.equal(compositor.compositesBuiltCount(), 1);
-  const firstColor = await tileColor(first, 0, 0);
+  const firstColor = await tileColor(first.bytes, 0, 0);
   assert.ok(firstColor.r > 150 && firstColor.b < 80, "the in-flight snapshot stays coherent");
 
   const rateLimited = await compositor.composite(SESSION_A);
@@ -142,7 +142,7 @@ test("a frame ingested during an in-flight build remains dirty for the next boun
   const rebuilt = await compositor.composite(SESSION_A);
   assert.ok(rebuilt);
   assert.equal(compositor.compositesBuiltCount(), 2, "the intervening ingest triggers a later build");
-  const rebuiltColor = await tileColor(rebuilt, 0, 0);
+  const rebuiltColor = await tileColor(rebuilt.bytes, 0, 0);
   assert.ok(rebuiltColor.b > 150 && rebuiltColor.r < 80, "the newest frame becomes visible");
 });
 

--- a/services/tapestry/test/layout.test.ts
+++ b/services/tapestry/test/layout.test.ts
@@ -8,6 +8,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { TapestryCompositor } from "../src/composite.js";
+import { TapestryStore } from "../src/store.js";
+
 import {
   SESSION_A,
   authHeaders,
@@ -17,6 +20,7 @@ import {
   sleep,
   startService,
   testConfig,
+  tileColor,
 } from "./helpers.js";
 
 interface LayoutBody {
@@ -134,4 +138,37 @@ test("an empty build still publishes a truthful 1x1 layout with no cells", async
   } finally {
     await service.close();
   }
+});
+
+test("an earlier snapshot keeps its own bytes, revision and layout across a later build", async () => {
+  let now = 1_000;
+  const config = testConfig({ compositeMinIntervalMs: 1_000 });
+  const store = new TapestryStore(config.sessionIds, config.maxParticipantsPerSession);
+  const compositor = new TapestryCompositor(config, store, () => now);
+
+  store.ingest(SESSION_A, "p1", await makeJpeg(255, 0, 0, config.tileSizePx), now);
+  compositor.markDirty(SESSION_A);
+  const snapshotA = await compositor.composite(SESSION_A);
+  assert.ok(snapshotA);
+  const revisionA = snapshotA.revision;
+  const cellsA = snapshotA.layout.cells.map((cell) => cell.id);
+
+  // Content arrives and build B completes while A's response is conceptually
+  // still being written. Snapshot A must stay wholly A.
+  now += config.compositeMinIntervalMs;
+  store.ingest(SESSION_A, "p2", await makeJpeg(0, 0, 255, config.tileSizePx), now);
+  compositor.markDirty(SESSION_A);
+  const snapshotB = await compositor.composite(SESSION_A);
+  assert.ok(snapshotB);
+  assert.notEqual(snapshotB.revision, revisionA);
+
+  assert.equal(snapshotA.revision, revisionA, "A keeps its own revision");
+  assert.deepEqual(snapshotA.layout.cells.map((cell) => cell.id), cellsA, "A keeps its own layout");
+  const colorA = await tileColor(snapshotA.bytes, 0, 0);
+  assert.ok(colorA.r > 150 && colorA.b < 80, "A keeps its own bytes (red tile only)");
+  assert.equal(snapshotA.layout.cells.length, 1, "A predates the second participant");
+
+  const colorB = await tileColor(snapshotB.bytes, 100, 0);
+  assert.ok(colorB.b > 150 && colorB.r < 80, "B carries the new content");
+  assert.equal(snapshotB.layout.cells.length, 2);
 });

--- a/services/tapestry/test/layout.test.ts
+++ b/services/tapestry/test/layout.test.ts
@@ -25,6 +25,7 @@ import {
 
 interface LayoutBody {
   revision: number;
+  frameTtlMs: number;
   columns: number;
   rows: number;
   tileSizePx: number;
@@ -53,6 +54,7 @@ test("the composite names its build revision and the layout matches the same bui
     assert.equal(layoutRes.status, 200);
     const layout = (await layoutRes.json()) as LayoutBody;
     assert.equal(String(layout.revision), revision, "layout and composite describe one build");
+    assert.equal(layout.frameTtlMs, 10_000, "freshness rides with the layout");
     assert.equal(layout.columns, 3);
     assert.equal(layout.rows, 1);
     assert.equal(layout.tileSizePx, 100);

--- a/services/tapestry/test/layout.test.ts
+++ b/services/tapestry/test/layout.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Layout/revision acceptance tests: the served composite names its build
+ * revision, and the layout endpoint returns the grid captured by the same
+ * build — so an overlay can only draw names over the exact image they
+ * belong to (TAP-02, issue #129; builds on the monotonic revision of #108).
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  SESSION_A,
+  authHeaders,
+  getComposite,
+  makeJpeg,
+  postFrame,
+  sleep,
+  startService,
+  testConfig,
+} from "./helpers.js";
+
+interface LayoutBody {
+  revision: number;
+  columns: number;
+  rows: number;
+  tileSizePx: number;
+  cells: Array<{ id: string; column: number; row: number }>;
+}
+
+async function getLayout(baseUrl: string, sessionId: string): Promise<Response> {
+  return fetch(`${baseUrl}/tapestry/sessions/${sessionId}/layout`, {
+    headers: authHeaders(),
+  });
+}
+
+test("the composite names its build revision and the layout matches the same build", async () => {
+  const service = await startService(testConfig());
+  try {
+    await postFrame(service.baseUrl, SESSION_A, "zz", await makeJpeg(255, 0, 0));
+    await postFrame(service.baseUrl, SESSION_A, "aa", await makeJpeg(0, 0, 255));
+    await postFrame(service.baseUrl, SESSION_A, "mm", await makeJpeg(0, 220, 0));
+
+    const composite = await getComposite(service.baseUrl, SESSION_A);
+    assert.equal(composite.status, 200);
+    const revision = composite.headers.get("x-tapestry-revision");
+    assert.ok(revision, "the composite carries its build revision");
+
+    const layoutRes = await getLayout(service.baseUrl, SESSION_A);
+    assert.equal(layoutRes.status, 200);
+    const layout = (await layoutRes.json()) as LayoutBody;
+    assert.equal(String(layout.revision), revision, "layout and composite describe one build");
+    assert.equal(layout.columns, 3);
+    assert.equal(layout.rows, 1);
+    assert.equal(layout.tileSizePx, 100);
+    // First-seen order: zz arrived first, then aa, then mm.
+    assert.deepEqual(layout.cells, [
+      { id: "zz", column: 0, row: 0 },
+      { id: "aa", column: 1, row: 0 },
+      { id: "mm", column: 2, row: 0 },
+    ]);
+  } finally {
+    await service.close();
+  }
+});
+
+test("a rebuild advances both revision and layout atomically", async () => {
+  const service = await startService(testConfig());
+  try {
+    await postFrame(service.baseUrl, SESSION_A, "p1", await makeJpeg(255, 0, 0));
+    const first = await getComposite(service.baseUrl, SESSION_A);
+    const firstRevision = first.headers.get("x-tapestry-revision");
+
+    await postFrame(service.baseUrl, SESSION_A, "p2", await makeJpeg(0, 0, 255));
+    await sleep(1100); // rebuild rate limit
+    const second = await getComposite(service.baseUrl, SESSION_A);
+    const secondRevision = second.headers.get("x-tapestry-revision");
+    assert.ok(secondRevision && secondRevision !== firstRevision, "a new build advances the revision");
+
+    const layout = (await (await getLayout(service.baseUrl, SESSION_A)).json()) as LayoutBody;
+    assert.equal(String(layout.revision), secondRevision);
+    assert.deepEqual(layout.cells, [
+      { id: "p1", column: 0, row: 0 },
+      { id: "p2", column: 1, row: 0 },
+    ]);
+  } finally {
+    await service.close();
+  }
+});
+
+test("the layout wraps to a second row at the column cap", async () => {
+  const service = await startService(testConfig({ gridColumns: 2 }));
+  try {
+    await postFrame(service.baseUrl, SESSION_A, "a", await makeJpeg(255, 0, 0));
+    await postFrame(service.baseUrl, SESSION_A, "b", await makeJpeg(0, 255, 0));
+    await postFrame(service.baseUrl, SESSION_A, "c", await makeJpeg(0, 0, 255));
+    await getComposite(service.baseUrl, SESSION_A);
+
+    const layout = (await (await getLayout(service.baseUrl, SESSION_A)).json()) as LayoutBody;
+    assert.equal(layout.columns, 2);
+    assert.equal(layout.rows, 2);
+    assert.deepEqual(layout.cells, [
+      { id: "a", column: 0, row: 0 },
+      { id: "b", column: 1, row: 0 },
+      { id: "c", column: 0, row: 1 },
+    ]);
+  } finally {
+    await service.close();
+  }
+});
+
+test("layout is 404 before the first build and 401 without the secret", async () => {
+  const service = await startService(testConfig());
+  try {
+    const early = await getLayout(service.baseUrl, SESSION_A);
+    assert.equal(early.status, 404);
+
+    const unauthorized = await fetch(`${service.baseUrl}/tapestry/sessions/${SESSION_A}/layout`);
+    assert.equal(unauthorized.status, 401);
+  } finally {
+    await service.close();
+  }
+});
+
+test("an empty build still publishes a truthful 1x1 layout with no cells", async () => {
+  const service = await startService(testConfig());
+  try {
+    const composite = await getComposite(service.baseUrl, SESSION_A);
+    const revision = composite.headers.get("x-tapestry-revision");
+    const layout = (await (await getLayout(service.baseUrl, SESSION_A)).json()) as LayoutBody;
+    assert.equal(String(layout.revision), revision);
+    assert.deepEqual(layout.cells, []);
+    assert.equal(layout.columns, 1);
+    assert.equal(layout.rows, 1);
+  } finally {
+    await service.close();
+  }
+});

--- a/src/app/api/ops/sessions/[id]/tapestry/manifest/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/manifest/__tests__/route.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+
+import { createRequest, mockParams } from '@/__tests__/helpers';
+
+const mocks = vi.hoisted(() => ({
+    requireStaff: vi.fn(),
+    sessionFindUnique: vi.fn(),
+    listParticipants: vi.fn(),
+    tapestryInternalUrl: vi.fn(),
+    tapestryParticipantId: vi.fn(),
+    fetch: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ requireStaff: mocks.requireStaff }));
+vi.mock('@/lib/db', () => ({
+    prisma: {
+        scheduledSession: { findUnique: mocks.sessionFindUnique },
+    },
+}));
+vi.mock('@/lib/livekit-server', () => ({
+    getRoomService: () => ({ listParticipants: mocks.listParticipants }),
+}));
+vi.mock('@/lib/tapestry', () => ({
+    tapestryInternalUrl: mocks.tapestryInternalUrl,
+    tapestryParticipantId: mocks.tapestryParticipantId,
+}));
+
+import { GET } from '../route';
+
+const SESSION_ID = 'event-1';
+const RAISED_AT = new Date('2026-08-04T11:59:00Z');
+
+function staffOk(role = 'OPERATOR', userId = 'staff-1') {
+    mocks.requireStaff.mockResolvedValue([{ userId, role }, null]);
+}
+
+function sessionOk() {
+    mocks.sessionFindUnique.mockResolvedValue({
+        id: SESSION_ID,
+        roomName: 'event-stage',
+        facilitatorId: 'facilitator-1',
+        participants: [
+            {
+                participantIdentity: 'lk-ana',
+                leftAt: null,
+                raisedAt: RAISED_AT,
+                publishGrantedAt: null,
+                publishRevokedAt: null,
+                staffUser: null,
+            },
+            {
+                participantIdentity: 'lk-beto',
+                leftAt: null,
+                raisedAt: null,
+                publishGrantedAt: null,
+                publishRevokedAt: null,
+                staffUser: null,
+            },
+        ],
+    });
+}
+
+function tapestryOk() {
+    mocks.tapestryInternalUrl.mockReturnValue('http://tapestry:3100');
+    mocks.fetch.mockResolvedValue(new Response(
+        JSON.stringify({ participants: ['tp-ana', 'tp-beto'], frameTtlMs: 10_000 }),
+        { status: 200 },
+    ));
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mocks.fetch);
+    process.env.TAPESTRY_INTERNAL_SECRET = 'test-secret';
+    mocks.tapestryParticipantId.mockImplementation(
+        (identity: string) => `tp-${identity.replace('lk-', '')}`,
+    );
+    mocks.listParticipants.mockResolvedValue([
+        {
+            identity: 'lk-ana',
+            name: 'Ana',
+            tracks: [{ sid: 'TR_cam', source: 1, muted: false }],
+        },
+        {
+            identity: 'lk-beto',
+            name: 'Beto',
+            tracks: [{ sid: 'TR_cam', source: 1, muted: true }],
+        },
+    ]);
+    staffOk();
+    sessionOk();
+    tapestryOk();
+});
+
+describe('GET /api/ops/sessions/[id]/tapestry/manifest', () => {
+    it('builds the annotated manifest with one bounded fetch per source', async () => {
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        const body = await response.json();
+        expect(body.sessionId).toBe(SESSION_ID);
+        expect(body.liveStateAvailable).toBe(true);
+        expect(body.thumbnailFreshForSeconds).toBe(10);
+        expect(body.entries).toHaveLength(2);
+        expect(body.entries[0]).toMatchObject({
+            tileId: 'tp-ana',
+            position: 0,
+            displayName: 'Ana',
+            handRaised: true,
+            queuePosition: 1,
+            presence: 'connected',
+            camera: 'on',
+        });
+        expect(body.entries[0].thumbnailUrl).toContain(
+            `/api/ops/sessions/${SESSION_ID}/tapestry/tiles/tp-ana?v=`,
+        );
+        expect(body.entries[1]).toMatchObject({
+            tileId: 'tp-beto',
+            handRaised: false,
+            queuePosition: null,
+            camera: 'off',
+        });
+        expect(body.waitingHands).toEqual([
+            { displayName: 'Ana', queuePosition: 1, tileId: 'tp-ana' },
+        ]);
+        // Exactly one internal tapestry call: the tile list. Frames are
+        // referenced by cacheable URL, never fetched per tile.
+        expect(mocks.fetch).toHaveBeenCalledTimes(1);
+        expect(String(mocks.fetch.mock.calls[0][0])).toBe(
+            `http://tapestry:3100/tapestry/sessions/${SESSION_ID}/participants`,
+        );
+    });
+
+    it('rejects an unauthenticated caller', async () => {
+        mocks.requireStaff.mockResolvedValue([
+            null,
+            NextResponse.json({ error: 'Authentication required' }, { status: 401 }),
+        ]);
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(401);
+        expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a facilitator assigned to another event', async () => {
+        staffOk('FACILITATOR', 'staff-9');
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(403);
+        expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it('allows the assigned facilitator of this event', async () => {
+        staffOk('FACILITATOR', 'facilitator-1');
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(200);
+    });
+
+    it('returns 404 for an unknown session', async () => {
+        mocks.sessionFindUnique.mockResolvedValue(null);
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(404);
+        expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 503 when the tapestry service is not configured', async () => {
+        mocks.tapestryInternalUrl.mockReturnValue(null);
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(503);
+    });
+
+    it('returns 503 when the tapestry service fails or answers an invalid list', async () => {
+        mocks.fetch.mockRejectedValue(new Error('connection refused'));
+        expect((await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }))).status).toBe(503);
+
+        mocks.fetch.mockResolvedValue(new Response(
+            JSON.stringify({ participants: ['ok', 'has spaces'] }),
+            { status: 200 },
+        ));
+        expect((await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }))).status).toBe(503);
+    });
+
+    it('degrades presence and camera to unknown when LiveKit is down', async () => {
+        mocks.listParticipants.mockRejectedValue(new Error('livekit unreachable'));
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.liveStateAvailable).toBe(false);
+        expect(body.entries[0]).toMatchObject({ presence: 'unknown', camera: 'unknown' });
+        // Names, hands and tiles survive the outage.
+        expect(body.entries[0].handRaised).toBe(true);
+        expect(body.entries[0].displayName).toBe('Attendee');
+    });
+});

--- a/src/app/api/ops/sessions/[id]/tapestry/manifest/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/manifest/__tests__/route.test.ts
@@ -61,12 +61,21 @@ function sessionOk() {
     });
 }
 
+const LAYOUT = {
+    revision: 7,
+    frameTtlMs: 10_000,
+    columns: 2,
+    rows: 1,
+    tileSizePx: 100,
+    cells: [
+        { id: 'tp-ana', column: 0, row: 0 },
+        { id: 'tp-beto', column: 1, row: 0 },
+    ],
+};
+
 function tapestryOk() {
     mocks.tapestryInternalUrl.mockReturnValue('http://tapestry:3100');
-    mocks.fetch.mockResolvedValue(new Response(
-        JSON.stringify({ participants: ['tp-ana', 'tp-beto'], frameTtlMs: 10_000 }),
-        { status: 200 },
-    ));
+    mocks.fetch.mockResolvedValue(new Response(JSON.stringify(LAYOUT), { status: 200 }));
 }
 
 beforeEach(() => {
@@ -102,22 +111,25 @@ describe('GET /api/ops/sessions/[id]/tapestry/manifest', () => {
         const body = await response.json();
         expect(body.sessionId).toBe(SESSION_ID);
         expect(body.liveStateAvailable).toBe(true);
-        expect(body.thumbnailFreshForSeconds).toBe(10);
+        expect(body.layout).toEqual({ revision: 7, columns: 2, rows: 1, tileSizePx: 100 });
+        expect(body.tileFreshForSeconds).toBe(10);
         expect(body.entries).toHaveLength(2);
         expect(body.entries[0]).toMatchObject({
             tileId: 'tp-ana',
-            position: 0,
+            column: 0,
+            row: 0,
             displayName: 'Ana',
             handRaised: true,
             queuePosition: 1,
             presence: 'connected',
             camera: 'on',
         });
-        expect(body.entries[0].thumbnailUrl).toContain(
-            `/api/ops/sessions/${SESSION_ID}/tapestry/tiles/tp-ana?v=`,
-        );
+        // O(1) visual transport: entries never carry per-tile image URLs.
+        expect(body.entries[0]).not.toHaveProperty('thumbnailUrl');
         expect(body.entries[1]).toMatchObject({
             tileId: 'tp-beto',
+            column: 1,
+            row: 0,
             handRaised: false,
             queuePosition: null,
             camera: 'off',
@@ -125,11 +137,11 @@ describe('GET /api/ops/sessions/[id]/tapestry/manifest', () => {
         expect(body.waitingHands).toEqual([
             { displayName: 'Ana', queuePosition: 1, tileId: 'tp-ana' },
         ]);
-        // Exactly one internal tapestry call: the tile list. Frames are
-        // referenced by cacheable URL, never fetched per tile.
+        // Exactly one internal tapestry call: the build-time layout. No
+        // frames are fetched, per tile or otherwise.
         expect(mocks.fetch).toHaveBeenCalledTimes(1);
         expect(String(mocks.fetch.mock.calls[0][0])).toBe(
-            `http://tapestry:3100/tapestry/sessions/${SESSION_ID}/participants`,
+            `http://tapestry:3100/tapestry/sessions/${SESSION_ID}/layout`,
         );
     });
 
@@ -174,12 +186,25 @@ describe('GET /api/ops/sessions/[id]/tapestry/manifest', () => {
         expect(response.status).toBe(503);
     });
 
-    it('returns 503 when the tapestry service fails or answers an invalid list', async () => {
+    it('returns 503 when the tapestry service fails or answers an invalid layout', async () => {
         mocks.fetch.mockRejectedValue(new Error('connection refused'));
         expect((await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }))).status).toBe(503);
 
         mocks.fetch.mockResolvedValue(new Response(
-            JSON.stringify({ participants: ['ok', 'has spaces'] }),
+            JSON.stringify({ ...LAYOUT, cells: [{ id: 'has spaces', column: 0, row: 0 }] }),
+            { status: 200 },
+        ));
+        expect((await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }))).status).toBe(503);
+
+        // Duplicate tile ids make cell mapping ambiguous: fail safe.
+        mocks.fetch.mockResolvedValue(new Response(
+            JSON.stringify({
+                ...LAYOUT,
+                cells: [
+                    { id: 'tp-ana', column: 0, row: 0 },
+                    { id: 'tp-ana', column: 1, row: 0 },
+                ],
+            }),
             { status: 200 },
         ));
         expect((await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }))).status).toBe(503);

--- a/src/app/api/ops/sessions/[id]/tapestry/manifest/route.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/manifest/route.ts
@@ -1,0 +1,197 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { TrackSource } from 'livekit-server-sdk';
+
+import { requireStaff } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { getRoomService } from '@/lib/livekit-server';
+import { eventStaffPolicy } from '@/lib/staff-capabilities';
+import { tapestryInternalUrl, tapestryParticipantId } from '@/lib/tapestry';
+import {
+    buildTapestryManifest,
+    MAX_TAPESTRY_MANIFEST_ENTRIES,
+    type ManifestLiveParticipant,
+    type ManifestParticipant,
+} from '@/lib/tapestry-manifest';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_TAPESTRY_FRAME_TTL_MS = 10_000;
+const THUMBNAIL_REFRESH_MS = 5_000;
+const TAPESTRY_LOOKUP_TIMEOUT_MS = 750;
+
+/**
+ * Staff-only operational tapestry manifest (TAP-02, issue #129).
+ *
+ * One bounded response per poll: the tapestry tiles in display order joined
+ * with the authorized name, hand queue, presence and camera state of each
+ * person. Three lookups total — one database read, one LiveKit participant
+ * list, one internal tapestry list — so 150 participants cost the same as
+ * one. Thumbnails are referenced as epoch-versioned proxy URLs the browser
+ * caches within the refresh window; the route itself never fetches frames.
+ *
+ * Authorization matches the sibling tapestry routes: any staff session plus
+ * the event-scoped `canOperateEvent` policy. The payload is `private,
+ * no-store` and carries opaque tile ids only.
+ */
+
+type TapestryListSnapshot = {
+    tileIds: string[];
+    frameTtlMs: number;
+};
+
+async function fetchTapestryTileList(sessionId: string): Promise<TapestryListSnapshot | null> {
+    const internalUrl = tapestryInternalUrl();
+    if (!internalUrl || !process.env.TAPESTRY_INTERNAL_SECRET) {
+        return null;
+    }
+    try {
+        const response = await fetch(
+            `${internalUrl}/tapestry/sessions/${encodeURIComponent(sessionId)}/participants`,
+            {
+                headers: {
+                    'x-tapestry-internal-secret': process.env.TAPESTRY_INTERNAL_SECRET,
+                },
+                cache: 'no-store',
+                signal: AbortSignal.timeout(TAPESTRY_LOOKUP_TIMEOUT_MS),
+            },
+        );
+        if (!response.ok) return null;
+        const body = await response.json() as { participants?: unknown; frameTtlMs?: unknown };
+        if (
+            !Array.isArray(body.participants) ||
+            body.participants.length > MAX_TAPESTRY_MANIFEST_ENTRIES
+        ) {
+            return null;
+        }
+        const tileIds = body.participants.filter(
+            (value): value is string => typeof value === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(value),
+        );
+        if (tileIds.length !== body.participants.length) return null;
+        const frameTtlMs = typeof body.frameTtlMs === 'number' &&
+            Number.isFinite(body.frameTtlMs) &&
+            body.frameTtlMs >= 1_000 &&
+            body.frameTtlMs <= 60_000
+            ? body.frameTtlMs
+            : DEFAULT_TAPESTRY_FRAME_TTL_MS;
+        return { tileIds, frameTtlMs };
+    } catch {
+        return null;
+    }
+}
+
+function trackSourceLabel(source: TrackSource): string {
+    switch (source) {
+        case TrackSource.CAMERA:
+            return 'CAMERA';
+        case TrackSource.MICROPHONE:
+            return 'MICROPHONE';
+        case TrackSource.SCREEN_SHARE:
+            return 'SCREEN_SHARE';
+        case TrackSource.SCREEN_SHARE_AUDIO:
+            return 'SCREEN_SHARE_AUDIO';
+        default:
+            return 'UNKNOWN';
+    }
+}
+
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const [staff, errorResponse] = await requireStaff();
+    if (!staff) {
+        return errorResponse;
+    }
+    const { id } = await params;
+    const scheduledSession = await prisma.scheduledSession.findUnique({
+        where: { id },
+        select: {
+            id: true,
+            roomName: true,
+            facilitatorId: true,
+            participants: {
+                select: {
+                    participantIdentity: true,
+                    leftAt: true,
+                    raisedAt: true,
+                    publishGrantedAt: true,
+                    publishRevokedAt: true,
+                    staffUser: { select: { name: true } },
+                },
+            },
+        },
+    });
+    if (!scheduledSession) {
+        return NextResponse.json({ error: 'session_not_found' }, { status: 404 });
+    }
+    if (!eventStaffPolicy(
+        staff.role,
+        scheduledSession.facilitatorId === staff.userId,
+    ).canOperateEvent) {
+        return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 });
+    }
+
+    // The tapestry list is required: without it there is no tapestry to
+    // annotate, and an empty manifest would lie about the room. Degrade to
+    // the same dignified 503 as the sibling routes instead.
+    const tapestrySnapshot = await fetchTapestryTileList(scheduledSession.id);
+    if (!tapestrySnapshot) {
+        return NextResponse.json({ error: 'Tapestry unavailable' }, { status: 503 });
+    }
+
+    // LiveKit is advisory: an outage marks presence/camera unknown without
+    // hiding names, hands or tiles.
+    let liveStateAvailable = true;
+    let live = new Map<string, ManifestLiveParticipant>();
+    try {
+        live = new Map(
+            (await getRoomService().listParticipants(scheduledSession.roomName))
+                .map((participant) => [
+                    participant.identity,
+                    {
+                        name: participant.name,
+                        media: participant.tracks.map((track) => ({
+                            source: trackSourceLabel(track.source),
+                            muted: track.muted,
+                        })),
+                    },
+                ]),
+        );
+    } catch {
+        liveStateAvailable = false;
+    }
+
+    const participants: ManifestParticipant[] = scheduledSession.participants.map(
+        (participant) => ({
+            identity: participant.participantIdentity,
+            leftAt: participant.leftAt,
+            raisedAt: participant.raisedAt,
+            publishGrantedAt: participant.publishGrantedAt,
+            publishRevokedAt: participant.publishRevokedAt,
+            staffName: participant.staffUser?.name ?? null,
+        }),
+    );
+
+    const thumbnailEpoch = Math.floor(Date.now() / THUMBNAIL_REFRESH_MS);
+    const manifest = buildTapestryManifest({
+        sessionId: scheduledSession.id,
+        tileIds: tapestrySnapshot.tileIds,
+        frameTtlMs: tapestrySnapshot.frameTtlMs,
+        liveStateAvailable,
+        participants,
+        live,
+        tapestryIdFor: (identity) => {
+            try {
+                return tapestryParticipantId(identity);
+            } catch {
+                return null;
+            }
+        },
+        thumbnailUrlFor: (tileId) =>
+            `/api/ops/sessions/${encodeURIComponent(scheduledSession.id)}/tapestry/tiles/${encodeURIComponent(tileId)}?v=${thumbnailEpoch}`,
+    });
+
+    return NextResponse.json(manifest, {
+        headers: { 'cache-control': 'private, no-store' },
+    });
+}

--- a/src/app/api/ops/sessions/[id]/tapestry/manifest/route.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/manifest/route.ts
@@ -6,47 +6,41 @@ import { prisma } from '@/lib/db';
 import { getRoomService } from '@/lib/livekit-server';
 import { eventStaffPolicy } from '@/lib/staff-capabilities';
 import { tapestryInternalUrl, tapestryParticipantId } from '@/lib/tapestry';
+import { parseCompositeLayout, type CompositeLayout } from '@/lib/tapestry-layout';
 import {
     buildTapestryManifest,
-    MAX_TAPESTRY_MANIFEST_ENTRIES,
     type ManifestLiveParticipant,
     type ManifestParticipant,
 } from '@/lib/tapestry-manifest';
 
 export const dynamic = 'force-dynamic';
 
-const DEFAULT_TAPESTRY_FRAME_TTL_MS = 10_000;
-const THUMBNAIL_REFRESH_MS = 5_000;
 const TAPESTRY_LOOKUP_TIMEOUT_MS = 750;
 
 /**
  * Staff-only operational tapestry manifest (TAP-02, issue #129).
  *
- * One bounded response per poll: the tapestry tiles in display order joined
- * with the authorized name, hand queue, presence and camera state of each
- * person. Three lookups total — one database read, one LiveKit participant
- * list, one internal tapestry list — so 150 participants cost the same as
- * one. Thumbnails are referenced as epoch-versioned proxy URLs the browser
- * caches within the refresh window; the route itself never fetches frames.
+ * One bounded response per poll: the grid captured by the internal service's
+ * latest composite build, joined with the authorized name, hand queue,
+ * presence and camera state of each person. Three lookups total — one
+ * database read, one LiveKit participant list, one internal layout read — so
+ * 150 participants cost the same as one. No thumbnail URLs: the cockpit
+ * draws everything as semantic overlays over a single shared composite
+ * image fetched once per poll.
  *
  * Authorization matches the sibling tapestry routes: any staff session plus
  * the event-scoped `canOperateEvent` policy. The payload is `private,
  * no-store` and carries opaque tile ids only.
  */
 
-type TapestryListSnapshot = {
-    tileIds: string[];
-    frameTtlMs: number;
-};
-
-async function fetchTapestryTileList(sessionId: string): Promise<TapestryListSnapshot | null> {
+async function fetchTapestryLayout(sessionId: string): Promise<CompositeLayout | null> {
     const internalUrl = tapestryInternalUrl();
     if (!internalUrl || !process.env.TAPESTRY_INTERNAL_SECRET) {
         return null;
     }
     try {
         const response = await fetch(
-            `${internalUrl}/tapestry/sessions/${encodeURIComponent(sessionId)}/participants`,
+            `${internalUrl}/tapestry/sessions/${encodeURIComponent(sessionId)}/layout`,
             {
                 headers: {
                     'x-tapestry-internal-secret': process.env.TAPESTRY_INTERNAL_SECRET,
@@ -56,24 +50,9 @@ async function fetchTapestryTileList(sessionId: string): Promise<TapestryListSna
             },
         );
         if (!response.ok) return null;
-        const body = await response.json() as { participants?: unknown; frameTtlMs?: unknown };
-        if (
-            !Array.isArray(body.participants) ||
-            body.participants.length > MAX_TAPESTRY_MANIFEST_ENTRIES
-        ) {
-            return null;
-        }
-        const tileIds = body.participants.filter(
-            (value): value is string => typeof value === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(value),
-        );
-        if (tileIds.length !== body.participants.length) return null;
-        const frameTtlMs = typeof body.frameTtlMs === 'number' &&
-            Number.isFinite(body.frameTtlMs) &&
-            body.frameTtlMs >= 1_000 &&
-            body.frameTtlMs <= 60_000
-            ? body.frameTtlMs
-            : DEFAULT_TAPESTRY_FRAME_TTL_MS;
-        return { tileIds, frameTtlMs };
+        // Fail safe: a malformed or hostile layout is "no overlay", never a
+        // trusted grid. Nothing internal is logged.
+        return parseCompositeLayout(await response.json());
     } catch {
         return null;
     }
@@ -131,11 +110,11 @@ export async function GET(
         return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 });
     }
 
-    // The tapestry list is required: without it there is no tapestry to
-    // annotate, and an empty manifest would lie about the room. Degrade to
-    // the same dignified 503 as the sibling routes instead.
-    const tapestrySnapshot = await fetchTapestryTileList(scheduledSession.id);
-    if (!tapestrySnapshot) {
+    // The layout is required: without it there is no composite to annotate,
+    // and an empty manifest would lie about the room. Degrade to the same
+    // dignified 503 as the sibling routes instead.
+    const layout = await fetchTapestryLayout(scheduledSession.id);
+    if (!layout) {
         return NextResponse.json({ error: 'Tapestry unavailable' }, { status: 503 });
     }
 
@@ -172,23 +151,13 @@ export async function GET(
         }),
     );
 
-    const thumbnailEpoch = Math.floor(Date.now() / THUMBNAIL_REFRESH_MS);
     const manifest = buildTapestryManifest({
         sessionId: scheduledSession.id,
-        tileIds: tapestrySnapshot.tileIds,
-        frameTtlMs: tapestrySnapshot.frameTtlMs,
+        layout,
         liveStateAvailable,
         participants,
         live,
-        tapestryIdFor: (identity) => {
-            try {
-                return tapestryParticipantId(identity);
-            } catch {
-                return null;
-            }
-        },
-        thumbnailUrlFor: (tileId) =>
-            `/api/ops/sessions/${encodeURIComponent(scheduledSession.id)}/tapestry/tiles/${encodeURIComponent(tileId)}?v=${thumbnailEpoch}`,
+        tapestryIdFor: (identity) => tapestryParticipantId(identity),
     });
 
     return NextResponse.json(manifest, {

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.readonly.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.readonly.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createRequest, mockParams } from '@/__tests__/helpers';
+
+/**
+ * TAP-02 review: the public hands sidecar is polled every few seconds, so a
+ * GET must be a pure read. This suite deliberately does NOT mock
+ * `@/lib/room-entitlement`: the real `resolveRoomViewer` runs against a
+ * mocked Prisma, and any create/update/upsert/transaction it (or the route)
+ * attempted would be caught by the spies below.
+ */
+
+const mocks = vi.hoisted(() => ({
+    webSessionFindUnique: vi.fn(),
+    sessionFindUnique: vi.fn(),
+    participantFindMany: vi.fn(),
+    participantFindFirst: vi.fn(),
+    participantCreate: vi.fn(),
+    participantUpdate: vi.fn(),
+    participantUpsert: vi.fn(),
+    transaction: vi.fn(),
+    listParticipants: vi.fn(),
+    tapestryInternalUrl: vi.fn(),
+    tapestryParticipantId: vi.fn(),
+    fetch: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+    prisma: {
+        webSession: { findUnique: mocks.webSessionFindUnique },
+        scheduledSession: { findUnique: mocks.sessionFindUnique },
+        sessionParticipant: {
+            findMany: mocks.participantFindMany,
+            findFirst: mocks.participantFindFirst,
+            create: mocks.participantCreate,
+            update: mocks.participantUpdate,
+            upsert: mocks.participantUpsert,
+        },
+        $transaction: mocks.transaction,
+    },
+}));
+vi.mock('@/lib/livekit-server', () => ({
+    getRoomService: () => ({ listParticipants: mocks.listParticipants }),
+    stableRoomIdentity: (_session: string, kind: string, id: string) => `lk-${kind}-${id}`,
+}));
+vi.mock('@/lib/tapestry', () => ({
+    tapestryInternalUrl: mocks.tapestryInternalUrl,
+    tapestryParticipantId: mocks.tapestryParticipantId,
+}));
+
+import { GET } from '../route';
+
+const SESSION_ID = 'event-1';
+const FUTURE = new Date('2027-01-01T00:00:00Z');
+
+function attendeeRequest() {
+    return createRequest('http://x', {
+        headers: { cookie: 'hb_session=test-token' },
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mocks.fetch);
+    process.env.TAPESTRY_INTERNAL_SECRET = 'test-secret';
+    mocks.webSessionFindUnique.mockResolvedValue({
+        displayName: 'Ana',
+        expiresAt: FUTURE,
+        revokedAt: null,
+        staffUser: null,
+        ticketEntitlement: {
+            id: 'ticket-1',
+            scheduledSessionId: SESSION_ID,
+            state: 'BOUND',
+            boundEmail: 'ana@example.org',
+            expiresAt: FUTURE,
+            revokedAt: null,
+            commerceEntitlement: null,
+        },
+    });
+    mocks.sessionFindUnique.mockResolvedValue({
+        id: SESSION_ID,
+        title: 'Event',
+        roomName: 'event-stage',
+        status: 'LIVE',
+        startedAt: null,
+        facilitatorId: 'facilitator-1',
+    });
+    mocks.participantFindFirst.mockResolvedValue(null);
+    mocks.participantFindMany.mockResolvedValue([]);
+    mocks.listParticipants.mockResolvedValue([]);
+    mocks.tapestryInternalUrl.mockReturnValue(null);
+    mocks.tapestryParticipantId.mockImplementation((identity: string) => `tp-${identity}`);
+});
+
+describe('GET /api/scheduled-sessions/[id]/tapestry/hands — read-only polling', () => {
+    it('performs zero writes across repeated polls', async () => {
+        for (let poll = 0; poll < 3; poll += 1) {
+            const response = await GET(attendeeRequest(), mockParams({ id: SESSION_ID }));
+            expect(response.status).toBe(200);
+        }
+
+        // The resolver validated session, entitlement and event…
+        expect(mocks.webSessionFindUnique).toHaveBeenCalledTimes(3);
+        expect(mocks.sessionFindUnique).toHaveBeenCalledTimes(3);
+        expect(mocks.participantFindMany).toHaveBeenCalledTimes(3);
+        // …without a single mutating Prisma operation.
+        expect(mocks.participantCreate).not.toHaveBeenCalled();
+        expect(mocks.participantUpdate).not.toHaveBeenCalled();
+        expect(mocks.participantUpsert).not.toHaveBeenCalled();
+        expect(mocks.transaction).not.toHaveBeenCalled();
+    });
+
+    it('bounds the historical hand query', async () => {
+        await GET(attendeeRequest(), mockParams({ id: SESSION_ID }));
+        expect(mocks.participantFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({ take: 150 }),
+        );
+    });
+
+    it('rejects an outsider still without writing anything', async () => {
+        mocks.webSessionFindUnique.mockResolvedValue(null);
+
+        const response = await GET(attendeeRequest(), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(401);
+        expect(mocks.participantCreate).not.toHaveBeenCalled();
+        expect(mocks.participantUpdate).not.toHaveBeenCalled();
+        expect(mocks.participantUpsert).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createRequest, mockParams } from '@/__tests__/helpers';
+
+const mocks = vi.hoisted(() => ({
+    resolveRoomPrincipal: vi.fn(),
+    findMany: vi.fn(),
+    listParticipants: vi.fn(),
+}));
+
+vi.mock('@/lib/room-entitlement', () => ({
+    resolveRoomPrincipal: mocks.resolveRoomPrincipal,
+}));
+vi.mock('@/lib/db', () => ({
+    prisma: {
+        sessionParticipant: { findMany: mocks.findMany },
+    },
+}));
+vi.mock('@/lib/livekit-server', () => ({
+    getRoomService: () => ({ listParticipants: mocks.listParticipants }),
+}));
+
+import { GET } from '../route';
+
+const SESSION_ID = 'event-1';
+
+function entitled() {
+    mocks.resolveRoomPrincipal.mockResolvedValue({
+        ok: true,
+        principal: {
+            session: { id: SESSION_ID, roomName: 'event-stage' },
+            ticketEntitlementId: 'ticket-1',
+        },
+    });
+}
+
+function participant(overrides: Record<string, unknown> = {}) {
+    return {
+        participantIdentity: 'lk-ana',
+        publishGrantedAt: null,
+        publishRevokedAt: null,
+        staffUser: null,
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    entitled();
+    mocks.findMany.mockResolvedValue([
+        participant({ participantIdentity: 'lk-ana' }),
+        participant({ participantIdentity: 'lk-beto' }),
+    ]);
+    mocks.listParticipants.mockResolvedValue([
+        { identity: 'lk-ana', name: 'Ana' },
+        { identity: 'lk-beto', name: 'Beto' },
+    ]);
+});
+
+describe('GET /api/scheduled-sessions/[id]/tapestry/hands', () => {
+    it('names connected waiting hands in queue order', async () => {
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(await response.json()).toEqual({
+            hands: [{ name: 'Ana' }, { name: 'Beto' }],
+            liveStateAvailable: true,
+        });
+    });
+
+    it('propagates the entitlement rejection for outsiders', async () => {
+        mocks.resolveRoomPrincipal.mockResolvedValue({
+            ok: false,
+            status: 403,
+            error: 'Not authorized',
+        });
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(403);
+        expect(mocks.findMany).not.toHaveBeenCalled();
+    });
+
+    it('excludes publishers, includes re-raisers after a revoked grant', async () => {
+        mocks.findMany.mockResolvedValue([
+            participant({
+                participantIdentity: 'lk-ana',
+                publishGrantedAt: new Date('2026-08-04T11:50:00Z'),
+            }),
+            participant({
+                participantIdentity: 'lk-beto',
+                publishGrantedAt: new Date('2026-08-04T11:50:00Z'),
+                publishRevokedAt: new Date('2026-08-04T11:55:00Z'),
+            }),
+        ]);
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(await response.json()).toMatchObject({ hands: [{ name: 'Beto' }] });
+    });
+
+    it('omits hands whose owner is no longer connected', async () => {
+        mocks.listParticipants.mockResolvedValue([{ identity: 'lk-ana', name: 'Ana' }]);
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(await response.json()).toMatchObject({ hands: [{ name: 'Ana' }] });
+    });
+
+    it('names nobody when LiveKit cannot confirm presence', async () => {
+        mocks.listParticipants.mockRejectedValue(new Error('livekit unreachable'));
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ hands: [], liveStateAvailable: false });
+    });
+
+    it('uses the staff account name for staff hands', async () => {
+        mocks.findMany.mockResolvedValue([
+            participant({ staffUser: { name: 'Julián' } }),
+        ]);
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(await response.json()).toMatchObject({ hands: [{ name: 'Julián' }] });
+    });
+});

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRequest, mockParams } from '@/__tests__/helpers';
 
 const mocks = vi.hoisted(() => ({
-    resolveRoomPrincipal: vi.fn(),
+    resolveRoomViewer: vi.fn(),
     findMany: vi.fn(),
     listParticipants: vi.fn(),
     tapestryInternalUrl: vi.fn(),
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@/lib/room-entitlement', () => ({
-    resolveRoomPrincipal: mocks.resolveRoomPrincipal,
+    resolveRoomViewer: mocks.resolveRoomViewer,
 }));
 vi.mock('@/lib/db', () => ({
     prisma: {
@@ -43,7 +43,7 @@ const LAYOUT = {
 };
 
 function entitled() {
-    mocks.resolveRoomPrincipal.mockResolvedValue({
+    mocks.resolveRoomViewer.mockResolvedValue({
         ok: true,
         principal: {
             session: { id: SESSION_ID, roomName: 'event-stage' },
@@ -118,7 +118,7 @@ describe('GET /api/scheduled-sessions/[id]/tapestry/hands', () => {
     });
 
     it('propagates the entitlement rejection for outsiders', async () => {
-        mocks.resolveRoomPrincipal.mockResolvedValue({
+        mocks.resolveRoomViewer.mockResolvedValue({
             ok: false,
             status: 403,
             error: 'Not authorized',

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.test.ts
@@ -6,6 +6,9 @@ const mocks = vi.hoisted(() => ({
     resolveRoomPrincipal: vi.fn(),
     findMany: vi.fn(),
     listParticipants: vi.fn(),
+    tapestryInternalUrl: vi.fn(),
+    tapestryParticipantId: vi.fn(),
+    fetch: vi.fn(),
 }));
 
 vi.mock('@/lib/room-entitlement', () => ({
@@ -19,10 +22,25 @@ vi.mock('@/lib/db', () => ({
 vi.mock('@/lib/livekit-server', () => ({
     getRoomService: () => ({ listParticipants: mocks.listParticipants }),
 }));
+vi.mock('@/lib/tapestry', () => ({
+    tapestryInternalUrl: mocks.tapestryInternalUrl,
+    tapestryParticipantId: mocks.tapestryParticipantId,
+}));
 
 import { GET } from '../route';
 
 const SESSION_ID = 'event-1';
+
+const LAYOUT = {
+    revision: 7,
+    columns: 2,
+    rows: 1,
+    tileSizePx: 100,
+    cells: [
+        { id: 'tp-ana', column: 0, row: 0 },
+        { id: 'tp-beto', column: 1, row: 0 },
+    ],
+};
 
 function entitled() {
     mocks.resolveRoomPrincipal.mockResolvedValue({
@@ -46,7 +64,13 @@ function participant(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('fetch', mocks.fetch);
+    process.env.TAPESTRY_INTERNAL_SECRET = 'test-secret';
     entitled();
+    mocks.tapestryInternalUrl.mockReturnValue('http://tapestry:3100');
+    mocks.tapestryParticipantId.mockImplementation(
+        (identity: string) => `tp-${identity.replace('lk-', '')}`,
+    );
     mocks.findMany.mockResolvedValue([
         participant({ participantIdentity: 'lk-ana' }),
         participant({ participantIdentity: 'lk-beto' }),
@@ -55,17 +79,41 @@ beforeEach(() => {
         { identity: 'lk-ana', name: 'Ana' },
         { identity: 'lk-beto', name: 'Beto' },
     ]);
+    mocks.fetch.mockResolvedValue(new Response(JSON.stringify(LAYOUT), { status: 200 }));
 });
 
 describe('GET /api/scheduled-sessions/[id]/tapestry/hands', () => {
-    it('names connected waiting hands in queue order', async () => {
+    it('names connected waiting hands in queue order with their grid cells', async () => {
         const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
 
         expect(response.status).toBe(200);
         expect(response.headers.get('cache-control')).toBe('private, no-store');
         expect(await response.json()).toEqual({
-            hands: [{ name: 'Ana' }, { name: 'Beto' }],
+            hands: [
+                { name: 'Ana', column: 0, row: 0 },
+                { name: 'Beto', column: 1, row: 0 },
+            ],
             liveStateAvailable: true,
+            layout: { revision: 7, columns: 2, rows: 1, tileSizePx: 100 },
+        });
+        // One bounded layout fetch, internal-secret gated.
+        expect(mocks.fetch).toHaveBeenCalledTimes(1);
+        const [url, init] = mocks.fetch.mock.calls[0];
+        expect(String(url)).toBe(`http://tapestry:3100/tapestry/sessions/${SESSION_ID}/layout`);
+        expect(init.headers['x-tapestry-internal-secret']).toBe('test-secret');
+    });
+
+    it('still names hands without cells when the layout is unavailable', async () => {
+        mocks.fetch.mockResolvedValue(new Response('{}', { status: 404 }));
+
+        const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
+        expect(await response.json()).toEqual({
+            hands: [
+                { name: 'Ana', column: null, row: null },
+                { name: 'Beto', column: null, row: null },
+            ],
+            liveStateAvailable: true,
+            layout: null,
         });
     });
 
@@ -95,7 +143,7 @@ describe('GET /api/scheduled-sessions/[id]/tapestry/hands', () => {
         ]);
 
         const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
-        expect(await response.json()).toMatchObject({ hands: [{ name: 'Beto' }] });
+        expect(await response.json()).toMatchObject({ hands: [{ name: 'Beto', column: 1 }] });
     });
 
     it('omits hands whose owner is no longer connected', async () => {
@@ -110,7 +158,11 @@ describe('GET /api/scheduled-sessions/[id]/tapestry/hands', () => {
 
         const response = await GET(createRequest('http://x'), mockParams({ id: SESSION_ID }));
         expect(response.status).toBe(200);
-        expect(await response.json()).toEqual({ hands: [], liveStateAvailable: false });
+        expect(await response.json()).toEqual({
+            hands: [],
+            liveStateAvailable: false,
+            layout: null,
+        });
     });
 
     it('uses the staff account name for staff hands', async () => {

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/route.ts
@@ -2,12 +2,14 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db';
 import { getRoomService } from '@/lib/livekit-server';
-import { resolveRoomPrincipal } from '@/lib/room-entitlement';
+import { resolveRoomViewer } from '@/lib/room-entitlement';
 import { tapestryInternalUrl, tapestryParticipantId } from '@/lib/tapestry';
 
 export const dynamic = 'force-dynamic';
 
 const LAYOUT_LOOKUP_TIMEOUT_MS = 750;
+/** Hard bound on the historical hand query; the live filter narrows it further. */
+const MAX_HAND_CANDIDATES = 150;
 
 /**
  * Public raised-hand names for the attendee tapestry (TAP-02, issue #129).
@@ -26,10 +28,12 @@ const LAYOUT_LOOKUP_TIMEOUT_MS = 750;
  * overlay when this layout's `revision` matches the composite's
  * `x-tapestry-revision`, so a name can never land on the wrong person.
  *
- * The gate is the same `resolveRoomPrincipal` entitlement check the room
- * token route uses, so only this event's attendees (and its operators) can
- * read the list. When LiveKit is unreachable the route names nobody rather
- * than listing people whose presence it cannot confirm.
+ * The gate is a read-only room viewer: it validates the web session,
+ * entitlement and event correspondence exactly like the token route, but
+ * performs zero writes — no participant upsert, no `leftAt` clearing, no
+ * presence revival. A polling GET must never mutate state. When LiveKit is
+ * unreachable the route names nobody rather than listing people whose
+ * presence it cannot confirm.
  */
 
 type PublicHand = {
@@ -85,7 +89,7 @@ export async function GET(
     { params }: { params: Promise<{ id: string }> },
 ) {
     const { id } = await params;
-    const entitlement = await resolveRoomPrincipal(request, id);
+    const entitlement = await resolveRoomViewer(request, id);
     if (!entitlement.ok) {
         return NextResponse.json(
             { error: entitlement.error },
@@ -100,6 +104,7 @@ export async function GET(
                 raisedAt: { not: null },
             },
             orderBy: { raisedAt: 'asc' },
+            take: MAX_HAND_CANDIDATES,
             select: {
                 participantIdentity: true,
                 publishGrantedAt: true,

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { prisma } from '@/lib/db';
+import { getRoomService } from '@/lib/livekit-server';
+import { resolveRoomPrincipal } from '@/lib/room-entitlement';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Public raised-hand names for the attendee tapestry (TAP-02, issue #129).
+ *
+ * The collective tapestry stays a single JPEG without identity metadata;
+ * this sidecar only names the people who chose to raise their hand — an
+ * explicit request for the floor — and only while they remain connected.
+ * It is deliberately not a directory: no tile position, no camera state,
+ * no presence of anyone else, no thumbnails, and a hand that lowers or
+ * disconnects disappears on the next poll.
+ *
+ * The gate is the same `resolveRoomPrincipal` entitlement check the room
+ * token route uses, so only this event's attendees (and its operators) can
+ * read the list. When LiveKit is unreachable the route names nobody rather
+ * than listing people whose presence it cannot confirm.
+ */
+
+type PublicHand = { name: string };
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    const entitlement = await resolveRoomPrincipal(request, id);
+    if (!entitlement.ok) {
+        return NextResponse.json(
+            { error: entitlement.error },
+            { status: entitlement.status },
+        );
+    }
+
+    const [participants, liveIdentities] = await Promise.all([
+        prisma.sessionParticipant.findMany({
+            where: {
+                scheduledSessionId: id,
+                raisedAt: { not: null },
+            },
+            orderBy: { raisedAt: 'asc' },
+            select: {
+                participantIdentity: true,
+                publishGrantedAt: true,
+                publishRevokedAt: true,
+                staffUser: { select: { name: true } },
+            },
+        }),
+        getRoomService()
+            .listParticipants(entitlement.principal.session.roomName)
+            .then(
+                (live) => new Map(live.map((p) => [p.identity, p.name.trim()] as const)),
+                () => null,
+            ),
+    ]);
+
+    if (!liveIdentities) {
+        return NextResponse.json(
+            { hands: [] as PublicHand[], liveStateAvailable: false },
+            { headers: { 'cache-control': 'private, no-store' } },
+        );
+    }
+
+    const hands: PublicHand[] = participants
+        // Waiting hands only: no active publish grant, past or present.
+        .filter((participant) =>
+            participant.publishGrantedAt === null ||
+            participant.publishRevokedAt !== null,
+        )
+        .filter((participant) => liveIdentities.has(participant.participantIdentity))
+        .map((participant) => ({
+            name: participant.staffUser?.name ??
+                (liveIdentities.get(participant.participantIdentity) || 'Attendee'),
+        }));
+
+    return NextResponse.json(
+        { hands, liveStateAvailable: true },
+        { headers: { 'cache-control': 'private, no-store' } },
+    );
+}

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/route.ts
@@ -3,8 +3,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { getRoomService } from '@/lib/livekit-server';
 import { resolveRoomPrincipal } from '@/lib/room-entitlement';
+import { tapestryInternalUrl, tapestryParticipantId } from '@/lib/tapestry';
 
 export const dynamic = 'force-dynamic';
+
+const LAYOUT_LOOKUP_TIMEOUT_MS = 750;
 
 /**
  * Public raised-hand names for the attendee tapestry (TAP-02, issue #129).
@@ -12,9 +15,16 @@ export const dynamic = 'force-dynamic';
  * The collective tapestry stays a single JPEG without identity metadata;
  * this sidecar only names the people who chose to raise their hand — an
  * explicit request for the floor — and only while they remain connected.
- * It is deliberately not a directory: no tile position, no camera state,
- * no presence of anyone else, no thumbnails, and a hand that lowers or
- * disconnects disappears on the next poll.
+ * It is deliberately not a directory: no camera state, no presence of
+ * anyone else, no thumbnails, and a hand that lowers or disconnects
+ * disappears on the next poll.
+ *
+ * Each hand optionally carries its cell in the composite grid so the room
+ * can draw the name over the person's own tile (the Zoom/Meet reading of
+ * #129). Cells come from the internal layout endpoint, which is captured
+ * by the same build as the served composite; the client only draws the
+ * overlay when this layout's `revision` matches the composite's
+ * `x-tapestry-revision`, so a name can never land on the wrong person.
  *
  * The gate is the same `resolveRoomPrincipal` entitlement check the room
  * token route uses, so only this event's attendees (and its operators) can
@@ -22,7 +32,53 @@ export const dynamic = 'force-dynamic';
  * than listing people whose presence it cannot confirm.
  */
 
-type PublicHand = { name: string };
+type PublicHand = {
+    name: string;
+    column: number | null;
+    row: number | null;
+};
+
+type CompositeLayout = {
+    revision: number;
+    columns: number;
+    rows: number;
+    tileSizePx: number;
+    cells: Array<{ id: string; column: number; row: number }>;
+};
+
+async function fetchCompositeLayout(sessionId: string): Promise<CompositeLayout | null> {
+    const internalUrl = tapestryInternalUrl();
+    if (!internalUrl || !process.env.TAPESTRY_INTERNAL_SECRET) {
+        return null;
+    }
+    try {
+        const response = await fetch(
+            `${internalUrl}/tapestry/sessions/${encodeURIComponent(sessionId)}/layout`,
+            {
+                headers: {
+                    'x-tapestry-internal-secret': process.env.TAPESTRY_INTERNAL_SECRET,
+                },
+                cache: 'no-store',
+                signal: AbortSignal.timeout(LAYOUT_LOOKUP_TIMEOUT_MS),
+            },
+        );
+        if (!response.ok) return null;
+        const body = await response.json() as Partial<CompositeLayout>;
+        if (
+            typeof body.revision !== 'number' ||
+            typeof body.columns !== 'number' ||
+            typeof body.rows !== 'number' ||
+            typeof body.tileSizePx !== 'number' ||
+            !Array.isArray(body.cells) ||
+            body.cells.length > 150
+        ) {
+            return null;
+        }
+        return body as CompositeLayout;
+    } catch {
+        return null;
+    }
+}
 
 export async function GET(
     request: NextRequest,
@@ -37,7 +93,7 @@ export async function GET(
         );
     }
 
-    const [participants, liveIdentities] = await Promise.all([
+    const [participants, liveIdentities, layout] = await Promise.all([
         prisma.sessionParticipant.findMany({
             where: {
                 scheduledSessionId: id,
@@ -57,15 +113,19 @@ export async function GET(
                 (live) => new Map(live.map((p) => [p.identity, p.name.trim()] as const)),
                 () => null,
             ),
+        fetchCompositeLayout(id),
     ]);
 
     if (!liveIdentities) {
         return NextResponse.json(
-            { hands: [] as PublicHand[], liveStateAvailable: false },
+            { hands: [] as PublicHand[], liveStateAvailable: false, layout: null },
             { headers: { 'cache-control': 'private, no-store' } },
         );
     }
 
+    const cellByTileId = new Map(
+        (layout?.cells ?? []).map((cell) => [cell.id, cell] as const),
+    );
     const hands: PublicHand[] = participants
         // Waiting hands only: no active publish grant, past or present.
         .filter((participant) =>
@@ -73,13 +133,37 @@ export async function GET(
             participant.publishRevokedAt !== null,
         )
         .filter((participant) => liveIdentities.has(participant.participantIdentity))
-        .map((participant) => ({
-            name: participant.staffUser?.name ??
-                (liveIdentities.get(participant.participantIdentity) || 'Attendee'),
-        }));
+        .map((participant) => {
+            let cell: { column: number; row: number } | null = null;
+            try {
+                cell = cellByTileId.get(
+                    tapestryParticipantId(participant.participantIdentity),
+                ) ?? null;
+            } catch {
+                // A missing/invalid internal secret means no overlay, never
+                // a configuration detail.
+            }
+            return {
+                name: participant.staffUser?.name ??
+                    (liveIdentities.get(participant.participantIdentity) || 'Attendee'),
+                column: cell?.column ?? null,
+                row: cell?.row ?? null,
+            };
+        });
 
     return NextResponse.json(
-        { hands, liveStateAvailable: true },
+        {
+            hands,
+            liveStateAvailable: true,
+            layout: layout
+                ? {
+                    revision: layout.revision,
+                    columns: layout.columns,
+                    rows: layout.rows,
+                    tileSizePx: layout.tileSizePx,
+                }
+                : null,
+        },
         { headers: { 'cache-control': 'private, no-store' } },
     );
 }

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db';
 import { getRoomService } from '@/lib/livekit-server';
 import { resolveRoomViewer } from '@/lib/room-entitlement';
 import { tapestryInternalUrl, tapestryParticipantId } from '@/lib/tapestry';
+import { parseCompositeLayout, type CompositeLayout } from '@/lib/tapestry-layout';
 
 export const dynamic = 'force-dynamic';
 
@@ -42,14 +43,6 @@ type PublicHand = {
     row: number | null;
 };
 
-type CompositeLayout = {
-    revision: number;
-    columns: number;
-    rows: number;
-    tileSizePx: number;
-    cells: Array<{ id: string; column: number; row: number }>;
-};
-
 async function fetchCompositeLayout(sessionId: string): Promise<CompositeLayout | null> {
     const internalUrl = tapestryInternalUrl();
     if (!internalUrl || !process.env.TAPESTRY_INTERNAL_SECRET) {
@@ -67,18 +60,9 @@ async function fetchCompositeLayout(sessionId: string): Promise<CompositeLayout 
             },
         );
         if (!response.ok) return null;
-        const body = await response.json() as Partial<CompositeLayout>;
-        if (
-            typeof body.revision !== 'number' ||
-            typeof body.columns !== 'number' ||
-            typeof body.rows !== 'number' ||
-            typeof body.tileSizePx !== 'number' ||
-            !Array.isArray(body.cells) ||
-            body.cells.length > 150
-        ) {
-            return null;
-        }
-        return body as CompositeLayout;
+        // Fail safe: a malformed or duplicate-bearing layout is "no overlay",
+        // never a trusted grid. Nothing internal is logged.
+        return parseCompositeLayout(await response.json());
     } catch {
         return null;
     }

--- a/src/app/api/tapestry/[sessionId]/__tests__/route.test.ts
+++ b/src/app/api/tapestry/[sessionId]/__tests__/route.test.ts
@@ -54,4 +54,22 @@ describe('GET /api/tapestry/[sessionId]', () => {
         expect(response.headers.get('cdn-cache-control')).toBe('public, max-age=2');
         expect(requireStaff).not.toHaveBeenCalled();
     });
+
+    it('passes the build revision through so overlays can match their layout', async () => {
+        global.fetch = vi.fn().mockResolvedValue(new Response(new Uint8Array([1, 2]), {
+            status: 200,
+            headers: { 'x-tapestry-revision': '42' },
+        }));
+        const { GET } = await import('../route');
+        const response = await GET(new NextRequest('http://localhost/api/tapestry/session-1'), context);
+        expect(response.status).toBe(200);
+        expect(response.headers.get('x-tapestry-revision')).toBe('42');
+    });
+
+    it('omits the revision header when the internal service predates it', async () => {
+        const { GET } = await import('../route');
+        const response = await GET(new NextRequest('http://localhost/api/tapestry/session-1'), context);
+        expect(response.status).toBe(200);
+        expect(response.headers.get('x-tapestry-revision')).toBeNull();
+    });
 });

--- a/src/app/api/tapestry/[sessionId]/route.ts
+++ b/src/app/api/tapestry/[sessionId]/route.ts
@@ -57,9 +57,16 @@ export async function GET(
         if (!response.ok) {
             return NextResponse.json({ error: 'Tapestry unavailable' }, { status: response.status === 404 ? 404 : 502 });
         }
+        // The revision header names the exact build these bytes came from;
+        // overlay consumers (raised-hand names) only draw when it matches
+        // the layout revision. It is an opaque build counter, not metadata.
+        const revision = response.headers.get('x-tapestry-revision');
         return new NextResponse(await response.arrayBuffer(), {
             status: 200,
-            headers: isPublic ? PUBLIC_CACHE_HEADERS : STAFF_CACHE_HEADERS,
+            headers: {
+                ...(isPublic ? PUBLIC_CACHE_HEADERS : STAFF_CACHE_HEADERS),
+                ...(revision ? { 'x-tapestry-revision': revision } : {}),
+            },
         });
     } catch {
         return NextResponse.json({ error: 'Tapestry unavailable' }, { status: 503 });

--- a/src/app/ops/events/[id]/page.tsx
+++ b/src/app/ops/events/[id]/page.tsx
@@ -104,6 +104,7 @@ export default async function EventPage({
                 healthCopy={copy.healthPanel}
                 admissionCopy={copy.admissionPanel}
                 tapestryCopy={copy.tapestryArrange}
+                opsTapestryCopy={copy.opsTapestry}
                 staffRoleLabels={messages[locale].staffRoles}
             />
         </section>

--- a/src/components/ops/ConductorCockpit.tsx
+++ b/src/components/ops/ConductorCockpit.tsx
@@ -9,6 +9,7 @@ import type { UiLocale } from '@/lib/i18n';
 import type { HealthLevel } from '@/lib/ops-health';
 
 import AdmissionConsole from './AdmissionConsole';
+import OpsTapestry from './OpsTapestry';
 import SessionLifecycleControl from './SessionLifecycleControl';
 import SpotlightConsole, { type SpotlightSummary } from './SpotlightConsole';
 import TapestryArrange from './TapestryArrange';
@@ -40,6 +41,7 @@ type Props = {
     healthCopy: Messages['ops']['healthPanel'];
     admissionCopy: Messages['ops']['admissionPanel'];
     tapestryCopy: Messages['ops']['tapestryArrange'];
+    opsTapestryCopy: Messages['ops']['opsTapestry'];
     staffRoleLabels: Messages['staffRoles'];
 };
 
@@ -69,6 +71,7 @@ export default function ConductorCockpit({
     healthCopy,
     admissionCopy,
     tapestryCopy,
+    opsTapestryCopy,
     staffRoleLabels,
 }: Props) {
     const [drawer, setDrawer] = useState<Drawer | null>(null);
@@ -316,7 +319,10 @@ export default function ConductorCockpit({
                         />
                     </div>
                     <div hidden={drawer !== 'tapestry'}>
-                        <TapestryArrange sessionId={session.id} copy={tapestryCopy} />
+                        <div className="space-y-6">
+                            <OpsTapestry sessionId={session.id} copy={opsTapestryCopy} />
+                            <TapestryArrange sessionId={session.id} copy={tapestryCopy} />
+                        </div>
                     </div>
                     <div hidden={drawer !== 'admission'}>
                         <AdmissionConsole

--- a/src/components/ops/ConductorCockpit.tsx
+++ b/src/components/ops/ConductorCockpit.tsx
@@ -320,7 +320,11 @@ export default function ConductorCockpit({
                     </div>
                     <div hidden={drawer !== 'tapestry'}>
                         <div className="space-y-6">
-                            <OpsTapestry sessionId={session.id} copy={opsTapestryCopy} />
+                            <OpsTapestry
+                                sessionId={session.id}
+                                copy={opsTapestryCopy}
+                                active={drawer === 'tapestry'}
+                            />
                             <TapestryArrange sessionId={session.id} copy={tapestryCopy} />
                         </div>
                     </div>

--- a/src/components/ops/OpsTapestry.tsx
+++ b/src/components/ops/OpsTapestry.tsx
@@ -1,22 +1,26 @@
 'use client';
 
 /**
- * Operational tapestry (TAP-02, issue #129): the staff-only view of the
- * tapestry with hands, names, presence and camera state per tile.
+ * Operational tapestry (TAP-02 review, issue #129): the staff-only view of
+ * the tapestry with hands, names, presence and camera state.
  *
- * One manifest request per poll — never a request per tile. Thumbnails are
- * the epoch-versioned proxy URLs the manifest carries, so the browser cache
- * deduplicates frames inside the refresh window. A missing or expired frame
- * falls back to a quiet deterministic color field with the person's name;
- * the fallback never says *why* the image is gone (consent, TTL, departure
- * and failure are intentionally indistinguishable).
+ * O(1) visual transport: ONE shared composite image per poll — the same
+ * JPEG the service already builds — plus ONE bounded manifest JSON. Names,
+ * hand badges and state markers are semantic overlays on that image, never
+ * per-tile <img> requests: 150 participants cost exactly the same as one.
+ * When the composite is unavailable the accessible list below still carries
+ * every state, without fetching any per-participant image.
  *
- * Every affordance has a hover, touch, keyboard and screen-reader
- * equivalent: tiles are buttons whose full state is always in the
- * accessible name, and activating one (pointer, Enter, Space) toggles a
- * textual detail line. The hand indicator is a labelled badge, never color
- * alone. Hand-count changes are announced once in a polite live region;
- * routine refreshes are silent.
+ * Freshness vs revision: the composite bytes refresh every accepted cycle
+ * (new object URL, previous revoked). The manifest's semantic revision only
+ * decides whether annotations re-render, and the layout revision only
+ * correlates overlays with the exact composite build they describe — an
+ * overlay draws solely when manifest.layout.revision matches the image's
+ * x-tapestry-revision, so a name can never land on the wrong person.
+ *
+ * Polling discipline: each new cycle aborts the previous one and carries a
+ * generation counter, so a slow earlier response can never overwrite a
+ * newer accepted state; unmounting aborts in-flight work and revokes URLs.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -26,191 +30,237 @@ import type {
     TapestryManifestEntry,
 } from '@/lib/tapestry-manifest';
 
-const POLL_INTERVAL_MS = 3_000;
-
-/** Four quiet fields, chosen deterministically by opaque tile id. */
-const FALLBACK_FIELDS = [
-    'bg-[var(--forest)]',
-    'bg-[var(--night)]',
-    'bg-[var(--border-subtle)]',
-    'bg-black/40',
-] as const;
-
-function fallbackField(tileId: string): string {
-    let hash = 0;
-    for (let index = 0; index < tileId.length; index += 1) {
-        hash = (hash * 31 + tileId.charCodeAt(index)) >>> 0;
-    }
-    return FALLBACK_FIELDS[hash % FALLBACK_FIELDS.length];
-}
-
 type Copy = Messages['ops']['opsTapestry'];
 
 type Props = {
     sessionId: string;
     copy: Copy;
+    /**
+     * Polling runs only while the view is actually shown (the cockpit mounts
+     * the drawer hidden): a hidden tapestry spends zero requests.
+     */
+    active?: boolean;
 };
 
-function fill(template: string, values: Record<string, string | number>): string {
-    return Object.entries(values).reduce(
-        (text, [key, value]) => text.replace(`{${key}}`, String(value)),
-        template,
-    );
+const POLL_MS = 3_000;
+
+function stateLabel(entry: TapestryManifestEntry, copy: Copy): string {
+    const parts = [
+        entry.displayName,
+        entry.handRaised && entry.queuePosition !== null
+            ? copy.handRaised.replace('{position}', String(entry.queuePosition))
+            : null,
+        copy.presence[entry.presence],
+        copy.camera[entry.camera],
+    ];
+    return parts.filter(Boolean).join(' — ');
 }
 
-function tileAccessibleName(entry: TapestryManifestEntry, copy: Copy): string {
-    const parts = [entry.displayName];
-    if (entry.handRaised && entry.queuePosition !== null) {
-        parts.push(fill(copy.handRaised, { position: entry.queuePosition }));
-    }
-    parts.push(copy.presence[entry.presence]);
-    parts.push(copy.camera[entry.camera]);
-    return parts.join(', ');
-}
-
-function Tile({ entry, copy }: { entry: TapestryManifestEntry; copy: Copy }) {
-    const [expanded, setExpanded] = useState(false);
-    // Track the exact URL that failed: the next epoch's URL gets a fresh
-    // chance, so a transient proxy error cannot wedge the fallback on.
-    const [failedUrl, setFailedUrl] = useState<string | null>(null);
-    const detailId = `ops-tapestry-detail-${entry.position}`;
-    const showImage = entry.thumbnailUrl !== null && entry.thumbnailUrl !== failedUrl;
-    const accessibleName = tileAccessibleName(entry, copy);
-
-    return (
-        <li className="flex w-28 flex-col items-center gap-1">
-            <button
-                type="button"
-                aria-label={accessibleName}
-                aria-expanded={expanded}
-                aria-controls={detailId}
-                title={accessibleName}
-                onClick={() => setExpanded((current) => !current)}
-                className="relative block h-20 w-28 overflow-hidden rounded border border-[var(--border-subtle)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--gold)]"
-            >
-                {showImage ? (
-                    // Tiles are already sized by the staff proxy; render the
-                    // bounded frame without stretching.
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                        src={entry.thumbnailUrl ?? undefined}
-                        alt={fill(copy.tileSnapshotAlt, { name: entry.displayName })}
-                        onError={() => setFailedUrl(entry.thumbnailUrl)}
-                        className="h-full w-full object-cover"
-                    />
-                ) : (
-                    <span
-                        role="img"
-                        aria-label={fill(copy.tileNoSnapshotAlt, { name: entry.displayName })}
-                        className={`block h-full w-full ${fallbackField(entry.tileId)}`}
-                    />
-                )}
-                {entry.handRaised && entry.queuePosition !== null ? (
-                    <span className="absolute left-1 top-1 rounded bg-[var(--pink)] px-1.5 py-0.5 text-xs font-semibold leading-4 text-[var(--night)]">
-                        {fill(copy.handRaised, { position: entry.queuePosition })}
-                    </span>
-                ) : null}
-            </button>
-            <span className="w-full break-words text-center text-xs leading-4 text-[var(--cream)]" title={entry.displayName}>
-                {entry.displayName}
-            </span>
-            <span
-                id={detailId}
-                hidden={!expanded}
-                className="w-full text-center text-xs leading-4 text-[var(--text-muted)]"
-            >
-                {copy.presence[entry.presence]} · {copy.camera[entry.camera]}
-            </span>
-        </li>
-    );
-}
-
-export default function OpsTapestry({ sessionId, copy }: Props) {
+export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
     const [manifest, setManifest] = useState<TapestryManifest | null>(null);
+    const [compositeSrc, setCompositeSrc] = useState<string | null>(null);
+    const [compositeRevision, setCompositeRevision] = useState<string | null>(null);
     const [unavailable, setUnavailable] = useState(false);
     const lastRevisionRef = useRef<string | null>(null);
 
     useEffect(() => {
-        let active = true;
-        const refresh = async () => {
+        if (!active) return;
+        let live = true;
+        let generation = 0;
+        let controller: AbortController | null = null;
+        let previousUrl: string | null = null;
+        const manifestUrl = `/api/ops/sessions/${encodeURIComponent(sessionId)}/tapestry/manifest`;
+        const compositeUrl = `/api/tapestry/${encodeURIComponent(sessionId)}`;
+
+        const cycle = async () => {
+            if (!live) return;
+            // A newer cycle supersedes any slower one still in flight.
+            const myGeneration = ++generation;
+            controller?.abort();
+            controller = new AbortController();
+            const signal = controller.signal;
+            let freshUrl: string | null = null;
             try {
-                const response = await fetch(
-                    `/api/ops/sessions/${encodeURIComponent(sessionId)}/tapestry/manifest`,
-                    { cache: 'no-store', credentials: 'same-origin' },
-                );
-                if (!response.ok) {
-                    if (active) setUnavailable(true);
+                const manifestRes = await fetch(manifestUrl, {
+                    cache: 'no-store', credentials: 'same-origin', signal,
+                });
+                if (!manifestRes.ok) {
+                    if (live && myGeneration === generation) setUnavailable(true);
                     return;
                 }
-                const next = await response.json() as TapestryManifest;
-                if (!active) return;
-                // Ignore stale renders: only repaint when the content revision
-                // actually moved, so a slow poll never reshuffles settled tiles.
+                const next = await manifestRes.json() as TapestryManifest;
+                if (!live || myGeneration !== generation) {
+                    // Unmounted or superseded while parsing: stop before
+                    // spending the composite fetch.
+                    return;
+                }
+
+                // The composite is the only image fetched, once per cycle,
+                // and its bytes update even when nothing semantic changed.
+                let freshRevision: string | null = null;
+                const compositeRes = await fetch(compositeUrl, {
+                    cache: 'no-store', credentials: 'same-origin', signal,
+                });
+                if (compositeRes.ok) {
+                    freshRevision = compositeRes.headers.get('x-tapestry-revision');
+                    freshUrl = URL.createObjectURL(await compositeRes.blob());
+                }
+
+                if (!live || myGeneration !== generation) {
+                    // A stale cycle must not touch state or leak its blob.
+                    if (freshUrl) URL.revokeObjectURL(freshUrl);
+                    return;
+                }
                 if (next.revision !== lastRevisionRef.current) {
                     lastRevisionRef.current = next.revision;
                     setManifest(next);
                 }
                 setUnavailable(false);
+                if (freshUrl) {
+                    setCompositeSrc(freshUrl);
+                    setCompositeRevision(freshRevision);
+                    if (previousUrl) URL.revokeObjectURL(previousUrl);
+                    previousUrl = freshUrl;
+                }
             } catch {
-                if (active) setUnavailable(true);
+                // Aborted by a newer cycle or unmount, or a transient
+                // network failure: the next tick retries.
             }
         };
-        void refresh();
-        const timer = setInterval(() => void refresh(), POLL_INTERVAL_MS);
-        return () => { active = false; clearInterval(timer); };
-    }, [sessionId]);
 
-    const handCount = manifest?.waitingHands.length ?? 0;
-    const handsSummary = handCount === 1
-        ? copy.handSummaryOne
-        : fill(copy.handsSummaryMany, { count: handCount });
-    const handsWithoutTile = (manifest?.waitingHands ?? [])
-        .filter((hand) => hand.tileId === null)
-        .map((hand) => hand.displayName);
+        void cycle();
+        const timer = setInterval(() => void cycle(), POLL_MS);
+        return () => {
+            live = false;
+            clearInterval(timer);
+            controller?.abort();
+            if (previousUrl) URL.revokeObjectURL(previousUrl);
+        };
+    }, [sessionId, active]);
+
+    if (!manifest && !unavailable) {
+        return <p className="text-sm text-[var(--text-muted)]">{copy.loading}</p>;
+    }
+    if (unavailable) {
+        return <p className="text-sm text-[var(--text-muted)]">{copy.unavailable}</p>;
+    }
+    if (!manifest) {
+        return null;
+    }
+
+    const handCount = manifest.waitingHands.length;
+    const overlayLayout = manifest.layout !== null &&
+        compositeRevision !== null &&
+        String(manifest.layout.revision) === compositeRevision
+        ? manifest.layout
+        : null;
+    const tilelessHands = manifest.waitingHands.filter((hand) => hand.tileId === null);
 
     return (
-        <section
-            className="rounded-lg border border-[var(--border-subtle)] p-4"
-            aria-label={copy.heading}
-        >
-            <div className="mb-3 flex items-center justify-between gap-3">
-                <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-                    {copy.heading}
-                </h2>
-                <span aria-live="polite" className="text-xs text-[var(--pink)]">
-                    {handCount > 0 ? handsSummary : ''}
-                </span>
-            </div>
-            {unavailable ? (
-                <p className="text-xs text-[var(--text-muted)]">{copy.unavailable}</p>
-            ) : manifest === null ? (
-                <p className="text-xs text-[var(--text-muted)]">{copy.loading}</p>
-            ) : (
-                <>
-                    {manifest.liveStateAvailable ? null : (
-                        <p className="mb-2 text-xs text-[var(--warning)]">
-                            {copy.liveStateUnknown}
-                        </p>
-                    )}
-                    {manifest.entries.length === 0 ? (
-                        <p className="text-xs text-[var(--text-muted)]">{copy.empty}</p>
-                    ) : (
-                        <ul className="flex flex-wrap gap-3">
+        <section aria-label={copy.heading} className="space-y-3">
+            <h3 className="text-sm font-medium text-[var(--cream)]">{copy.heading}</h3>
+            <span className="sr-only" aria-live="polite">
+                {handCount === 1
+                    ? copy.handSummaryOne
+                    : copy.handsSummaryMany.replace('{count}', String(handCount))}
+            </span>
+
+            {compositeSrc ? (
+                <div className="relative inline-block max-w-full">
+                    {/* The single image every visual state rides on. */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                        src={compositeSrc}
+                        alt={copy.compositeAlt}
+                        className="block max-w-full rounded-lg border border-[var(--border-subtle)]"
+                    />
+                    {overlayLayout ? (
+                        <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden rounded-lg">
                             {manifest.entries.map((entry) => (
-                                <Tile key={entry.tileId} entry={entry} copy={copy} />
+                                <CellOverlay key={entry.tileId} entry={entry} layout={overlayLayout} copy={copy} />
                             ))}
-                        </ul>
-                    )}
-                    {handsWithoutTile.length > 0 ? (
-                        <p className="mt-3 text-xs text-[var(--text-muted)]">
-                            {fill(copy.waitingWithoutTile, { names: handsWithoutTile.join(', ') })}
-                        </p>
+                        </div>
                     ) : null}
-                    <p className="mt-3 text-xs text-[var(--text-muted)]">
-                        {fill(copy.freshnessNote, { seconds: manifest.thumbnailFreshForSeconds })}
-                    </p>
-                </>
-            )}
+                </div>
+            ) : null}
+
+            {manifest.entries.length === 0 ? (
+                <p className="text-sm text-[var(--text-muted)]">{copy.empty}</p>
+            ) : null}
+
+            {tilelessHands.length > 0 ? (
+                <p className="text-xs text-[var(--gold)]">
+                    {copy.waitingWithoutTile.replace(
+                        '{names}',
+                        tilelessHands.map((hand) => `${hand.displayName} (#${hand.queuePosition})`).join(', '),
+                    )}
+                </p>
+            ) : null}
+
+            {/* The accessible state surface: every overlay fact as plain text.
+                Nothing hides behind hover, so mouse, touch, keyboard and
+                screen readers all get the same complete state. */}
+            {manifest.entries.length > 0 ? (
+                <ul className="space-y-1" aria-label={copy.heading}>
+                    {manifest.entries.map((entry) => (
+                        <li key={entry.tileId} className="text-xs text-[var(--text-muted)]">
+                            <span className="text-[var(--cream)]">{entry.displayName}</span>
+                            {entry.handRaised && entry.queuePosition !== null ? (
+                                <span className="ml-2 rounded bg-[var(--pink)] px-1.5 py-0.5 font-semibold text-[var(--night)]">
+                                    {copy.handRaised.replace('{position}', String(entry.queuePosition))}
+                                </span>
+                            ) : null}
+                            <span className="ml-2">{copy.presence[entry.presence]}</span>
+                            <span className="ml-2">{copy.camera[entry.camera]}</span>
+                            <span className="sr-only">{stateLabel(entry, copy)}</span>
+                        </li>
+                    ))}
+                </ul>
+            ) : null}
+
+            {manifest.tileFreshForSeconds !== null ? (
+                <p className="text-xs text-[var(--text-muted)]">
+                    {copy.freshnessNote.replace('{seconds}', String(manifest.tileFreshForSeconds))}
+                </p>
+            ) : null}
+            {!manifest.liveStateAvailable ? (
+                <p className="text-xs text-[var(--gold)]">{copy.liveStateUnknown}</p>
+            ) : null}
         </section>
+    );
+}
+
+function CellOverlay({
+    entry,
+    layout,
+    copy,
+}: {
+    entry: TapestryManifestEntry;
+    layout: { columns: number; rows: number };
+    copy: Copy;
+}) {
+    const left = `${(entry.column / layout.columns) * 100}%`;
+    const top = `${(entry.row / layout.rows) * 100}%`;
+    const width = `${100 / layout.columns}%`;
+    const height = `${100 / layout.rows}%`;
+    const dimmed = entry.presence === 'left' || entry.presence === 'reconnecting';
+    return (
+        <span className="absolute" style={{ left, top, width, height }}>
+            {dimmed ? <span className="absolute inset-0 bg-black/55" /> : null}
+            {entry.handRaised && entry.queuePosition !== null ? (
+                <span className="absolute left-0.5 top-0.5 rounded bg-[var(--pink)] px-1 py-0.5 text-xs font-semibold leading-4 text-[var(--night)]">
+                    {copy.handRaised.replace('{position}', String(entry.queuePosition))}
+                </span>
+            ) : null}
+            {entry.camera === 'off' ? (
+                <span className="absolute right-1 top-1 h-2.5 w-2.5 rounded-full border border-[var(--cream)] bg-transparent" />
+            ) : null}
+            <span
+                className="absolute bottom-0 left-0 max-w-full rounded-tr bg-black/70 px-1 py-0.5 text-xs leading-4 text-[var(--cream)]"
+                style={{ overflowWrap: 'anywhere' }}
+            >
+                {entry.displayName}
+            </span>
+        </span>
     );
 }

--- a/src/components/ops/OpsTapestry.tsx
+++ b/src/components/ops/OpsTapestry.tsx
@@ -87,7 +87,18 @@ export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
         let live = true;
         let generation = 0;
         let controller: AbortController | null = null;
-        let previousUrl: string | null = null;
+        // The ONE object URL the visible state currently owns. Any URL not
+        // transferred here is revoked by the cycle that created it.
+        let publishedUrl: string | null = null;
+
+        // Session-scoped reset: never carry manifest, names, overlays, the
+        // content cache or error state across a sessionId change. The next
+        // session starts from empty — if its first fetch fails, the UI shows
+        // ITS empty/error state, never the previous session's data.
+        lastContentKeyRef.current = null;
+        setView(null);
+        setUnavailable(false);
+
         const manifestUrl = `/api/ops/sessions/${encodeURIComponent(sessionId)}/tapestry/manifest`;
         // The consumer marker lets observability and tests tell this poll
         // apart from other composite consumers (health panel, room surface);
@@ -102,8 +113,11 @@ export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
             controller = new AbortController();
             const signal = controller.signal;
 
-            let correlated: { url: string; revision: string | null; manifest: TapestryManifest } | null = null;
-            let fallback: { url: string; revision: string | null; manifest: TapestryManifest } | null = null;
+            // Every object URL created this cycle is registered here.
+            // Exactly one may be chosen and transferred to the visible state;
+            // all others are revoked exactly once before the cycle returns.
+            const candidates: Array<{ url: string; revision: string | null; manifest: TapestryManifest }> = [];
+            let chosen: (typeof candidates)[number] | null = null;
 
             for (let attempt = 0; attempt < MAX_CORRELATION_ATTEMPTS; attempt += 1) {
                 if (!live || myGeneration !== generation) break;
@@ -128,30 +142,38 @@ export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
                         cache: 'no-store', credentials: 'same-origin', signal,
                     });
                     if (!manifestRes.ok) {
-                        URL.revokeObjectURL(url);
+                        URL.revokeObjectURL(url); // never became a candidate
+                        for (const c of candidates) URL.revokeObjectURL(c.url);
                         if (live && myGeneration === generation) setUnavailable(true);
                         return;
                     }
                     const manifest = await manifestRes.json() as TapestryManifest;
-                    const pair = { url, revision, manifest };
+                    candidates.push({ url, revision, manifest });
+                    url = null; // ownership moved into the candidates registry
                     const layoutRevision = manifest.layout?.revision ?? null;
                     // 3-4. Matching revisions (or no grid to correlate)
                     // publish as one accepted state; a mismatch retries.
                     if (layoutRevision === null || String(layoutRevision) === revision) {
-                        correlated = pair;
+                        chosen = candidates[candidates.length - 1];
                         break;
                     }
-                    if (fallback) URL.revokeObjectURL(fallback.url);
-                    fallback = pair;
                 } catch {
                     // Aborted by a newer cycle or unmount, or a transient
-                    // failure: leak nothing, the next tick retries.
-                    if (url) URL.revokeObjectURL(url);
-                    return;
+                    // failure. Stop attempting: the freshest candidate (if
+                    // any) still serves as the safe fallback below.
+                    if (url) URL.revokeObjectURL(url); // never became a candidate
+                    break;
                 }
             }
 
-            const chosen = correlated ?? fallback;
+            // Safe fallback: the freshest candidate; the render-time
+            // revision check keeps its overlays hidden while mismatched.
+            if (!chosen && candidates.length > 0) chosen = candidates[candidates.length - 1];
+            // Revoke every non-chosen candidate exactly once.
+            for (const c of candidates) {
+                if (c !== chosen) URL.revokeObjectURL(c.url);
+            }
+
             let manifestOnly: TapestryManifest | null = null;
             if (!chosen) {
                 // Composite unavailable from the start of the cycle: keep the
@@ -169,35 +191,34 @@ export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
                     return;
                 }
             }
+            // A stale generation discards its chosen URL before dying.
             if (!live || myGeneration !== generation) {
                 if (chosen) URL.revokeObjectURL(chosen.url);
                 return;
             }
 
+            const manifest = chosen?.manifest ?? manifestOnly;
+            if (!manifest) return;
             setUnavailable(false);
-            setView((prev) => {
-                const manifest = chosen?.manifest ?? manifestOnly ?? prev?.manifest;
-                if (!manifest) return prev;
-                // Semantic + layout gate: the manifest object (and with it
-                // the accessible list and overlays) is replaced only when
-                // content or grid changed; the image bytes always refresh.
-                const contentKey = `${manifest.revision}:${manifest.layout?.revision ?? 'none'}`;
-                const manifestChanged = contentKey !== lastContentKeyRef.current;
-                if (manifestChanged) lastContentKeyRef.current = contentKey;
-                const next: TapestryView = {
-                    compositeUrl: chosen ? chosen.url : prev?.compositeUrl ?? null,
-                    buildRevision: chosen ? chosen.revision : prev?.buildRevision ?? null,
-                    manifest: manifestChanged || !prev ? manifest : prev.manifest,
-                };
-                if (prev?.compositeUrl && prev.compositeUrl !== next.compositeUrl) {
-                    URL.revokeObjectURL(prev.compositeUrl);
-                }
-                if (previousUrl && previousUrl !== next.compositeUrl) {
-                    URL.revokeObjectURL(previousUrl);
-                }
-                previousUrl = next.compositeUrl;
-                return next;
-            });
+            // Session + semantic + layout key: content never crosses
+            // sessions, and a layout advance is stored even when names,
+            // order, hands, camera and presence are identical.
+            const contentKey = `${sessionId}:${manifest.revision}:${manifest.layout?.revision ?? 'none'}`;
+            const manifestChanged = contentKey !== lastContentKeyRef.current;
+            if (manifestChanged) lastContentKeyRef.current = contentKey;
+            setView((prev) => ({
+                compositeUrl: chosen ? chosen.url : prev?.compositeUrl ?? null,
+                buildRevision: chosen ? chosen.revision : prev?.buildRevision ?? null,
+                manifest: manifestChanged || !prev ? manifest : prev.manifest,
+            }));
+            // Ownership transfer, outside the state updater: the chosen URL
+            // now belongs to the visible state; the retired one is revoked
+            // exactly once, here or at cleanup.
+            if (chosen) {
+                const retired = publishedUrl;
+                publishedUrl = chosen.url;
+                if (retired && retired !== chosen.url) URL.revokeObjectURL(retired);
+            }
         };
 
         void cycle();
@@ -206,7 +227,10 @@ export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
             live = false;
             clearInterval(timer);
             controller?.abort();
-            if (previousUrl) URL.revokeObjectURL(previousUrl);
+            if (publishedUrl) {
+                URL.revokeObjectURL(publishedUrl);
+                publishedUrl = null;
+            }
         };
     }, [sessionId, active]);
 

--- a/src/components/ops/OpsTapestry.tsx
+++ b/src/components/ops/OpsTapestry.tsx
@@ -43,6 +43,25 @@ type Props = {
 };
 
 const POLL_MS = 3_000;
+/**
+ * Bounded correlation attempts per cycle (TAP-02 re-review): composite and
+ * manifest are one correlated unit — a frame can land between the two reads,
+ * so a mismatched pair is retried immediately, never more than this many
+ * times per cycle, and never proportionally to the participant count.
+ */
+const MAX_CORRELATION_ATTEMPTS = 3;
+
+/**
+ * One accepted cycle's state: image, build revision and manifest are only
+ * ever published together, as a single correlated unit. The overlay check at
+ * render (`layout.revision === buildRevision`) suppresses annotations on any
+ * fallback pair whose revisions disagree.
+ */
+type TapestryView = {
+    compositeUrl: string | null;
+    buildRevision: string | null;
+    manifest: TapestryManifest;
+};
 
 function stateLabel(entry: TapestryManifestEntry, copy: Copy): string {
     const parts = [
@@ -57,11 +76,11 @@ function stateLabel(entry: TapestryManifestEntry, copy: Copy): string {
 }
 
 export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
-    const [manifest, setManifest] = useState<TapestryManifest | null>(null);
-    const [compositeSrc, setCompositeSrc] = useState<string | null>(null);
-    const [compositeRevision, setCompositeRevision] = useState<string | null>(null);
+    const [view, setView] = useState<TapestryView | null>(null);
     const [unavailable, setUnavailable] = useState(false);
-    const lastRevisionRef = useRef<string | null>(null);
+    // Content key = semantic revision + layout revision: a layout advance is
+    // stored even when names, order, hands, camera and presence are identical.
+    const lastContentKeyRef = useRef<string | null>(null);
 
     useEffect(() => {
         if (!active) return;
@@ -82,53 +101,103 @@ export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
             controller?.abort();
             controller = new AbortController();
             const signal = controller.signal;
-            let freshUrl: string | null = null;
-            try {
-                const manifestRes = await fetch(manifestUrl, {
-                    cache: 'no-store', credentials: 'same-origin', signal,
-                });
-                if (!manifestRes.ok) {
-                    if (live && myGeneration === generation) setUnavailable(true);
-                    return;
-                }
-                const next = await manifestRes.json() as TapestryManifest;
-                if (!live || myGeneration !== generation) {
-                    // Unmounted or superseded while parsing: stop before
-                    // spending the composite fetch.
-                    return;
-                }
 
-                // The composite is the only image fetched, once per cycle,
-                // and its bytes update even when nothing semantic changed.
-                let freshRevision: string | null = null;
-                const compositeRes = await fetch(compositeUrl, {
-                    cache: 'no-store', credentials: 'same-origin', signal,
-                });
-                if (compositeRes.ok) {
-                    freshRevision = compositeRes.headers.get('x-tapestry-revision');
-                    freshUrl = URL.createObjectURL(await compositeRes.blob());
-                }
+            let correlated: { url: string; revision: string | null; manifest: TapestryManifest } | null = null;
+            let fallback: { url: string; revision: string | null; manifest: TapestryManifest } | null = null;
 
-                if (!live || myGeneration !== generation) {
-                    // A stale cycle must not touch state or leak its blob.
-                    if (freshUrl) URL.revokeObjectURL(freshUrl);
+            for (let attempt = 0; attempt < MAX_CORRELATION_ATTEMPTS; attempt += 1) {
+                if (!live || myGeneration !== generation) break;
+                let url: string | null = null;
+                try {
+                    // 1. Composite first, 2. manifest immediately after: the
+                    // pair is accepted only when both describe the same build.
+                    const compositeRes = await fetch(compositeUrl, {
+                        cache: 'no-store', credentials: 'same-origin', signal,
+                    });
+                    if (!compositeRes.ok) break; // keep previous image; semantic refresh below
+                    const revision = compositeRes.headers.get('x-tapestry-revision');
+                    const blob = await compositeRes.blob();
+                    if (!live || myGeneration !== generation) {
+                        // Superseded or unmounted mid-read: stop before
+                        // spending the manifest fetch or creating any blob.
+                        return;
+                    }
+                    url = URL.createObjectURL(blob);
+
+                    const manifestRes = await fetch(manifestUrl, {
+                        cache: 'no-store', credentials: 'same-origin', signal,
+                    });
+                    if (!manifestRes.ok) {
+                        URL.revokeObjectURL(url);
+                        if (live && myGeneration === generation) setUnavailable(true);
+                        return;
+                    }
+                    const manifest = await manifestRes.json() as TapestryManifest;
+                    const pair = { url, revision, manifest };
+                    const layoutRevision = manifest.layout?.revision ?? null;
+                    // 3-4. Matching revisions (or no grid to correlate)
+                    // publish as one accepted state; a mismatch retries.
+                    if (layoutRevision === null || String(layoutRevision) === revision) {
+                        correlated = pair;
+                        break;
+                    }
+                    if (fallback) URL.revokeObjectURL(fallback.url);
+                    fallback = pair;
+                } catch {
+                    // Aborted by a newer cycle or unmount, or a transient
+                    // failure: leak nothing, the next tick retries.
+                    if (url) URL.revokeObjectURL(url);
                     return;
                 }
-                if (next.revision !== lastRevisionRef.current) {
-                    lastRevisionRef.current = next.revision;
-                    setManifest(next);
-                }
-                setUnavailable(false);
-                if (freshUrl) {
-                    setCompositeSrc(freshUrl);
-                    setCompositeRevision(freshRevision);
-                    if (previousUrl) URL.revokeObjectURL(previousUrl);
-                    previousUrl = freshUrl;
-                }
-            } catch {
-                // Aborted by a newer cycle or unmount, or a transient
-                // network failure: the next tick retries.
             }
+
+            const chosen = correlated ?? fallback;
+            let manifestOnly: TapestryManifest | null = null;
+            if (!chosen) {
+                // Composite unavailable from the start of the cycle: keep the
+                // previous image and still refresh the semantic list.
+                try {
+                    const manifestRes = await fetch(manifestUrl, {
+                        cache: 'no-store', credentials: 'same-origin', signal,
+                    });
+                    if (!manifestRes.ok) {
+                        if (live && myGeneration === generation) setUnavailable(true);
+                        return;
+                    }
+                    manifestOnly = await manifestRes.json() as TapestryManifest;
+                } catch {
+                    return;
+                }
+            }
+            if (!live || myGeneration !== generation) {
+                if (chosen) URL.revokeObjectURL(chosen.url);
+                return;
+            }
+
+            setUnavailable(false);
+            setView((prev) => {
+                const manifest = chosen?.manifest ?? manifestOnly ?? prev?.manifest;
+                if (!manifest) return prev;
+                // Semantic + layout gate: the manifest object (and with it
+                // the accessible list and overlays) is replaced only when
+                // content or grid changed; the image bytes always refresh.
+                const contentKey = `${manifest.revision}:${manifest.layout?.revision ?? 'none'}`;
+                const manifestChanged = contentKey !== lastContentKeyRef.current;
+                if (manifestChanged) lastContentKeyRef.current = contentKey;
+                const next: TapestryView = {
+                    compositeUrl: chosen ? chosen.url : prev?.compositeUrl ?? null,
+                    buildRevision: chosen ? chosen.revision : prev?.buildRevision ?? null,
+                    manifest: manifestChanged || !prev ? manifest : prev.manifest,
+                };
+                if (prev?.compositeUrl && prev.compositeUrl !== next.compositeUrl) {
+                    URL.revokeObjectURL(prev.compositeUrl);
+                }
+                if (previousUrl && previousUrl !== next.compositeUrl) {
+                    URL.revokeObjectURL(previousUrl);
+                }
+                previousUrl = next.compositeUrl;
+                return next;
+            });
         };
 
         void cycle();
@@ -141,20 +210,23 @@ export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
         };
     }, [sessionId, active]);
 
-    if (!manifest && !unavailable) {
+    if (!view && !unavailable) {
         return <p className="text-sm text-[var(--text-muted)]">{copy.loading}</p>;
     }
     if (unavailable) {
         return <p className="text-sm text-[var(--text-muted)]">{copy.unavailable}</p>;
     }
-    if (!manifest) {
+    if (!view) {
         return null;
     }
 
+    const { manifest, compositeUrl: compositeSrc, buildRevision } = view;
     const handCount = manifest.waitingHands.length;
+    // Annotations draw only on a correlated pair: a fallback whose layout
+    // revision disagrees with the image renders the list, never an overlay.
     const overlayLayout = manifest.layout !== null &&
-        compositeRevision !== null &&
-        String(manifest.layout.revision) === compositeRevision
+        buildRevision !== null &&
+        String(manifest.layout.revision) === buildRevision
         ? manifest.layout
         : null;
     const tilelessHands = manifest.waitingHands.filter((hand) => hand.tileId === null);

--- a/src/components/ops/OpsTapestry.tsx
+++ b/src/components/ops/OpsTapestry.tsx
@@ -70,7 +70,10 @@ export default function OpsTapestry({ sessionId, copy, active = true }: Props) {
         let controller: AbortController | null = null;
         let previousUrl: string | null = null;
         const manifestUrl = `/api/ops/sessions/${encodeURIComponent(sessionId)}/tapestry/manifest`;
-        const compositeUrl = `/api/tapestry/${encodeURIComponent(sessionId)}`;
+        // The consumer marker lets observability and tests tell this poll
+        // apart from other composite consumers (health panel, room surface);
+        // the route ignores unknown query params.
+        const compositeUrl = `/api/tapestry/${encodeURIComponent(sessionId)}?view=ops-tapestry`;
 
         const cycle = async () => {
             if (!live) return;

--- a/src/components/ops/OpsTapestry.tsx
+++ b/src/components/ops/OpsTapestry.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+/**
+ * Operational tapestry (TAP-02, issue #129): the staff-only view of the
+ * tapestry with hands, names, presence and camera state per tile.
+ *
+ * One manifest request per poll — never a request per tile. Thumbnails are
+ * the epoch-versioned proxy URLs the manifest carries, so the browser cache
+ * deduplicates frames inside the refresh window. A missing or expired frame
+ * falls back to a quiet deterministic color field with the person's name;
+ * the fallback never says *why* the image is gone (consent, TTL, departure
+ * and failure are intentionally indistinguishable).
+ *
+ * Every affordance has a hover, touch, keyboard and screen-reader
+ * equivalent: tiles are buttons whose full state is always in the
+ * accessible name, and activating one (pointer, Enter, Space) toggles a
+ * textual detail line. The hand indicator is a labelled badge, never color
+ * alone. Hand-count changes are announced once in a polite live region;
+ * routine refreshes are silent.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { Messages } from '@/lib/i18n';
+import type {
+    TapestryManifest,
+    TapestryManifestEntry,
+} from '@/lib/tapestry-manifest';
+
+const POLL_INTERVAL_MS = 3_000;
+
+/** Four quiet fields, chosen deterministically by opaque tile id. */
+const FALLBACK_FIELDS = [
+    'bg-[var(--forest)]',
+    'bg-[var(--night)]',
+    'bg-[var(--border-subtle)]',
+    'bg-black/40',
+] as const;
+
+function fallbackField(tileId: string): string {
+    let hash = 0;
+    for (let index = 0; index < tileId.length; index += 1) {
+        hash = (hash * 31 + tileId.charCodeAt(index)) >>> 0;
+    }
+    return FALLBACK_FIELDS[hash % FALLBACK_FIELDS.length];
+}
+
+type Copy = Messages['ops']['opsTapestry'];
+
+type Props = {
+    sessionId: string;
+    copy: Copy;
+};
+
+function fill(template: string, values: Record<string, string | number>): string {
+    return Object.entries(values).reduce(
+        (text, [key, value]) => text.replace(`{${key}}`, String(value)),
+        template,
+    );
+}
+
+function tileAccessibleName(entry: TapestryManifestEntry, copy: Copy): string {
+    const parts = [entry.displayName];
+    if (entry.handRaised && entry.queuePosition !== null) {
+        parts.push(fill(copy.handRaised, { position: entry.queuePosition }));
+    }
+    parts.push(copy.presence[entry.presence]);
+    parts.push(copy.camera[entry.camera]);
+    return parts.join(', ');
+}
+
+function Tile({ entry, copy }: { entry: TapestryManifestEntry; copy: Copy }) {
+    const [expanded, setExpanded] = useState(false);
+    // Track the exact URL that failed: the next epoch's URL gets a fresh
+    // chance, so a transient proxy error cannot wedge the fallback on.
+    const [failedUrl, setFailedUrl] = useState<string | null>(null);
+    const detailId = `ops-tapestry-detail-${entry.position}`;
+    const showImage = entry.thumbnailUrl !== null && entry.thumbnailUrl !== failedUrl;
+    const accessibleName = tileAccessibleName(entry, copy);
+
+    return (
+        <li className="flex w-28 flex-col items-center gap-1">
+            <button
+                type="button"
+                aria-label={accessibleName}
+                aria-expanded={expanded}
+                aria-controls={detailId}
+                title={accessibleName}
+                onClick={() => setExpanded((current) => !current)}
+                className="relative block h-20 w-28 overflow-hidden rounded border border-[var(--border-subtle)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--gold)]"
+            >
+                {showImage ? (
+                    // Tiles are already sized by the staff proxy; render the
+                    // bounded frame without stretching.
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                        src={entry.thumbnailUrl ?? undefined}
+                        alt={fill(copy.tileSnapshotAlt, { name: entry.displayName })}
+                        onError={() => setFailedUrl(entry.thumbnailUrl)}
+                        className="h-full w-full object-cover"
+                    />
+                ) : (
+                    <span
+                        role="img"
+                        aria-label={fill(copy.tileNoSnapshotAlt, { name: entry.displayName })}
+                        className={`block h-full w-full ${fallbackField(entry.tileId)}`}
+                    />
+                )}
+                {entry.handRaised && entry.queuePosition !== null ? (
+                    <span className="absolute left-1 top-1 rounded bg-[var(--pink)] px-1.5 py-0.5 text-xs font-semibold leading-4 text-[var(--night)]">
+                        {fill(copy.handRaised, { position: entry.queuePosition })}
+                    </span>
+                ) : null}
+            </button>
+            <span className="w-full break-words text-center text-xs leading-4 text-[var(--cream)]" title={entry.displayName}>
+                {entry.displayName}
+            </span>
+            <span
+                id={detailId}
+                hidden={!expanded}
+                className="w-full text-center text-xs leading-4 text-[var(--text-muted)]"
+            >
+                {copy.presence[entry.presence]} · {copy.camera[entry.camera]}
+            </span>
+        </li>
+    );
+}
+
+export default function OpsTapestry({ sessionId, copy }: Props) {
+    const [manifest, setManifest] = useState<TapestryManifest | null>(null);
+    const [unavailable, setUnavailable] = useState(false);
+    const lastRevisionRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        let active = true;
+        const refresh = async () => {
+            try {
+                const response = await fetch(
+                    `/api/ops/sessions/${encodeURIComponent(sessionId)}/tapestry/manifest`,
+                    { cache: 'no-store', credentials: 'same-origin' },
+                );
+                if (!response.ok) {
+                    if (active) setUnavailable(true);
+                    return;
+                }
+                const next = await response.json() as TapestryManifest;
+                if (!active) return;
+                // Ignore stale renders: only repaint when the content revision
+                // actually moved, so a slow poll never reshuffles settled tiles.
+                if (next.revision !== lastRevisionRef.current) {
+                    lastRevisionRef.current = next.revision;
+                    setManifest(next);
+                }
+                setUnavailable(false);
+            } catch {
+                if (active) setUnavailable(true);
+            }
+        };
+        void refresh();
+        const timer = setInterval(() => void refresh(), POLL_INTERVAL_MS);
+        return () => { active = false; clearInterval(timer); };
+    }, [sessionId]);
+
+    const handCount = manifest?.waitingHands.length ?? 0;
+    const handsSummary = handCount === 1
+        ? copy.handSummaryOne
+        : fill(copy.handsSummaryMany, { count: handCount });
+    const handsWithoutTile = (manifest?.waitingHands ?? [])
+        .filter((hand) => hand.tileId === null)
+        .map((hand) => hand.displayName);
+
+    return (
+        <section
+            className="rounded-lg border border-[var(--border-subtle)] p-4"
+            aria-label={copy.heading}
+        >
+            <div className="mb-3 flex items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                    {copy.heading}
+                </h2>
+                <span aria-live="polite" className="text-xs text-[var(--pink)]">
+                    {handCount > 0 ? handsSummary : ''}
+                </span>
+            </div>
+            {unavailable ? (
+                <p className="text-xs text-[var(--text-muted)]">{copy.unavailable}</p>
+            ) : manifest === null ? (
+                <p className="text-xs text-[var(--text-muted)]">{copy.loading}</p>
+            ) : (
+                <>
+                    {manifest.liveStateAvailable ? null : (
+                        <p className="mb-2 text-xs text-[var(--warning)]">
+                            {copy.liveStateUnknown}
+                        </p>
+                    )}
+                    {manifest.entries.length === 0 ? (
+                        <p className="text-xs text-[var(--text-muted)]">{copy.empty}</p>
+                    ) : (
+                        <ul className="flex flex-wrap gap-3">
+                            {manifest.entries.map((entry) => (
+                                <Tile key={entry.tileId} entry={entry} copy={copy} />
+                            ))}
+                        </ul>
+                    )}
+                    {handsWithoutTile.length > 0 ? (
+                        <p className="mt-3 text-xs text-[var(--text-muted)]">
+                            {fill(copy.waitingWithoutTile, { names: handsWithoutTile.join(', ') })}
+                        </p>
+                    ) : null}
+                    <p className="mt-3 text-xs text-[var(--text-muted)]">
+                        {fill(copy.freshnessNote, { seconds: manifest.thumbnailFreshForSeconds })}
+                    </p>
+                </>
+            )}
+        </section>
+    );
+}

--- a/src/components/ops/__tests__/ConductorCockpit.test.tsx
+++ b/src/components/ops/__tests__/ConductorCockpit.test.tsx
@@ -60,6 +60,7 @@ const props = {
     healthCopy: messages.en.ops.healthPanel,
     admissionCopy: messages.en.ops.admissionPanel,
     tapestryCopy: messages.en.ops.tapestryArrange,
+    opsTapestryCopy: messages.en.ops.opsTapestry,
     staffRoleLabels: messages.en.staffRoles,
 };
 

--- a/src/components/ops/__tests__/OpsTapestry.test.tsx
+++ b/src/components/ops/__tests__/OpsTapestry.test.tsx
@@ -149,12 +149,13 @@ describe('OpsTapestry', () => {
         expect(view.container.querySelectorAll('li')).toHaveLength(150);
     });
 
-    it('shows the unavailable state without fetching the composite', async () => {
+    it('shows the unavailable state when both reads fail', async () => {
         global.fetch = stubFetch(() => new Response('down', { status: 503 }));
         const view = render(<OpsTapestry sessionId="session-1" copy={copyEs} />);
 
         expect(await view.findByText(copyEs.unavailable)).toBeInTheDocument();
-        expect(fetch).toHaveBeenCalledTimes(1);
+        // One composite attempt + one semantic attempt, then it stops.
+        expect(fetch).toHaveBeenCalledTimes(2);
         expect(view.container.querySelectorAll('img')).toHaveLength(0);
     });
 
@@ -210,30 +211,31 @@ describe('OpsTapestry', () => {
         });
         const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
 
-        // Cycle A starts (manifest pending). Cycle B starts after the interval.
+        // Cycle A starts (composite pending). Cycle B starts after the interval.
         await act(async () => { await vi.advanceTimersByTimeAsync(3_000); });
-        expect(deferred).toHaveLength(2); // A manifest + B manifest
+        expect(deferred).toHaveLength(2); // A composite + B composite
 
         // B completes first: its state must win.
         const manifestB = manifest({ revision: 'rev-b' });
         await act(async () => {
-            deferred[1].resolve(manifestResponse(manifestB));
+            deferred[1].resolve(compositeResponse('7', 'jpeg-b'));
             await vi.advanceTimersByTimeAsync(0);
         });
-        expect(deferred).toHaveLength(3); // B composite
+        expect(deferred).toHaveLength(3); // B manifest
         await act(async () => {
-            deferred[2].resolve(compositeResponse('7', 'jpeg-b'));
+            deferred[2].resolve(manifestResponse(manifestB));
             await vi.advanceTimersByTimeAsync(0);
         });
         expect(view.getByRole('img', { name: copy.compositeAlt })).toHaveAttribute('src', 'blob:composite-1');
 
-        // A resolves late: its generation is stale, so it stops before its
-        // composite fetch, touches nothing, and the state stays B's.
+        // A resolves late: its generation is stale, so it stops right after
+        // the composite read — no manifest fetch, no blob, no state change.
         await act(async () => {
-            deferred[0].resolve(manifestResponse(manifest({ revision: 'rev-old' })));
+            deferred[0].resolve(compositeResponse('7', 'jpeg-a'));
             await vi.advanceTimersByTimeAsync(0);
         });
-        expect(deferred).toHaveLength(3); // A never spends its composite fetch
+        expect(deferred).toHaveLength(3);
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
         expect(view.getByRole('img', { name: copy.compositeAlt })).toHaveAttribute('src', 'blob:composite-1');
         expect(screen.getByText('Ana', { selector: 'li span' })).toBeInTheDocument();
     });
@@ -245,12 +247,84 @@ describe('OpsTapestry', () => {
         const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
 
         view.unmount();
-        // A late manifest response must not even trigger the composite
-        // fetch: no state update, no blob, nothing to leak.
-        deferred[0](manifestResponse(manifest()));
+        // A late composite response must stop before the manifest fetch and
+        // before any object URL: no state update, nothing to leak.
+        deferred[0](compositeResponse());
         await act(async () => { await Promise.resolve(); });
 
         expect(deferred).toHaveLength(1);
         expect(URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('reconverges R→R+1 within one cycle and stores layout R+1 despite an identical semantic hash', async () => {
+        vi.useFakeTimers();
+        let compositeCalls = 0;
+        let manifestCalls = 0;
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/manifest')) {
+                manifestCalls += 1;
+                // Cycle 2, attempt 1: a frame landed between the reads, the
+                // layout read is still R=7. Attempt 2 sees the build R+1=8.
+                // The semantic revision string NEVER changes.
+                const layoutRevision = manifestCalls >= 3 ? 8 : 7;
+                return Promise.resolve(manifestResponse(manifest({
+                    layout: { revision: layoutRevision, columns: 2, rows: 1, tileSizePx: 100 },
+                })));
+            }
+            compositeCalls += 1;
+            return Promise.resolve(compositeResponse(compositeCalls === 1 ? '7' : '8'));
+        });
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        // Cycle 1: correlated at R=7, overlay draws.
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+        expect(view.container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+
+        // Cycle 2: first pair mismatches (8 vs 7), the bounded retry pairs
+        // 8 with 8 and the overlay survives the build advance.
+        await act(async () => { await vi.advanceTimersByTimeAsync(3_000); });
+        expect(manifestCalls).toBe(3); // 1 (cycle 1) + 2 (mismatch + retry)
+        expect(compositeCalls).toBe(3);
+        // The name still sits over Ana's cell: layout 8 was stored even
+        // though names, order, hands, camera and presence are identical.
+        const overlayTag = view.container.querySelector('[aria-hidden="true"] span.absolute.bottom-0');
+        expect(overlayTag).toHaveTextContent('Ana');
+        expect(view.getByRole('img', { name: copy.compositeAlt })).toBeInTheDocument();
+        vi.useRealTimers();
+    });
+
+    it('stays bounded under continuous ingest mismatch and converges when a pair aligns', async () => {
+        vi.useFakeTimers();
+        let aligned = false;
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/manifest')) {
+                return Promise.resolve(manifestResponse(manifest({
+                    layout: { revision: aligned ? 9 : 7, columns: 2, rows: 1, tileSizePx: 100 },
+                })));
+            }
+            return Promise.resolve(compositeResponse('9'));
+        });
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        // Cycle 1 under permanent mismatch: exactly MAX attempts, overlay
+        // suppressed, the truthful list still renders.
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+        expect(fetch).toHaveBeenCalledTimes(6); // 3 attempts × 2 reads
+        expect(view.container.querySelector('[aria-hidden="true"]')).toBeNull();
+        expect(screen.getByText('Ana', { selector: 'li span' })).toBeInTheDocument();
+
+        // Cycle 2: same bounded cost — no storm, no growth, no overlay.
+        await act(async () => { await vi.advanceTimersByTimeAsync(3_000); });
+        expect(fetch).toHaveBeenCalledTimes(12);
+        expect(view.container.querySelector('[aria-hidden="true"]')).toBeNull();
+
+        // When a correlated pair appears, the overlay reconverges.
+        aligned = true;
+        await act(async () => { await vi.advanceTimersByTimeAsync(3_000); });
+        expect(view.container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+        expect(fetch).toHaveBeenCalledTimes(14); // back to 2 reads per cycle
+        vi.useRealTimers();
     });
 });

--- a/src/components/ops/__tests__/OpsTapestry.test.tsx
+++ b/src/components/ops/__tests__/OpsTapestry.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { messages } from '@/lib/i18n';
+import type { TapestryManifest } from '@/lib/tapestry-manifest';
+import OpsTapestry from '../OpsTapestry';
+
+const COPY = messages.en.ops.opsTapestry;
+
+function manifest(overrides: Partial<TapestryManifest> = {}): TapestryManifest {
+    return {
+        sessionId: 'event-1',
+        revision: 'rev-1',
+        thumbnailFreshForSeconds: 10,
+        liveStateAvailable: true,
+        entries: [
+            {
+                tileId: 'tp-ana',
+                position: 0,
+                displayName: 'Ana',
+                handRaised: true,
+                queuePosition: 1,
+                presence: 'connected',
+                camera: 'on',
+                thumbnailUrl: '/tiles/tp-ana?v=1',
+            },
+            {
+                tileId: 'tp-beto',
+                position: 1,
+                displayName: 'Beto',
+                handRaised: false,
+                queuePosition: null,
+                presence: 'reconnecting',
+                camera: 'off',
+                thumbnailUrl: null,
+            },
+        ],
+        waitingHands: [
+            { displayName: 'Ana', queuePosition: 1, tileId: 'tp-ana' },
+            { displayName: 'Cora', queuePosition: 2, tileId: null },
+        ],
+        ...overrides,
+    };
+}
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+    const fetchMock = vi.fn().mockResolvedValue({
+        ok,
+        status,
+        json: async () => body,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+});
+
+describe('OpsTapestry', () => {
+    it('shows names, the hand badge and state per tile from one manifest poll', async () => {
+        const fetchMock = mockFetch(manifest());
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        expect(await screen.findByText('Ana')).toBeInTheDocument();
+        expect(screen.getByText('Beto')).toBeInTheDocument();
+        expect(screen.getByText('Hand 1')).toBeInTheDocument();
+        // The full state is in the accessible name of every tile button.
+        expect(screen.getByRole('button', {
+            name: 'Ana, Hand 1, present, camera on',
+        })).toBeInTheDocument();
+        expect(screen.getByRole('button', {
+            name: 'Beto, reconnecting, camera off',
+        })).toBeInTheDocument();
+        // One bounded request per poll — never one per tile.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(String(fetchMock.mock.calls[0][0])).toBe(
+            '/api/ops/sessions/event-1/tapestry/manifest',
+        );
+    });
+
+    it('announces the hand count and lists hands waiting without a snapshot', async () => {
+        mockFetch(manifest());
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        expect(await screen.findByText('2 hands raised')).toBeInTheDocument();
+        expect(screen.getByText('Waiting without a snapshot: Cora')).toBeInTheDocument();
+    });
+
+    it('uses the dignified fallback when a tile has no current snapshot', async () => {
+        mockFetch(manifest());
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        expect(await screen.findByRole('img', {
+            name: 'Beto: no current tapestry snapshot',
+        })).toBeInTheDocument();
+    });
+
+    it('falls back when a thumbnail fails to load and retries the next epoch', async () => {
+        mockFetch(manifest());
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        const image = await screen.findByAltText('Recent tapestry snapshot of Ana');
+        image.dispatchEvent(new Event('error'));
+        expect(await screen.findByRole('img', {
+            name: 'Ana: no current tapestry snapshot',
+        })).toBeInTheDocument();
+    });
+
+    it('expands textual state on activation for touch, keyboard and pointer alike', async () => {
+        mockFetch(manifest());
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        const tile = await screen.findByRole('button', { name: 'Ana, Hand 1, present, camera on' });
+        expect(tile).toHaveAttribute('aria-expanded', 'false');
+        await userEvent.click(tile);
+        expect(tile).toHaveAttribute('aria-expanded', 'true');
+        const detail = document.getElementById(tile.getAttribute('aria-controls')!);
+        expect(detail).not.toBeNull();
+        expect(detail).toHaveTextContent('present · camera on');
+        expect(detail).toBeVisible();
+        // Keyboard: the tile is a native button, focusable and activatable.
+        await userEvent.keyboard('{Enter}');
+        expect(tile).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('renders the truthful empty state with zero participants', async () => {
+        mockFetch(manifest({ entries: [], waitingHands: [] }));
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        expect(await screen.findByText(
+            'No tiles yet — they appear as people share a snapshot.',
+        )).toBeInTheDocument();
+    });
+
+    it('keeps the queue operable message when the tapestry is unavailable', async () => {
+        mockFetch({}, false, 503);
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        expect(await screen.findByText(/tapestry is unavailable/i)).toBeInTheDocument();
+    });
+
+    it('warns when presence and camera cannot be confirmed', async () => {
+        mockFetch(manifest({ liveStateAvailable: false }));
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        expect(await screen.findByText(/Presence and camera unconfirmed/i)).toBeInTheDocument();
+    });
+
+    it('uses singular copy for exactly one hand', async () => {
+        mockFetch(manifest({
+            waitingHands: [{ displayName: 'Ana', queuePosition: 1, tileId: 'tp-ana' }],
+        }));
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        expect(await screen.findByText('1 hand raised')).toBeInTheDocument();
+    });
+
+    it('scales to a full room without per-tile requests', async () => {
+        const entries = Array.from({ length: 150 }, (_, index) => ({
+            tileId: `tp-${index}`,
+            position: index,
+            displayName: `Person ${index}`,
+            handRaised: false,
+            queuePosition: null,
+            presence: 'connected' as const,
+            camera: 'off' as const,
+            thumbnailUrl: `/tiles/tp-${index}?v=1`,
+        }));
+        const fetchMock = mockFetch(manifest({ entries }));
+        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+
+        expect(await screen.findByText('Person 149')).toBeInTheDocument();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/ops/__tests__/OpsTapestry.test.tsx
+++ b/src/components/ops/__tests__/OpsTapestry.test.tsx
@@ -1,179 +1,256 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { messages } from '@/lib/i18n';
 import type { TapestryManifest } from '@/lib/tapestry-manifest';
+
 import OpsTapestry from '../OpsTapestry';
 
-const COPY = messages.en.ops.opsTapestry;
+const copy = messages.en.ops.opsTapestry;
+const copyEs = messages.es.ops.opsTapestry;
 
 function manifest(overrides: Partial<TapestryManifest> = {}): TapestryManifest {
     return {
-        sessionId: 'event-1',
-        revision: 'rev-1',
-        thumbnailFreshForSeconds: 10,
+        sessionId: 'session-1',
+        revision: 'rev-a',
         liveStateAvailable: true,
+        layout: { revision: 7, columns: 2, rows: 1, tileSizePx: 100 },
+        tileFreshForSeconds: 10,
         entries: [
             {
                 tileId: 'tp-ana',
-                position: 0,
                 displayName: 'Ana',
                 handRaised: true,
                 queuePosition: 1,
                 presence: 'connected',
-                camera: 'on',
-                thumbnailUrl: '/tiles/tp-ana?v=1',
+                camera: 'off',
+                column: 1,
+                row: 0,
             },
             {
                 tileId: 'tp-beto',
-                position: 1,
                 displayName: 'Beto',
                 handRaised: false,
                 queuePosition: null,
                 presence: 'reconnecting',
-                camera: 'off',
-                thumbnailUrl: null,
+                camera: 'unknown',
+                column: 0,
+                row: 0,
             },
         ],
-        waitingHands: [
-            { displayName: 'Ana', queuePosition: 1, tileId: 'tp-ana' },
-            { displayName: 'Cora', queuePosition: 2, tileId: null },
-        ],
+        waitingHands: [{ displayName: 'Ana', queuePosition: 1, tileId: 'tp-ana' }],
         ...overrides,
     };
 }
 
-function mockFetch(body: unknown, ok = true, status = 200) {
-    const fetchMock = vi.fn().mockResolvedValue({
-        ok,
-        status,
-        json: async () => body,
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    return fetchMock;
+function manifestResponse(body: TapestryManifest, status = 200) {
+    return new Response(JSON.stringify(body), { status });
 }
+
+function compositeResponse(revision: string | null = '7', bytes = 'jpeg') {
+    return new Response(new Blob([bytes]), {
+        status: 200,
+        headers: revision ? { 'x-tapestry-revision': revision } : {},
+    });
+}
+
+let blobCounter = 0;
+
+function stubFetch(handler: (url: string) => Promise<Response> | Response) {
+    return vi.fn().mockImplementation((input: RequestInfo | URL) => handler(String(input)));
+}
+
+beforeEach(() => {
+    blobCounter = 0;
+    URL.createObjectURL = vi.fn(() => `blob:composite-${++blobCounter}`);
+    URL.revokeObjectURL = vi.fn();
+});
 
 afterEach(() => {
     cleanup();
-    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
 });
 
 describe('OpsTapestry', () => {
-    it('shows names, the hand badge and state per tile from one manifest poll', async () => {
-        const fetchMock = mockFetch(manifest());
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
-
-        expect(await screen.findByText('Ana')).toBeInTheDocument();
-        expect(screen.getByText('Beto')).toBeInTheDocument();
-        expect(screen.getByText('Hand 1')).toBeInTheDocument();
-        // The full state is in the accessible name of every tile button.
-        expect(screen.getByRole('button', {
-            name: 'Ana, Hand 1, present, camera on',
-        })).toBeInTheDocument();
-        expect(screen.getByRole('button', {
-            name: 'Beto, reconnecting, camera off',
-        })).toBeInTheDocument();
-        // One bounded request per poll — never one per tile.
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(String(fetchMock.mock.calls[0][0])).toBe(
-            '/api/ops/sessions/event-1/tapestry/manifest',
-        );
+    it('shows the loading state before the first response', () => {
+        global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+        expect(view.getByText(copy.loading)).toBeInTheDocument();
     });
 
-    it('announces the hand count and lists hands waiting without a snapshot', async () => {
-        mockFetch(manifest());
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
-
-        expect(await screen.findByText('2 hands raised')).toBeInTheDocument();
-        expect(screen.getByText('Waiting without a snapshot: Cora')).toBeInTheDocument();
+    it('spends zero requests while inactive (hidden cockpit drawer)', async () => {
+        vi.useFakeTimers();
+        global.fetch = vi.fn();
+        render(<OpsTapestry sessionId="session-1" copy={copy} active={false} />);
+        await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+        expect(fetch).not.toHaveBeenCalled();
+        vi.useRealTimers();
     });
 
-    it('uses the dignified fallback when a tile has no current snapshot', async () => {
-        mockFetch(manifest());
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+    it('renders one composite with overlays and an accessible state list', async () => {
+        global.fetch = stubFetch((url) =>
+            url.includes('/tapestry/manifest') ? manifestResponse(manifest()) : compositeResponse());
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
 
-        expect(await screen.findByRole('img', {
-            name: 'Beto: no current tapestry snapshot',
-        })).toBeInTheDocument();
+        const image = await view.findByRole('img', { name: copy.compositeAlt });
+        expect(image).toHaveAttribute('src', 'blob:composite-1');
+        // Overlay: the name sits over Ana's own cell (column 1 of 2 → 50%).
+        const overlayTag = view.container.querySelector('[aria-hidden="true"] span.absolute.bottom-0');
+        expect(overlayTag).toHaveTextContent('Ana');
+        expect(overlayTag?.parentElement).toHaveStyle({ left: '50%' });
+        // Exactly one image element exists — never one per participant.
+        expect(view.container.querySelectorAll('img')).toHaveLength(1);
+        // The accessible list carries every state as plain text.
+        const row = screen.getByText('Ana', { selector: 'li span' }).closest('li')!;
+        expect(row).toHaveTextContent('Hand 1');
+        expect(row).toHaveTextContent('present');
+        expect(row).toHaveTextContent('camera off');
+        expect(screen.getByText('Beto', { selector: 'li span' }).closest('li')!).toHaveTextContent('reconnecting');
+        // Two bounded requests per cycle: manifest JSON + composite image.
+        expect(fetch).toHaveBeenCalledTimes(2);
     });
 
-    it('falls back when a thumbnail fails to load and retries the next epoch', async () => {
-        mockFetch(manifest());
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+    it('omits overlays when the composite revision disagrees with the layout', async () => {
+        global.fetch = stubFetch((url) =>
+            url.includes('/tapestry/manifest') ? manifestResponse(manifest()) : compositeResponse('8'));
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
 
-        const image = await screen.findByAltText('Recent tapestry snapshot of Ana');
-        image.dispatchEvent(new Event('error'));
-        expect(await screen.findByRole('img', {
-            name: 'Ana: no current tapestry snapshot',
-        })).toBeInTheDocument();
+        await view.findByRole('img', { name: copy.compositeAlt });
+        expect(view.container.querySelector('[aria-hidden="true"]')).toBeNull();
+        // The truthful list remains either way.
+        expect(screen.getByText('Ana', { selector: 'li span' })).toBeInTheDocument();
     });
 
-    it('expands textual state on activation for touch, keyboard and pointer alike', async () => {
-        mockFetch(manifest());
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
-
-        const tile = await screen.findByRole('button', { name: 'Ana, Hand 1, present, camera on' });
-        expect(tile).toHaveAttribute('aria-expanded', 'false');
-        await userEvent.click(tile);
-        expect(tile).toHaveAttribute('aria-expanded', 'true');
-        const detail = document.getElementById(tile.getAttribute('aria-controls')!);
-        expect(detail).not.toBeNull();
-        expect(detail).toHaveTextContent('present · camera on');
-        expect(detail).toBeVisible();
-        // Keyboard: the tile is a native button, focusable and activatable.
-        await userEvent.keyboard('{Enter}');
-        expect(tile).toHaveAttribute('aria-expanded', 'false');
-    });
-
-    it('renders the truthful empty state with zero participants', async () => {
-        mockFetch(manifest({ entries: [], waitingHands: [] }));
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
-
-        expect(await screen.findByText(
-            'No tiles yet — they appear as people share a snapshot.',
-        )).toBeInTheDocument();
-    });
-
-    it('keeps the queue operable message when the tapestry is unavailable', async () => {
-        mockFetch({}, false, 503);
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
-
-        expect(await screen.findByText(/tapestry is unavailable/i)).toBeInTheDocument();
-    });
-
-    it('warns when presence and camera cannot be confirmed', async () => {
-        mockFetch(manifest({ liveStateAvailable: false }));
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
-
-        expect(await screen.findByText(/Presence and camera unconfirmed/i)).toBeInTheDocument();
-    });
-
-    it('uses singular copy for exactly one hand', async () => {
-        mockFetch(manifest({
-            waitingHands: [{ displayName: 'Ana', queuePosition: 1, tileId: 'tp-ana' }],
-        }));
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
-
-        expect(await screen.findByText('1 hand raised')).toBeInTheDocument();
-    });
-
-    it('scales to a full room without per-tile requests', async () => {
-        const entries = Array.from({ length: 150 }, (_, index) => ({
-            tileId: `tp-${index}`,
-            position: index,
-            displayName: `Person ${index}`,
-            handRaised: false,
-            queuePosition: null,
+    it('stays O(1) with 150 participants: two requests, one image', async () => {
+        const entries = Array.from({ length: 150 }, (_, i) => ({
+            tileId: `tp-${i}`,
+            displayName: `Person ${i}`,
+            handRaised: i === 0,
+            queuePosition: i === 0 ? 1 : null,
             presence: 'connected' as const,
-            camera: 'off' as const,
-            thumbnailUrl: `/tiles/tp-${index}?v=1`,
+            camera: 'on' as const,
+            column: i % 15,
+            row: Math.floor(i / 15),
         }));
-        const fetchMock = mockFetch(manifest({ entries }));
-        render(<OpsTapestry sessionId="event-1" copy={COPY} />);
+        global.fetch = stubFetch((url) =>
+            url.includes('/tapestry/manifest')
+                ? manifestResponse(manifest({
+                    layout: { revision: 7, columns: 15, rows: 10, tileSizePx: 100 },
+                    entries,
+                }))
+                : compositeResponse());
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
 
-        expect(await screen.findByText('Person 149')).toBeInTheDocument();
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        await view.findByRole('img', { name: copy.compositeAlt });
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(view.container.querySelectorAll('img')).toHaveLength(1);
+        expect(view.container.querySelectorAll('li')).toHaveLength(150);
+    });
+
+    it('shows the unavailable state without fetching the composite', async () => {
+        global.fetch = stubFetch(() => new Response('down', { status: 503 }));
+        const view = render(<OpsTapestry sessionId="session-1" copy={copyEs} />);
+
+        expect(await view.findByText(copyEs.unavailable)).toBeInTheDocument();
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(view.container.querySelectorAll('img')).toHaveLength(0);
+    });
+
+    it('shows the empty state when the room has no tiles', async () => {
+        global.fetch = stubFetch((url) =>
+            url.includes('/tapestry/manifest')
+                ? manifestResponse(manifest({ entries: [], waitingHands: [] }))
+                : compositeResponse());
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        expect(await view.findByText(copy.empty)).toBeInTheDocument();
+    });
+
+    it('lists waiting hands without a tile', async () => {
+        global.fetch = stubFetch((url) =>
+            url.includes('/tapestry/manifest')
+                ? manifestResponse(manifest({
+                    waitingHands: [
+                        { displayName: 'Ana', queuePosition: 1, tileId: 'tp-ana' },
+                        { displayName: 'Cele', queuePosition: 2, tileId: null },
+                    ],
+                }))
+                : compositeResponse());
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        expect(await view.findByText(/Waiting without a snapshot: Cele \(#2\)/)).toBeInTheDocument();
+    });
+
+    it('refreshes the composite bytes even when the semantic revision is unchanged', async () => {
+        vi.useFakeTimers();
+        global.fetch = stubFetch((url) =>
+            url.includes('/tapestry/manifest') ? manifestResponse(manifest()) : compositeResponse());
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+        const firstSrc = view.getByRole('img', { name: copy.compositeAlt }).getAttribute('src');
+
+        await act(async () => { await vi.advanceTimersByTimeAsync(3_000); });
+        const secondSrc = view.getByRole('img', { name: copy.compositeAlt }).getAttribute('src');
+
+        // Same order, names and states — but the image visibly updated and
+        // the previous object URL was revoked.
+        expect(secondSrc).not.toBe(firstSrc);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith(firstSrc);
+    });
+
+    it('ignores a slower earlier cycle that resolves after a newer one', async () => {
+        vi.useFakeTimers();
+        const deferred: Array<{ url: string; resolve: (r: Response) => void }> = [];
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            return new Promise<Response>((resolve) => deferred.push({ url, resolve }));
+        });
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        // Cycle A starts (manifest pending). Cycle B starts after the interval.
+        await act(async () => { await vi.advanceTimersByTimeAsync(3_000); });
+        expect(deferred).toHaveLength(2); // A manifest + B manifest
+
+        // B completes first: its state must win.
+        const manifestB = manifest({ revision: 'rev-b' });
+        await act(async () => {
+            deferred[1].resolve(manifestResponse(manifestB));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(deferred).toHaveLength(3); // B composite
+        await act(async () => {
+            deferred[2].resolve(compositeResponse('7', 'jpeg-b'));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(view.getByRole('img', { name: copy.compositeAlt })).toHaveAttribute('src', 'blob:composite-1');
+
+        // A resolves late: its generation is stale, so it stops before its
+        // composite fetch, touches nothing, and the state stays B's.
+        await act(async () => {
+            deferred[0].resolve(manifestResponse(manifest({ revision: 'rev-old' })));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(deferred).toHaveLength(3); // A never spends its composite fetch
+        expect(view.getByRole('img', { name: copy.compositeAlt })).toHaveAttribute('src', 'blob:composite-1');
+        expect(screen.getByText('Ana', { selector: 'li span' })).toBeInTheDocument();
+    });
+
+    it('aborts and leaks nothing when unmounted mid-cycle', async () => {
+        const deferred: Array<(r: Response) => void> = [];
+        global.fetch = vi.fn().mockImplementation(() =>
+            new Promise<Response>((resolve) => deferred.push(resolve)));
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        view.unmount();
+        // A late manifest response must not even trigger the composite
+        // fetch: no state update, no blob, nothing to leak.
+        deferred[0](manifestResponse(manifest()));
+        await act(async () => { await Promise.resolve(); });
+
+        expect(deferred).toHaveLength(1);
+        expect(URL.createObjectURL).not.toHaveBeenCalled();
     });
 });

--- a/src/components/ops/__tests__/OpsTapestry.test.tsx
+++ b/src/components/ops/__tests__/OpsTapestry.test.tsx
@@ -327,4 +327,157 @@ describe('OpsTapestry', () => {
         expect(fetch).toHaveBeenCalledTimes(14); // back to 2 reads per cycle
         vi.useRealTimers();
     });
+
+    it('mismatch→match: revokes the fallback URL exactly once and keeps the chosen one until unmount', async () => {
+        let manifestCalls = 0;
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/manifest')) {
+                manifestCalls += 1;
+                // Attempt 1: layout still at R=7 while the composite built
+                // R=8 (mismatch, fallback candidate A). Attempt 2: R=8
+                // (correlated candidate B).
+                return Promise.resolve(manifestResponse(manifest({
+                    layout: { revision: manifestCalls === 1 ? 7 : 8, columns: 2, rows: 1, tileSizePx: 100 },
+                })));
+            }
+            return Promise.resolve(compositeResponse('8'));
+        });
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        await act(async () => { await Promise.resolve(); });
+        // B (blob:composite-2) is the visible state; A was discarded.
+        expect(view.getByRole('img', { name: copy.compositeAlt })).toHaveAttribute('src', 'blob:composite-2');
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:composite-1');
+        expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:composite-2');
+
+        // B lives until unmount, then is revoked exactly once.
+        view.unmount();
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:composite-2');
+    });
+
+    it('mismatch→error: revokes the failed attempt and the published fallback at unmount — no orphan blobs', async () => {
+        let manifestCalls = 0;
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/manifest')) {
+                manifestCalls += 1;
+                if (manifestCalls === 2) return Promise.reject(new Error('network down'));
+                return Promise.resolve(manifestResponse(manifest({
+                    layout: { revision: 7, columns: 2, rows: 1, tileSizePx: 100 },
+                })));
+            }
+            return Promise.resolve(compositeResponse('8'));
+        });
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        await act(async () => { await Promise.resolve(); });
+        // Attempt 2's blob (composite-2) failed before becoming a candidate:
+        // revoked immediately. Candidate A (composite-1) became the safe
+        // fallback and was published.
+        expect(view.getByRole('img', { name: copy.compositeAlt })).toHaveAttribute('src', 'blob:composite-1');
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:composite-2');
+        // The list is still truthful; overlays stay hidden (layout 7 ≠ build 8).
+        expect(screen.getByText('Ana', { selector: 'li span' })).toBeInTheDocument();
+        expect(view.container.querySelector('[aria-hidden="true"]')).toBeNull();
+
+        // The published fallback is revoked at unmount: nothing orphaned.
+        view.unmount();
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:composite-1');
+    });
+
+    it('session A→B with identical revisions shows only B and revokes A', async () => {
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/manifest')) {
+                // Both sessions report the SAME semantic revision and layout
+                // revision; only the session scopes the content.
+                if (url.includes('session-2')) {
+                    return Promise.resolve(manifestResponse(manifest({
+                        sessionId: 'session-2',
+                        entries: [{ ...manifest().entries[0], displayName: 'Caro' }],
+                    })));
+                }
+                return Promise.resolve(manifestResponse(manifest()));
+            }
+            return Promise.resolve(compositeResponse('7'));
+        });
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+        expect(await screen.findByText('Ana', { selector: 'li span' })).toBeInTheDocument();
+        expect(view.getByRole('img', { name: copy.compositeAlt })).toHaveAttribute('src', 'blob:composite-1');
+
+        view.rerender(<OpsTapestry sessionId="session-2" copy={copy} />);
+        // The reset is immediate: A's names, list and image are gone before
+        // B's first fetch even resolves.
+        expect(screen.queryByText('Ana', { selector: 'li span' })).not.toBeInTheDocument();
+        expect(view.container.querySelector('img')).toBeNull();
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:composite-1');
+
+        // B answers with identical revisions: the session-scoped cache lets
+        // B's manifest in, and only B's data shows.
+        expect(await screen.findByText('Caro', { selector: 'li span' })).toBeInTheDocument();
+        expect(screen.queryByText('Ana', { selector: 'li span' })).not.toBeInTheDocument();
+        expect(view.getByRole('img', { name: copy.compositeAlt })).toHaveAttribute('src', 'blob:composite-2');
+    });
+
+    it('session A→B with identical revisions and B failing never resurrects A', async () => {
+        vi.useFakeTimers();
+        const deferred: Array<{ url: string; resolve: (r: Response) => void }> = [];
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            return new Promise<Response>((resolve) => deferred.push({ url, resolve }));
+        });
+        const view = render(<OpsTapestry sessionId="session-1" copy={copy} />);
+
+        // A's first cycle completes: Ana published with blob:composite-1.
+        expect(deferred).toHaveLength(1); // A composite
+        await act(async () => {
+            deferred[0].resolve(compositeResponse('7'));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(deferred).toHaveLength(2); // A manifest
+        await act(async () => {
+            deferred[1].resolve(manifestResponse(manifest()));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(screen.getByText('Ana', { selector: 'li span' })).toBeInTheDocument();
+
+        // A's next cycle starts (composite in flight) when the switch happens.
+        await act(async () => { await vi.advanceTimersByTimeAsync(3_000); });
+        expect(deferred).toHaveLength(3);
+        view.rerender(<OpsTapestry sessionId="session-2" copy={copy} />);
+        // Immediate reset: no A data, A's published URL revoked, loading state.
+        expect(screen.queryByText('Ana', { selector: 'li span' })).not.toBeInTheDocument();
+        expect(view.container.querySelector('img')).toBeNull();
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:composite-1');
+
+        // A's late response lands after the switch: ignored before creating
+        // any blob, cleaning up after itself.
+        await act(async () => {
+            deferred[2].resolve(compositeResponse('7', 'jpeg-a-late'));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1); // still only A's first blob
+        expect(screen.queryByText('Ana', { selector: 'li span' })).not.toBeInTheDocument();
+
+        // B fails on both reads: B's unavailable state, never A's data.
+        expect(deferred).toHaveLength(4); // B composite
+        await act(async () => {
+            deferred[3].resolve(new Response('down', { status: 503 }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(deferred).toHaveLength(5); // B manifest (semantic path)
+        await act(async () => {
+            deferred[4].resolve(new Response('down', { status: 503 }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(screen.getByText(copy.unavailable)).toBeInTheDocument();
+        expect(screen.queryByText('Ana', { selector: 'li span' })).not.toBeInTheDocument();
+        vi.useRealTimers();
+    });
 });

--- a/src/components/session/HandRaiseButton.tsx
+++ b/src/components/session/HandRaiseButton.tsx
@@ -153,6 +153,11 @@ export default function HandRaiseButton({
                     {state?.raised ? copy.hand.lower : copy.hand.raise}
                 </button>
             ) : null}
+            {!state?.canPublish ? (
+                <p className="max-w-xs text-center text-xs leading-4 text-[var(--text-muted)]">
+                    {copy.hand.namingConsent}
+                </p>
+            ) : null}
             {state?.canPublish && stageInvitationAccepted ? (
                 <p role="status" className="text-xs text-[var(--lime)]">
                     {copy.hand.onStage}

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -106,7 +106,16 @@ function ThumbnailTapestryView({
         let active = true;
         let generation = 0;
         let controller: AbortController | null = null;
-        let previousUrl: string | null = null;
+        // The ONE object URL the visible state currently owns. Any URL not
+        // transferred here is revoked by the cycle that created it.
+        let publishedUrl: string | null = null;
+
+        // Session-scoped reset: never carry image, names or overlays across
+        // a sessionId change. The next session starts from empty — if its
+        // first fetch fails, the UI shows ITS waiting state, never the
+        // previous session's data.
+        setView(null);
+
         const compositeUrl = `/api/tapestry/${encodeURIComponent(sessionId)}`;
         // Raised-hand names ride a cookie-authorized sidecar: the collective
         // JPEG stays anonymous, and only people who chose to request the
@@ -133,8 +142,11 @@ function ThumbnailTapestryView({
             controller = new AbortController();
             const signal = controller.signal;
 
-            let correlated: { url: string; revision: string | null; hands: HandsSnapshot } | null = null;
-            let fallback: { url: string; revision: string | null; hands: HandsSnapshot } | null = null;
+            // Every object URL created this cycle is registered here.
+            // Exactly one may be chosen and transferred to the visible state;
+            // all others are revoked exactly once before the cycle returns.
+            const candidates: Array<{ url: string; revision: string | null; hands: HandsSnapshot }> = [];
+            let chosen: (typeof candidates)[number] | null = null;
 
             for (let attempt = 0; attempt < MAX_CORRELATION_ATTEMPTS; attempt += 1) {
                 if (!active || myGeneration !== generation) break;
@@ -155,29 +167,36 @@ function ThumbnailTapestryView({
                     }
                     url = URL.createObjectURL(blob);
                     const hands = staffOnly ? EMPTY_HANDS : await fetchHands(signal);
-                    const pair = { url, revision, hands };
+                    candidates.push({ url, revision, hands });
+                    url = null; // ownership moved into the candidates registry
                     const layoutRevision = hands.layout?.revision ?? null;
                     if (staffOnly || layoutRevision === null || String(layoutRevision) === revision) {
-                        correlated = pair;
+                        chosen = candidates[candidates.length - 1];
                         break;
                     }
-                    if (fallback) URL.revokeObjectURL(fallback.url);
-                    fallback = pair;
                 } catch {
                     // Aborted by a newer cycle or unmount, or a transient
-                    // failure: the tapestry is optional and the next tick retries.
-                    if (url) URL.revokeObjectURL(url);
-                    return;
+                    // failure. Stop attempting: the freshest candidate (if
+                    // any) still serves as the safe fallback below.
+                    if (url) URL.revokeObjectURL(url); // never became a candidate
+                    break;
                 }
             }
 
+            // Safe fallback: the freshest candidate; the render-time
+            // revision check keeps its tags hidden while mismatched.
+            if (!chosen && candidates.length > 0) chosen = candidates[candidates.length - 1];
+            // Revoke every non-chosen candidate exactly once.
+            for (const c of candidates) {
+                if (c !== chosen) URL.revokeObjectURL(c.url);
+            }
+
             if (!active || myGeneration !== generation) {
-                const stale = correlated ?? fallback;
-                if (stale) URL.revokeObjectURL(stale.url);
+                // A stale generation discards its chosen URL before dying.
+                if (chosen) URL.revokeObjectURL(chosen.url);
                 return;
             }
 
-            const chosen = correlated ?? fallback;
             if (!chosen) {
                 // Composite unavailable: keep the previous image, still
                 // refresh names so departures retire them.
@@ -194,18 +213,17 @@ function ThumbnailTapestryView({
                 return;
             }
 
-            setView((prev) => {
-                const next: TapestryView = {
-                    compositeUrl: chosen.url,
-                    buildRevision: chosen.revision,
-                    hands: chosen.hands,
-                };
-                if (prev?.compositeUrl && prev.compositeUrl !== next.compositeUrl) {
-                    URL.revokeObjectURL(prev.compositeUrl);
-                }
-                previousUrl = next.compositeUrl;
-                return next;
+            setView({
+                compositeUrl: chosen.url,
+                buildRevision: chosen.revision,
+                hands: chosen.hands,
             });
+            // Ownership transfer, outside the state updater: the chosen URL
+            // now belongs to the visible state; the retired one is revoked
+            // exactly once, here or at cleanup.
+            const retired = publishedUrl;
+            publishedUrl = chosen.url;
+            if (retired && retired !== chosen.url) URL.revokeObjectURL(retired);
         };
 
         void cycle();
@@ -214,7 +232,10 @@ function ThumbnailTapestryView({
             active = false;
             clearInterval(timer);
             controller?.abort();
-            if (previousUrl) URL.revokeObjectURL(previousUrl);
+            if (publishedUrl) {
+                URL.revokeObjectURL(publishedUrl);
+                publishedUrl = null;
+            }
         };
     }, [sessionId, staffOnly]);
 

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -10,6 +10,26 @@ type Props = {
     labels?: Messages['tapestry'];
 };
 
+type PublicHand = {
+    name: string;
+    column: number | null;
+    row: number | null;
+};
+
+type CompositeLayout = {
+    revision: number;
+    columns: number;
+    rows: number;
+    tileSizePx: number;
+};
+
+type HandsSnapshot = {
+    hands: PublicHand[];
+    layout: CompositeLayout | null;
+};
+
+const EMPTY_HANDS: HandsSnapshot = { hands: [], layout: null };
+
 export default function ThumbnailTapestry({ sessionId, staffOnly = false, labels }: Props) {
     if (labels) {
         return <ThumbnailTapestryView sessionId={sessionId} staffOnly={staffOnly} labels={labels} />;
@@ -22,13 +42,44 @@ function LocalizedThumbnailTapestry({ sessionId, staffOnly = false }: Props) {
     return <ThumbnailTapestryView sessionId={sessionId} staffOnly={staffOnly} labels={copy.tapestry} />;
 }
 
+function parseHands(body: unknown): HandsSnapshot {
+    const raw = body as {
+        hands?: Array<{ name?: unknown; column?: unknown; row?: unknown }>;
+        layout?: Partial<CompositeLayout> | null;
+    };
+    const hands = Array.isArray(raw?.hands)
+        ? raw.hands.flatMap((hand) => {
+            const name = typeof hand.name === 'string' ? hand.name.trim() : '';
+            if (!name) return [];
+            const column = typeof hand.column === 'number' ? hand.column : null;
+            const row = typeof hand.row === 'number' ? hand.row : null;
+            return [{ name, column, row }];
+        })
+        : [];
+    const layout = raw?.layout &&
+        typeof raw.layout.revision === 'number' &&
+        typeof raw.layout.columns === 'number' &&
+        typeof raw.layout.rows === 'number' &&
+        raw.layout.columns > 0 &&
+        raw.layout.rows > 0
+        ? {
+            revision: raw.layout.revision,
+            columns: raw.layout.columns,
+            rows: raw.layout.rows,
+            tileSizePx: typeof raw.layout.tileSizePx === 'number' ? raw.layout.tileSizePx : 0,
+        }
+        : null;
+    return { hands, layout };
+}
+
 function ThumbnailTapestryView({
     sessionId,
     staffOnly,
     labels,
 }: Props & { labels: Messages['tapestry'] }) {
     const [src, setSrc] = useState<string | null>(null);
-    const [raisedHands, setRaisedHands] = useState<string[]>([]);
+    const [compositeRevision, setCompositeRevision] = useState<string | null>(null);
+    const [snapshot, setSnapshot] = useState<HandsSnapshot>(EMPTY_HANDS);
     useEffect(() => {
         let active = true;
         let previous: string | null = null;
@@ -38,9 +89,11 @@ function ThumbnailTapestryView({
                     cache: 'no-store', credentials: staffOnly ? 'same-origin' : 'omit',
                 });
                 if (!response.ok) return;
+                const revision = response.headers.get('x-tapestry-revision');
                 const next = URL.createObjectURL(await response.blob());
                 if (!active) { URL.revokeObjectURL(next); return; }
                 setSrc(next);
+                setCompositeRevision(revision);
                 if (previous) URL.revokeObjectURL(previous);
                 previous = next;
             } catch { /* tapestry is optional */ }
@@ -65,31 +118,61 @@ function ThumbnailTapestryView({
                     { cache: 'no-store', credentials: 'same-origin' },
                 );
                 if (!response.ok) return;
-                const body = await response.json() as { hands?: Array<{ name?: unknown }> };
+                const next = parseHands(await response.json());
                 if (!active) return;
-                const names = Array.isArray(body.hands)
-                    ? body.hands
-                        .map((hand) => typeof hand.name === 'string' ? hand.name.trim() : '')
-                        .filter((name) => name.length > 0)
-                    : [];
-                setRaisedHands(names);
+                setSnapshot(next);
             } catch { /* the hand list is advisory */ }
         };
         void load();
         const timer = setInterval(() => void load(), 5_000);
         return () => { active = false; clearInterval(timer); };
     }, [sessionId, staffOnly]);
+
+    const names = snapshot.hands.map((hand) => hand.name);
+    // Zoom/Meet-style name tags over each raised hand's own tile. The layout
+    // and the composite must name the same build — otherwise the grid may
+    // have shifted and a tag could land on the wrong person, so we omit the
+    // overlay (the accessible names line below remains either way).
+    const layout = compositeRevision !== null &&
+        snapshot.layout !== null &&
+        String(snapshot.layout.revision) === compositeRevision
+        ? snapshot.layout
+        : null;
+    const overlayHands = layout
+        ? snapshot.hands.filter((hand) => hand.column !== null && hand.row !== null)
+        : [];
+
     return <section aria-label={labels.label} className="w-full">
         <h2 className="mb-2 text-sm font-medium text-[var(--cream)]">{labels.label}</h2>
         {src ? (
-            // The composite is sized to the active participant set; render at
-            // natural size (capped by the container) instead of stretching.
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={src} alt={labels.latestAlt} className="max-w-full rounded-lg border border-[var(--border-subtle)]" />
+            <div className="relative inline-block max-w-full">
+                {/* The composite is sized to the active participant set; render
+                    at natural size (capped by the container) instead of
+                    stretching. Percentage-positioned tags scale with it. */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={src} alt={labels.latestAlt} className="block max-w-full rounded-lg border border-[var(--border-subtle)]" />
+                {overlayHands.length > 0 && layout ? (
+                    <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden rounded-lg">
+                        {overlayHands.map((hand) => (
+                            <span
+                                key={`${hand.name}-${hand.column}-${hand.row}`}
+                                className="absolute left-0 top-0 max-w-[33%] rounded bg-black/70 px-1.5 py-0.5 text-xs leading-4 text-[var(--cream)]"
+                                style={{
+                                    left: `${((hand.column ?? 0) / layout.columns) * 100}%`,
+                                    top: `${(((hand.row ?? 0) + 1) / layout.rows) * 100}%`,
+                                    transform: 'translateY(-100%)',
+                                }}
+                            >
+                                {hand.name}
+                            </span>
+                        ))}
+                    </div>
+                ) : null}
+            </div>
         ) : <p className="text-xs text-[var(--text-muted)]">{labels.waiting}</p>}
-        {raisedHands.length > 0 ? (
+        {names.length > 0 ? (
             <p aria-live="polite" className="mt-2 text-xs text-[var(--gold)]">
-                {labels.raisedHands.replace('{names}', raisedHands.join(', '))}
+                {labels.raisedHands.replace('{names}', names.join(', '))}
             </p>
         ) : null}
     </section>;

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -82,25 +82,48 @@ function ThumbnailTapestryView({
     const [snapshot, setSnapshot] = useState<HandsSnapshot>(EMPTY_HANDS);
     useEffect(() => {
         let active = true;
+        let generation = 0;
+        let controller: AbortController | null = null;
         let previous: string | null = null;
         const load = async () => {
+            if (!active) return;
+            // A newer poll supersedes a slower earlier one; a late response
+            // can never overwrite fresher state (TAP-02 review).
+            const myGeneration = ++generation;
+            controller?.abort();
+            controller = new AbortController();
+            let next: string | null = null;
             try {
                 const response = await fetch(`/api/tapestry/${encodeURIComponent(sessionId)}`, {
-                    cache: 'no-store', credentials: staffOnly ? 'same-origin' : 'omit',
+                    cache: 'no-store',
+                    credentials: staffOnly ? 'same-origin' : 'omit',
+                    signal: controller.signal,
                 });
                 if (!response.ok) return;
                 const revision = response.headers.get('x-tapestry-revision');
-                const next = URL.createObjectURL(await response.blob());
-                if (!active) { URL.revokeObjectURL(next); return; }
+                next = URL.createObjectURL(await response.blob());
+                if (!active || myGeneration !== generation) {
+                    URL.revokeObjectURL(next);
+                    return;
+                }
                 setSrc(next);
                 setCompositeRevision(revision);
                 if (previous) URL.revokeObjectURL(previous);
                 previous = next;
-            } catch { /* tapestry is optional */ }
+            } catch {
+                // Aborted by a newer poll or unmount, or a transient failure:
+                // the tapestry is optional and the next tick retries.
+                if (next) URL.revokeObjectURL(next);
+            }
         };
         void load();
         const timer = setInterval(() => void load(), 2_000);
-        return () => { active = false; clearInterval(timer); if (previous) URL.revokeObjectURL(previous); };
+        return () => {
+            active = false;
+            clearInterval(timer);
+            controller?.abort();
+            if (previous) URL.revokeObjectURL(previous);
+        };
     }, [sessionId, staffOnly]);
     useEffect(() => {
         // Raised-hand names ride a separate, cookie-authorized sidecar on the
@@ -111,21 +134,27 @@ function ThumbnailTapestryView({
         // advisory — any rejection simply leaves it empty.
         if (staffOnly) return;
         let active = true;
+        let generation = 0;
+        let controller: AbortController | null = null;
         const load = async () => {
+            if (!active) return;
+            const myGeneration = ++generation;
+            controller?.abort();
+            controller = new AbortController();
             try {
                 const response = await fetch(
                     `/api/scheduled-sessions/${encodeURIComponent(sessionId)}/tapestry/hands`,
-                    { cache: 'no-store', credentials: 'same-origin' },
+                    { cache: 'no-store', credentials: 'same-origin', signal: controller.signal },
                 );
                 if (!response.ok) return;
                 const next = parseHands(await response.json());
-                if (!active) return;
+                if (!active || myGeneration !== generation) return;
                 setSnapshot(next);
             } catch { /* the hand list is advisory */ }
         };
         void load();
         const timer = setInterval(() => void load(), 5_000);
-        return () => { active = false; clearInterval(timer); };
+        return () => { active = false; clearInterval(timer); controller?.abort(); };
     }, [sessionId, staffOnly]);
 
     const names = snapshot.hands.map((hand) => hand.name);

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -28,6 +28,7 @@ function ThumbnailTapestryView({
     labels,
 }: Props & { labels: Messages['tapestry'] }) {
     const [src, setSrc] = useState<string | null>(null);
+    const [raisedHands, setRaisedHands] = useState<string[]>([]);
     useEffect(() => {
         let active = true;
         let previous: string | null = null;
@@ -48,6 +49,36 @@ function ThumbnailTapestryView({
         const timer = setInterval(() => void load(), 2_000);
         return () => { active = false; clearInterval(timer); if (previous) URL.revokeObjectURL(previous); };
     }, [sessionId, staffOnly]);
+    useEffect(() => {
+        // Raised-hand names ride a separate, cookie-authorized sidecar on the
+        // public/room surface: the collective JPEG stays anonymous, and only
+        // people who chose to request the floor are named, only while
+        // connected. Staff tools (staffOnly) already have the operational
+        // manifest and keep their original fetch contract. The list is
+        // advisory — any rejection simply leaves it empty.
+        if (staffOnly) return;
+        let active = true;
+        const load = async () => {
+            try {
+                const response = await fetch(
+                    `/api/scheduled-sessions/${encodeURIComponent(sessionId)}/tapestry/hands`,
+                    { cache: 'no-store', credentials: 'same-origin' },
+                );
+                if (!response.ok) return;
+                const body = await response.json() as { hands?: Array<{ name?: unknown }> };
+                if (!active) return;
+                const names = Array.isArray(body.hands)
+                    ? body.hands
+                        .map((hand) => typeof hand.name === 'string' ? hand.name.trim() : '')
+                        .filter((name) => name.length > 0)
+                    : [];
+                setRaisedHands(names);
+            } catch { /* the hand list is advisory */ }
+        };
+        void load();
+        const timer = setInterval(() => void load(), 5_000);
+        return () => { active = false; clearInterval(timer); };
+    }, [sessionId, staffOnly]);
     return <section aria-label={labels.label} className="w-full">
         <h2 className="mb-2 text-sm font-medium text-[var(--cream)]">{labels.label}</h2>
         {src ? (
@@ -56,5 +87,10 @@ function ThumbnailTapestryView({
             // eslint-disable-next-line @next/next/no-img-element
             <img src={src} alt={labels.latestAlt} className="max-w-full rounded-lg border border-[var(--border-subtle)]" />
         ) : <p className="text-xs text-[var(--text-muted)]">{labels.waiting}</p>}
+        {raisedHands.length > 0 ? (
+            <p aria-live="polite" className="mt-2 text-xs text-[var(--gold)]">
+                {labels.raisedHands.replace('{names}', raisedHands.join(', '))}
+            </p>
+        ) : null}
     </section>;
 }

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -72,105 +72,167 @@ function parseHands(body: unknown): HandsSnapshot {
     return { hands, layout };
 }
 
+const POLL_MS = 2_000;
+/**
+ * Bounded correlation attempts per cycle (TAP-02 re-review): the composite
+ * and the hands sidecar are one correlated visual unit, so a mismatched pair
+ * is retried immediately, never more than this per cycle, never
+ * proportionally to the participant count.
+ */
+const MAX_CORRELATION_ATTEMPTS = 3;
+
+/**
+ * One accepted cycle: image, build revision and hands snapshot are only ever
+ * published together. The overlay check at render suppresses name tags on
+ * any pair whose layout revision disagrees with the image, while the
+ * accessible names line always reflects the freshest accepted hands — so
+ * lowering a hand or leaving retires the name with priority, and a tag can
+ * never sit on the wrong person's cell.
+ */
+type TapestryView = {
+    compositeUrl: string | null;
+    buildRevision: string | null;
+    hands: HandsSnapshot;
+};
+
 function ThumbnailTapestryView({
     sessionId,
     staffOnly,
     labels,
 }: Props & { labels: Messages['tapestry'] }) {
-    const [src, setSrc] = useState<string | null>(null);
-    const [compositeRevision, setCompositeRevision] = useState<string | null>(null);
-    const [snapshot, setSnapshot] = useState<HandsSnapshot>(EMPTY_HANDS);
+    const [view, setView] = useState<TapestryView | null>(null);
+
     useEffect(() => {
         let active = true;
         let generation = 0;
         let controller: AbortController | null = null;
-        let previous: string | null = null;
-        const load = async () => {
+        let previousUrl: string | null = null;
+        const compositeUrl = `/api/tapestry/${encodeURIComponent(sessionId)}`;
+        // Raised-hand names ride a cookie-authorized sidecar: the collective
+        // JPEG stays anonymous, and only people who chose to request the
+        // floor are named, only while connected. Staff tools (staffOnly)
+        // keep their original composite-only fetch contract.
+        const handsUrl = `/api/scheduled-sessions/${encodeURIComponent(sessionId)}/tapestry/hands`;
+
+        const fetchHands = async (signal: AbortSignal): Promise<HandsSnapshot> => {
+            const response = await fetch(handsUrl, {
+                cache: 'no-store', credentials: 'same-origin', signal,
+            });
+            // A rejection (expired/left session) retires names with priority;
+            // only a network-level failure keeps the previous snapshot.
+            if (!response.ok) return EMPTY_HANDS;
+            return parseHands(await response.json());
+        };
+
+        // ONE coordinator for the whole visual unit: composite first, hands
+        // immediately after, published only as one accepted cycle's result.
+        const cycle = async () => {
             if (!active) return;
-            // A newer poll supersedes a slower earlier one; a late response
-            // can never overwrite fresher state (TAP-02 review).
             const myGeneration = ++generation;
             controller?.abort();
             controller = new AbortController();
-            let next: string | null = null;
-            try {
-                const response = await fetch(`/api/tapestry/${encodeURIComponent(sessionId)}`, {
-                    cache: 'no-store',
-                    credentials: staffOnly ? 'same-origin' : 'omit',
-                    signal: controller.signal,
-                });
-                if (!response.ok) return;
-                const revision = response.headers.get('x-tapestry-revision');
-                next = URL.createObjectURL(await response.blob());
-                if (!active || myGeneration !== generation) {
-                    URL.revokeObjectURL(next);
+            const signal = controller.signal;
+
+            let correlated: { url: string; revision: string | null; hands: HandsSnapshot } | null = null;
+            let fallback: { url: string; revision: string | null; hands: HandsSnapshot } | null = null;
+
+            for (let attempt = 0; attempt < MAX_CORRELATION_ATTEMPTS; attempt += 1) {
+                if (!active || myGeneration !== generation) break;
+                let url: string | null = null;
+                try {
+                    const compositeRes = await fetch(compositeUrl, {
+                        cache: 'no-store',
+                        credentials: staffOnly ? 'same-origin' : 'omit',
+                        signal,
+                    });
+                    if (!compositeRes.ok) break; // keep previous image; hands still refresh below
+                    const revision = compositeRes.headers.get('x-tapestry-revision');
+                    const blob = await compositeRes.blob();
+                    if (!active || myGeneration !== generation) {
+                        // Superseded or unmounted mid-read: stop before
+                        // spending the sidecar fetch or creating any blob.
+                        return;
+                    }
+                    url = URL.createObjectURL(blob);
+                    const hands = staffOnly ? EMPTY_HANDS : await fetchHands(signal);
+                    const pair = { url, revision, hands };
+                    const layoutRevision = hands.layout?.revision ?? null;
+                    if (staffOnly || layoutRevision === null || String(layoutRevision) === revision) {
+                        correlated = pair;
+                        break;
+                    }
+                    if (fallback) URL.revokeObjectURL(fallback.url);
+                    fallback = pair;
+                } catch {
+                    // Aborted by a newer cycle or unmount, or a transient
+                    // failure: the tapestry is optional and the next tick retries.
+                    if (url) URL.revokeObjectURL(url);
                     return;
                 }
-                setSrc(next);
-                setCompositeRevision(revision);
-                if (previous) URL.revokeObjectURL(previous);
-                previous = next;
-            } catch {
-                // Aborted by a newer poll or unmount, or a transient failure:
-                // the tapestry is optional and the next tick retries.
-                if (next) URL.revokeObjectURL(next);
             }
+
+            if (!active || myGeneration !== generation) {
+                const stale = correlated ?? fallback;
+                if (stale) URL.revokeObjectURL(stale.url);
+                return;
+            }
+
+            const chosen = correlated ?? fallback;
+            if (!chosen) {
+                // Composite unavailable: keep the previous image, still
+                // refresh names so departures retire them.
+                if (staffOnly) return;
+                try {
+                    const hands = await fetchHands(signal);
+                    if (!active || myGeneration !== generation) return;
+                    setView((prev) => ({
+                        compositeUrl: prev?.compositeUrl ?? null,
+                        buildRevision: prev?.buildRevision ?? null,
+                        hands,
+                    }));
+                } catch { /* transient: next tick retries */ }
+                return;
+            }
+
+            setView((prev) => {
+                const next: TapestryView = {
+                    compositeUrl: chosen.url,
+                    buildRevision: chosen.revision,
+                    hands: chosen.hands,
+                };
+                if (prev?.compositeUrl && prev.compositeUrl !== next.compositeUrl) {
+                    URL.revokeObjectURL(prev.compositeUrl);
+                }
+                previousUrl = next.compositeUrl;
+                return next;
+            });
         };
-        void load();
-        const timer = setInterval(() => void load(), 2_000);
+
+        void cycle();
+        const timer = setInterval(() => void cycle(), POLL_MS);
         return () => {
             active = false;
             clearInterval(timer);
             controller?.abort();
-            if (previous) URL.revokeObjectURL(previous);
+            if (previousUrl) URL.revokeObjectURL(previousUrl);
         };
-    }, [sessionId, staffOnly]);
-    useEffect(() => {
-        // Raised-hand names ride a separate, cookie-authorized sidecar on the
-        // public/room surface: the collective JPEG stays anonymous, and only
-        // people who chose to request the floor are named, only while
-        // connected. Staff tools (staffOnly) already have the operational
-        // manifest and keep their original fetch contract. The list is
-        // advisory — any rejection simply leaves it empty.
-        if (staffOnly) return;
-        let active = true;
-        let generation = 0;
-        let controller: AbortController | null = null;
-        const load = async () => {
-            if (!active) return;
-            const myGeneration = ++generation;
-            controller?.abort();
-            controller = new AbortController();
-            try {
-                const response = await fetch(
-                    `/api/scheduled-sessions/${encodeURIComponent(sessionId)}/tapestry/hands`,
-                    { cache: 'no-store', credentials: 'same-origin', signal: controller.signal },
-                );
-                if (!response.ok) return;
-                const next = parseHands(await response.json());
-                if (!active || myGeneration !== generation) return;
-                setSnapshot(next);
-            } catch { /* the hand list is advisory */ }
-        };
-        void load();
-        const timer = setInterval(() => void load(), 5_000);
-        return () => { active = false; clearInterval(timer); controller?.abort(); };
     }, [sessionId, staffOnly]);
 
-    const names = snapshot.hands.map((hand) => hand.name);
+    const names = (view?.hands ?? EMPTY_HANDS).hands.map((hand) => hand.name);
     // Zoom/Meet-style name tags over each raised hand's own tile. The layout
     // and the composite must name the same build — otherwise the grid may
     // have shifted and a tag could land on the wrong person, so we omit the
     // overlay (the accessible names line below remains either way).
-    const layout = compositeRevision !== null &&
-        snapshot.layout !== null &&
-        String(snapshot.layout.revision) === compositeRevision
-        ? snapshot.layout
+    const layout = view !== null &&
+        view.buildRevision !== null &&
+        view.hands.layout !== null &&
+        String(view.hands.layout.revision) === view.buildRevision
+        ? view.hands.layout
         : null;
-    const overlayHands = layout
-        ? snapshot.hands.filter((hand) => hand.column !== null && hand.row !== null)
+    const overlayHands = layout && view
+        ? view.hands.hands.filter((hand) => hand.column !== null && hand.row !== null)
         : [];
-
+    const src = view?.compositeUrl ?? null;
     return <section aria-label={labels.label} className="w-full">
         <h2 className="mb-2 text-sm font-medium text-[var(--cream)]">{labels.label}</h2>
         {src ? (

--- a/src/components/session/__tests__/HandRaiseButton.test.tsx
+++ b/src/components/session/__tests__/HandRaiseButton.test.tsx
@@ -54,6 +54,15 @@ describe('HandRaiseButton', () => {
         vi.unstubAllGlobals();
     });
 
+    it('informs the naming-consent scope before the first raise', async () => {
+        const { fetchMock } = mockFetchSequence([state()]);
+        vi.stubGlobal('fetch', fetchMock);
+        render(<HandRaiseButton sessionId="event-1" />);
+
+        await waitFor(() => screen.getByRole('button', { name: /Raise hand/i }));
+        expect(screen.getByText(/While your hand is raised, your name appears/)).toBeInTheDocument();
+    });
+
     it('raises the hand with POST and reports the queue position', async () => {
         const { fetchMock, calls } = mockFetchSequence([
             state(),

--- a/src/components/session/__tests__/ThumbnailTapestry.test.tsx
+++ b/src/components/session/__tests__/ThumbnailTapestry.test.tsx
@@ -31,5 +31,48 @@ describe('ThumbnailTapestry', () => {
         expect(view.getByText('Esperando imágenes.')).toBeInTheDocument();
         await waitFor(() => expect(fetch).toHaveBeenCalled());
         expect(vi.mocked(fetch).mock.calls[0][1]?.credentials).toBe('same-origin');
+        // Staff tools keep their original fetch contract: no hand sidecar.
+        expect(vi.mocked(fetch).mock.calls.some(([input]) =>
+            String(input).includes('/tapestry/hands'),
+        )).toBe(false);
+    });
+
+    it('names raised hands from the authorized sidecar, never from the JPEG', async () => {
+        URL.createObjectURL = vi.fn(() => 'blob:tapestry');
+        URL.revokeObjectURL = vi.fn();
+        global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                return new Response(JSON.stringify({
+                    hands: [{ name: 'Ana' }, { name: 'Beto' }],
+                    liveStateAvailable: true,
+                }), { status: 200 });
+            }
+            return new Response(new Blob(['jpeg']), { status: 200 });
+        });
+
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        expect(await view.findByText('Raised hands: Ana, Beto')).toBeInTheDocument();
+        const handsCall = vi.mocked(fetch).mock.calls.find(([input]) =>
+            String(input).includes('/tapestry/hands'),
+        );
+        // The sidecar is cookie-authorized even on the public surface.
+        expect(handsCall?.[1]?.credentials).toBe('same-origin');
+    });
+
+    it('stays silent when the hand list is rejected or empty', async () => {
+        global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                return new Response(JSON.stringify({ error: 'Not authorized' }), { status: 403 });
+            }
+            return new Response(new Blob(['jpeg']), { status: 200 });
+        });
+
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalled());
+        expect(view.queryByText(/Raised hands:/)).not.toBeInTheDocument();
     });
 });

--- a/src/components/session/__tests__/ThumbnailTapestry.test.tsx
+++ b/src/components/session/__tests__/ThumbnailTapestry.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render as rtlRender, waitFor } from '@testing-library/react';
+import { act, cleanup, render as rtlRender, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -128,5 +128,72 @@ describe('ThumbnailTapestry', () => {
 
         await waitFor(() => expect(fetch).toHaveBeenCalled());
         expect(view.queryByText(/Raised hands:/)).not.toBeInTheDocument();
+    });
+
+    it('never lets a slower earlier composite poll overwrite a newer one', async () => {
+        vi.useFakeTimers();
+        let counter = 0;
+        URL.createObjectURL = vi.fn(() => `blob:frame-${++counter}`);
+        URL.revokeObjectURL = vi.fn();
+        const deferred: Array<{ url: string; resolve: (r: Response) => void }> = [];
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                return Promise.resolve(new Response(JSON.stringify({ hands: [] }), { status: 200 }));
+            }
+            return new Promise<Response>((resolve) => deferred.push({ url, resolve }));
+        });
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        // Poll A starts; poll B starts after the interval while A is pending.
+        await act(async () => { await vi.advanceTimersByTimeAsync(2_000); });
+        expect(deferred).toHaveLength(2);
+
+        // B resolves first and wins.
+        await act(async () => {
+            deferred[1].resolve(new Response(new Blob(['jpeg-b']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': '9' },
+            }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-1');
+
+        // A resolves late: ignored, its blob revoked, image stays B's.
+        await act(async () => {
+            deferred[0].resolve(new Response(new Blob(['jpeg-a']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': '7' },
+            }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-1');
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-2');
+        vi.useRealTimers();
+    });
+
+    it('aborts and leaks nothing when unmounted with a poll in flight', async () => {
+        URL.createObjectURL = vi.fn(() => 'blob:frame-x');
+        URL.revokeObjectURL = vi.fn();
+        const deferred: Array<(r: Response) => void> = [];
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                return Promise.resolve(new Response(JSON.stringify({ hands: [] }), { status: 200 }));
+            }
+            return new Promise<Response>((resolve) => deferred.push(resolve));
+        });
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        view.unmount();
+        await act(async () => {
+            deferred[0](new Response(new Blob(['jpeg']), { status: 200 }));
+            await Promise.resolve();
+        });
+
+        // The late blob was created by the in-flight request but must be
+        // revoked immediately, never displayed.
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-x');
+        expect(view.container.querySelector('img')).toBeNull();
     });
 });

--- a/src/components/session/__tests__/ThumbnailTapestry.test.tsx
+++ b/src/components/session/__tests__/ThumbnailTapestry.test.tsx
@@ -290,4 +290,181 @@ describe('ThumbnailTapestry', () => {
         expect(view.container.querySelector('[aria-hidden="true"]')).not.toBeNull();
         vi.useRealTimers();
     });
+
+    it('mismatch→match: revokes the fallback URL exactly once and keeps the chosen one until unmount', async () => {
+        let counter = 0;
+        URL.createObjectURL = vi.fn(() => `blob:frame-${++counter}`);
+        URL.revokeObjectURL = vi.fn();
+        let handsCalls = 0;
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                handsCalls += 1;
+                // Attempt 1: layout at R=7 vs composite R=8 (fallback A).
+                // Attempt 2: R=8 (correlated B).
+                return Promise.resolve(new Response(JSON.stringify({
+                    hands: [{ name: 'Ana', column: 1, row: 0 }],
+                    liveStateAvailable: true,
+                    layout: { revision: handsCalls === 1 ? 7 : 8, columns: 2, rows: 1, tileSizePx: 100 },
+                }), { status: 200 }));
+            }
+            return Promise.resolve(new Response(new Blob(['jpeg']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': '8' },
+            }));
+        });
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        await waitFor(() => expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-2'));
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-1');
+        expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:frame-2');
+
+        view.unmount();
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-2');
+    });
+
+    it('mismatch→error: revokes the failed attempt and the published fallback at unmount — no orphan blobs', async () => {
+        let counter = 0;
+        URL.createObjectURL = vi.fn(() => `blob:frame-${++counter}`);
+        URL.revokeObjectURL = vi.fn();
+        let handsCalls = 0;
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                handsCalls += 1;
+                if (handsCalls === 2) return Promise.reject(new Error('network down'));
+                return Promise.resolve(new Response(JSON.stringify({
+                    hands: [{ name: 'Ana', column: 1, row: 0 }],
+                    liveStateAvailable: true,
+                    layout: { revision: 7, columns: 2, rows: 1, tileSizePx: 100 },
+                }), { status: 200 }));
+            }
+            return Promise.resolve(new Response(new Blob(['jpeg']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': '8' },
+            }));
+        });
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        await waitFor(() => expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-1'));
+        // Attempt 2's blob failed before becoming a candidate: revoked.
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-2');
+        // Fallback published: names line truthful, tag hidden (7 ≠ 8).
+        expect(view.getByText('Raised hands: Ana')).toBeInTheDocument();
+        expect(view.container.querySelector('[aria-hidden="true"]')).toBeNull();
+
+        view.unmount();
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-1');
+    });
+
+    it('session A→B with identical revisions shows only B and revokes A', async () => {
+        let counter = 0;
+        URL.createObjectURL = vi.fn(() => `blob:frame-${++counter}`);
+        URL.revokeObjectURL = vi.fn();
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                // Both sessions report the SAME layout revision; only the
+                // session scopes the names.
+                const name = url.includes('session-2') ? 'Caro' : 'Ana';
+                return Promise.resolve(new Response(JSON.stringify({
+                    hands: [{ name, column: 1, row: 0 }],
+                    liveStateAvailable: true,
+                    layout: { revision: 7, columns: 2, rows: 1, tileSizePx: 100 },
+                }), { status: 200 }));
+            }
+            return Promise.resolve(new Response(new Blob(['jpeg']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': '7' },
+            }));
+        });
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+        expect(await view.findByText('Raised hands: Ana')).toBeInTheDocument();
+        expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-1');
+
+        view.rerender(<ThumbnailTapestry sessionId="session-2" />);
+        // Immediate reset: A's image, names and tags are gone before B's
+        // first fetch resolves.
+        expect(view.queryByText(/Raised hands:/)).not.toBeInTheDocument();
+        expect(view.container.querySelector('img')).toBeNull();
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-1');
+
+        // B answers: only B's data shows, with its own URL.
+        expect(await view.findByText('Raised hands: Caro')).toBeInTheDocument();
+        expect(view.queryByText(/Ana/)).not.toBeInTheDocument();
+        expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-2');
+    });
+
+    it('session A→B with identical revisions and B failing never resurrects A', async () => {
+        vi.useFakeTimers();
+        let counter = 0;
+        URL.createObjectURL = vi.fn(() => `blob:frame-${++counter}`);
+        URL.revokeObjectURL = vi.fn();
+        const deferred: Array<{ url: string; resolve: (r: Response) => void; reject: (e: Error) => void }> = [];
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            return new Promise<Response>((resolve, reject) => deferred.push({ url, resolve, reject }));
+        });
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        // A's first cycle completes: Ana named, image blob:frame-1.
+        expect(deferred).toHaveLength(1); // A composite
+        await act(async () => {
+            deferred[0].resolve(new Response(new Blob(['jpeg']), {
+                status: 200, headers: { 'x-tapestry-revision': '7' },
+            }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(deferred).toHaveLength(2); // A hands
+        await act(async () => {
+            deferred[1].resolve(new Response(JSON.stringify({
+                hands: [{ name: 'Ana', column: 1, row: 0 }],
+                liveStateAvailable: true,
+                layout: { revision: 7, columns: 2, rows: 1, tileSizePx: 100 },
+            }), { status: 200 }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(view.getByText('Raised hands: Ana')).toBeInTheDocument();
+
+        // A's next cycle starts (composite in flight) when the switch happens.
+        await act(async () => { await vi.advanceTimersByTimeAsync(2_000); });
+        expect(deferred).toHaveLength(3);
+        view.rerender(<ThumbnailTapestry sessionId="session-2" />);
+        // Immediate reset: no A data, A's published URL revoked.
+        expect(view.queryByText(/Raised hands:/)).not.toBeInTheDocument();
+        expect(view.container.querySelector('img')).toBeNull();
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-1');
+
+        // A's late response lands after the switch: ignored before creating
+        // any blob.
+        await act(async () => {
+            deferred[2].resolve(new Response(new Blob(['jpeg-a-late']), {
+                status: 200, headers: { 'x-tapestry-revision': '7' },
+            }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+        expect(view.queryByText(/Raised hands:/)).not.toBeInTheDocument();
+
+        // B fails on both reads: B's waiting state, never A's data.
+        expect(deferred).toHaveLength(4); // B composite
+        await act(async () => {
+            deferred[3].resolve(new Response('down', { status: 503 }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(deferred).toHaveLength(5); // B hands (name-retirement path)
+        await act(async () => {
+            deferred[4].resolve(new Response('down', { status: 503 }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(view.container.querySelector('img')).toBeNull();
+        expect(view.queryByText(/Raised hands:/)).not.toBeInTheDocument();
+        expect(view.queryByText(/Ana/)).not.toBeInTheDocument();
+        vi.useRealTimers();
+    });
 });

--- a/src/components/session/__tests__/ThumbnailTapestry.test.tsx
+++ b/src/components/session/__tests__/ThumbnailTapestry.test.tsx
@@ -44,8 +44,9 @@ describe('ThumbnailTapestry', () => {
             const url = String(input);
             if (url.includes('/tapestry/hands')) {
                 return new Response(JSON.stringify({
-                    hands: [{ name: 'Ana' }, { name: 'Beto' }],
+                    hands: [{ name: 'Ana', column: null, row: null }, { name: 'Beto', column: null, row: null }],
                     liveStateAvailable: true,
+                    layout: null,
                 }), { status: 200 });
             }
             return new Response(new Blob(['jpeg']), { status: 200 });
@@ -59,6 +60,59 @@ describe('ThumbnailTapestry', () => {
         );
         // The sidecar is cookie-authorized even on the public surface.
         expect(handsCall?.[1]?.credentials).toBe('same-origin');
+    });
+
+    it('draws each name over its own tile when composite and layout revisions match', async () => {
+        URL.createObjectURL = vi.fn(() => 'blob:tapestry');
+        URL.revokeObjectURL = vi.fn();
+        global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                return new Response(JSON.stringify({
+                    hands: [{ name: 'Ana', column: 1, row: 0 }],
+                    liveStateAvailable: true,
+                    layout: { revision: 7, columns: 2, rows: 1, tileSizePx: 100 },
+                }), { status: 200 });
+            }
+            return new Response(new Blob(['jpeg']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': '7' },
+            });
+        });
+
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        const tag = await view.findByText('Ana', { selector: 'span' });
+        expect(tag).toHaveStyle({ left: '50%', top: '100%' });
+        // The visual overlay never double-announces: the names line carries
+        // the accessible form.
+        expect(tag.closest('[aria-hidden="true"]')).not.toBeNull();
+    });
+
+    it('omits the overlay when the revisions disagree rather than misplacing a name', async () => {
+        URL.createObjectURL = vi.fn(() => 'blob:tapestry');
+        URL.revokeObjectURL = vi.fn();
+        global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                return new Response(JSON.stringify({
+                    hands: [{ name: 'Ana', column: 1, row: 0 }],
+                    liveStateAvailable: true,
+                    layout: { revision: 8, columns: 2, rows: 1, tileSizePx: 100 },
+                }), { status: 200 });
+            }
+            return new Response(new Blob(['jpeg']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': '7' },
+            });
+        });
+
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        // The accessible line still names the hand…
+        expect(await view.findByText('Raised hands: Ana')).toBeInTheDocument();
+        // …but no tag is drawn over a possibly-shifted grid.
+        expect(view.container.querySelector('[aria-hidden="true"]')).toBeNull();
     });
 
     it('stays silent when the hand list is rejected or empty', async () => {

--- a/src/components/session/__tests__/ThumbnailTapestry.test.tsx
+++ b/src/components/session/__tests__/ThumbnailTapestry.test.tsx
@@ -159,7 +159,8 @@ describe('ThumbnailTapestry', () => {
         });
         expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-1');
 
-        // A resolves late: ignored, its blob revoked, image stays B's.
+        // A resolves late: its generation is stale, so it stops right after
+        // the composite read — no blob is ever created for it, image stays B's.
         await act(async () => {
             deferred[0].resolve(new Response(new Blob(['jpeg-a']), {
                 status: 200,
@@ -168,7 +169,7 @@ describe('ThumbnailTapestry', () => {
             await vi.advanceTimersByTimeAsync(0);
         });
         expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-1');
-        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-2');
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
         vi.useRealTimers();
     });
 
@@ -191,9 +192,102 @@ describe('ThumbnailTapestry', () => {
             await Promise.resolve();
         });
 
-        // The late blob was created by the in-flight request but must be
-        // revoked immediately, never displayed.
-        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-x');
+        // The late response stops before creating any blob: nothing to
+        // leak, nothing displayed.
+        expect(URL.createObjectURL).not.toHaveBeenCalled();
         expect(view.container.querySelector('img')).toBeNull();
+    });
+
+    it('reconverges R→R+1 within one cycle and keeps the tag over the right tile', async () => {
+        vi.useFakeTimers();
+        let counter = 0;
+        URL.createObjectURL = vi.fn(() => `blob:frame-${++counter}`);
+        URL.revokeObjectURL = vi.fn();
+        let compositeCalls = 0;
+        let handsCalls = 0;
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                handsCalls += 1;
+                // Cycle 2, attempt 1: layout read still at R=7 while the
+                // composite already built R+1=8. Attempt 2 sees R=8.
+                const layoutRevision = handsCalls >= 3 ? 8 : 7;
+                return Promise.resolve(new Response(JSON.stringify({
+                    hands: [{ name: 'Ana', column: 1, row: 0 }],
+                    liveStateAvailable: true,
+                    layout: { revision: layoutRevision, columns: 2, rows: 1, tileSizePx: 100 },
+                }), { status: 200 }));
+            }
+            compositeCalls += 1;
+            return Promise.resolve(new Response(new Blob(['jpeg']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': compositeCalls === 1 ? '7' : '8' },
+            }));
+        });
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        // Cycle 1: correlated at R=7 — the tag draws over Ana's cell.
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+        expect(view.container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+
+        // Cycle 2: first pair mismatches (8 vs 7); the bounded retry aligns
+        // 8 with 8 and the tag survives the build advance, on the same cell.
+        await act(async () => { await vi.advanceTimersByTimeAsync(2_000); });
+        expect(handsCalls).toBe(3);
+        const tag = view.container.querySelector('[aria-hidden="true"] span.absolute');
+        expect(tag).toHaveTextContent('Ana');
+        expect(tag).toHaveStyle({ left: '50%' });
+        vi.useRealTimers();
+    });
+
+    it('stays bounded under continuous mismatch, retires names with priority, and reconverges', async () => {
+        vi.useFakeTimers();
+        let counter = 0;
+        URL.createObjectURL = vi.fn(() => `blob:frame-${++counter}`);
+        URL.revokeObjectURL = vi.fn();
+        let aligned = false;
+        let handRaised = true;
+        global.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes('/tapestry/hands')) {
+                return Promise.resolve(new Response(JSON.stringify({
+                    hands: handRaised ? [{ name: 'Ana', column: 1, row: 0 }] : [],
+                    liveStateAvailable: true,
+                    layout: { revision: aligned ? 9 : 7, columns: 2, rows: 1, tileSizePx: 100 },
+                }), { status: 200 }));
+            }
+            return Promise.resolve(new Response(new Blob(['jpeg']), {
+                status: 200,
+                headers: { 'x-tapestry-revision': '9' },
+            }));
+        });
+        const view = render(<ThumbnailTapestry sessionId="session-1" />);
+
+        // Permanent mismatch: exactly MAX attempts per cycle, no tag over a
+        // possibly-shifted grid — but the accessible line still names Ana.
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+        expect(fetch).toHaveBeenCalledTimes(6); // 3 attempts × 2 reads
+        expect(view.container.querySelector('[aria-hidden="true"]')).toBeNull();
+        expect(view.getByText('Raised hands: Ana')).toBeInTheDocument();
+
+        // Next cycle: same bounded cost, no storm.
+        await act(async () => { await vi.advanceTimersByTimeAsync(2_000); });
+        expect(fetch).toHaveBeenCalledTimes(12);
+
+        // Ana lowers her hand mid-mismatch: the name retires immediately,
+        // without waiting for any correlation.
+        handRaised = false;
+        await act(async () => { await vi.advanceTimersByTimeAsync(2_000); });
+        expect(view.queryByText(/Raised hands:/)).not.toBeInTheDocument();
+        expect(fetch).toHaveBeenCalledTimes(18);
+
+        // Correlation returns: the component reconverges (tag container is
+        // drawable again once a hand exists).
+        aligned = true;
+        handRaised = true;
+        await act(async () => { await vi.advanceTimersByTimeAsync(2_000); });
+        expect(fetch).toHaveBeenCalledTimes(20); // back to 2 reads per cycle
+        expect(view.container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+        vi.useRealTimers();
     });
 });

--- a/src/lib/__tests__/tapestry-layout.test.ts
+++ b/src/lib/__tests__/tapestry-layout.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_COMPOSITE_CELLS, parseCompositeLayout } from '../tapestry-layout';
+
+function validLayout(overrides: Record<string, unknown> = {}) {
+    return {
+        revision: 7,
+        columns: 2,
+        rows: 1,
+        tileSizePx: 100,
+        frameTtlMs: 10_000,
+        cells: [
+            { id: 'tp-ana', column: 0, row: 0 },
+            { id: 'tp-beto', column: 1, row: 0 },
+        ],
+        ...overrides,
+    };
+}
+
+describe('parseCompositeLayout', () => {
+    it('accepts a well-formed layout', () => {
+        expect(parseCompositeLayout(validLayout())).toEqual({
+            revision: 7,
+            columns: 2,
+            rows: 1,
+            tileSizePx: 100,
+            frameTtlMs: 10_000,
+            cells: [
+                { id: 'tp-ana', column: 0, row: 0 },
+                { id: 'tp-beto', column: 1, row: 0 },
+            ],
+        });
+    });
+
+    it('rejects duplicate tile ids rather than picking one', () => {
+        const body = validLayout({
+            cells: [
+                { id: 'tp-ana', column: 0, row: 0 },
+                { id: 'tp-ana', column: 1, row: 0 },
+            ],
+        });
+        expect(parseCompositeLayout(body)).toBeNull();
+    });
+
+    it('rejects more cells than the 150-participant cap', () => {
+        const cells = Array.from({ length: MAX_COMPOSITE_CELLS + 1 }, (_, i) => ({
+            id: `tp-${i}`,
+            column: 0,
+            row: 0,
+        }));
+        expect(parseCompositeLayout(validLayout({ columns: 1, rows: 1, cells }))).toBeNull();
+    });
+
+    it('accepts exactly 150 cells', () => {
+        const cells = Array.from({ length: MAX_COMPOSITE_CELLS }, (_, i) => ({
+            id: `tp-${i}`,
+            column: i % 15,
+            row: Math.floor(i / 15),
+        }));
+        const parsed = parseCompositeLayout(validLayout({ columns: 15, rows: 10, cells }));
+        expect(parsed?.cells).toHaveLength(150);
+    });
+
+    it.each([
+        ['an invalid tile id shape', { cells: [{ id: 'bad id!', column: 0, row: 0 }] }],
+        ['a cell beyond the grid', { cells: [{ id: 'tp-a', column: 5, row: 0 }] }],
+        ['a negative revision', { revision: -1 }],
+        ['zero columns', { columns: 0 }],
+        ['a missing cells array', { cells: undefined }],
+        ['a non-integer column', { cells: [{ id: 'tp-a', column: 0.5, row: 0 }] }],
+        ['null', null],
+        ['a string', 'not-a-layout'],
+    ])('fails safe on %s', (_label, override) => {
+        const body = override === null || typeof override !== 'object' || Array.isArray(override)
+            ? override
+            : validLayout(override);
+        expect(parseCompositeLayout(body)).toBeNull();
+    });
+
+    it('degrades freshness when the service predates frameTtlMs', () => {
+        const parsed = parseCompositeLayout(validLayout({ frameTtlMs: undefined }));
+        expect(parsed?.frameTtlMs).toBeNull();
+    });
+});

--- a/src/lib/__tests__/tapestry-manifest.test.ts
+++ b/src/lib/__tests__/tapestry-manifest.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildTapestryManifest,
+    MAX_TAPESTRY_MANIFEST_ENTRIES,
+    type ManifestLiveParticipant,
+    type ManifestParticipant,
+} from '../tapestry-manifest';
+
+const NOW = new Date('2026-08-04T12:00:00Z');
+const EARLIER = new Date('2026-08-04T11:59:00Z');
+
+function participant(overrides: Partial<ManifestParticipant> = {}): ManifestParticipant {
+    return {
+        identity: 'lk-a',
+        leftAt: null,
+        raisedAt: null,
+        publishGrantedAt: null,
+        publishRevokedAt: null,
+        staffName: null,
+        ...overrides,
+    };
+}
+
+function live(overrides: Partial<ManifestLiveParticipant> = {}): ManifestLiveParticipant {
+    return { name: 'Ana', media: [], ...overrides };
+}
+
+function buildInput(overrides: Record<string, unknown> = {}) {
+    return {
+        sessionId: 'session-1',
+        tileIds: ['tp-a', 'tp-b'],
+        frameTtlMs: 10_000,
+        liveStateAvailable: true,
+        participants: [participant()],
+        live: new Map<string, ManifestLiveParticipant>(),
+        tapestryIdFor: (identity: string) => `tp-${identity.replace('lk-', '')}`,
+        thumbnailUrlFor: (tileId: string) => `/tiles/${tileId}`,
+        ...overrides,
+    };
+}
+
+describe('buildTapestryManifest', () => {
+    it('maps tiles in display order with names and defaults', () => {
+        const manifest = buildTapestryManifest(buildInput({
+            live: new Map([['lk-a', live()]]),
+        }));
+        expect(manifest.entries).toHaveLength(2);
+        expect(manifest.entries[0]).toMatchObject({
+            tileId: 'tp-a',
+            position: 0,
+            displayName: 'Ana',
+            handRaised: false,
+            queuePosition: null,
+            presence: 'connected',
+            camera: 'off',
+            thumbnailUrl: '/tiles/tp-a',
+        });
+        // A tile without a database row gets the dignified generic entry.
+        expect(manifest.entries[1]).toMatchObject({
+            tileId: 'tp-b',
+            position: 1,
+            displayName: 'Attendee',
+            presence: 'reconnecting',
+            camera: 'unknown',
+        });
+    });
+
+    it('marks waiting hands with stable queue positions on tile and summary', () => {
+        const manifest = buildTapestryManifest(buildInput({
+            participants: [
+                participant({ identity: 'lk-b', raisedAt: NOW }),
+                participant({ identity: 'lk-a', raisedAt: EARLIER }),
+            ],
+        }));
+        expect(manifest.entries[0]).toMatchObject({ tileId: 'tp-a', handRaised: true, queuePosition: 1 });
+        expect(manifest.entries[1]).toMatchObject({ tileId: 'tp-b', handRaised: true, queuePosition: 2 });
+        expect(manifest.waitingHands.map((hand) => hand.queuePosition)).toEqual([1, 2]);
+        expect(manifest.waitingHands[0].tileId).toBe('tp-a');
+    });
+
+    it('lists a waiting hand without a tile in the summary only', () => {
+        const manifest = buildTapestryManifest(buildInput({
+            participants: [participant({ identity: 'lk-z', raisedAt: NOW })],
+        }));
+        expect(manifest.entries.every((entry) => !entry.handRaised)).toBe(true);
+        expect(manifest.waitingHands).toEqual([
+            { displayName: 'Attendee', queuePosition: 1, tileId: null },
+        ]);
+    });
+
+    it('excludes publishers from the waiting queue', () => {
+        const manifest = buildTapestryManifest(buildInput({
+            participants: [participant({
+                raisedAt: EARLIER,
+                publishGrantedAt: NOW,
+            })],
+        }));
+        expect(manifest.entries[0].handRaised).toBe(false);
+        expect(manifest.waitingHands).toEqual([]);
+    });
+
+    it('derives presence: left, unknown, reconnecting, connected', () => {
+        const base = buildInput({
+            tileIds: ['tp-a', 'tp-b', 'tp-c', 'tp-d'],
+            participants: [
+                participant({ identity: 'lk-a', leftAt: NOW }),
+                participant({ identity: 'lk-b' }),
+                participant({ identity: 'lk-c' }),
+                participant({ identity: 'lk-d' }),
+            ],
+            live: new Map([['lk-d', live()]]),
+        });
+        const connected = buildTapestryManifest(base);
+        expect(connected.entries.map((entry) => entry.presence)).toEqual([
+            'left', 'reconnecting', 'reconnecting', 'connected',
+        ]);
+        const outage = buildTapestryManifest({ ...base, liveStateAvailable: false });
+        expect(outage.entries.map((entry) => entry.presence)).toEqual([
+            'left', 'unknown', 'unknown', 'unknown',
+        ]);
+    });
+
+    it('derives camera state from published tracks', () => {
+        const manifest = buildTapestryManifest(buildInput({
+            participants: [
+                participant({ identity: 'lk-a' }),
+                participant({ identity: 'lk-b' }),
+            ],
+            live: new Map([
+                ['lk-a', live({ media: [{ source: 'CAMERA', muted: false }] })],
+                ['lk-b', live({ media: [{ source: 'CAMERA', muted: true }] })],
+            ]),
+        }));
+        expect(manifest.entries[0].camera).toBe('on');
+        expect(manifest.entries[1].camera).toBe('off');
+    });
+
+    it('uses the staff account name when the participant is staff', () => {
+        const manifest = buildTapestryManifest(buildInput({
+            participants: [participant({ staffName: 'Julián' })],
+            live: new Map([['lk-a', live()]]),
+        }));
+        expect(manifest.entries[0].displayName).toBe('Julián');
+    });
+
+    it('bounds entries to the manifest cap', () => {
+        const tileIds = Array.from(
+            { length: MAX_TAPESTRY_MANIFEST_ENTRIES + 10 },
+            (_, index) => `tp-${index}`,
+        );
+        const manifest = buildTapestryManifest(buildInput({ tileIds, participants: [] }));
+        expect(manifest.entries).toHaveLength(MAX_TAPESTRY_MANIFEST_ENTRIES);
+    });
+
+    it('changes revision when state changes and keeps it when identical', () => {
+        const input = buildInput({ participants: [participant()] });
+        const first = buildTapestryManifest(input);
+        const same = buildTapestryManifest(input);
+        expect(first.revision).toBe(same.revision);
+        const raised = buildTapestryManifest({
+            ...input,
+            participants: [participant({ raisedAt: NOW })],
+        });
+        expect(raised.revision).not.toBe(first.revision);
+        const reordered = buildTapestryManifest({
+            ...input,
+            tileIds: ['tp-b', 'tp-a'],
+        });
+        expect(reordered.revision).not.toBe(first.revision);
+    });
+
+    it('skips participants whose identity cannot be mapped to a tile id', () => {
+        const manifest = buildTapestryManifest(buildInput({
+            tapestryIdFor: () => null,
+        }));
+        expect(manifest.entries[0]).toMatchObject({
+            tileId: 'tp-a',
+            displayName: 'Attendee',
+            presence: 'reconnecting',
+        });
+    });
+
+    it('rounds the freshness TTL up to whole seconds', () => {
+        const manifest = buildTapestryManifest(buildInput({ frameTtlMs: 10_500 }));
+        expect(manifest.thumbnailFreshForSeconds).toBe(11);
+    });
+});

--- a/src/lib/__tests__/tapestry-manifest.test.ts
+++ b/src/lib/__tests__/tapestry-manifest.test.ts
@@ -1,18 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
+import type { CompositeLayout } from '../tapestry-layout';
 import {
     buildTapestryManifest,
-    MAX_TAPESTRY_MANIFEST_ENTRIES,
     type ManifestLiveParticipant,
     type ManifestParticipant,
 } from '../tapestry-manifest';
 
-const NOW = new Date('2026-08-04T12:00:00Z');
-const EARLIER = new Date('2026-08-04T11:59:00Z');
+const SESSION_ID = 'session-1';
 
 function participant(overrides: Partial<ManifestParticipant> = {}): ManifestParticipant {
     return {
-        identity: 'lk-a',
+        identity: 'lk-ana',
         leftAt: null,
         raisedAt: null,
         publishGrantedAt: null,
@@ -22,167 +21,195 @@ function participant(overrides: Partial<ManifestParticipant> = {}): ManifestPart
     };
 }
 
-function live(overrides: Partial<ManifestLiveParticipant> = {}): ManifestLiveParticipant {
-    return { name: 'Ana', media: [], ...overrides };
-}
-
-function buildInput(overrides: Record<string, unknown> = {}) {
+function layout(cells: Array<{ id: string; column: number; row: number }>, overrides: Partial<CompositeLayout> = {}): CompositeLayout {
     return {
-        sessionId: 'session-1',
-        tileIds: ['tp-a', 'tp-b'],
+        revision: 7,
+        columns: 2,
+        rows: 1,
+        tileSizePx: 100,
         frameTtlMs: 10_000,
-        liveStateAvailable: true,
-        participants: [participant()],
-        live: new Map<string, ManifestLiveParticipant>(),
-        tapestryIdFor: (identity: string) => `tp-${identity.replace('lk-', '')}`,
-        thumbnailUrlFor: (tileId: string) => `/tiles/${tileId}`,
+        cells,
         ...overrides,
     };
 }
 
+function live(name: string, media: ManifestLiveParticipant['media'] = []): ManifestLiveParticipant {
+    return { name, media };
+}
+
+function build(overrides: Partial<Parameters<typeof buildTapestryManifest>[0]> = {}) {
+    return buildTapestryManifest({
+        sessionId: SESSION_ID,
+        layout: layout([{ id: 'tp-lk-ana', column: 0, row: 0 }]),
+        liveStateAvailable: true,
+        participants: [participant()],
+        live: new Map([['lk-ana', live('Ana', [{ source: 'CAMERA', muted: false }])]]),
+        tapestryIdFor: (identity: string) => `tp-${identity}`,
+        ...overrides,
+    });
+}
+
 describe('buildTapestryManifest', () => {
-    it('maps tiles in display order with names and defaults', () => {
-        const manifest = buildTapestryManifest(buildInput({
-            live: new Map([['lk-a', live()]]),
-        }));
-        expect(manifest.entries).toHaveLength(2);
-        expect(manifest.entries[0]).toMatchObject({
-            tileId: 'tp-a',
-            position: 0,
-            displayName: 'Ana',
-            handRaised: false,
-            queuePosition: null,
-            presence: 'connected',
-            camera: 'off',
-            thumbnailUrl: '/tiles/tp-a',
+    it('maps a tiled participant to name, cell, presence and camera', () => {
+        const manifest = build();
+        expect(manifest.entries).toEqual([
+            {
+                tileId: 'tp-lk-ana',
+                displayName: 'Ana',
+                handRaised: false,
+                queuePosition: null,
+                presence: 'connected',
+                camera: 'on',
+                column: 0,
+                row: 0,
+            },
+        ]);
+        expect(manifest.layout).toEqual({ revision: 7, columns: 2, rows: 1, tileSizePx: 100 });
+        expect(manifest.tileFreshForSeconds).toBe(10);
+        expect(manifest.waitingHands).toEqual([]);
+    });
+
+    it('marks a waiting hand with its queue position', () => {
+        const manifest = build({
+            participants: [participant({ raisedAt: new Date('2026-08-04T12:00:00Z') })],
         });
-        // A tile without a database row gets the dignified generic entry.
-        expect(manifest.entries[1]).toMatchObject({
-            tileId: 'tp-b',
-            position: 1,
+        expect(manifest.entries[0]).toMatchObject({ handRaised: true, queuePosition: 1 });
+        expect(manifest.waitingHands).toEqual([
+            { displayName: 'Ana', queuePosition: 1, tileId: 'tp-lk-ana' },
+        ]);
+    });
+
+    it('does not treat an on-stage publisher as a waiting hand', () => {
+        const manifest = build({
+            participants: [participant({
+                raisedAt: new Date('2026-08-04T12:00:00Z'),
+                publishGrantedAt: new Date('2026-08-04T12:01:00Z'),
+            })],
+        });
+        expect(manifest.entries[0]).toMatchObject({ handRaised: false, queuePosition: null });
+        expect(manifest.waitingHands).toEqual([]);
+    });
+
+    it('counts a re-raiser after a revoked grant as waiting again', () => {
+        const manifest = build({
+            participants: [participant({
+                raisedAt: new Date('2026-08-04T12:05:00Z'),
+                publishGrantedAt: new Date('2026-08-04T12:01:00Z'),
+                publishRevokedAt: new Date('2026-08-04T12:03:00Z'),
+            })],
+        });
+        expect(manifest.entries[0]).toMatchObject({ handRaised: true, queuePosition: 1 });
+    });
+
+    it('prefers the staff account name over the LiveKit name', () => {
+        const manifest = build({
+            participants: [participant({ staffName: 'Julián' })],
+        });
+        expect(manifest.entries[0].displayName).toBe('Julián');
+    });
+
+    it('reports presence states truthfully', () => {
+        const left = build({
+            participants: [participant({ leftAt: new Date() })],
+            live: new Map(),
+        });
+        expect(left.entries[0].presence).toBe('left');
+
+        const reconnecting = build({ live: new Map() });
+        expect(reconnecting.entries[0].presence).toBe('reconnecting');
+
+        const unknown = build({ liveStateAvailable: false });
+        expect(unknown.entries[0].presence).toBe('unknown');
+        expect(unknown.liveStateAvailable).toBe(false);
+    });
+
+    it('reports camera states truthfully', () => {
+        expect(build().entries[0].camera).toBe('on');
+        expect(build({
+            live: new Map([['lk-ana', live('Ana', [{ source: 'CAMERA', muted: true }])]]),
+        }).entries[0].camera).toBe('off');
+        expect(build({
+            live: new Map([['lk-ana', live('Ana')]]),
+        }).entries[0].camera).toBe('off');
+        expect(build({ live: new Map() }).entries[0].camera).toBe('unknown');
+    });
+
+    it('keeps a tile without a database row dignified and anonymous', () => {
+        const manifest = build({
+            layout: layout([{ id: 'tp-stranger', column: 0, row: 0 }]),
+            participants: [],
+            live: new Map(),
+        });
+        expect(manifest.entries[0]).toMatchObject({
+            tileId: 'tp-stranger',
             displayName: 'Attendee',
+            handRaised: false,
             presence: 'reconnecting',
             camera: 'unknown',
         });
     });
 
-    it('marks waiting hands with stable queue positions on tile and summary', () => {
-        const manifest = buildTapestryManifest(buildInput({
+    it('lists waiting hands without a tile separately, with tileId null', () => {
+        const manifest = build({
             participants: [
-                participant({ identity: 'lk-b', raisedAt: NOW }),
-                participant({ identity: 'lk-a', raisedAt: EARLIER }),
-            ],
-        }));
-        expect(manifest.entries[0]).toMatchObject({ tileId: 'tp-a', handRaised: true, queuePosition: 1 });
-        expect(manifest.entries[1]).toMatchObject({ tileId: 'tp-b', handRaised: true, queuePosition: 2 });
-        expect(manifest.waitingHands.map((hand) => hand.queuePosition)).toEqual([1, 2]);
-        expect(manifest.waitingHands[0].tileId).toBe('tp-a');
-    });
-
-    it('lists a waiting hand without a tile in the summary only', () => {
-        const manifest = buildTapestryManifest(buildInput({
-            participants: [participant({ identity: 'lk-z', raisedAt: NOW })],
-        }));
-        expect(manifest.entries.every((entry) => !entry.handRaised)).toBe(true);
-        expect(manifest.waitingHands).toEqual([
-            { displayName: 'Attendee', queuePosition: 1, tileId: null },
-        ]);
-    });
-
-    it('excludes publishers from the waiting queue', () => {
-        const manifest = buildTapestryManifest(buildInput({
-            participants: [participant({
-                raisedAt: EARLIER,
-                publishGrantedAt: NOW,
-            })],
-        }));
-        expect(manifest.entries[0].handRaised).toBe(false);
-        expect(manifest.waitingHands).toEqual([]);
-    });
-
-    it('derives presence: left, unknown, reconnecting, connected', () => {
-        const base = buildInput({
-            tileIds: ['tp-a', 'tp-b', 'tp-c', 'tp-d'],
-            participants: [
-                participant({ identity: 'lk-a', leftAt: NOW }),
-                participant({ identity: 'lk-b' }),
-                participant({ identity: 'lk-c' }),
-                participant({ identity: 'lk-d' }),
-            ],
-            live: new Map([['lk-d', live()]]),
-        });
-        const connected = buildTapestryManifest(base);
-        expect(connected.entries.map((entry) => entry.presence)).toEqual([
-            'left', 'reconnecting', 'reconnecting', 'connected',
-        ]);
-        const outage = buildTapestryManifest({ ...base, liveStateAvailable: false });
-        expect(outage.entries.map((entry) => entry.presence)).toEqual([
-            'left', 'unknown', 'unknown', 'unknown',
-        ]);
-    });
-
-    it('derives camera state from published tracks', () => {
-        const manifest = buildTapestryManifest(buildInput({
-            participants: [
-                participant({ identity: 'lk-a' }),
-                participant({ identity: 'lk-b' }),
+                participant({ raisedAt: new Date('2026-08-04T12:00:00Z') }),
+                participant({ identity: 'lk-beto', raisedAt: new Date('2026-08-04T12:01:00Z') }),
             ],
             live: new Map([
-                ['lk-a', live({ media: [{ source: 'CAMERA', muted: false }] })],
-                ['lk-b', live({ media: [{ source: 'CAMERA', muted: true }] })],
+                ['lk-ana', live('Ana')],
+                ['lk-beto', live('Beto')],
             ]),
-        }));
-        expect(manifest.entries[0].camera).toBe('on');
-        expect(manifest.entries[1].camera).toBe('off');
-    });
-
-    it('uses the staff account name when the participant is staff', () => {
-        const manifest = buildTapestryManifest(buildInput({
-            participants: [participant({ staffName: 'Julián' })],
-            live: new Map([['lk-a', live()]]),
-        }));
-        expect(manifest.entries[0].displayName).toBe('Julián');
-    });
-
-    it('bounds entries to the manifest cap', () => {
-        const tileIds = Array.from(
-            { length: MAX_TAPESTRY_MANIFEST_ENTRIES + 10 },
-            (_, index) => `tp-${index}`,
-        );
-        const manifest = buildTapestryManifest(buildInput({ tileIds, participants: [] }));
-        expect(manifest.entries).toHaveLength(MAX_TAPESTRY_MANIFEST_ENTRIES);
-    });
-
-    it('changes revision when state changes and keeps it when identical', () => {
-        const input = buildInput({ participants: [participant()] });
-        const first = buildTapestryManifest(input);
-        const same = buildTapestryManifest(input);
-        expect(first.revision).toBe(same.revision);
-        const raised = buildTapestryManifest({
-            ...input,
-            participants: [participant({ raisedAt: NOW })],
         });
-        expect(raised.revision).not.toBe(first.revision);
-        const reordered = buildTapestryManifest({
-            ...input,
-            tileIds: ['tp-b', 'tp-a'],
-        });
-        expect(reordered.revision).not.toBe(first.revision);
+        expect(manifest.waitingHands).toEqual([
+            { displayName: 'Ana', queuePosition: 1, tileId: 'tp-lk-ana' },
+            { displayName: 'Beto', queuePosition: 2, tileId: null },
+        ]);
     });
 
-    it('skips participants whose identity cannot be mapped to a tile id', () => {
-        const manifest = buildTapestryManifest(buildInput({
-            tapestryIdFor: () => null,
-        }));
-        expect(manifest.entries[0]).toMatchObject({
-            tileId: 'tp-a',
-            displayName: 'Attendee',
-            presence: 'reconnecting',
+    it('exposes an empty layout as no overlay surface, with generic freshness', () => {
+        const manifest = build({ layout: null });
+        expect(manifest.layout).toBeNull();
+        expect(manifest.tileFreshForSeconds).toBeNull();
+        expect(manifest.entries).toEqual([]);
+        // A waiting hand still surfaces textually without any grid.
+        const withHand = build({
+            layout: null,
+            participants: [participant({ raisedAt: new Date('2026-08-04T12:00:00Z') })],
         });
+        expect(withHand.waitingHands).toEqual([
+            { displayName: 'Ana', queuePosition: 1, tileId: null },
+        ]);
     });
 
-    it('rounds the freshness TTL up to whole seconds', () => {
-        const manifest = buildTapestryManifest(buildInput({ frameTtlMs: 10_500 }));
-        expect(manifest.thumbnailFreshForSeconds).toBe(11);
+    it('changes revision when semantic state changes, not otherwise', () => {
+        const a = build();
+        const same = build();
+        const handUp = build({
+            participants: [participant({ raisedAt: new Date('2026-08-04T12:00:00Z') })],
+        });
+        expect(a.revision).toBe(same.revision);
+        expect(a.revision).not.toBe(handUp.revision);
+    });
+
+    it('orders queue positions across tiled and tile-less hands together', () => {
+        const manifest = build({
+            layout: layout([
+                { id: 'tp-lk-ana', column: 0, row: 0 },
+                { id: 'tp-lk-cele', column: 1, row: 0 },
+            ]),
+            participants: [
+                participant({ identity: 'lk-cele', raisedAt: new Date('2026-08-04T12:02:00Z') }),
+                participant({ identity: 'lk-beto', raisedAt: new Date('2026-08-04T12:01:00Z') }),
+                participant({ identity: 'lk-ana', raisedAt: new Date('2026-08-04T12:00:00Z') }),
+            ],
+            live: new Map([
+                ['lk-ana', live('Ana')],
+                ['lk-beto', live('Beto')],
+                ['lk-cele', live('Cele')],
+            ]),
+        });
+        expect(manifest.entries[0]).toMatchObject({ tileId: 'tp-lk-ana', queuePosition: 1 });
+        expect(manifest.entries[1]).toMatchObject({ tileId: 'tp-lk-cele', queuePosition: 3 });
+        expect(manifest.waitingHands.map((hand) => hand.displayName)).toEqual(['Ana', 'Beto', 'Cele']);
     });
 });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -195,6 +195,7 @@ export type Messages = {
         stopCamera: string;
         shareSnapshot: string;
         permissionDenied: string;
+        raisedHands: string;
     };
     staffRoles: Record<LocalizedStaffRole, string>;
     staffRoleDescriptions: Record<LocalizedStaffRole, string>;
@@ -427,6 +428,22 @@ export type Messages = {
             moveLeft: string;
             moveRight: string;
         };
+        opsTapestry: {
+            heading: string;
+            loading: string;
+            unavailable: string;
+            empty: string;
+            tileSnapshotAlt: string;
+            tileNoSnapshotAlt: string;
+            handRaised: string;
+            waitingWithoutTile: string;
+            handSummaryOne: string;
+            handsSummaryMany: string;
+            freshnessNote: string;
+            liveStateUnknown: string;
+            presence: Record<'connected' | 'reconnecting' | 'left' | 'unknown', string>;
+            camera: Record<'on' | 'off' | 'unknown', string>;
+        };
         cockpit: {
             roomTitle: string;
             roomHint: string;
@@ -625,6 +642,7 @@ export const messages: Record<UiLocale, Messages> = {
             stopCamera: 'Dejar de compartir la cámara con el tapiz',
             shareSnapshot: 'Compartir una imagen de cámara',
             permissionDenied: 'No se otorgó permiso para usar la cámara. Igual podés participar de la sesión.',
+            raisedHands: 'Manos levantadas: {names}',
         },
         staffRoles: {
             FACILITATOR: 'Facilitador/a',
@@ -905,6 +923,31 @@ export const messages: Record<UiLocale, Messages> = {
                 moveLeft: 'Mover tesela {index} a la izquierda',
                 moveRight: 'Mover tesela {index} a la derecha',
             },
+            opsTapestry: {
+                heading: 'Tapiz operativo',
+                loading: 'Leyendo la sala…',
+                unavailable: 'El tapiz no está disponible. La cola de manos sigue operativa desde el panel de escena.',
+                empty: 'Todavía no hay teselas: aparecen cuando las personas comparten imagen.',
+                tileSnapshotAlt: 'Miniatura reciente de {name}',
+                tileNoSnapshotAlt: '{name}: sin miniatura actual',
+                handRaised: 'Mano {position}',
+                waitingWithoutTile: 'Esperan sin imagen: {names}',
+                handSummaryOne: '1 mano levantada',
+                handsSummaryMany: '{count} manos levantadas',
+                freshnessNote: 'Las miniaturas se renuevan cada {seconds} s aproximadamente.',
+                liveStateUnknown: 'Presencia y cámara sin confirmar: la conexión en vivo está caída.',
+                presence: {
+                    connected: 'presente',
+                    reconnecting: 'reconectando',
+                    left: 'salió',
+                    unknown: 'presencia sin confirmar',
+                },
+                camera: {
+                    on: 'cámara encendida',
+                    off: 'cámara apagada',
+                    unknown: 'cámara sin confirmar',
+                },
+            },
             cockpit: {
                 roomTitle: 'Sala en vivo',
                 roomHint: 'La escena permanece conectada mientras abrís las herramientas.',
@@ -1101,6 +1144,7 @@ export const messages: Record<UiLocale, Messages> = {
             stopCamera: 'Stop sharing your camera with the tapestry',
             shareSnapshot: 'Share a camera snapshot',
             permissionDenied: 'Camera permission was not granted. You can still take part in the session.',
+            raisedHands: 'Raised hands: {names}',
         },
         staffRoles: {
             FACILITATOR: 'Facilitator',
@@ -1380,6 +1424,31 @@ export const messages: Record<UiLocale, Messages> = {
                 tileAlt: 'Tapestry tile {index}',
                 moveLeft: 'Move tile {index} left',
                 moveRight: 'Move tile {index} right',
+            },
+            opsTapestry: {
+                heading: 'Operational tapestry',
+                loading: 'Reading the room…',
+                unavailable: 'The tapestry is unavailable. The hand queue stays operational from the scene panel.',
+                empty: 'No tiles yet — they appear as people share a snapshot.',
+                tileSnapshotAlt: 'Recent tapestry snapshot of {name}',
+                tileNoSnapshotAlt: '{name}: no current tapestry snapshot',
+                handRaised: 'Hand {position}',
+                waitingWithoutTile: 'Waiting without a snapshot: {names}',
+                handSummaryOne: '1 hand raised',
+                handsSummaryMany: '{count} hands raised',
+                freshnessNote: 'Snapshots refresh about every {seconds}s.',
+                liveStateUnknown: 'Presence and camera unconfirmed: the live connection is down.',
+                presence: {
+                    connected: 'present',
+                    reconnecting: 'reconnecting',
+                    left: 'left',
+                    unknown: 'presence unconfirmed',
+                },
+                camera: {
+                    on: 'camera on',
+                    off: 'camera off',
+                    unknown: 'camera unconfirmed',
+                },
             },
             cockpit: {
                 roomTitle: 'Live room',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -171,6 +171,7 @@ export type Messages = {
         onStage: string;
         queuedPrefix: string;
         queuedSuffix: string;
+        namingConsent: string;
     };
     stage: {
         label: string;
@@ -433,8 +434,7 @@ export type Messages = {
             loading: string;
             unavailable: string;
             empty: string;
-            tileSnapshotAlt: string;
-            tileNoSnapshotAlt: string;
+            compositeAlt: string;
             handRaised: string;
             waitingWithoutTile: string;
             handSummaryOne: string;
@@ -618,6 +618,7 @@ export const messages: Record<UiLocale, Messages> = {
             onStage: 'Estás en escena — activá el micrófono y la cámara abajo.',
             queuedPrefix: 'Mano levantada — sos la persona número',
             queuedSuffix: 'en la fila.',
+            namingConsent: 'Mientras tengas la mano levantada, tu nombre aparece sobre tu imagen en el tapiz de esta sesión. Al bajar la mano o salir, el nombre se retira; nada queda publicado fuera de la sesión.',
         },
         stage: {
             label: 'Escena',
@@ -928,8 +929,7 @@ export const messages: Record<UiLocale, Messages> = {
                 loading: 'Leyendo la sala…',
                 unavailable: 'El tapiz no está disponible. La cola de manos sigue operativa desde el panel de escena.',
                 empty: 'Todavía no hay teselas: aparecen cuando las personas comparten imagen.',
-                tileSnapshotAlt: 'Miniatura reciente de {name}',
-                tileNoSnapshotAlt: '{name}: sin miniatura actual',
+                compositeAlt: 'Vista actual del tapiz de la sesión',
                 handRaised: 'Mano {position}',
                 waitingWithoutTile: 'Esperan sin imagen: {names}',
                 handSummaryOne: '1 mano levantada',
@@ -1120,6 +1120,7 @@ export const messages: Record<UiLocale, Messages> = {
             onStage: 'You are on stage — enable microphone and camera below.',
             queuedPrefix: 'Hand raised — you are number',
             queuedSuffix: 'in the queue.',
+            namingConsent: 'While your hand is raised, your name appears over your image in this session’s tapestry. Lowering your hand or leaving removes it; nothing is published beyond the session.',
         },
         stage: {
             label: 'Stage',
@@ -1430,8 +1431,7 @@ export const messages: Record<UiLocale, Messages> = {
                 loading: 'Reading the room…',
                 unavailable: 'The tapestry is unavailable. The hand queue stays operational from the scene panel.',
                 empty: 'No tiles yet — they appear as people share a snapshot.',
-                tileSnapshotAlt: 'Recent tapestry snapshot of {name}',
-                tileNoSnapshotAlt: '{name}: no current tapestry snapshot',
+                compositeAlt: 'Current session tapestry view',
                 handRaised: 'Hand {position}',
                 waitingWithoutTile: 'Waiting without a snapshot: {names}',
                 handSummaryOne: '1 hand raised',

--- a/src/lib/room-entitlement.ts
+++ b/src/lib/room-entitlement.ts
@@ -33,19 +33,42 @@ export type RoomEntitlementResult =
         error: 'Authentication required' | 'Not authorized' | 'Session not found';
     };
 
+type RoomAccessBase = {
+    session: RoomPrincipal['session'];
+    identity: string;
+    displayName: string;
+    role: RoomPrincipal['role'];
+    isAssignedFacilitator: boolean;
+    canPublishInitially: boolean;
+    ticketEntitlementId: string | null;
+    staffUserId: string | null;
+    existingParticipant: {
+        id: string;
+        publishGrantedAt: Date | null;
+        publishRevokedAt: Date | null;
+    } | null;
+};
+
+type RoomAccessResult =
+    | { ok: true; access: RoomAccessBase }
+    | {
+        ok: false;
+        status: 401 | 403 | 404;
+        error: 'Authentication required' | 'Not authorized' | 'Session not found';
+    };
+
 /**
- * Resolve the opaque weekend web session against current database state.
- *
- * This is intentionally called for every token request: a revoked cookie or
- * ticket stops working immediately. Ticket sessions are event-scoped. Global
- * operators/admins may observe any active event, while a facilitator is scoped
- * to the event they facilitate.
+ * Read-only half of room access resolution: cookie, entitlement, event
+ * correspondence and policy — validated against current database state on
+ * every call. It never writes: no participant upsert, no `leftAt` clearing,
+ * no preflight grant. Polling GETs must use this instead of
+ * `resolveRoomPrincipal`, which reconciles durable presence by design.
  */
-export async function resolveRoomPrincipal(
+async function resolveRoomAccess(
     request: NextRequest,
     scheduledSessionId: string,
     now = new Date(),
-): Promise<RoomEntitlementResult> {
+): Promise<RoomAccessResult> {
     const cookieValue = request.cookies.get(SESSION_COOKIE_NAME)?.value;
     if (!cookieValue) {
         return { ok: false, status: 401, error: 'Authentication required' };
@@ -180,11 +203,8 @@ export async function resolveRoomPrincipal(
         principalKind,
         principalId,
     );
-    // The seed reserves Julián's slot before a LiveKit identity exists, so that
-    // row initially carries a random placeholder identity. Resolve by the
-    // event-scoped principal first and migrate that row to the stable identity.
-    // Otherwise an upsert keyed only by identity attempts to insert a second
-    // `(session, staff)` row and hits the migration's partial unique index.
+    // Read-only lookup: the existing row, when there is one, informs
+    // canPublish for viewers without materializing presence.
     const existingParticipant = await prisma.sessionParticipant.findFirst({
         where: {
             scheduledSessionId: scheduledSession.id,
@@ -192,13 +212,99 @@ export async function resolveRoomPrincipal(
                 ? { ticketEntitlementId }
                 : { staffUserId: staffUserId! }),
         },
-        select: { id: true },
+        select: { id: true, publishGrantedAt: true, publishRevokedAt: true },
     });
+
+    return {
+        ok: true,
+        access: {
+            session: {
+                id: scheduledSession.id,
+                title: scheduledSession.title,
+                roomName: scheduledSession.roomName,
+                status: scheduledSession.status,
+                startedAt: scheduledSession.startedAt,
+            },
+            identity,
+            displayName,
+            role,
+            isAssignedFacilitator,
+            canPublishInitially,
+            ticketEntitlementId,
+            staffUserId,
+            existingParticipant,
+        },
+    };
+}
+
+/**
+ * Read-only room viewer for polling GETs (TAP-02 review): validates the web
+ * session, entitlement and event correspondence exactly like the token
+ * route, but performs zero writes and zero presence changes. `canPublish`
+ * reflects the existing participant row only — a viewer who never joined
+ * truthfully has no grant.
+ */
+export async function resolveRoomViewer(
+    request: NextRequest,
+    scheduledSessionId: string,
+    now = new Date(),
+): Promise<RoomEntitlementResult> {
+    const result = await resolveRoomAccess(request, scheduledSessionId, now);
+    if (!result.ok) {
+        return result;
+    }
+    const { access } = result;
+    return {
+        ok: true,
+        principal: {
+            session: access.session,
+            identity: access.identity,
+            displayName: access.displayName,
+            role: access.role,
+            isAssignedFacilitator: access.isAssignedFacilitator,
+            canPublish:
+                access.existingParticipant !== null &&
+                access.existingParticipant.publishGrantedAt !== null &&
+                access.existingParticipant.publishRevokedAt === null,
+            ticketEntitlementId: access.ticketEntitlementId,
+            staffUserId: access.staffUserId,
+        },
+    };
+}
+
+/**
+ * Resolve the opaque weekend web session against current database state.
+ *
+ * This is intentionally called for every token request: a revoked cookie or
+ * ticket stops working immediately. Ticket sessions are event-scoped. Global
+ * operators/admins may observe any active event, while a facilitator is scoped
+ * to the event they facilitate.
+ *
+ * Joining is a write: this resolver reconciles the durable participant row
+ * (stable identity, cleared `leftAt`, facilitator preflight grant). Read-only
+ * polling surfaces must use {@link resolveRoomViewer} instead.
+ */
+export async function resolveRoomPrincipal(
+    request: NextRequest,
+    scheduledSessionId: string,
+    now = new Date(),
+): Promise<RoomEntitlementResult> {
+    const result = await resolveRoomAccess(request, scheduledSessionId, now);
+    if (!result.ok) {
+        return result;
+    }
+    const { access } = result;
+    const existingParticipant = access.existingParticipant;
+    // The seed reserves Julián's slot before a LiveKit identity exists, so that
+    // row initially carries a random placeholder identity. Resolve by the
+    // event-scoped principal first and migrate that row to the stable identity.
+    // Otherwise an upsert keyed only by identity attempts to insert a second
+    // `(session, staff)` row and hits the migration's partial unique index.
     const participant = existingParticipant
         ? await prisma.sessionParticipant.update({
             where: { id: existingParticipant.id },
             data: {
-                participantIdentity: identity,
+                participantIdentity: access.identity,
                 leftAt: null,
             },
             select: {
@@ -209,18 +315,18 @@ export async function resolveRoomPrincipal(
         : await prisma.sessionParticipant.upsert({
             where: {
                 scheduledSessionId_participantIdentity: {
-                    scheduledSessionId: scheduledSession.id,
-                    participantIdentity: identity,
+                    scheduledSessionId: scheduledSessionId,
+                    participantIdentity: access.identity,
                 },
             },
             create: {
-                scheduledSessionId: scheduledSession.id,
-                participantIdentity: identity,
-                ticketEntitlementId,
-                staffUserId,
-                publishGrantedAt: canPublishInitially ? now : null,
-                grantVersion: canPublishInitially ? 1 : 0,
-                grantReason: canPublishInitially
+                scheduledSessionId: scheduledSessionId,
+                participantIdentity: access.identity,
+                ticketEntitlementId: access.ticketEntitlementId,
+                staffUserId: access.staffUserId,
+                publishGrantedAt: access.canPublishInitially ? now : null,
+                grantVersion: access.canPublishInitially ? 1 : 0,
+                grantReason: access.canPublishInitially
                     ? 'Facilitator preflight grant'
                     : null,
             },
@@ -236,22 +342,16 @@ export async function resolveRoomPrincipal(
     return {
         ok: true,
         principal: {
-            session: {
-                id: scheduledSession.id,
-                title: scheduledSession.title,
-                roomName: scheduledSession.roomName,
-                status: scheduledSession.status,
-                startedAt: scheduledSession.startedAt,
-            },
-            identity,
-            displayName,
-            role,
-            isAssignedFacilitator,
+            session: access.session,
+            identity: access.identity,
+            displayName: access.displayName,
+            role: access.role,
+            isAssignedFacilitator: access.isAssignedFacilitator,
             canPublish:
                 participant.publishGrantedAt !== null &&
                 participant.publishRevokedAt === null,
-            ticketEntitlementId,
-            staffUserId,
+            ticketEntitlementId: access.ticketEntitlementId,
+            staffUserId: access.staffUserId,
         },
     };
 }

--- a/src/lib/tapestry-layout.ts
+++ b/src/lib/tapestry-layout.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared validation for the internal tapestry service's layout endpoint
+ * (TAP-02 review, hardening): every consumer — the staff manifest and the
+ * public hands sidecar — parses the response through this single validator.
+ *
+ * Fail-safe by contract: anything unexpected returns null, and the caller
+ * degrades to "no overlay" instead of trusting a malformed grid. Nothing
+ * internal is logged or surfaced: the absence of a layout says enough.
+ */
+
+/** Opaque tile ids are URL-safe and length-bounded, as in the service config. */
+const TILE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+/** Hard cap matching the service's maxParticipantsPerSession. */
+export const MAX_COMPOSITE_CELLS = 150;
+
+export type CompositeLayoutCell = {
+    id: string;
+    column: number;
+    row: number;
+};
+
+export type CompositeLayout = {
+    revision: number;
+    columns: number;
+    rows: number;
+    tileSizePx: number;
+    frameTtlMs: number | null;
+    cells: CompositeLayoutCell[];
+};
+
+function isNonNegativeInteger(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+/**
+ * Parse an untrusted layout response. Returns null when the shape, bounds
+ * or uniqueness constraints are not met — including duplicate tile ids,
+ * which would make cell lookup ambiguous and could misplace an overlay.
+ */
+export function parseCompositeLayout(body: unknown): CompositeLayout | null {
+    const raw = body as Partial<CompositeLayout> | null;
+    if (!raw || typeof raw !== 'object') {
+        return null;
+    }
+    if (
+        !isNonNegativeInteger(raw.revision) ||
+        !isNonNegativeInteger(raw.columns) || raw.columns < 1 ||
+        !isNonNegativeInteger(raw.rows) || raw.rows < 1 ||
+        !isNonNegativeInteger(raw.tileSizePx) || raw.tileSizePx < 1 ||
+        !Array.isArray(raw.cells) ||
+        raw.cells.length > MAX_COMPOSITE_CELLS
+    ) {
+        return null;
+    }
+
+    const seen = new Set<string>();
+    const cells: CompositeLayoutCell[] = [];
+    for (const cell of raw.cells) {
+        if (
+            !cell || typeof cell !== 'object' ||
+            typeof cell.id !== 'string' ||
+            !TILE_ID_PATTERN.test(cell.id) ||
+            !isNonNegativeInteger(cell.column) || cell.column >= raw.columns ||
+            !isNonNegativeInteger(cell.row) || cell.row >= raw.rows
+        ) {
+            return null;
+        }
+        if (seen.has(cell.id)) {
+            // A duplicated tile id makes every name/cell mapping suspect.
+            return null;
+        }
+        seen.add(cell.id);
+        cells.push({ id: cell.id, column: cell.column, row: cell.row });
+    }
+
+    return {
+        revision: raw.revision,
+        columns: raw.columns,
+        rows: raw.rows,
+        tileSizePx: raw.tileSizePx,
+        // Older internal services predate frameTtlMs; freshness copy degrades
+        // to a generic note rather than a fabricated number.
+        frameTtlMs: isNonNegativeInteger(raw.frameTtlMs) && raw.frameTtlMs > 0
+            ? raw.frameTtlMs
+            : null,
+        cells,
+    };
+}

--- a/src/lib/tapestry-manifest.ts
+++ b/src/lib/tapestry-manifest.ts
@@ -1,0 +1,228 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Canonical staff-only tapestry manifest (TAP-02, issue #129).
+ *
+ * The manifest annotates the tapestry tiles the internal service already
+ * renders: who raised their hand, their authorized name, presence, camera
+ * state and thumbnail freshness. It is the single bounded response the
+ * operational surface polls — one database read, one LiveKit list and one
+ * tapestry list per build, never a query per tile.
+ *
+ * Privacy invariants:
+ * - `tileId` is the opaque HMAC id from `@/lib/tapestry`; LiveKit identities,
+ *   names and emails never appear in keys, URLs or logs.
+ * - Names come from the already-authorized sources the participants endpoint
+ *   uses (staff account name, LiveKit display name, or the 'Attendee'
+ *   fallback). Nothing new is collected.
+ * - A tile only exists here while the internal service holds a current
+ *   consented frame; consent withdrawal or TTL expiry removes the tile and
+ *   the entry with it. The UI fallback never distinguishes *why*.
+ *
+ * This module is pure: no database, LiveKit, fetch, clock or localization,
+ * so the contract is testable without mocks.
+ */
+
+export const MAX_TAPESTRY_MANIFEST_ENTRIES = 150;
+
+export type TapestryPresence = 'connected' | 'reconnecting' | 'left' | 'unknown';
+export type TapestryCamera = 'on' | 'off' | 'unknown';
+
+export type TapestryManifestEntry = {
+    /** Opaque tapestry participant id (`tp-…`), never a LiveKit identity. */
+    tileId: string;
+    /** Display order index, matching the arrangement the service composes. */
+    position: number;
+    displayName: string;
+    handRaised: boolean;
+    /** 1-based position among waiting hands; null when not waiting. */
+    queuePosition: number | null;
+    presence: TapestryPresence;
+    camera: TapestryCamera;
+    /** Staff tile proxy URL, or null when no current consented frame exists. */
+    thumbnailUrl: string | null;
+};
+
+export type TapestryManifestWaitingHand = {
+    displayName: string;
+    queuePosition: number;
+    /** Null when the person has no tile in the tapestry (no consented frame). */
+    tileId: string | null;
+};
+
+export type TapestryManifest = {
+    sessionId: string;
+    /**
+     * Content hash of order + per-tile state. Clients compare revisions to
+     * detect change cheaply and never render stale state as current.
+     */
+    revision: string;
+    thumbnailFreshForSeconds: number;
+    liveStateAvailable: boolean;
+    entries: TapestryManifestEntry[];
+    /** Every waiting hand, including those without a tile. */
+    waitingHands: TapestryManifestWaitingHand[];
+};
+
+/** Database participant row projected to what the manifest needs. */
+export type ManifestParticipant = {
+    identity: string;
+    leftAt: Date | null;
+    raisedAt: Date | null;
+    publishGrantedAt: Date | null;
+    publishRevokedAt: Date | null;
+    staffName: string | null;
+};
+
+/** LiveKit presence projected to what the manifest needs. */
+export type ManifestLiveParticipant = {
+    name: string;
+    media: Array<{ source: string; muted: boolean }>;
+};
+
+export type BuildTapestryManifestInput = {
+    sessionId: string;
+    /** Tile ids in display order, as listed by the internal service. */
+    tileIds: string[];
+    frameTtlMs: number;
+    liveStateAvailable: boolean;
+    participants: ManifestParticipant[];
+    live: ReadonlyMap<string, ManifestLiveParticipant>;
+    /** Maps a LiveKit identity to its opaque tile id; null when unmappable. */
+    tapestryIdFor: (identity: string) => string | null;
+    /** Builds the staff thumbnail proxy URL for a tile. */
+    thumbnailUrlFor: (tileId: string) => string;
+};
+
+function hasActiveGrant(participant: ManifestParticipant): boolean {
+    return participant.publishGrantedAt !== null &&
+        participant.publishRevokedAt === null;
+}
+
+function isWaiting(participant: ManifestParticipant): boolean {
+    return participant.raisedAt !== null && !hasActiveGrant(participant);
+}
+
+function displayNameFor(
+    participant: ManifestParticipant | null,
+    live: ManifestLiveParticipant | undefined,
+): string {
+    return participant?.staffName ?? (live?.name.trim() || 'Attendee');
+}
+
+function presenceFor(
+    participant: ManifestParticipant | null,
+    live: ManifestLiveParticipant | undefined,
+    liveStateAvailable: boolean,
+): TapestryPresence {
+    if (participant?.leftAt) return 'left';
+    if (!liveStateAvailable) return 'unknown';
+    if (live) return 'connected';
+    return 'reconnecting';
+}
+
+function cameraFor(
+    live: ManifestLiveParticipant | undefined,
+): TapestryCamera {
+    if (!live) return 'unknown';
+    const cameraTrack = live.media.find((track) => track.source === 'CAMERA');
+    return cameraTrack && !cameraTrack.muted ? 'on' : 'off';
+}
+
+function revisionFor(
+    tileIds: string[],
+    entries: TapestryManifestEntry[],
+    waitingHands: TapestryManifestWaitingHand[],
+): string {
+    const state = entries.map((entry) => [
+        entry.tileId,
+        entry.displayName,
+        entry.handRaised ? 1 : 0,
+        entry.queuePosition ?? 0,
+        entry.presence,
+        entry.camera,
+        entry.thumbnailUrl ? 1 : 0,
+    ]);
+    const waiting = waitingHands.map((hand) => [
+        hand.displayName,
+        hand.queuePosition,
+        hand.tileId ?? '',
+    ]);
+    return createHash('sha256')
+        .update(JSON.stringify([tileIds, state, waiting]))
+        .digest('hex')
+        .slice(0, 16);
+}
+
+export function buildTapestryManifest(
+    input: BuildTapestryManifestInput,
+): TapestryManifest {
+    const tileIds = input.tileIds.slice(0, MAX_TAPESTRY_MANIFEST_ENTRIES);
+    const tileSet = new Set(tileIds);
+
+    // Index database participants by their opaque tile id. Participants whose
+    // identity cannot be mapped (e.g. missing internal secret) are skipped
+    // rather than leaking configuration detail.
+    const byTileId = new Map<string, ManifestParticipant>();
+    const liveByTileId = new Map<string, ManifestLiveParticipant>();
+    for (const participant of input.participants) {
+        const tileId = input.tapestryIdFor(participant.identity);
+        if (!tileId) continue;
+        byTileId.set(tileId, participant);
+        const live = input.live.get(participant.identity);
+        if (live) liveByTileId.set(tileId, live);
+    }
+
+    // Waiting hands in queue order, computed once so tiles and the summary
+    // agree. Ties fall back to identity for a stable order, matching the
+    // hand queue's tie-break rule.
+    const waiting = input.participants
+        .filter(isWaiting)
+        .sort((a, b) => {
+            const delta = a.raisedAt!.getTime() - b.raisedAt!.getTime();
+            return delta !== 0 ? delta : a.identity.localeCompare(b.identity);
+        });
+    const queuePositionByIdentity = new Map<string, number>();
+    const waitingHands: TapestryManifestWaitingHand[] = waiting.map(
+        (participant, index) => {
+            const tileId = input.tapestryIdFor(participant.identity);
+            const queuePosition = index + 1;
+            queuePositionByIdentity.set(participant.identity, queuePosition);
+            return {
+                displayName: displayNameFor(
+                    participant,
+                    input.live.get(participant.identity),
+                ),
+                queuePosition,
+                tileId: tileId && tileSet.has(tileId) ? tileId : null,
+            };
+        },
+    );
+
+    const entries: TapestryManifestEntry[] = tileIds.map((tileId, position) => {
+        const participant = byTileId.get(tileId) ?? null;
+        const live = liveByTileId.get(tileId);
+        const queuePosition = participant
+            ? queuePositionByIdentity.get(participant.identity) ?? null
+            : null;
+        return {
+            tileId,
+            position,
+            displayName: displayNameFor(participant, live),
+            handRaised: queuePosition !== null,
+            queuePosition,
+            presence: presenceFor(participant, live, input.liveStateAvailable),
+            camera: cameraFor(live),
+            thumbnailUrl: input.thumbnailUrlFor(tileId),
+        };
+    });
+
+    return {
+        sessionId: input.sessionId,
+        revision: revisionFor(tileIds, entries, waitingHands),
+        thumbnailFreshForSeconds: Math.max(1, Math.ceil(input.frameTtlMs / 1_000)),
+        liveStateAvailable: input.liveStateAvailable,
+        entries,
+        waitingHands,
+    };
+}

--- a/src/lib/tapestry-manifest.ts
+++ b/src/lib/tapestry-manifest.ts
@@ -1,70 +1,83 @@
 import { createHash } from 'node:crypto';
 
+import type { CompositeLayout } from '@/lib/tapestry-layout';
+
 /**
  * Canonical staff-only tapestry manifest (TAP-02, issue #129).
  *
- * The manifest annotates the tapestry tiles the internal service already
- * renders: who raised their hand, their authorized name, presence, camera
- * state and thumbnail freshness. It is the single bounded response the
- * operational surface polls — one database read, one LiveKit list and one
- * tapestry list per build, never a query per tile.
+ * The manifest annotates the composite the internal tapestry service already
+ * builds: who each tile is (authorized display name only), whether their
+ * hand is raised and where in the queue, their presence and camera state —
+ * plus the grid cell each tile occupies so the cockpit can draw everything
+ * as semantic overlays over ONE shared composite image (O(1) visual
+ * transport: no per-tile thumbnail URLs).
  *
- * Privacy invariants:
- * - `tileId` is the opaque HMAC id from `@/lib/tapestry`; LiveKit identities,
- *   names and emails never appear in keys, URLs or logs.
- * - Names come from the already-authorized sources the participants endpoint
- *   uses (staff account name, LiveKit display name, or the 'Attendee'
- *   fallback). Nothing new is collected.
- * - A tile only exists here while the internal service holds a current
- *   consented frame; consent withdrawal or TTL expiry removes the tile and
- *   the entry with it. The UI fallback never distinguishes *why*.
+ * Privacy contract: entries are keyed by the opaque tapestry tile id (HMAC),
+ * never by LiveKit identity or any internal id. Names come from the
+ * already-authorized room name / staff account name — the same source the
+ * room itself shows. Nothing here exposes emails, ticket ids, LiveKit
+ * identities or join history.
  *
- * This module is pure: no database, LiveKit, fetch, clock or localization,
- * so the contract is testable without mocks.
+ * Truthfulness contract: the manifest never invents state. Tiles come from
+ * the service's build-time layout; presence/camera fall back to 'unknown'
+ * when LiveKit is unreachable; `layout` is null when the service has not
+ * built a composite yet, and overlays only render when the manifest layout
+ * revision matches the composite's `x-tapestry-revision`.
  */
-
-export const MAX_TAPESTRY_MANIFEST_ENTRIES = 150;
 
 export type TapestryPresence = 'connected' | 'reconnecting' | 'left' | 'unknown';
 export type TapestryCamera = 'on' | 'off' | 'unknown';
 
 export type TapestryManifestEntry = {
-    /** Opaque tapestry participant id (`tp-…`), never a LiveKit identity. */
+    /** Opaque tile id (HMAC of the room identity) — safe to render, never reversible. */
     tileId: string;
-    /** Display order index, matching the arrangement the service composes. */
-    position: number;
+    /** Authorized display name (staff account name or room display name). */
     displayName: string;
     handRaised: boolean;
-    /** 1-based position among waiting hands; null when not waiting. */
+    /** 1-based position among waiting hands; null when no hand is raised. */
     queuePosition: number | null;
     presence: TapestryPresence;
     camera: TapestryCamera;
-    /** Staff tile proxy URL, or null when no current consented frame exists. */
-    thumbnailUrl: string | null;
+    /** Grid cell in the composite this manifest's `layout` describes. */
+    column: number;
+    row: number;
 };
 
 export type TapestryManifestWaitingHand = {
     displayName: string;
     queuePosition: number;
-    /** Null when the person has no tile in the tapestry (no consented frame). */
+    /** Null when the person has no tapestry tile (e.g. snapshot not shared). */
     tileId: string | null;
+};
+
+export type TapestryManifestLayout = {
+    /** Build revision of the composite this layout was captured with. */
+    revision: number;
+    columns: number;
+    rows: number;
+    tileSizePx: number;
 };
 
 export type TapestryManifest = {
     sessionId: string;
     /**
-     * Content hash of order + per-tile state. Clients compare revisions to
-     * detect change cheaply and never render stale state as current.
+     * Cheap change detector for the semantic state (order, hands, presence,
+     * camera, names). Clients re-render annotations only when it changes —
+     * visual freshness is the composite image's own concern, refreshed every
+     * poll regardless of this revision.
      */
     revision: string;
-    thumbnailFreshForSeconds: number;
+    /** False when LiveKit presence could not be read; presence entries are 'unknown'. */
     liveStateAvailable: boolean;
+    /** Grid + build revision from the internal service; null when never built. */
+    layout: TapestryManifestLayout | null;
+    /** How long a participant tile stays fresh without a new frame; null if unknown. */
+    tileFreshForSeconds: number | null;
     entries: TapestryManifestEntry[];
-    /** Every waiting hand, including those without a tile. */
+    /** Waiting hands without a tile, so staff still sees them truthfully. */
     waitingHands: TapestryManifestWaitingHand[];
 };
 
-/** Database participant row projected to what the manifest needs. */
 export type ManifestParticipant = {
     identity: string;
     leftAt: Date | null;
@@ -74,154 +87,156 @@ export type ManifestParticipant = {
     staffName: string | null;
 };
 
-/** LiveKit presence projected to what the manifest needs. */
 export type ManifestLiveParticipant = {
     name: string;
+    /** LiveKit track list; a CAMERA source track means video published. */
     media: Array<{ source: string; muted: boolean }>;
 };
 
 export type BuildTapestryManifestInput = {
     sessionId: string;
-    /** Tile ids in display order, as listed by the internal service. */
-    tileIds: string[];
-    frameTtlMs: number;
+    /** Validated internal layout (cells already bounded and deduplicated). */
+    layout: CompositeLayout | null;
     liveStateAvailable: boolean;
     participants: ManifestParticipant[];
     live: ReadonlyMap<string, ManifestLiveParticipant>;
-    /** Maps a LiveKit identity to its opaque tile id; null when unmappable. */
-    tapestryIdFor: (identity: string) => string | null;
-    /** Builds the staff thumbnail proxy URL for a tile. */
-    thumbnailUrlFor: (tileId: string) => string;
+    /** Maps a room identity to its opaque tapestry tile id. */
+    tapestryIdFor: (identity: string) => string;
 };
 
 function hasActiveGrant(participant: ManifestParticipant): boolean {
-    return participant.publishGrantedAt !== null &&
-        participant.publishRevokedAt === null;
+    return participant.publishGrantedAt !== null && participant.publishRevokedAt === null;
 }
 
-function isWaiting(participant: ManifestParticipant): boolean {
+function isWaitingHand(participant: ManifestParticipant): boolean {
     return participant.raisedAt !== null && !hasActiveGrant(participant);
 }
 
 function displayNameFor(
     participant: ManifestParticipant | null,
-    live: ManifestLiveParticipant | undefined,
+    live: ReadonlyMap<string, ManifestLiveParticipant>,
+    identity: string | null,
 ): string {
-    return participant?.staffName ?? (live?.name.trim() || 'Attendee');
+    return (
+        participant?.staffName ??
+        (identity ? live.get(identity)?.name.trim() : '') ??
+        'Attendee'
+    ) || 'Attendee';
 }
 
 function presenceFor(
     participant: ManifestParticipant | null,
-    live: ManifestLiveParticipant | undefined,
+    live: ReadonlyMap<string, ManifestLiveParticipant>,
     liveStateAvailable: boolean,
 ): TapestryPresence {
-    if (participant?.leftAt) return 'left';
-    if (!liveStateAvailable) return 'unknown';
-    if (live) return 'connected';
+    if (participant?.leftAt) {
+        return 'left';
+    }
+    if (!liveStateAvailable) {
+        return 'unknown';
+    }
+    if (participant && live.has(participant.identity)) {
+        return 'connected';
+    }
+    // No explicit leave and not in the room right now: they may return.
     return 'reconnecting';
 }
 
 function cameraFor(
-    live: ManifestLiveParticipant | undefined,
+    liveParticipant: ManifestLiveParticipant | undefined,
 ): TapestryCamera {
-    if (!live) return 'unknown';
-    const cameraTrack = live.media.find((track) => track.source === 'CAMERA');
-    return cameraTrack && !cameraTrack.muted ? 'on' : 'off';
+    if (!liveParticipant) {
+        return 'unknown';
+    }
+    return liveParticipant.media.some((track) => track.source === 'CAMERA' && !track.muted)
+        ? 'on'
+        : 'off';
 }
 
-function revisionFor(
-    tileIds: string[],
-    entries: TapestryManifestEntry[],
-    waitingHands: TapestryManifestWaitingHand[],
-): string {
-    const state = entries.map((entry) => [
-        entry.tileId,
-        entry.displayName,
-        entry.handRaised ? 1 : 0,
-        entry.queuePosition ?? 0,
-        entry.presence,
-        entry.camera,
-        entry.thumbnailUrl ? 1 : 0,
-    ]);
-    const waiting = waitingHands.map((hand) => [
-        hand.displayName,
-        hand.queuePosition,
-        hand.tileId ?? '',
-    ]);
-    return createHash('sha256')
-        .update(JSON.stringify([tileIds, state, waiting]))
-        .digest('hex')
-        .slice(0, 16);
-}
-
-export function buildTapestryManifest(
-    input: BuildTapestryManifestInput,
-): TapestryManifest {
-    const tileIds = input.tileIds.slice(0, MAX_TAPESTRY_MANIFEST_ENTRIES);
-    const tileSet = new Set(tileIds);
-
-    // Index database participants by their opaque tile id. Participants whose
-    // identity cannot be mapped (e.g. missing internal secret) are skipped
-    // rather than leaking configuration detail.
+/**
+ * Build the staff manifest from already-fetched state. Pure and total: no
+ * I/O, no clocks, no secrets — every rule is testable here.
+ */
+export function buildTapestryManifest(input: BuildTapestryManifestInput): TapestryManifest {
     const byTileId = new Map<string, ManifestParticipant>();
-    const liveByTileId = new Map<string, ManifestLiveParticipant>();
     for (const participant of input.participants) {
-        const tileId = input.tapestryIdFor(participant.identity);
-        if (!tileId) continue;
-        byTileId.set(tileId, participant);
-        const live = input.live.get(participant.identity);
-        if (live) liveByTileId.set(tileId, live);
+        byTileId.set(input.tapestryIdFor(participant.identity), participant);
     }
 
-    // Waiting hands in queue order, computed once so tiles and the summary
-    // agree. Ties fall back to identity for a stable order, matching the
-    // hand queue's tie-break rule.
-    const waiting = input.participants
-        .filter(isWaiting)
-        .sort((a, b) => {
-            const delta = a.raisedAt!.getTime() - b.raisedAt!.getTime();
-            return delta !== 0 ? delta : a.identity.localeCompare(b.identity);
-        });
-    const queuePositionByIdentity = new Map<string, number>();
-    const waitingHands: TapestryManifestWaitingHand[] = waiting.map(
-        (participant, index) => {
-            const tileId = input.tapestryIdFor(participant.identity);
-            const queuePosition = index + 1;
-            queuePositionByIdentity.set(participant.identity, queuePosition);
-            return {
-                displayName: displayNameFor(
-                    participant,
-                    input.live.get(participant.identity),
-                ),
-                queuePosition,
-                tileId: tileId && tileSet.has(tileId) ? tileId : null,
-            };
-        },
-    );
+    const liveByTileId = new Map<string, ManifestLiveParticipant>();
+    for (const participant of input.participants) {
+        const liveParticipant = input.live.get(participant.identity);
+        if (liveParticipant) {
+            liveByTileId.set(input.tapestryIdFor(participant.identity), liveParticipant);
+        }
+    }
 
-    const entries: TapestryManifestEntry[] = tileIds.map((tileId, position) => {
-        const participant = byTileId.get(tileId) ?? null;
-        const live = liveByTileId.get(tileId);
-        const queuePosition = participant
-            ? queuePositionByIdentity.get(participant.identity) ?? null
-            : null;
+    // Queue positions derive from raisedAt order across ALL waiting hands,
+    // not just tiled ones — the SpotlightConsole counts the same people.
+    const waiting = input.participants
+        .filter(isWaitingHand)
+        .sort((a, b) => (a.raisedAt?.getTime() ?? 0) - (b.raisedAt?.getTime() ?? 0));
+    const queuePositionByTileId = new Map<string, number>();
+    waiting.forEach((participant, index) => {
+        queuePositionByTileId.set(input.tapestryIdFor(participant.identity), index + 1);
+    });
+
+    const cells = input.layout?.cells ?? [];
+    const entries: TapestryManifestEntry[] = cells.map((cell) => {
+        const participant = byTileId.get(cell.id) ?? null;
         return {
-            tileId,
-            position,
-            displayName: displayNameFor(participant, live),
-            handRaised: queuePosition !== null,
-            queuePosition,
-            presence: presenceFor(participant, live, input.liveStateAvailable),
-            camera: cameraFor(live),
-            thumbnailUrl: input.thumbnailUrlFor(tileId),
+            tileId: cell.id,
+            displayName: displayNameFor(participant, input.live, participant?.identity ?? null),
+            handRaised: participant ? isWaitingHand(participant) : false,
+            queuePosition: queuePositionByTileId.get(cell.id) ?? null,
+            presence: presenceFor(participant, input.live, input.liveStateAvailable),
+            camera: cameraFor(liveByTileId.get(cell.id)),
+            column: cell.column,
+            row: cell.row,
         };
     });
 
+    const waitingHands: TapestryManifestWaitingHand[] = waiting.map((participant, index) => {
+        const tileId = input.tapestryIdFor(participant.identity);
+        return {
+            displayName: displayNameFor(participant, input.live, participant.identity),
+            queuePosition: index + 1,
+            tileId: byTileId.has(tileId) && cells.some((cell) => cell.id === tileId)
+                ? tileId
+                : null,
+        };
+    });
+
+    const revision = createHash('sha256')
+        .update(JSON.stringify(entries.map((entry) => [
+            entry.tileId,
+            entry.displayName,
+            entry.handRaised,
+            entry.queuePosition,
+            entry.presence,
+            entry.camera,
+            entry.column,
+            entry.row,
+        ])))
+        .update(JSON.stringify(waitingHands))
+        .digest('hex')
+        .slice(0, 16);
+
     return {
         sessionId: input.sessionId,
-        revision: revisionFor(tileIds, entries, waitingHands),
-        thumbnailFreshForSeconds: Math.max(1, Math.ceil(input.frameTtlMs / 1_000)),
+        revision,
         liveStateAvailable: input.liveStateAvailable,
+        layout: input.layout
+            ? {
+                revision: input.layout.revision,
+                columns: input.layout.columns,
+                rows: input.layout.rows,
+                tileSizePx: input.layout.tileSizePx,
+            }
+            : null,
+        tileFreshForSeconds: input.layout?.frameTtlMs
+            ? Math.max(1, Math.round(input.layout.frameTtlMs / 1000))
+            : null,
         entries,
         waitingHands,
     };


### PR DESCRIPTION
## TAP-02 — Tapestry operativo con manos, nombres y presencia

Closes #129 (queda Done en el kanban cuando esta PR se revise y mergee).

> **Actualización re-review (2026-08-04, `9460ca5`):** correlación composite/layout como unidad única con reconciliación acotada, coordinador único en la sala pública, tests de convergencia R→R+1, fase de mismatch en la medición e2e. Respuesta punto por punto en [este comentario](https://github.com/AlterMundi/harmonic-beacon-webapp/pull/145#issuecomment-5187769894). El fix de la bomba de tiempo de auth vive ahora en **PR #149** (se retira de esta historia cuando aquella mergee).

### Resumen del contrato

**Manifiesto staff-only** — `GET /api/ops/sessions/[id]/tapestry/manifest`

```ts
type TapestryManifest = {
    sessionId: string;
    revision: string;                    // hash de contenido: orden + estado por tile
    layout: {                            // grilla del último build del composite
        revision: number;
        columns: number;
        rows: number;
        tileSizePx: number;
    } | null;
    tileFreshForSeconds: number | null;  // TTL de teselas del servicio
    liveStateAvailable: boolean;
    entries: Array<{
        tileId: string;                  // id opaco tp-… (HMAC), nunca identidad LiveKit
        column: number;                  // celda en la grilla del composite
        row: number;
        displayName: string;             // nombre autorizado (staff / LiveKit / 'Attendee')
        handRaised: boolean;
        queuePosition: number | null;
        presence: 'connected' | 'reconnecting' | 'left' | 'unknown';
        camera: 'on' | 'off' | 'unknown';
    }>;                                  // SIN thumbnailUrl: transporte O(1)
    waitingHands: Array<{ displayName: string; queuePosition: number; tileId: string | null }>;
};
```

Tres lookups acotados por poll (1 DB + 1 LiveKit + 1 lectura interna de layout). `private, no-store`. Cero requests por tesela.

**Sidecar público de manos** — `GET /api/scheduled-sessions/[id]/tapestry/hands`: solo `{ name, column, row }` de manos en espera y conectadas, gated por **`resolveRoomViewer` (read-only puro, cero escrituras Prisma)** — test dedicado que lo prueba. Sin cámara, presencia de terceros ni thumbnails. Query acotada a 150. Cada mano suma su celda del grid para el overlay Zoom/Meet.

**Transporte visual O(1)** — el cockpit dibuja UNA imagen compartida por poll (el JPEG que el servicio ya construye) + overlays semánticos posicionados desde el layout de build-time (nombre, badge de mano, marcador de cámara apagada, atenuación por presencia). Una lista accesible en texto plano lleva el estado completo de cada persona. Con el drawer cerrado el polling no gasta nada.

**Snapshots correlacionados por build revision** — cada build del servicio publica un objeto inmutable `{ bytes, revision, layout }`; `composite.jpg` y `/layout` siempre describen el mismo build. Los clientes leen composite → semántica como **una unidad correlacionada** y publican imagen + estado solo como un ciclo aceptado: un frame que entra entre las dos lecturas produce mismatch → retry inmediato estrictamente acotado (máx 3 intentos/ciclo, O(1) respecto de participantes) → si persiste, fallback seguro (imagen + lista veraz, overlays ocultos) hasta reconverger. `layout.revision` forma parte del criterio de actualización del manifiesto aunque el hash semántico no cambie. Ocultar temporalmente es seguro; converger es obligatorio (STAGE_GRAMMAR §6.4).

**Polling seguro** — un solo coordinador por componente (sin timers independientes para la misma unidad visual) + AbortController + request generation: una respuesta lenta y vieja jamás pisa estado más nuevo ni gasta el segundo fetch; unmount aborta y revoca. En la sala pública, la línea accesible de nombres y los tags derivan del mismo estado de manos aceptado; un rechazo del sidecar o bajar la mano retira el nombre con prioridad, sin esperar correlación. Tests de interleaving A/B, unmount, R→R+1 y mismatch continuo en ambos.

### Privacidad y consentimiento

Canon de producto confirmado por **Annie (2026-08-04)**: levantar la mano ES el consentimiento para ser nombrado públicamente, con alcance exacto: nombre solo dentro de la sesión, solo mientras la mano siga levantada y la persona conectada, solo sobre su celda del tapiz; bajar la mano o desconectarse lo retira; no autoriza email, ID interno, identidad LiveKit, cámara, presencia, thumbnail individual ni historial; no convierte el tapiz en directorio permanente; staff conserva su vista operativa. El control de mano explica este alcance en ES/EN junto al botón, antes del primer raise. Registrado en STAGE_GRAMMAR §6.4 y en #129.

### Verificación

- Local (node@22): `tsc --noEmit` ✅, `eslint` ✅, **765 tests** ✅, `next build` ✅, servicio tapestry **29/29** + build ✅.
- Medición real: `e2e/tests/ops-tapestry-requests.spec.ts` — 0/1/50/150 participantes → requests acotados idénticos, 0 por tesela, 1 `<img>`, 0 con drawer cerrado; fase de mismatch de ingest continuo → techo explícito por ciclo, overlay oculto, reconvergencia (corre en CI).
- Tests nuevos: cero-escrituras del resolver, validador fail-safe (duplicados/formato/150), interleaving ingest/composite/layout, out-of-order A/B y unmount en ambos pollers, convergencia R→R+1 con hash semántico idéntico, mismatch continuo acotado con retiro prioritario del nombre, copy de consentimiento.

### Archivos compartidos tocados

- `src/lib/room-entitlement.ts` — nuevo `resolveRoomViewer` extraído de base compartida; `resolveRoomPrincipal` intacto (tests existentes verdes).
- `src/lib/i18n.ts` — keys nuevas (`hand.namingConsent`, `opsTapestry.compositeAlt`), dos keys obsoletas removidas.
- `src/components/ops/ConductorCockpit.tsx` — solo pasa `active` a OpsTapestry.
- `services/tapestry` — snapshot atómico + endpoint `/layout` + header `x-tapestry-revision` (coordinado con #40/#108).
- `docs/design/STAGE_GRAMMAR.md` — §6.4 actualizado (capa O(1), canon, modelo correlacionado).

El fix de la bomba de tiempo de tests auth (`expiresAt` hardcodeado) va en **PR #149**, separada como pidió el re-review; `f2f663c` se retira de esta historia en el rebase posterior a su merge.

Sin migraciones Prisma, sin cambios de audio/codecs/mezcla ni lifecycle de LiveKit.
