### PR TITLE
test(auth): defuse hardcoded 2026-08-05 ticket expiry time-bomb

### DIFF
--- a/src/app/api/auth/ticket/__tests__/route.test.ts
+++ b/src/app/api/auth/ticket/__tests__/route.test.ts
@@ -42,7 +42,7 @@ function ticketRow(overrides: Partial<EntitlementRow> = {}): EntitlementRow {
         state: 'ISSUED',
         boundEmail: null,
         boundAt: null,
-        expiresAt: new Date('2026-08-05T00:00:00.000Z'),
+        expiresAt: new Date('2027-08-05T00:00:00.000Z'),
         revokedAt: null,
         ...overrides,
     };

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -179,7 +179,7 @@ async function attendeeRow(entitlement: Record<string, unknown> = {}) {
             tier: 'GLOBAL_SOUTH',
             codeLastFour: '4XZP',
             state: 'BOUND',
-            expiresAt: new Date('2026-08-05T00:00:00.000Z'),
+            expiresAt: new Date('2027-08-05T00:00:00.000Z'),
             revokedAt: null,
             ...entitlement,
         },


### PR DESCRIPTION
## Fix urgente: bomba de tiempo en fixtures de tests auth

**`main` comenzó a fallar después de 2026-08-05T00:00:00Z.** Dos fixtures tienen `expiresAt` hardcodeado a `2026-08-05T00:00:00.000Z`; pasada esa fecha los tickets mockeados vencen y 12 tests fallan con 401 en `main` limpio:

- `src/lib/__tests__/auth.test.ts` (5 tests)
- `src/app/api/auth/ticket/__tests__/route.test.ts` (7 tests)

Cualquier corrida de CI sobre main (o cualquier PR rebasada) falla hasta que esto entre.

### Cambio

Únicamente el bump de las dos fechas (`2026-08-05` → `2027-08-05`), una línea por archivo. Sin código de producción, sin archivos de ninguna otra feature.

### Evidencia

- **Antes** (main limpio, `28f1135`, corridos el 2026-08-04 ~18:30 CST = 2026-08-05 00:30 UTC): `12 failed` — todos 401 por ticket expirado. Verificado también con `git stash` sobre la rama de trabajo para descartar interferencia.
- **Después** (esta rama): `47 passed (47)` en los dos archivos afectados; CI de esta PR corre la suite completa.

### Contexto

Detectado durante la verificación de #145 (observación del review de @nicoechaniz pidiendo separarlo de esa PR funcional — va aquí solo, como pediste). Si conviene una solución estructural (fechas relativas a `Date.now()` en los fixtures), la propongo como follow-up aparte; esta PR es el desbloqueo mínimo.

Review rápida apreciada, @nicoechaniz — main está rojo para cualquier PR nueva.
