### PR TITLE
test(e2e): gate functional journeys on Firefox

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,6 +103,12 @@ jobs:
           --project=w320
           --project=android-chrome
 
+      - name: Install Firefox after Chromium screenshot gates
+        run: npx playwright install --with-deps firefox
+
+      - name: Run Firefox functional and accessibility gates
+        run: npx playwright test --project=firefox
+
       - name: Install WebKit after Chromium screenshot gates
         run: npx playwright install --with-deps webkit
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -77,6 +77,25 @@ export default defineConfig({
             grepInvert: WEBKIT_ATTENDEE_CONTINUITY,
         },
         {
+            // A second desktop engine catches focus, form, cookie and
+            // navigation regressions that Chromium alone cannot expose. The
+            // dedicated media-continuity matrix remains on Chromium/WebKit;
+            // Firefox runs every other functional/accessibility suite.
+            name: 'firefox',
+            use: {
+                ...devices['Desktop Firefox'],
+                viewport: { width: 1440, height: 900 },
+                launchOptions: {
+                    args: [],
+                    firefoxUserPrefs: {
+                        'media.navigator.streams.fake': true,
+                        'media.navigator.permission.disabled': true,
+                    },
+                },
+            },
+            testIgnore: [PER_WIDTH, MEDIA_CONTINUITY],
+        },
+        {
             // Playwright WebKit catches engine-specific autoplay and media
             // lifecycle failures. A real iPhone Safari remains the launch gate.
             name: 'iphone-webkit',


### PR DESCRIPTION
## Outcome

Adds Firefox as a required desktop-engine quality gate for #69.

- runs every non-responsive, non-media functional/accessibility suite in Firefox;
- covers public access, keyboard focus, axe checks, roles/capabilities, hand queue, controlled invitation, global termination, stage consent and two consecutive `FACILITATOR_OP` lifecycles;
- keeps screenshot baselines on Chromium before installing Firefox dependencies;
- keeps the dedicated fake-device media matrix on Chromium/WebKit;
- documents that automation does not replace physical iPhone/Android/Firefox evidence.

## Evidence

Fresh local synthetic stack:

- PostgreSQL 16 throwaway fixture + all migrations;
- LiveKit v1.13.4 dev server;
- Playwright Firefox 151 / build 1532;
- `npx playwright test --project=firefox`: **24/24 passed** in 2.1 minutes;
- `npx playwright test --list --project=firefox`: exactly 24 tests across 8 files;
- `git diff --check`: passed.

The temporary containers were stopped and removed after the run. No participant data, production credential, audio path or runtime UI changed.

## Risk / rollback

The cost is additional CI duration and browser download. It runs after Chromium visual gates so dependency/font installation cannot perturb their baselines. Rollback is reverting `0b0322f`.

Refs #69 and #24.
