### PR TITLE
test(e2e): make the ops session heading locator unambiguous

### DIFF
--- a/e2e/tests/accessibility.spec.ts
+++ b/e2e/tests/accessibility.spec.ts
@@ -108,7 +108,11 @@ stackTest.describe('role surfaces', () => {
             'E2E Facilitator',
             ROUTES.opsSession(SESSION_ES.id),
         );
-        await expect(page.getByText(SESSION_ES.title)).toBeVisible();
+        await expect(page.getByRole('heading', {
+            level: 1,
+            name: `Harmonic Projection — ${SESSION_ES.title}`,
+            exact: true,
+        })).toBeVisible();
         await assertAccessible(page, 'ops-session-console', testInfo);
 
         for (const [name, selector] of [


### PR DESCRIPTION
## Why

The Firefox accessibility gate intermittently failed because `getByText(SESSION_ES.title)` matched both the page `<h1>` and a cockpit label. Playwright strict mode correctly rejected the ambiguous locator.

## Change

Target the exact level-1 accessible heading for the ops session. Product behavior is unchanged.

## Evidence

- Firefox full `e2e/tests/accessibility.spec.ts`: 6/6 passed
- `npx tsc --noEmit`
- `npx eslint e2e/tests/accessibility.spec.ts`
- `git diff --check`

## Risk / rollback

Test-only, low risk. Revert commit `aef5ecf` to roll back.

Supports #69 and unblocks the independent diagnostics PR #153 CI rerun.