### PR TITLE
fix(auth): make dual-room participant joins race-safe

### DIFF
--- a/src/lib/__tests__/room-entitlement.integration.test.ts
+++ b/src/lib/__tests__/room-entitlement.integration.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createRequest } from '@/__tests__/helpers';
+import { prisma } from '@/lib/db';
+import { digestSessionToken } from '@/lib/session-auth';
+
+vi.mock('@/lib/livekit-server', () => ({
+    stableRoomIdentity: (eventId: string, kind: string, principalId: string) =>
+        `race:${eventId}:${kind}:${principalId}`,
+}));
+
+const integration = process.env.ROOM_ENTITLEMENT_INTEGRATION_TEST === '1'
+    ? describe
+    : describe.skip;
+
+const NOW = new Date('2026-08-05T12:00:00.000Z');
+const SESSION_ID = '91000000-0000-4000-8000-000000000156';
+const FACILITATOR_ID = '92000000-0000-4000-8000-000000000156';
+const TICKET_ID = '93000000-0000-4000-8000-000000000156';
+const TICKET_COOKIE = 'room-entitlement-race-ticket';
+const STAFF_COOKIE = 'room-entitlement-race-staff';
+
+function request(cookie: string) {
+    return createRequest(`/api/scheduled-sessions/${SESSION_ID}/token`, {
+        headers: { cookie: `hb_session=${cookie}` },
+    });
+}
+
+integration('room entitlement PostgreSQL concurrency', () => {
+    beforeAll(async () => {
+        const configured = process.env.DATABASE_URL;
+        if (!configured) throw new Error('room entitlement integration DATABASE_URL is required');
+        const expectedDatabase = new URL(configured).pathname.replace(/^\//, '');
+        const [{ database }] = await prisma.$queryRaw<Array<{ database: string }>>`
+            SELECT current_database() AS "database"
+        `;
+        if (!expectedDatabase.endsWith('_test') || database !== expectedDatabase) {
+            throw new Error(
+                'room entitlement integration writes are restricted to the exact configured *_test database',
+            );
+        }
+
+        await prisma.webSession.deleteMany({
+            where: { tokenDigest: { in: [
+                digestSessionToken(TICKET_COOKIE),
+                digestSessionToken(STAFF_COOKIE),
+            ] } },
+        });
+        await prisma.sessionParticipant.deleteMany({ where: { scheduledSessionId: SESSION_ID } });
+        await prisma.ticketEntitlement.deleteMany({ where: { id: TICKET_ID } });
+        await prisma.scheduledSession.deleteMany({ where: { id: SESSION_ID } });
+        await prisma.user.deleteMany({ where: { id: FACILITATOR_ID } });
+
+        await prisma.user.create({
+            data: {
+                id: FACILITATOR_ID,
+                email: 'room-race-facilitator@integration.invalid',
+                name: 'Race facilitator',
+                role: 'FACILITATOR',
+                passwordDigest: 'not-used',
+            },
+        });
+        await prisma.scheduledSession.create({
+            data: {
+                id: SESSION_ID,
+                title: 'Room entitlement race integration',
+                roomName: 'room-entitlement-race-integration',
+                language: 'SPANISH',
+                scheduledAt: NOW,
+                status: 'LIVE',
+                paidMode: true,
+                attendeeCap: 150,
+                facilitatorId: FACILITATOR_ID,
+            },
+        });
+        await prisma.ticketEntitlement.create({
+            data: {
+                id: TICKET_ID,
+                scheduledSessionId: SESSION_ID,
+                codeDigest: 'a'.repeat(64),
+                codeLastFour: 'R156',
+                tier: 'GLOBAL_SOUTH',
+                state: 'BOUND',
+                boundEmail: 'room-race-attendee@integration.invalid',
+                boundAt: NOW,
+                expiresAt: new Date('2026-08-06T12:00:00.000Z'),
+            },
+        });
+        await prisma.webSession.createMany({
+            data: [
+                {
+                    tokenDigest: digestSessionToken(TICKET_COOKIE),
+                    displayName: 'Race attendee',
+                    ticketEntitlementId: TICKET_ID,
+                    expiresAt: new Date('2026-08-06T12:00:00.000Z'),
+                },
+                {
+                    tokenDigest: digestSessionToken(STAFF_COOKIE),
+                    displayName: 'Race facilitator',
+                    staffUserId: FACILITATOR_ID,
+                    expiresAt: new Date('2026-08-06T12:00:00.000Z'),
+                },
+            ],
+        });
+        // Force PostgreSQL's non-arbiter principal-link constraint to win for
+        // every contender after the first. Production exposed the same P2002
+        // when Stage and Beacon materialized one fresh principal together:
+        // the upsert arbitrates `(session, identity)`, while the independent
+        // `(session, ticket|staff)` partial index can still reject the insert.
+        // The first insert keeps the canonical identity; delayed contenders
+        // get a trigger-only identity so they collide solely on the principal
+        // link. Application code must then re-read the canonical winner.
+        await prisma.$executeRawUnsafe(
+            'CREATE SEQUENCE room_entitlement_race_sequence START 1',
+        );
+        await prisma.$executeRawUnsafe(`
+            CREATE OR REPLACE FUNCTION room_entitlement_race_delay()
+            RETURNS trigger AS $$
+            DECLARE
+                contender bigint;
+            BEGIN
+                IF NEW.scheduled_session_id = '${SESSION_ID}'::uuid THEN
+                    contender := nextval('room_entitlement_race_sequence');
+                    IF contender > 1 THEN
+                        PERFORM pg_sleep(0.05);
+                        NEW.participant_identity := NEW.participant_identity || '-contender-' || contender;
+                    END IF;
+                END IF;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql
+        `);
+        await prisma.$executeRawUnsafe(`
+            CREATE TRIGGER room_entitlement_race_delay_trigger
+            BEFORE INSERT ON session_participants
+            FOR EACH ROW EXECUTE FUNCTION room_entitlement_race_delay()
+        `);
+    });
+
+    beforeEach(async () => {
+        await prisma.sessionParticipant.deleteMany({ where: { scheduledSessionId: SESSION_ID } });
+        await prisma.$executeRawUnsafe(
+            'ALTER SEQUENCE room_entitlement_race_sequence RESTART WITH 1',
+        );
+    });
+
+    afterAll(async () => {
+        await prisma.$executeRawUnsafe(
+            'DROP TRIGGER IF EXISTS room_entitlement_race_delay_trigger ON session_participants',
+        );
+        await prisma.$executeRawUnsafe(
+            'DROP FUNCTION IF EXISTS room_entitlement_race_delay()',
+        );
+        await prisma.$executeRawUnsafe(
+            'DROP SEQUENCE IF EXISTS room_entitlement_race_sequence',
+        );
+        await prisma.webSession.deleteMany({
+            where: { tokenDigest: { in: [
+                digestSessionToken(TICKET_COOKIE),
+                digestSessionToken(STAFF_COOKIE),
+            ] } },
+        });
+        await prisma.sessionParticipant.deleteMany({ where: { scheduledSessionId: SESSION_ID } });
+        await prisma.ticketEntitlement.deleteMany({ where: { id: TICKET_ID } });
+        await prisma.scheduledSession.deleteMany({ where: { id: SESSION_ID } });
+        await prisma.user.deleteMany({ where: { id: FACILITATOR_ID } });
+        await prisma.$disconnect();
+    });
+
+    it.each([
+        ['ticket', TICKET_COOKIE, TICKET_ID, null],
+        ['staff', STAFF_COOKIE, null, FACILITATOR_ID],
+    ] as const)(
+        'converges concurrent fresh %s joins onto one canonical participant',
+        async (_kind, cookie, ticketEntitlementId, staffUserId) => {
+            const { resolveRoomPrincipal } = await import('../room-entitlement');
+            const results = await Promise.all(
+                Array.from({ length: 24 }, () =>
+                    resolveRoomPrincipal(request(cookie), SESSION_ID, NOW)),
+            );
+
+            expect(results.every((result) => result.ok)).toBe(true);
+            const successful = results.filter((result) => result.ok);
+            expect(new Set(successful.map((result) => result.principal.identity)).size).toBe(1);
+
+            const participants = await prisma.sessionParticipant.findMany({
+                where: { scheduledSessionId: SESSION_ID },
+            });
+            expect(participants).toHaveLength(1);
+            expect(participants[0]).toMatchObject({
+                participantIdentity: successful[0].principal.identity,
+                ticketEntitlementId,
+                staffUserId,
+                leftAt: null,
+            });
+        },
+    );
+});

--- a/src/lib/__tests__/room-entitlement.test.ts
+++ b/src/lib/__tests__/room-entitlement.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Prisma } from '@prisma/client';
+
 import { createRequest } from '@/__tests__/helpers';
 
 const findWebSession = vi.fn();
@@ -53,6 +55,13 @@ const activeTicketSession = {
 function request(withCookie = true) {
     return createRequest('/api/scheduled-sessions/event-1/token', {
         headers: withCookie ? { cookie: 'hb_session=opaque-cookie' } : {},
+    });
+}
+
+function prismaError(code: string) {
+    return new Prisma.PrismaClientKnownRequestError('room participant write failed', {
+        code,
+        clientVersion: 'test',
     });
 }
 
@@ -151,6 +160,107 @@ describe('resolveRoomPrincipal', () => {
         expect(upsertParticipant).toHaveBeenCalledWith(expect.objectContaining({
             update: { leftAt: null },
         }));
+    });
+
+    it('recovers a concurrent ticket insert only from the exact canonical winner', async () => {
+        findParticipant
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ id: 'ticket-race-winner' });
+        upsertParticipant.mockRejectedValue(prismaError('P2002'));
+        updateParticipant.mockResolvedValue({
+            publishGrantedAt: now,
+            publishRevokedAt: null,
+        });
+
+        const { resolveRoomPrincipal } = await import('../room-entitlement');
+        const result = await resolveRoomPrincipal(request(), 'event-1', now);
+
+        expect(result).toMatchObject({
+            ok: true,
+            principal: {
+                identity: 'opaque:event-1:ticket:ticket-1',
+                canPublish: true,
+            },
+        });
+        expect(findParticipant).toHaveBeenLastCalledWith({
+            where: {
+                scheduledSessionId: 'event-1',
+                participantIdentity: 'opaque:event-1:ticket:ticket-1',
+                ticketEntitlementId: 'ticket-1',
+            },
+            select: { id: true },
+        });
+        expect(updateParticipant).toHaveBeenCalledWith({
+            where: { id: 'ticket-race-winner' },
+            data: { leftAt: null },
+            select: {
+                publishGrantedAt: true,
+                publishRevokedAt: true,
+            },
+        });
+    });
+
+    it('recovers the equivalent concurrent staff insert', async () => {
+        findWebSession.mockResolvedValue({
+            expiresAt: new Date('2026-08-03T00:00:00Z'),
+            revokedAt: null,
+            ticketEntitlement: null,
+            staffUser: {
+                id: 'facilitator-1',
+                name: 'Julián',
+                role: 'FACILITATOR',
+                disabledAt: null,
+            },
+        });
+        findParticipant
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ id: 'staff-race-winner' });
+        upsertParticipant.mockRejectedValue(prismaError('P2002'));
+        updateParticipant.mockResolvedValue({
+            publishGrantedAt: now,
+            publishRevokedAt: null,
+        });
+
+        const { resolveRoomPrincipal } = await import('../room-entitlement');
+        const result = await resolveRoomPrincipal(request(), 'event-1', now);
+
+        expect(result).toMatchObject({
+            ok: true,
+            principal: {
+                identity: 'opaque:event-1:staff:facilitator-1',
+                canPublish: true,
+            },
+        });
+        expect(findParticipant).toHaveBeenLastCalledWith({
+            where: {
+                scheduledSessionId: 'event-1',
+                participantIdentity: 'opaque:event-1:staff:facilitator-1',
+                staffUserId: 'facilitator-1',
+            },
+            select: { id: true },
+        });
+    });
+
+    it('does not hide a unique conflict without the exact canonical principal', async () => {
+        findParticipant
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null);
+        const conflict = prismaError('P2002');
+        upsertParticipant.mockRejectedValue(conflict);
+
+        const { resolveRoomPrincipal } = await import('../room-entitlement');
+        await expect(resolveRoomPrincipal(request(), 'event-1', now)).rejects.toBe(conflict);
+        expect(updateParticipant).not.toHaveBeenCalled();
+    });
+
+    it('does not retry a non-unique participant write failure', async () => {
+        const failure = prismaError('P2025');
+        upsertParticipant.mockRejectedValue(failure);
+
+        const { resolveRoomPrincipal } = await import('../room-entitlement');
+        await expect(resolveRoomPrincipal(request(), 'event-1', now)).rejects.toBe(failure);
+        expect(findParticipant).toHaveBeenCalledTimes(1);
+        expect(updateParticipant).not.toHaveBeenCalled();
     });
 
     it('versions commerce identities so old-token cleanup cannot kick restored access', async () => {

--- a/src/lib/room-entitlement.ts
+++ b/src/lib/room-entitlement.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server';
 
+import { Prisma } from '@prisma/client';
+
 import { prisma } from '@/lib/db';
 import { stableRoomIdentity } from '@/lib/livekit-server';
 import { eventStaffPolicy } from '@/lib/staff-capabilities';
@@ -56,6 +58,49 @@ type RoomAccessResult =
         status: 401 | 403 | 404;
         error: 'Authentication required' | 'Not authorized' | 'Session not found';
     };
+
+type ParticipantGrantState = {
+    publishGrantedAt: Date | null;
+    publishRevokedAt: Date | null;
+};
+
+async function recoverConcurrentParticipant(
+    access: RoomAccessBase,
+    error: unknown,
+): Promise<ParticipantGrantState> {
+    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== 'P2002') {
+        throw error;
+    }
+
+    // The identity upsert has one arbiter, while the event-scoped ticket and
+    // staff links are protected by separate partial unique indexes. Under a
+    // fresh Stage+Beacon join PostgreSQL may report one of those independent
+    // conflicts even though the other request already created the exact same
+    // principal. Recover only that exact canonical winner: an unrelated
+    // P2002, stale identity or mismatched principal must remain an error.
+    const winner = await prisma.sessionParticipant.findFirst({
+        where: {
+            scheduledSessionId: access.session.id,
+            participantIdentity: access.identity,
+            ...(access.ticketEntitlementId
+                ? { ticketEntitlementId: access.ticketEntitlementId }
+                : { staffUserId: access.staffUserId! }),
+        },
+        select: { id: true },
+    });
+    if (!winner) {
+        throw error;
+    }
+
+    return prisma.sessionParticipant.update({
+        where: { id: winner.id },
+        data: { leftAt: null },
+        select: {
+            publishGrantedAt: true,
+            publishRevokedAt: true,
+        },
+    });
+}
 
 /**
  * Read-only half of room access resolution: cookie, entitlement, event
@@ -300,44 +345,49 @@ export async function resolveRoomPrincipal(
     // event-scoped principal first and migrate that row to the stable identity.
     // Otherwise an upsert keyed only by identity attempts to insert a second
     // `(session, staff)` row and hits the migration's partial unique index.
-    const participant = existingParticipant
-        ? await prisma.sessionParticipant.update({
-            where: { id: existingParticipant.id },
-            data: {
-                participantIdentity: access.identity,
-                leftAt: null,
-            },
-            select: {
-                publishGrantedAt: true,
-                publishRevokedAt: true,
-            },
-        })
-        : await prisma.sessionParticipant.upsert({
-            where: {
-                scheduledSessionId_participantIdentity: {
+    let participant: ParticipantGrantState;
+    try {
+        participant = existingParticipant
+            ? await prisma.sessionParticipant.update({
+                where: { id: existingParticipant.id },
+                data: {
+                    participantIdentity: access.identity,
+                    leftAt: null,
+                },
+                select: {
+                    publishGrantedAt: true,
+                    publishRevokedAt: true,
+                },
+            })
+            : await prisma.sessionParticipant.upsert({
+                where: {
+                    scheduledSessionId_participantIdentity: {
+                        scheduledSessionId: scheduledSessionId,
+                        participantIdentity: access.identity,
+                    },
+                },
+                create: {
                     scheduledSessionId: scheduledSessionId,
                     participantIdentity: access.identity,
+                    ticketEntitlementId: access.ticketEntitlementId,
+                    staffUserId: access.staffUserId,
+                    publishGrantedAt: access.canPublishInitially ? now : null,
+                    grantVersion: access.canPublishInitially ? 1 : 0,
+                    grantReason: access.canPublishInitially
+                        ? 'Facilitator preflight grant'
+                        : null,
                 },
-            },
-            create: {
-                scheduledSessionId: scheduledSessionId,
-                participantIdentity: access.identity,
-                ticketEntitlementId: access.ticketEntitlementId,
-                staffUserId: access.staffUserId,
-                publishGrantedAt: access.canPublishInitially ? now : null,
-                grantVersion: access.canPublishInitially ? 1 : 0,
-                grantReason: access.canPublishInitially
-                    ? 'Facilitator preflight grant'
-                    : null,
-            },
-            update: {
-                leftAt: null,
-            },
-            select: {
-                publishGrantedAt: true,
-                publishRevokedAt: true,
-            },
-        });
+                update: {
+                    leftAt: null,
+                },
+                select: {
+                    publishGrantedAt: true,
+                    publishRevokedAt: true,
+                },
+            });
+    } catch (error) {
+        participant = await recoverConcurrentParticipant(access, error);
+    }
 
     return {
         ok: true,


### PR DESCRIPTION
## Diagnosis

Stage and Beacon request tokens concurrently. SessionParticipant upserts arbitrate the scheduled_session_id + participant_identity unique index, while PostgreSQL independently enforces the partial ticket and staff principal indexes. Either independent index can report P2002 after the sibling request creates the same canonical principal.

Observed twice in browser CI, including run 30981420190.

## Change

- On P2002 only, re-read the exact canonical winner by session + identity + ticket/staff link.
- Clear leftAt and preserve its durable grant.
- Re-throw non-P2002 failures and P2002 without that exact winner.
- Add real PostgreSQL concurrency coverage for ticket and staff joins; the test deterministically forces the non-arbiter constraint path.

## Evidence

Before the fix, both PostgreSQL cases failed with:
- ticket principal partial-index P2002
- staff principal partial-index P2002

After the fix:
- focused unit: 21/21
- PostgreSQL integration: 2/2, 24 concurrent requests per principal
- full Vitest: 777 passed, 9 skipped
- TypeScript: pass
- ESLint (changed files): pass
- production build: pass
- 12 repeated real Chromium attendee journeys against isolated PostgreSQL passed during investigation

No audio path, codec, gain, routing, schema, migration, or production environment changed.

## Risk and rollback

The recovery is deliberately fail-closed unless all canonical keys match. Rollback is a normal revert of commit d684409; no data migration is involved.

Closes #156
