### PR TITLE
perf(ops): pause visual polling in hidden drawers

### DIFF
--- a/e2e/tests/ops-tapestry-requests.spec.ts
+++ b/e2e/tests/ops-tapestry-requests.spec.ts
@@ -158,3 +158,77 @@ stackTest('operational tapestry stays O(1) at 0/1/50/150 participants', async ({
     mismatched = false;
     await expect(section.locator('[aria-hidden="true"]')).toBeVisible({ timeout: 10_000 });
 });
+
+stackTest('hidden health preview spends 0/N/0 requests while the rail stays live', async ({ page }) => {
+    stackTest.slow();
+    const counters = { health: 0, composite: 0 };
+
+    page.on('request', (request) => {
+        if (request.frame() !== page.mainFrame()) return;
+        const url = request.url();
+        if (url.includes('/api/ops/health')) counters.health += 1;
+        if (
+            url.includes(`/api/tapestry/${SESSION_ES.id}`) &&
+            !url.includes('view=ops-tapestry')
+        ) {
+            counters.composite += 1;
+        }
+    });
+
+    await page.route('**/api/ops/health**', async (route) => {
+        const green = { status: 'green', detail: 'Synthetic healthy check', latencyMs: 1 };
+        await route.fulfill({
+            json: {
+                status: 'green',
+                checkedAt: new Date().toISOString(),
+                session: { id: SESSION_ES.id, title: SESSION_ES.title, status: 'LIVE' },
+                checks: {
+                    postgres: green,
+                    livekit: green,
+                    stageRoom: green,
+                    publisherGrants: green,
+                    bedPublisher: green,
+                    tapestry: green,
+                },
+            },
+        });
+    });
+    await page.route(`**/api/tapestry/${SESSION_ES.id}**`, async (route) => {
+        await route.fulfill({
+            body: Buffer.from('R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', 'base64'),
+            contentType: 'image/gif',
+            headers: { 'x-tapestry-revision': '7' },
+        });
+    });
+    await page.route(`**/session/${SESSION_ES.id}?surface=cockpit`, async (route) => {
+        await route.fulfill({ contentType: 'text/html', body: '<html><body>room stub</body></html>' });
+    });
+
+    await loginViaDashboard(page, 'OPERATOR', 'Hidden Preview Op', ROUTES.opsSession(SESSION_ES.id));
+    await expect.poll(() => counters.health).toBeGreaterThanOrEqual(1);
+    await page.waitForTimeout(2_500);
+    expect(counters.composite, 'closed health drawer').toBe(0);
+
+    await page.locator('[data-signal="health"]').click();
+    const drawer = page.getByRole('dialog');
+    await expect(drawer.getByRole('region', { name: /Tapestry|Tapiz/i })).toBeVisible();
+    await expect.poll(() => counters.composite).toBeGreaterThanOrEqual(1);
+    await page.waitForTimeout(2_500);
+    const openSpend = counters.composite;
+    expect(openSpend, 'open health drawer').toBeGreaterThanOrEqual(1);
+    expect(openSpend, 'one coordinator while open').toBeLessThanOrEqual(3);
+
+    await drawer.getByRole('button', { name: /Return to the live room|Volver a la sala/i }).click();
+    const compositeAtClose = counters.composite;
+    const healthAtClose = counters.health;
+    await expect.poll(() => counters.health, { timeout: 12_000 }).toBeGreaterThan(healthAtClose);
+    expect(counters.composite, 'closed preview remains paused while rail health refreshes')
+        .toBe(compositeAtClose);
+
+    await page.locator('[data-signal="health"]').click();
+    await expect.poll(() => counters.composite).toBeGreaterThan(compositeAtClose);
+    await drawer.getByRole('button', { name: /Return to the live room|Volver a la sala/i }).click();
+    const compositeAtSecondClose = counters.composite;
+    await page.waitForTimeout(2_500);
+    expect(counters.composite, 'second close leaves no accumulated timer').toBe(compositeAtSecondClose);
+});

--- a/src/app/ops/health/OpsHealthClient.tsx
+++ b/src/app/ops/health/OpsHealthClient.tsx
@@ -98,6 +98,7 @@ export default function OpsHealthClient({
     copy,
     staffRoles,
     onLevelChange,
+    visualActive = true,
 }: {
     role: StaffRole;
     sessionId?: string;
@@ -105,6 +106,7 @@ export default function OpsHealthClient({
     copy: Messages['ops']['healthPanel'];
     staffRoles: Messages['staffRoles'];
     onLevelChange?: (level: HealthLevel) => void;
+    visualActive?: boolean;
 }) {
     const [report, setReport] = useState<OperatorHealthReport | null>(null);
     const [endpointError, setEndpointError] = useState<string | null>(null);
@@ -189,6 +191,7 @@ export default function OpsHealthClient({
                     sessionId={report.session.id}
                     staffOnly
                     labels={messages[locale].tapestry}
+                    active={visualActive}
                 />
             ) : null}
 

--- a/src/components/ops/ConductorCockpit.tsx
+++ b/src/components/ops/ConductorCockpit.tsx
@@ -344,6 +344,7 @@ export default function ConductorCockpit({
                             copy={healthCopy}
                             staffRoles={staffRoleLabels}
                             onLevelChange={onHealthChange}
+                            visualActive={drawer === 'health'}
                         />
                     </div>
                 </aside>

--- a/src/components/ops/__tests__/ConductorCockpit.test.tsx
+++ b/src/components/ops/__tests__/ConductorCockpit.test.tsx
@@ -14,6 +14,7 @@ const callbacks = vi.hoisted(() => ({
         sessionStatus?: 'SCHEDULED' | 'LIVE' | 'ENDED' | 'CANCELLED';
     }) => void),
     health: null as null | ((level: 'green' | 'yellow' | 'red') => void),
+    healthVisualActive: null as boolean | null,
 }));
 
 vi.mock('../SessionLifecycleControl', () => ({
@@ -35,8 +36,15 @@ vi.mock('../AdmissionConsole', () => ({
     default: () => <div data-testid="admission-panel">Admission</div>,
 }));
 vi.mock('@/app/ops/health/OpsHealthClient', () => ({
-    default: ({ onLevelChange }: { onLevelChange?: typeof callbacks.health }) => {
+    default: ({
+        onLevelChange,
+        visualActive,
+    }: {
+        onLevelChange?: typeof callbacks.health;
+        visualActive?: boolean;
+    }) => {
         callbacks.health = onLevelChange ?? null;
+        callbacks.healthVisualActive = visualActive ?? true;
         return <div data-testid="health-panel">Health</div>;
     },
 }));
@@ -69,6 +77,7 @@ afterEach(() => {
     callbacks.lifecycle = null;
     callbacks.summary = null;
     callbacks.health = null;
+    callbacks.healthVisualActive = null;
 });
 
 describe('ConductorCockpit', () => {
@@ -140,5 +149,21 @@ describe('ConductorCockpit', () => {
         fireEvent.keyDown(window, { key: 'Escape' });
         await waitFor(() => expect(trigger).toHaveFocus());
         expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    it('activates the health preview only while its drawer is visible', () => {
+        render(<ConductorCockpit {...props} />);
+        expect(callbacks.healthVisualActive).toBe(false);
+
+        fireEvent.click(screen.getByRole('button', { name: /Health.*yellow/i }));
+        expect(callbacks.healthVisualActive).toBe(true);
+
+        fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', {
+            name: /Return to the live room/,
+        }));
+        expect(callbacks.healthVisualActive).toBe(false);
+
+        fireEvent.click(screen.getByRole('button', { name: /Hands/i }));
+        expect(callbacks.healthVisualActive).toBe(false);
     });
 });

--- a/src/components/session/ThumbnailTapestry.tsx
+++ b/src/components/session/ThumbnailTapestry.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocale } from '@/context/LocaleContext';
 import type { Messages } from '@/lib/i18n';
 
@@ -8,6 +8,7 @@ type Props = {
     sessionId: string;
     staffOnly?: boolean;
     labels?: Messages['tapestry'];
+    active?: boolean;
 };
 
 type PublicHand = {
@@ -30,16 +31,41 @@ type HandsSnapshot = {
 
 const EMPTY_HANDS: HandsSnapshot = { hands: [], layout: null };
 
-export default function ThumbnailTapestry({ sessionId, staffOnly = false, labels }: Props) {
+export default function ThumbnailTapestry({
+    sessionId,
+    staffOnly = false,
+    labels,
+    active = true,
+}: Props) {
     if (labels) {
-        return <ThumbnailTapestryView sessionId={sessionId} staffOnly={staffOnly} labels={labels} />;
+        return (
+            <ThumbnailTapestryView
+                sessionId={sessionId}
+                staffOnly={staffOnly}
+                labels={labels}
+                active={active}
+            />
+        );
     }
-    return <LocalizedThumbnailTapestry sessionId={sessionId} staffOnly={staffOnly} />;
+    return (
+        <LocalizedThumbnailTapestry
+            sessionId={sessionId}
+            staffOnly={staffOnly}
+            active={active}
+        />
+    );
 }
 
-function LocalizedThumbnailTapestry({ sessionId, staffOnly = false }: Props) {
+function LocalizedThumbnailTapestry({ sessionId, staffOnly = false, active = true }: Props) {
     const { copy } = useLocale();
-    return <ThumbnailTapestryView sessionId={sessionId} staffOnly={staffOnly} labels={copy.tapestry} />;
+    return (
+        <ThumbnailTapestryView
+            sessionId={sessionId}
+            staffOnly={staffOnly}
+            labels={copy.tapestry}
+            active={active}
+        />
+    );
 }
 
 function parseHands(body: unknown): HandsSnapshot {
@@ -99,13 +125,22 @@ function ThumbnailTapestryView({
     sessionId,
     staffOnly,
     labels,
+    active = true,
 }: Props & { labels: Messages['tapestry'] }) {
     const [view, setView] = useState<TapestryView | null>(null);
+    const pollingControl = useRef<(next: boolean) => void>(() => undefined);
+    const activeRef = useRef(active);
+    // The session lifecycle effect may restart in the same commit as a
+    // visibility change. Give it the current value immediately so a hidden
+    // next session never spends one stale eager request before effects flush.
+    activeRef.current = active;
 
     useEffect(() => {
-        let active = true;
+        let alive = true;
+        let polling = false;
         let generation = 0;
         let controller: AbortController | null = null;
+        let timer: ReturnType<typeof setInterval> | null = null;
         // The ONE object URL the visible state currently owns. Any URL not
         // transferred here is revoked by the cycle that created it.
         let publishedUrl: string | null = null;
@@ -136,7 +171,7 @@ function ThumbnailTapestryView({
         // ONE coordinator for the whole visual unit: composite first, hands
         // immediately after, published only as one accepted cycle's result.
         const cycle = async () => {
-            if (!active) return;
+            if (!alive || !polling) return;
             const myGeneration = ++generation;
             controller?.abort();
             controller = new AbortController();
@@ -149,7 +184,7 @@ function ThumbnailTapestryView({
             let chosen: (typeof candidates)[number] | null = null;
 
             for (let attempt = 0; attempt < MAX_CORRELATION_ATTEMPTS; attempt += 1) {
-                if (!active || myGeneration !== generation) break;
+                if (!alive || !polling || myGeneration !== generation) break;
                 let url: string | null = null;
                 try {
                     const compositeRes = await fetch(compositeUrl, {
@@ -160,7 +195,7 @@ function ThumbnailTapestryView({
                     if (!compositeRes.ok) break; // keep previous image; hands still refresh below
                     const revision = compositeRes.headers.get('x-tapestry-revision');
                     const blob = await compositeRes.blob();
-                    if (!active || myGeneration !== generation) {
+                    if (!alive || !polling || myGeneration !== generation) {
                         // Superseded or unmounted mid-read: stop before
                         // spending the sidecar fetch or creating any blob.
                         return;
@@ -191,7 +226,7 @@ function ThumbnailTapestryView({
                 if (c !== chosen) URL.revokeObjectURL(c.url);
             }
 
-            if (!active || myGeneration !== generation) {
+            if (!alive || !polling || myGeneration !== generation) {
                 // A stale generation discards its chosen URL before dying.
                 if (chosen) URL.revokeObjectURL(chosen.url);
                 return;
@@ -203,7 +238,7 @@ function ThumbnailTapestryView({
                 if (staffOnly) return;
                 try {
                     const hands = await fetchHands(signal);
-                    if (!active || myGeneration !== generation) return;
+                    if (!alive || !polling || myGeneration !== generation) return;
                     setView((prev) => ({
                         compositeUrl: prev?.compositeUrl ?? null,
                         buildRevision: prev?.buildRevision ?? null,
@@ -226,18 +261,44 @@ function ThumbnailTapestryView({
             if (retired && retired !== chosen.url) URL.revokeObjectURL(retired);
         };
 
-        void cycle();
-        const timer = setInterval(() => void cycle(), POLL_MS);
-        return () => {
-            active = false;
-            clearInterval(timer);
+        const stop = () => {
+            if (!polling) return;
+            polling = false;
+            generation += 1;
+            if (timer) {
+                clearInterval(timer);
+                timer = null;
+            }
             controller?.abort();
+            controller = null;
+        };
+        const start = () => {
+            if (!alive || polling) return;
+            polling = true;
+            void cycle();
+            timer = setInterval(() => void cycle(), POLL_MS);
+        };
+        pollingControl.current = (next) => {
+            if (next) start();
+            else stop();
+        };
+        if (activeRef.current) start();
+
+        return () => {
+            alive = false;
+            stop();
+            pollingControl.current = () => undefined;
             if (publishedUrl) {
                 URL.revokeObjectURL(publishedUrl);
                 publishedUrl = null;
             }
         };
     }, [sessionId, staffOnly]);
+
+    useEffect(() => {
+        activeRef.current = active;
+        pollingControl.current(active);
+    }, [active]);
 
     const names = (view?.hands ?? EMPTY_HANDS).hands.map((hand) => hand.name);
     // Zoom/Meet-style name tags over each raised hand's own tile. The layout

--- a/src/components/session/__tests__/ThumbnailTapestry.test.tsx
+++ b/src/components/session/__tests__/ThumbnailTapestry.test.tsx
@@ -16,7 +16,9 @@ describe('ThumbnailTapestry', () => {
     it('omits cookies when loading the public composite', async () => {
         URL.createObjectURL = vi.fn(() => 'blob:tapestry');
         URL.revokeObjectURL = vi.fn();
-        global.fetch = vi.fn().mockResolvedValue(new Response(new Blob(['jpeg']), { status: 200 }));
+        global.fetch = vi.fn().mockImplementation(() =>
+            Promise.resolve(new Response(new Blob(['jpeg']), { status: 200 })),
+        );
         render(<ThumbnailTapestry sessionId="session-1" />);
         await waitFor(() => expect(fetch).toHaveBeenCalled());
         expect(vi.mocked(fetch).mock.calls[0][1]?.credentials).toBe('omit');
@@ -35,6 +37,95 @@ describe('ThumbnailTapestry', () => {
         expect(vi.mocked(fetch).mock.calls.some(([input]) =>
             String(input).includes('/tapestry/hands'),
         )).toBe(false);
+    });
+
+    it('pauses hidden polling, preserves the last frame, and refreshes immediately on resume', async () => {
+        vi.useFakeTimers();
+        let counter = 0;
+        URL.createObjectURL = vi.fn(() => `blob:frame-${++counter}`);
+        URL.revokeObjectURL = vi.fn();
+        const deferred: Array<(response: Response) => void> = [];
+        global.fetch = vi.fn().mockImplementation(() =>
+            new Promise<Response>((resolve) => deferred.push(resolve)),
+        );
+
+        const view = render(
+            <ThumbnailTapestry sessionId="session-1" staffOnly active={false} />,
+        );
+        await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+        expect(fetch).not.toHaveBeenCalled();
+
+        view.rerender(<ThumbnailTapestry sessionId="session-1" staffOnly active />);
+        expect(deferred).toHaveLength(1);
+        await act(async () => {
+            deferred[0](new Response(new Blob(['jpeg-1']), { status: 200 }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-1');
+
+        view.rerender(<ThumbnailTapestry sessionId="session-1" staffOnly active={false} />);
+        await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-1');
+        expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+        view.rerender(<ThumbnailTapestry sessionId="session-1" staffOnly active />);
+        expect(deferred).toHaveLength(2);
+        await act(async () => {
+            deferred[1](new Response(new Blob(['jpeg-2']), { status: 200 }));
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:frame-2');
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-1');
+
+        view.unmount();
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-2');
+        vi.useRealTimers();
+    });
+
+    it('aborts every stale cycle across ten rapid visibility changes without timer buildup', async () => {
+        vi.useFakeTimers();
+        URL.createObjectURL = vi.fn(() => 'blob:unexpected');
+        URL.revokeObjectURL = vi.fn();
+        const deferred: Array<{ signal?: AbortSignal; resolve: (response: Response) => void }> = [];
+        global.fetch = vi.fn().mockImplementation((_input: RequestInfo | URL, init?: RequestInit) =>
+            new Promise<Response>((resolve) => deferred.push({
+                signal: init?.signal ?? undefined,
+                resolve,
+            })),
+        );
+        const view = render(
+            <ThumbnailTapestry sessionId="session-1" staffOnly active={false} />,
+        );
+
+        for (let change = 0; change < 10; change += 1) {
+            view.rerender(
+                <ThumbnailTapestry
+                    sessionId="session-1"
+                    staffOnly
+                    active={change % 2 === 0}
+                />,
+            );
+        }
+        expect(deferred).toHaveLength(5);
+        expect(deferred.every(({ signal }) => signal?.aborted)).toBe(true);
+
+        await act(async () => { await vi.advanceTimersByTimeAsync(20_000); });
+        expect(fetch).toHaveBeenCalledTimes(5);
+
+        await act(async () => {
+            for (const request of deferred) {
+                request.resolve(new Response(new Blob(['late']), { status: 200 }));
+            }
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(URL.createObjectURL).not.toHaveBeenCalled();
+        expect(view.container.querySelector('img')).toBeNull();
+        vi.useRealTimers();
     });
 
     it('names raised hands from the authorized sidecar, never from the JPEG', async () => {


### PR DESCRIPTION
## Outcome

The cockpit keeps aggregate health polling alive for its rail signal, but the hidden health preview now spends zero composite requests. Opening the health drawer refreshes immediately and runs exactly one coordinator; closing it aborts in-flight work, clears the timer, preserves the last useful frame, and resumes without a burst.

## Change

- Add an explicit active contract to ThumbnailTapestry.
- Keep object URL ownership across pause/resume; revoke replacements and unmounts exactly once.
- Abort stale generations and suppress stale-session eager requests.
- Pass health drawer visibility explicitly from ConductorCockpit.
- Keep standalone /ops/health behavior active by default.
- Add unit coverage for hidden/open/hidden, ten rapid transitions, abort, late responses, timers and blob lifecycle.
- Add a real-browser 0/N/0 request measurement proving the health endpoint continues refreshing while the visual preview is paused.

## Evidence

- focused unit: 27/27
- full Vitest: 776 passed, 7 skipped
- TypeScript: pass
- ESLint changed files: pass
- production build: pass
- Chromium cockpit measurement: 1/1 in 13.7 s
- Existing O(1) 0/1/50/150 contract remains unchanged

No Room mount, LiveKit connection, audio gesture, track, codec, gain, public tapestry contract, schema or production environment changed.

## Risk and rollback

The new prop defaults active, so every existing public and standalone consumer preserves prior behavior. Only the hidden cockpit health preview opts out. Rollback is a normal revert of commit 65a1bf0; no data change is involved.

Closes #152
