### PR TITLE
fix(deploy): normalize private network membership

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,8 +47,13 @@ jobs:
           test "$(sudo -n stat -c '%a:%U:%G' /etc/harmonic-beacon/commerce.env)" = "600:root:root"
           test "$(sudo -n docker network inspect pmp_beacon_internal --format '{{.Internal}}')" = true
           members="$(sudo -n docker network inspect pmp_beacon_internal \
-            --format '{{range .Containers}}{{println .Name}}{{end}}' | sort)"
-          test "$members" = $'beacon-app\npmp-myth-worker\npmp-myth-worker-secondary'
+            --format '{{range .Containers}}{{println .Name}}{{end}}' | \
+            sed '/^[[:space:]]*$/d' | sort)"
+          expected_members=$'beacon-app\npmp-myth-worker\npmp-myth-worker-secondary'
+          if [ "$members" != "$expected_members" ]; then
+            printf 'Unexpected pmp_beacon_internal members:\n%s\n' "$members" >&2
+            exit 1
+          fi
           sudo -n docker compose --project-name app \
             --env-file /etc/harmonic-beacon/production.env config --quiet
 
@@ -158,8 +163,13 @@ jobs:
         run: |
           set -euo pipefail
           members="$(sudo -n docker network inspect pmp_beacon_internal \
-            --format '{{range .Containers}}{{println .Name}}{{end}}' | sort)"
-          test "$members" = $'beacon-app\npmp-myth-worker\npmp-myth-worker-secondary'
+            --format '{{range .Containers}}{{println .Name}}{{end}}' | \
+            sed '/^[[:space:]]*$/d' | sort)"
+          expected_members=$'beacon-app\npmp-myth-worker\npmp-myth-worker-secondary'
+          if [ "$members" != "$expected_members" ]; then
+            printf 'Unexpected pmp_beacon_internal members:\n%s\n' "$members" >&2
+            exit 1
+          fi
 
           container_has_env_name() {
             sudo -n docker inspect "$1" \

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -46,6 +46,15 @@ describe('production deploy contract', () => {
     expect(workflow).not.toMatch(/runs-on:\s+self-hosted\s*$/m);
   });
 
+  it('normalizes Docker network templates before exact membership checks', () => {
+    expect(
+      workflow.match(/sed '\/\^\[\[:space:\]\]\*\$\/d'/g),
+    ).toHaveLength(2);
+    expect(
+      workflow.match(/Unexpected pmp_beacon_internal members:/g),
+    ).toHaveLength(2);
+  });
+
   it('preserves and restores app and tapestry independently', () => {
     expect(workflow).toContain(
       'harmonic-beacon/app:rollback-${GITHUB_RUN_ID}',


### PR DESCRIPTION
## Outcome

Unblocks the fail-closed production deploy after GitHub run 30985349289 proved Docker can emit an empty template line before the three valid `pmp_beacon_internal` members. The old exact string comparison rejected the valid topology before any image preservation, migration, or container recreation.

- removes only blank/whitespace-only lines before sorting and exact membership comparison;
- keeps the same strict allowlist of `beacon-app`, `pmp-myth-worker`, and `pmp-myth-worker-secondary`;
- applies the normalization both before deploy and in the post-deploy private-boundary gate;
- emits only container names on mismatch, never environment values or secrets;
- adds a contract test requiring both normalization points and diagnostics.

## Evidence

- Failed release attempt #9/2: all code/contract tests passed, then prerequisites failed; no production mutation steps ran.
- Exact production command after normalization: `beacon-app,pmp-myth-worker,pmp-myth-worker-secondary`.
- Focused deploy contract: 7/7 passed.
- TypeScript: passed.
- Full ESLint quiet: passed.
- Diff check: passed.

## Risk and rollback

No application, data, commerce, media or audio behavior changes. The comparison remains fail-closed for every nonblank unexpected member. Rollback is a single revert of this commit.

Relates to #112 and #124.