### PR TITLE
fix(deploy): restrict mona runner privileges

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,16 @@ jobs:
         run: |
           set -euo pipefail
           test "$(hostname -s)" = mona
+          test "$(id -un)" = beacon-runner
+          test -x /usr/local/sbin/hb-deploy
 
       - uses: actions/checkout@v4
+
+      - name: Verify privileged helper provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmp --silent deploy/hb-deploy-root /usr/local/sbin/hb-deploy
 
       - uses: actions/setup-node@v4
         with:
@@ -42,40 +50,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sudo -n test -r /etc/harmonic-beacon/production.env
-          sudo -n test -r /etc/harmonic-beacon/commerce.env
-          test "$(sudo -n stat -c '%a:%U:%G' /etc/harmonic-beacon/commerce.env)" = "600:root:root"
-          test "$(sudo -n docker network inspect pmp_beacon_internal --format '{{.Internal}}')" = true
-          members="$(sudo -n docker network inspect pmp_beacon_internal \
-            --format '{{range .Containers}}{{println .Name}}{{end}}' | \
-            sed '/^[[:space:]]*$/d' | sort)"
-          expected_members=$'beacon-app\npmp-myth-worker\npmp-myth-worker-secondary'
-          if [ "$members" != "$expected_members" ]; then
-            printf 'Unexpected pmp_beacon_internal members:\n%s\n' "$members" >&2
-            exit 1
-          fi
-          sudo -n docker compose --project-name app \
-            --env-file /etc/harmonic-beacon/production.env config --quiet
+          sudo -n /usr/local/sbin/hb-deploy preflight \
+            "$GITHUB_WORKSPACE" "$GITHUB_SHA"
 
       - name: Preserve immutable rollback image
         id: rollback
         shell: bash
         run: |
           set -euo pipefail
-          previous_app="$(sudo -n docker inspect beacon-app --format '{{.Image}}' 2>/dev/null || true)"
-          if [ -n "$previous_app" ]; then
-            sudo -n docker tag "$previous_app" "harmonic-beacon/app:rollback-${GITHUB_RUN_ID}"
-            echo 'app_available=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'app_available=false' >> "$GITHUB_OUTPUT"
-          fi
-          previous_tapestry="$(sudo -n docker inspect beacon-tapestry --format '{{.Image}}' 2>/dev/null || true)"
-          if [ -n "$previous_tapestry" ]; then
-            sudo -n docker tag "$previous_tapestry" "harmonic-beacon/tapestry:rollback-${GITHUB_RUN_ID}"
-            echo 'tapestry_available=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'tapestry_available=false' >> "$GITHUB_OUTPUT"
-          fi
+          sudo -n /usr/local/sbin/hb-deploy preserve "$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Build commit image
         shell: bash
@@ -84,39 +67,29 @@ jobs:
           database_schema_version="$(find prisma/migrations -mindepth 1 -maxdepth 1 \
             -type d -printf '%f\n' | sort | tail -1)"
           test -n "$database_schema_version"
-          sudo -n env BEACON_IMAGE_TAG="$GITHUB_SHA" \
-            BEACON_GIT_SHA="$GITHUB_SHA" \
-            BEACON_BUILD_TIME="$build_time" \
-            BEACON_DATABASE_SCHEMA_VERSION="$database_schema_version" \
-            docker compose \
-            --project-name app --env-file /etc/harmonic-beacon/production.env \
-            build app tapestry
+          sudo -n /usr/local/sbin/hb-deploy build \
+            "$GITHUB_WORKSPACE" "$GITHUB_SHA" "$build_time" "$database_schema_version"
 
       - name: Apply additive migrations
         shell: bash
         run: |
-          sudo -n env BEACON_IMAGE_TAG="$GITHUB_SHA" docker compose \
-            --project-name app --env-file /etc/harmonic-beacon/production.env \
-            run --rm --no-deps app npx prisma migrate deploy
-          sudo -n env BEACON_IMAGE_TAG="$GITHUB_SHA" docker compose \
-            --project-name app --env-file /etc/harmonic-beacon/production.env \
-            run --rm --no-deps app npx prisma migrate status
+          sudo -n /usr/local/sbin/hb-deploy migrate \
+            "$GITHUB_WORKSPACE" "$GITHUB_SHA"
 
       - name: Replace app, reconciler and tapestry
         shell: bash
         run: |
-          sudo -n env BEACON_IMAGE_TAG="$GITHUB_SHA" docker compose \
-            --project-name app --env-file /etc/harmonic-beacon/production.env \
-            up -d --no-deps --force-recreate app commerce-reconciler tapestry
+          sudo -n /usr/local/sbin/hb-deploy replace \
+            "$GITHUB_WORKSPACE" "$GITHUB_SHA"
 
       - name: Wait for readiness
         shell: bash
         run: |
           set -euo pipefail
           for _attempt in $(seq 1 60); do
-            app_health="$(sudo -n docker inspect beacon-app --format '{{.State.Health.Status}}' 2>/dev/null || true)"
-            worker_health="$(sudo -n docker inspect beacon-commerce-reconciler --format '{{.State.Health.Status}}' 2>/dev/null || true)"
-            tapestry_health="$(sudo -n docker inspect beacon-tapestry --format '{{.State.Health.Status}}' 2>/dev/null || true)"
+            app_health="$(sudo -n /usr/local/sbin/hb-deploy health beacon-app 2>/dev/null || true)"
+            worker_health="$(sudo -n /usr/local/sbin/hb-deploy health beacon-commerce-reconciler 2>/dev/null || true)"
+            tapestry_health="$(sudo -n /usr/local/sbin/hb-deploy health beacon-tapestry 2>/dev/null || true)"
             if [ "$app_health" = healthy ] && [ "$worker_health" = healthy ] && \
               [ "$tapestry_health" = healthy ] && \
               curl --fail --silent --show-error http://127.0.0.1:3000/api/health/ready >/dev/null; then
@@ -124,10 +97,8 @@ jobs:
             fi
             sleep 2
           done
-          sudo -n docker compose --project-name app \
-            --env-file /etc/harmonic-beacon/production.env ps
-          sudo -n docker logs --tail 100 beacon-app || true
-          sudo -n docker logs --tail 100 beacon-commerce-reconciler || true
+          sudo -n /usr/local/sbin/hb-deploy status \
+            "$GITHUB_WORKSPACE" "$GITHUB_SHA"
           exit 1
 
       - name: Verify deployed revision publicly
@@ -162,37 +133,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          members="$(sudo -n docker network inspect pmp_beacon_internal \
-            --format '{{range .Containers}}{{println .Name}}{{end}}' | \
-            sed '/^[[:space:]]*$/d' | sort)"
-          expected_members=$'beacon-app\npmp-myth-worker\npmp-myth-worker-secondary'
-          if [ "$members" != "$expected_members" ]; then
-            printf 'Unexpected pmp_beacon_internal members:\n%s\n' "$members" >&2
-            exit 1
-          fi
-
-          container_has_env_name() {
-            sudo -n docker inspect "$1" \
-              --format '{{range .Config.Env}}{{println .}}{{end}}' | \
-              cut -d= -f1 | grep -Fxq "$2"
-          }
-          container_has_commerce_key() {
-            sudo -n docker inspect "$1" \
-              --format '{{range .Config.Env}}{{println .}}{{end}}' | \
-              cut -d= -f1 | grep -Eq '^BEACON_COMMERCE_SERVICE_KEY_'
-          }
-          container_has_env_name beacon-app BEACON_COMMERCE_SERVICE_KEY_CURRENT_ID
-          container_has_env_name beacon-app BEACON_COMMERCE_SERVICE_KEY_CURRENT
-          for container in beacon-postgres beacon-livekit beacon-playlist-bot \
-            beacon-tapestry beacon-commerce-reconciler pmp-myth-api \
-            pmp-myth-worker pmp-myth-worker-secondary \
-            pmp-myth-postgres pmp-myth-waha pmp-myth-rag pmp-myth-gateway; do
-            if sudo -n docker inspect "$container" >/dev/null 2>&1 && \
-              container_has_commerce_key "$container"; then
-              echo "Commerce bearer reached unexpected container: $container" >&2
-              exit 1
-            fi
-          done
+          sudo -n /usr/local/sbin/hb-deploy boundary
 
           for method in GET PUT; do
             code="$(curl --silent --show-error --output /dev/null \
@@ -210,48 +151,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          worker_expected=false
-          if [ "${{ steps.rollback.outputs.app_available }}" = true ]; then
-            sudo -n env BEACON_IMAGE_TAG="rollback-${GITHUB_RUN_ID}" docker compose \
-              --project-name app --env-file /etc/harmonic-beacon/production.env \
-              up -d --no-deps --force-recreate app
-            if sudo -n docker run --rm --entrypoint test \
-              "harmonic-beacon/app:rollback-${GITHUB_RUN_ID}" \
-              -f /app/scripts/commerce-media-worker.ts; then
-              sudo -n env BEACON_IMAGE_TAG="rollback-${GITHUB_RUN_ID}" docker compose \
-                --project-name app --env-file /etc/harmonic-beacon/production.env \
-                up -d --no-deps --force-recreate commerce-reconciler
-              worker_expected=true
-            else
-              sudo -n docker stop beacon-commerce-reconciler 2>/dev/null || true
-            fi
-          fi
-          if [ "${{ steps.rollback.outputs.tapestry_available }}" = true ]; then
-            sudo -n env BEACON_IMAGE_TAG="rollback-${GITHUB_RUN_ID}" docker compose \
-              --project-name app --env-file /etc/harmonic-beacon/production.env \
-              up -d --no-deps --force-recreate tapestry
-          fi
-          for _attempt in $(seq 1 60); do
-            app_ready=true
-            worker_ready=true
-            tapestry_ready=true
-            if [ "${{ steps.rollback.outputs.app_available }}" = true ]; then
-              if [ "$(sudo -n docker inspect beacon-app --format '{{.State.Health.Status}}' 2>/dev/null || true)" != healthy ] || \
-                ! curl --fail --silent --show-error http://127.0.0.1:3000/api/health/ready >/dev/null; then
-                app_ready=false
-              fi
-            fi
-            if [ "$worker_expected" = true ]; then
-              [ "$(sudo -n docker inspect beacon-commerce-reconciler --format '{{.State.Health.Status}}' 2>/dev/null || true)" = healthy ] || worker_ready=false
-            fi
-            if [ "${{ steps.rollback.outputs.tapestry_available }}" = true ]; then
-              [ "$(sudo -n docker inspect beacon-tapestry --format '{{.State.Health.Status}}' 2>/dev/null || true)" = healthy ] || tapestry_ready=false
-            fi
-            if [ "$app_ready" = true ] && [ "$worker_ready" = true ] && [ "$tapestry_ready" = true ]; then
-              exit 0
-            fi
-            sleep 2
-          done
-          sudo -n docker compose --project-name app \
-            --env-file /etc/harmonic-beacon/production.env ps
-          exit 1
+          sudo -n /usr/local/sbin/hb-deploy rollback \
+            "$GITHUB_WORKSPACE" "$GITHUB_RUN_ID" \
+            "${{ steps.rollback.outputs.app_available }}" \
+            "${{ steps.rollback.outputs.tapestry_available }}"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -57,7 +57,9 @@ interactive-login group. The only sudo command available to that identity is
 the root-owned `/usr/local/sbin/hb-deploy` entrypoint. That entrypoint validates
 the exact Actions workspace, commit SHA, run id, service allowlists and every
 other argument before performing the fixed release operations. It never accepts
-an arbitrary command, path, container or environment value.
+an arbitrary command, path, container or environment value, and it pins Compose
+to the tracked `docker-compose.yml` so an untracked override cannot broaden the
+deployment.
 
 Install the reviewed helper and sudo policy from an exact release checkout:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,10 +51,52 @@ unreviewed PR code must not execute on the production host.
 
 An organization administrator must place the mona runner in a runner group that
 is restricted to this repository and the `Deploy` workflow. Keep it offline
-until that restriction exists. The sudoers policy must allow only the explicit
-Docker, stat and file-read commands used by the workflow, without a general root
-shell. If the dedicated runner is unavailable, use the manual deploy below over
-the separately controlled SSH path; a generic runner is never an acceptable
+until that restriction exists. Run the service as the dedicated
+`beacon-runner` system identity: it must not belong to `docker`, `sudo`, or an
+interactive-login group. The only sudo command available to that identity is
+the root-owned `/usr/local/sbin/hb-deploy` entrypoint. That entrypoint validates
+the exact Actions workspace, commit SHA, run id, service allowlists and every
+other argument before performing the fixed release operations. It never accepts
+an arbitrary command, path, container or environment value.
+
+Install the reviewed helper and sudo policy from an exact release checkout:
+
+```bash
+sudo install -o root -g root -m 0755 \
+  deploy/hb-deploy-root /usr/local/sbin/hb-deploy
+sudo install -o root -g root -m 0440 \
+  deploy/beacon-runner.sudoers /etc/sudoers.d/harmonic-beacon-runner
+sudo visudo -cf /etc/sudoers.d/harmonic-beacon-runner
+```
+
+When migrating an already registered runner, stop its generated service before
+changing ownership, create the non-login identity, reinstall the service for
+that identity, and then start it again:
+
+```bash
+cd /opt/actions-runner
+sudo ./svc.sh stop
+sudo ./svc.sh uninstall
+sudo useradd --system --home-dir /opt/actions-runner \
+  --shell /usr/sbin/nologin beacon-runner
+sudo chown -R beacon-runner:beacon-runner /opt/actions-runner
+sudo ./svc.sh install beacon-runner
+sudo ./svc.sh start
+```
+
+Confirm both sides of the boundary: the helper preflight succeeds, while a root
+shell and direct Docker access are denied.
+
+```bash
+sudo -u beacon-runner sudo -n /usr/local/sbin/hb-deploy preflight \
+  /opt/actions-runner/_work/harmonic-beacon-webapp/harmonic-beacon-webapp \
+  <exact-commit-sha>
+! sudo -u beacon-runner sudo -n /usr/bin/id
+! sudo -u beacon-runner sudo -n /usr/bin/docker ps
+```
+
+If the dedicated runner is unavailable, use the manual deploy below over the
+separately controlled SSH path; a generic runner is never an acceptable
 fallback.
 
 ## Manual deploy on mona

--- a/deploy/beacon-runner.sudoers
+++ b/deploy/beacon-runner.sudoers
@@ -1,0 +1,5 @@
+Defaults:beacon-runner env_reset
+Defaults:beacon-runner !setenv
+
+Cmnd_Alias HARMONIC_BEACON_DEPLOY = /usr/local/sbin/hb-deploy *
+beacon-runner ALL=(root) NOPASSWD: HARMONIC_BEACON_DEPLOY

--- a/deploy/hb-deploy-root
+++ b/deploy/hb-deploy-root
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+
+# Root-owned deployment entrypoint for the dedicated mona Actions runner.
+# The runner may invoke this file through sudo, but cannot invoke Docker or an
+# arbitrary root shell directly. Keep every accepted argument fail-closed.
+
+set -euo pipefail
+
+readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH
+
+readonly PRODUCTION_ENV='/etc/harmonic-beacon/production.env'
+readonly COMMERCE_ENV='/etc/harmonic-beacon/commerce.env'
+readonly WORKSPACE='/opt/actions-runner/_work/harmonic-beacon-webapp/harmonic-beacon-webapp'
+readonly PRIVATE_NETWORK='pmp_beacon_internal'
+readonly EXPECTED_NETWORK_MEMBERS=$'beacon-app\npmp-myth-worker\npmp-myth-worker-secondary'
+
+die() {
+  printf 'hb-deploy: %s\n' "$*" >&2
+  exit 1
+}
+
+require_root() {
+  [ "${EUID}" -eq 0 ] || die 'must run as root through the restricted sudo rule'
+}
+
+validate_sha() {
+  [[ "$1" =~ ^[0-9a-f]{40}$ ]] || die 'invalid commit SHA'
+}
+
+validate_run_id() {
+  [[ "$1" =~ ^[1-9][0-9]{0,19}$ ]] || die 'invalid Actions run id'
+}
+
+validate_build_time() {
+  [[ "$1" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] ||
+    die 'invalid UTC build time'
+}
+
+validate_schema_version() {
+  [[ "$1" =~ ^[0-9]{14}_[a-z0-9_]+$ ]] || die 'invalid database schema version'
+}
+
+validate_boolean() {
+  [ "$1" = true ] || [ "$1" = false ] || die 'invalid boolean'
+}
+
+validate_workspace() {
+  [ "$1" = "$WORKSPACE" ] || die 'unexpected Actions workspace'
+  [ "$(realpath -e -- "$1")" = "$WORKSPACE" ] || die 'workspace must not redirect elsewhere'
+  [ -f "$WORKSPACE/docker-compose.yml" ] || die 'compose manifest is missing'
+}
+
+validate_checkout() {
+  local expected_sha="$1"
+  local actual_sha
+
+  validate_sha "$expected_sha"
+  actual_sha="$(git -c safe.directory="$WORKSPACE" -C "$WORKSPACE" rev-parse HEAD)"
+  [ "$actual_sha" = "$expected_sha" ] || die 'workspace revision does not match requested release'
+  git -c safe.directory="$WORKSPACE" -C "$WORKSPACE" diff --quiet -- ||
+    die 'workspace has tracked changes'
+  git -c safe.directory="$WORKSPACE" -C "$WORKSPACE" diff --cached --quiet -- ||
+    die 'workspace index has tracked changes'
+}
+
+validate_container() {
+  case "$1" in
+    beacon-app | beacon-commerce-reconciler | beacon-tapestry) ;;
+    *) die 'container is not in the deploy health allowlist' ;;
+  esac
+}
+
+compose() {
+  local workspace="$1"
+  local image_tag="$2"
+  shift 2
+
+  (
+    cd "$workspace"
+    BEACON_IMAGE_TAG="$image_tag" docker compose \
+      --project-name app --env-file "$PRODUCTION_ENV" "$@"
+  )
+}
+
+network_members() {
+  docker network inspect "$PRIVATE_NETWORK" \
+    --format '{{range .Containers}}{{println .Name}}{{end}}' |
+    sed '/^[[:space:]]*$/d' |
+    sort
+}
+
+require_exact_private_network() {
+  local members
+
+  [ "$(docker network inspect "$PRIVATE_NETWORK" --format '{{.Internal}}')" = true ] ||
+    die 'commerce network is not internal'
+  members="$(network_members)"
+  if [ "$members" != "$EXPECTED_NETWORK_MEMBERS" ]; then
+    printf 'Unexpected %s members:\n%s\n' "$PRIVATE_NETWORK" "$members" >&2
+    exit 1
+  fi
+}
+
+container_has_env_name() {
+  docker inspect "$1" \
+    --format '{{range .Config.Env}}{{println .}}{{end}}' |
+    cut -d= -f1 |
+    grep -Fxq "$2"
+}
+
+container_has_commerce_key() {
+  docker inspect "$1" \
+    --format '{{range .Config.Env}}{{println .}}{{end}}' |
+    cut -d= -f1 |
+    grep -Eq '^BEACON_COMMERCE_SERVICE_KEY_'
+}
+
+preflight() {
+  local workspace="$1"
+  local sha="$2"
+
+  validate_workspace "$workspace"
+  validate_checkout "$sha"
+  [ -r "$PRODUCTION_ENV" ] || die 'production environment is not readable by root'
+  [ -r "$COMMERCE_ENV" ] || die 'commerce environment is not readable by root'
+  [ "$(stat -c '%a:%U:%G' "$COMMERCE_ENV")" = '600:root:root' ] ||
+    die 'commerce environment permissions are not 600:root:root'
+  require_exact_private_network
+  compose "$workspace" "$sha" config --quiet
+}
+
+preserve() {
+  local run_id="$1"
+  local previous_app
+  local previous_tapestry
+
+  validate_run_id "$run_id"
+  previous_app="$(docker inspect beacon-app --format '{{.Image}}' 2>/dev/null || true)"
+  if [ -n "$previous_app" ]; then
+    docker tag "$previous_app" "harmonic-beacon/app:rollback-${run_id}"
+    printf 'app_available=true\n'
+  else
+    printf 'app_available=false\n'
+  fi
+
+  previous_tapestry="$(docker inspect beacon-tapestry --format '{{.Image}}' 2>/dev/null || true)"
+  if [ -n "$previous_tapestry" ]; then
+    docker tag "$previous_tapestry" "harmonic-beacon/tapestry:rollback-${run_id}"
+    printf 'tapestry_available=true\n'
+  else
+    printf 'tapestry_available=false\n'
+  fi
+}
+
+build() {
+  local workspace="$1"
+  local sha="$2"
+  local build_time="$3"
+  local schema_version="$4"
+
+  validate_workspace "$workspace"
+  validate_checkout "$sha"
+  validate_build_time "$build_time"
+  validate_schema_version "$schema_version"
+  (
+    cd "$workspace"
+    BEACON_IMAGE_TAG="$sha" \
+      BEACON_GIT_SHA="$sha" \
+      BEACON_BUILD_TIME="$build_time" \
+      BEACON_DATABASE_SCHEMA_VERSION="$schema_version" \
+      docker compose --project-name app --env-file "$PRODUCTION_ENV" \
+      build app tapestry
+  )
+}
+
+migrate() {
+  local workspace="$1"
+  local sha="$2"
+
+  validate_workspace "$workspace"
+  validate_checkout "$sha"
+  compose "$workspace" "$sha" run --rm --no-deps app npx prisma migrate deploy
+  compose "$workspace" "$sha" run --rm --no-deps app npx prisma migrate status
+}
+
+replace() {
+  local workspace="$1"
+  local sha="$2"
+
+  validate_workspace "$workspace"
+  validate_checkout "$sha"
+  compose "$workspace" "$sha" up -d --no-deps --force-recreate \
+    app commerce-reconciler tapestry
+}
+
+health() {
+  validate_container "$1"
+  docker inspect "$1" --format '{{.State.Health.Status}}'
+}
+
+status() {
+  local workspace="$1"
+  local sha="$2"
+
+  validate_workspace "$workspace"
+  validate_checkout "$sha"
+  compose "$workspace" "$sha" ps
+  for container in beacon-app beacon-commerce-reconciler beacon-tapestry; do
+    docker inspect "$container" \
+      --format 'name={{.Name}} status={{.State.Status}} health={{.State.Health.Status}} restarts={{.RestartCount}}'
+  done
+}
+
+boundary() {
+  require_exact_private_network
+  container_has_env_name beacon-app BEACON_COMMERCE_SERVICE_KEY_CURRENT_ID ||
+    die 'app is missing commerce key id'
+  container_has_env_name beacon-app BEACON_COMMERCE_SERVICE_KEY_CURRENT ||
+    die 'app is missing commerce key'
+
+  for container in beacon-postgres beacon-livekit beacon-playlist-bot \
+    beacon-tapestry beacon-commerce-reconciler pmp-myth-api \
+    pmp-myth-worker pmp-myth-worker-secondary pmp-myth-postgres \
+    pmp-myth-waha pmp-myth-rag pmp-myth-gateway; do
+    if docker inspect "$container" >/dev/null 2>&1 && container_has_commerce_key "$container"; then
+      die "commerce bearer reached unexpected container: $container"
+    fi
+  done
+}
+
+rollback() {
+  local workspace="$1"
+  local run_id="$2"
+  local app_available="$3"
+  local tapestry_available="$4"
+  local rollback_tag
+  local worker_expected=false
+
+  validate_workspace "$workspace"
+  validate_run_id "$run_id"
+  validate_boolean "$app_available"
+  validate_boolean "$tapestry_available"
+  rollback_tag="rollback-${run_id}"
+
+  if [ "$app_available" = true ]; then
+    compose "$workspace" "$rollback_tag" up -d --no-deps --force-recreate app
+    if docker run --rm --entrypoint test \
+      "harmonic-beacon/app:${rollback_tag}" \
+      -f /app/scripts/commerce-media-worker.ts; then
+      compose "$workspace" "$rollback_tag" up -d --no-deps --force-recreate \
+        commerce-reconciler
+      worker_expected=true
+    else
+      docker stop beacon-commerce-reconciler 2>/dev/null || true
+    fi
+  fi
+
+  if [ "$tapestry_available" = true ]; then
+    compose "$workspace" "$rollback_tag" up -d --no-deps --force-recreate tapestry
+  fi
+
+  for _attempt in $(seq 1 60); do
+    local app_ready=true
+    local worker_ready=true
+    local tapestry_ready=true
+    if [ "$app_available" = true ]; then
+      if [ "$(health beacon-app 2>/dev/null || true)" != healthy ] || \
+        ! curl --fail --silent --show-error http://127.0.0.1:3000/api/health/ready >/dev/null; then
+        app_ready=false
+      fi
+    fi
+    if [ "$worker_expected" = true ] && \
+      [ "$(health beacon-commerce-reconciler 2>/dev/null || true)" != healthy ]; then
+      worker_ready=false
+    fi
+    if [ "$tapestry_available" = true ] && \
+      [ "$(health beacon-tapestry 2>/dev/null || true)" != healthy ]; then
+      tapestry_ready=false
+    fi
+    if [ "$app_ready" = true ] && [ "$worker_ready" = true ] && \
+      [ "$tapestry_ready" = true ]; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  compose "$workspace" "$rollback_tag" ps
+  die 'rollback services did not become ready'
+}
+
+usage() {
+  printf '%s\n' 'usage: hb-deploy {preflight|preserve|build|migrate|replace|health|status|boundary|rollback} ...' >&2
+  exit 2
+}
+
+require_root
+[ "$#" -gt 0 ] || usage
+command="$1"
+shift
+
+case "$command" in
+  preflight) [ "$#" -eq 2 ] || usage; preflight "$@" ;;
+  preserve) [ "$#" -eq 1 ] || usage; preserve "$@" ;;
+  build) [ "$#" -eq 4 ] || usage; build "$@" ;;
+  migrate) [ "$#" -eq 2 ] || usage; migrate "$@" ;;
+  replace) [ "$#" -eq 2 ] || usage; replace "$@" ;;
+  health) [ "$#" -eq 1 ] || usage; health "$@" ;;
+  status) [ "$#" -eq 2 ] || usage; status "$@" ;;
+  boundary) [ "$#" -eq 0 ] || usage; boundary ;;
+  rollback) [ "$#" -eq 4 ] || usage; rollback "$@" ;;
+  *) usage ;;
+esac

--- a/deploy/hb-deploy-root
+++ b/deploy/hb-deploy-root
@@ -78,7 +78,7 @@ compose() {
 
   (
     cd "$workspace"
-    BEACON_IMAGE_TAG="$image_tag" docker compose \
+    BEACON_IMAGE_TAG="$image_tag" docker compose --file "$workspace/docker-compose.yml" \
       --project-name app --env-file "$PRODUCTION_ENV" "$@"
   )
 }
@@ -169,7 +169,8 @@ build() {
       BEACON_GIT_SHA="$sha" \
       BEACON_BUILD_TIME="$build_time" \
       BEACON_DATABASE_SCHEMA_VERSION="$schema_version" \
-      docker compose --project-name app --env-file "$PRODUCTION_ENV" \
+      docker compose --file "$workspace/docker-compose.yml" \
+      --project-name app --env-file "$PRODUCTION_ENV" \
       build app tapestry
   )
 }

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -96,6 +96,11 @@ describe('production deploy contract', () => {
     expect(rootHelper).toContain("[[ \"$1\" =~ ^[0-9a-f]{40}$ ]]");
     expect(rootHelper).toContain("die 'workspace has tracked changes'");
     expect(rootHelper).toContain("die 'workspace index has tracked changes'");
+    expect(
+      rootHelper.match(
+        /docker compose --file "\$workspace\/docker-compose\.yml"/g,
+      ),
+    ).toHaveLength(2);
     expect(rootHelper).not.toMatch(/\beval\b|\bbash -c\b|\bsh -c\b/);
     expect(
       statSync(join(process.cwd(), 'deploy/hb-deploy-root')).mode & 0o111,

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -9,6 +9,8 @@ describe('production deploy contract', () => {
   const compose = readRepositoryFile('docker-compose.yml');
   const ciWorkflow = readRepositoryFile('.github/workflows/ci.yml');
   const workflow = readRepositoryFile('.github/workflows/deploy.yml');
+  const rootHelper = readRepositoryFile('deploy/hb-deploy-root');
+  const runnerSudoers = readRepositoryFile('deploy/beacon-runner.sudoers');
 
   it('gives app and tapestry independent commit-tagged images', () => {
     expect(compose).toContain(
@@ -20,9 +22,11 @@ describe('production deploy contract', () => {
   });
 
   it('builds, replaces and waits for tapestry in every release', () => {
-    expect(workflow).toMatch(/build app tapestry/);
-    expect(workflow).toMatch(
-      /up -d --no-deps --force-recreate app commerce-reconciler tapestry/,
+    const normalizedHelper = rootHelper.replace(/\\\n\s*/g, '');
+
+    expect(rootHelper).toMatch(/build app tapestry/);
+    expect(normalizedHelper).toContain(
+      'up -d --no-deps --force-recreate app commerce-reconciler tapestry',
     );
     expect(workflow).toContain('tapestry_health=');
     expect(workflow).toContain('[ "$tapestry_health" = healthy ]');
@@ -34,7 +38,7 @@ describe('production deploy contract', () => {
     expect(compose).toContain(
       'BEACON_DATABASE_SCHEMA_VERSION=${BEACON_DATABASE_SCHEMA_VERSION:-unknown}',
     );
-    expect(workflow).toContain('BEACON_GIT_SHA="$GITHUB_SHA"');
+    expect(rootHelper).toContain('BEACON_GIT_SHA="$sha"');
     expect(workflow).toContain('EXPECTED_GIT_SHA="$GITHUB_SHA"');
     expect(workflow).toContain('health?.gitSha !== process.env.EXPECTED_GIT_SHA');
     expect(workflow).toContain('https://live.harmonicbeacon.com/api/health');
@@ -43,24 +47,25 @@ describe('production deploy contract', () => {
   it('can only schedule production deploys on the verified mona runner', () => {
     expect(workflow).toContain('runs-on: [self-hosted, mona]');
     expect(workflow).toContain('test "$(hostname -s)" = mona');
+    expect(workflow).toContain('test "$(id -un)" = beacon-runner');
+    expect(workflow).toContain(
+      'cmp --silent deploy/hb-deploy-root /usr/local/sbin/hb-deploy',
+    );
     expect(workflow).not.toMatch(/runs-on:\s+self-hosted\s*$/m);
   });
 
-  it('normalizes Docker network templates before exact membership checks', () => {
-    expect(
-      workflow.match(/sed '\/\^\[\[:space:\]\]\*\$\/d'/g),
-    ).toHaveLength(2);
-    expect(
-      workflow.match(/Unexpected pmp_beacon_internal members:/g),
-    ).toHaveLength(2);
+  it('normalizes Docker network templates before the centralized exact membership check', () => {
+    expect(rootHelper).toContain("sed '/^[[:space:]]*$/d'");
+    expect(rootHelper).toContain("readonly EXPECTED_NETWORK_MEMBERS=$'beacon-app\\npmp-myth-worker\\npmp-myth-worker-secondary'");
+    expect(rootHelper).toContain("die 'commerce network is not internal'");
   });
 
   it('preserves and restores app and tapestry independently', () => {
-    expect(workflow).toContain(
-      'harmonic-beacon/app:rollback-${GITHUB_RUN_ID}',
+    expect(rootHelper).toContain(
+      'harmonic-beacon/app:rollback-${run_id}',
     );
-    expect(workflow).toContain(
-      'harmonic-beacon/tapestry:rollback-${GITHUB_RUN_ID}',
+    expect(rootHelper).toContain(
+      'harmonic-beacon/tapestry:rollback-${run_id}',
     );
     expect(workflow).toContain(
       'steps.rollback.outputs.app_available == \'true\'',
@@ -68,8 +73,44 @@ describe('production deploy contract', () => {
     expect(workflow).toContain(
       'steps.rollback.outputs.tapestry_available == \'true\'',
     );
-    expect(workflow).toContain('worker_expected=true');
-    expect(workflow).toContain('[ "$tapestry_ready" = true ]');
+    expect(rootHelper).toContain('worker_expected=true');
+    expect(rootHelper).toContain('[ "$tapestry_ready" = true ]');
+  });
+
+  it('funnels every privileged workflow operation through the validated helper', () => {
+    const privilegedLines = workflow
+      .split('\n')
+      .filter((line) => line.includes('sudo -n'));
+
+    expect(privilegedLines.length).toBeGreaterThan(0);
+    expect(
+      privilegedLines.every((line) =>
+        line.includes('sudo -n /usr/local/sbin/hb-deploy'),
+      ),
+    ).toBe(true);
+    expect(workflow).not.toMatch(/sudo -n (?:env |docker |test |stat )/);
+    expect(rootHelper).toContain('[ "${EUID}" -eq 0 ]');
+    expect(rootHelper).toContain(
+      "readonly WORKSPACE='/opt/actions-runner/_work/harmonic-beacon-webapp/harmonic-beacon-webapp'",
+    );
+    expect(rootHelper).toContain("[[ \"$1\" =~ ^[0-9a-f]{40}$ ]]");
+    expect(rootHelper).toContain("die 'workspace has tracked changes'");
+    expect(rootHelper).toContain("die 'workspace index has tracked changes'");
+    expect(rootHelper).not.toMatch(/\beval\b|\bbash -c\b|\bsh -c\b/);
+    expect(
+      statSync(join(process.cwd(), 'deploy/hb-deploy-root')).mode & 0o111,
+    ).not.toBe(0);
+  });
+
+  it('grants the runner no generic sudo or direct Docker command', () => {
+    expect(runnerSudoers).toContain(
+      'Cmnd_Alias HARMONIC_BEACON_DEPLOY = /usr/local/sbin/hb-deploy *',
+    );
+    expect(runnerSudoers).toContain(
+      'beacon-runner ALL=(root) NOPASSWD: HARMONIC_BEACON_DEPLOY',
+    );
+    expect(runnerSudoers).not.toContain('NOPASSWD: ALL');
+    expect(runnerSudoers).not.toMatch(/\/(?:usr\/bin\/)?docker\b/);
   });
 
   it('audits the production dependencies of both deployable packages', () => {


### PR DESCRIPTION
Closes the remaining least-privilege gap in #112.

## Diagnosis

The production runner group, selected repository and selected `release` workflow are correctly isolated, but the generated service runs as the host `debian` identity. That identity has inherited `NOPASSWD: ALL`, so a workflow process currently has a generic root path even though the deploy itself uses only bounded commands.

## Change

- require the service identity `beacon-runner`;
- route every privileged workflow operation through one root-owned `/usr/local/sbin/hb-deploy` helper;
- validate the exact Actions workspace, clean tracked checkout, commit SHA, UTC build time, schema version, run id, booleans, health container allowlist and private-network membership;
- retain independent app/tapestry rollback, additive migrations, exact public provenance and private-boundary gates;
- add a sudoers artifact granting only that helper, with no direct Docker or generic sudo;
- verify the installed helper is byte-identical to the release checkout before code gates;
- remove raw production logs from failure output and keep only sanitized service state;
- document installation, migration and denial checks.

## Evidence

- real mona candidate `preflight` and `boundary` succeeded read-only against deployed `3531c95`;
- candidate rejected an unallowlisted container, wrong workspace and malformed SHA;
- sudoers candidate parsed with `visudo`;
- 783 unit/component tests passed, 9 opt-in integrations skipped;
- tapestry 29/29 passed, including 30-second soak;
- TypeScript, ESLint quiet, production dependency audits and build passed;
- deploy contract 9/9 and `bash -n` passed; diff check clean.

## Rollout

After remote gates: install the exact reviewed helper/sudoers as root, stop the idle runner, move its files to the non-login `beacon-runner` identity, reinstall/start the generated service, prove direct sudo/Docker denial, then deploy the merged SHA through `release`. Production containers are not touched during identity migration.

## Rollback

Before pushing `release`, runner migration rolls back by reinstalling the generated service as `debian`; production remains untouched. During the release, the existing immutable app/tapestry rollback tags and readiness/provenance/boundary gates remain in force.