### PR TITLE
fix: hide stale sessions from public checkout

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -35,6 +35,7 @@ const SESSION_2 = {
     language: 'ENGLISH' as const,
     scheduledAt: new Date('2026-08-08T20:00:00.000Z'),
 };
+const NOW = new Date('2026-08-05T12:00:00.000Z');
 
 function mountDb(findMany: ReturnType<typeof vi.fn>) {
     const prisma = { scheduledSession: { findMany } };
@@ -49,6 +50,8 @@ async function renderPage(searchParams: Record<string, string | string[] | undef
 
 describe('landing page', () => {
     beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
         vi.resetModules();
         loginFormProps.mockClear();
         requestLocaleMock.mockReset();
@@ -60,6 +63,7 @@ describe('landing page', () => {
         vi.unstubAllEnvs();
         vi.doUnmock('@/lib/db');
         vi.restoreAllMocks();
+        vi.useRealTimers();
     });
 
     it('shows both sessions with their language and time', async () => {
@@ -94,14 +98,44 @@ describe('landing page', () => {
         expect(findMany).toHaveBeenCalledWith(
             expect.objectContaining({
                 where: {
-                    status: { in: ['SCHEDULED', 'LIVE'] },
                     isTest: false,
+                    endedAt: null,
+                    OR: [
+                        { status: 'SCHEDULED', scheduledAt: { gte: NOW } },
+                        {
+                            status: 'LIVE',
+                            startedAt: { gte: new Date('2026-08-04T12:00:00.000Z') },
+                        },
+                    ],
                 },
             }),
         );
         // No paid-mode or attendee-cap columns leak into the public page.
         const select = findMany.mock.calls[0][0].select;
         expect(Object.keys(select).sort()).toEqual(['id', 'language', 'scheduledAt']);
+    });
+
+    it('fails closed when a missed lifecycle transition leaves an old session LIVE', async () => {
+        const findMany = mountDb(vi.fn().mockResolvedValue([SATURDAY, SESSION_2]));
+        vi.stubEnv('TICKET_PURCHASE_URL', 'https://tickets.example.invalid/harmonic-beacon');
+
+        await renderPage();
+
+        const where = findMany.mock.calls[0][0].where;
+        expect(where).toEqual(expect.objectContaining({
+            isTest: false,
+            endedAt: null,
+            OR: expect.arrayContaining([
+                {
+                    status: 'LIVE',
+                    startedAt: { gte: new Date('2026-08-04T12:00:00.000Z') },
+                },
+            ]),
+        }));
+        expect(where.OR[1].startedAt.gte.getTime()).toBeGreaterThan(
+            new Date('2026-08-02T16:48:28.622Z').getTime(),
+        );
+        expect(screen.getAllByRole('link', { name: /Comprar entrada/ })).toHaveLength(2);
     });
 
     it('excludes test fixtures from public discovery and purchase links by durable data', async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,11 @@ type WeekendEvent = {
 };
 
 const INTERNAL_NEXT = /^\/session(\/[A-Za-z0-9_-]+)*$/;
+// A missed lifecycle transition must not leave an old LIVE row advertising the
+// current checkout indefinitely. Weekend sessions last hours, not days; 24
+// hours keeps a delayed/extended live room discoverable while failing closed
+// before a stale row can be presented as the next paid event.
+const PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function safeNext(raw: string | string[] | undefined): string | undefined {
     const value = Array.isArray(raw) ? raw[0] : raw;
@@ -34,10 +39,17 @@ function safeNext(raw: string | string[] | undefined): string | undefined {
 
 async function weekendEvents(): Promise<WeekendEvent[] | null> {
     try {
+        const now = new Date();
+        const liveStartedAfter = new Date(now.getTime() - PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS);
+
         return await prisma.scheduledSession.findMany({
             where: {
-                status: { in: ["SCHEDULED", "LIVE"] },
                 isTest: false,
+                endedAt: null,
+                OR: [
+                    { status: "SCHEDULED", scheduledAt: { gte: now } },
+                    { status: "LIVE", startedAt: { gte: liveStartedAfter } },
+                ],
             },
             orderBy: { scheduledAt: "asc" },
             select: { id: true, language: true, scheduledAt: true },


### PR DESCRIPTION
## Diagnosis

The post-deploy browser smoke found that the completed August 2 demo was still rendered on `/` with the current Spanish Ticket Tailor URL. The durable row was left `LIVE` with no `endedAt`, and public discovery trusted status alone.

## Change

- Scheduled sessions are public only while their start is still in the future.
- Live sessions must have no `endedAt` and a real `startedAt` within the last 24 hours.
- Test fixtures remain excluded and the selected public payload remains minimal.
- No production row, catalog, price, URL, entitlement, or commerce contract changes.

The 24-hour ceiling is intentionally conservative: it preserves delayed/extended weekend rooms while preventing a missed lifecycle transition from advertising a stale session indefinitely.

## Evidence

- Focused landing suite: 12/12
- Full unit suite: 784 passed, 9 opt-in integration tests skipped
- TypeScript: `npx tsc --noEmit`
- ESLint: green
- Production build: green
- `git diff --check`: green
- Read-only production evidence before the change: expired Aug 2 session `LIVE`, started Aug 2, no `endedAt`; Aug 8 ES/EN rows `SCHEDULED`. No participant data read.

## Risk and rollback

Risk is limited to public event discovery. A genuinely continuous event older than 24 hours would no longer be advertised, while direct ticket login remains available. Roll back this single commit/PR to restore prior discovery behavior.

## Post-deploy verification

Refresh the public root and prove only the two Aug 8 sessions render, with their language-specific checkout links; re-check health/provenance and private-route boundary.

Refs #41