### PR TITLE
fix: prevent readiness response caching

### DIFF
--- a/src/app/api/health/__tests__/ready-route.test.ts
+++ b/src/app/api/health/__tests__/ready-route.test.ts
@@ -16,6 +16,7 @@ describe('GET /api/health/ready', () => {
 
         expect(status).toBe(200);
         expect(body).toEqual({ status: 'ok', checks: { database: 'ok' } });
+        expect(response.headers.get('cache-control')).toBe('no-store');
     });
 
     it('returns 503 when the database query rejects', async () => {
@@ -32,6 +33,7 @@ describe('GET /api/health/ready', () => {
 
         expect(status).toBe(503);
         expect(body).toEqual({ status: 'error', checks: { database: 'unreachable' } });
+        expect(response.headers.get('cache-control')).toBe('no-store');
     });
 
     it('returns 503 marked as timeout when the database hangs instead of failing', async () => {

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -6,6 +6,7 @@ import { OperationTimeoutError, withTimeout } from '@/lib/with-timeout';
 export const dynamic = 'force-dynamic';
 
 const DB_CHECK_TIMEOUT_MS = 3000;
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' };
 
 /**
  * GET /api/health/ready
@@ -18,7 +19,10 @@ const DB_CHECK_TIMEOUT_MS = 3000;
 export async function GET() {
     try {
         await withTimeout(prisma.$queryRaw`SELECT 1`, DB_CHECK_TIMEOUT_MS, 'Database check');
-        return NextResponse.json({ status: 'ok', checks: { database: 'ok' } });
+        return NextResponse.json(
+            { status: 'ok', checks: { database: 'ok' } },
+            { headers: NO_STORE_HEADERS },
+        );
     } catch (error) {
         // Redacted: a pg auth failure carries the full connection string,
         // password included, in error.message — and stdout is shipped to a
@@ -32,7 +36,7 @@ export async function GET() {
                         error instanceof OperationTimeoutError ? 'timeout' : 'unreachable',
                 },
             },
-            { status: 503 },
+            { status: 503, headers: NO_STORE_HEADERS },
         );
     }
 }


### PR DESCRIPTION
## Diagnosis

The live #27 cache-policy audit found that `/api/health` returns `Cache-Control: no-store`, while `/api/health/ready` returned no cache policy on either success or failure. A readiness result must describe the current database state; a browser or intermediary must never reuse a stale green or red response.

## Change

- Add `Cache-Control: no-store` to both 200 and 503 readiness responses.
- Assert the header on both branches.
- No Nginx, DNS, secrets, data, commerce, UI, media, or audio changes.

## Evidence

- Focused readiness tests: 5/5
- Full unit suite: 784 passed, 9 opt-in integration tests skipped
- TypeScript: green
- ESLint: green
- Production build: green
- `git diff --check`: green

## Risk / rollback

Only response caching metadata changes. Roll back the commit to restore previous headers; health semantics and payload are unchanged.

Refs #27