### PR TITLE
fix: block production E2E dashboard deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,6 +135,17 @@ jobs:
           set -euo pipefail
           sudo -n /usr/local/sbin/hb-deploy boundary
 
+          for method in GET POST; do
+            code="$(curl --silent --show-error --output /dev/null \
+              --request "$method" --header 'Content-Type: application/json' \
+              --data '{}' --write-out '%{http_code}' \
+              https://live.harmonicbeacon.com/api/test-login)"
+            test "$code" = 404 || {
+              echo "Production test-login $method returned $code instead of 404" >&2
+              exit 1
+            }
+          done
+
           for method in GET PUT; do
             code="$(curl --silent --show-error --output /dev/null \
               --request "$method" --header 'Content-Type: application/json' \

--- a/deploy/hb-deploy-root
+++ b/deploy/hb-deploy-root
@@ -126,6 +126,9 @@ preflight() {
   [ -r "$COMMERCE_ENV" ] || die 'commerce environment is not readable by root'
   [ "$(stat -c '%a:%U:%G' "$COMMERCE_ENV")" = '600:root:root' ] ||
     die 'commerce environment permissions are not 600:root:root'
+  if grep -Fxq 'E2E_DASHBOARD_ENABLED=1' "$PRODUCTION_ENV"; then
+    die 'production E2E dashboard must be disabled before deploy'
+  fi
   require_exact_private_network
   compose "$workspace" "$sha" config --quiet
 }

--- a/src/app/api/test-login/__tests__/route.test.ts
+++ b/src/app/api/test-login/__tests__/route.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NextRequest } from 'next/server';
+
+const prisma = vi.hoisted(() => ({
+    scheduledSession: { findUnique: vi.fn() },
+    ticketEntitlement: { create: vi.fn() },
+    user: { upsert: vi.fn() },
+    webSession: { create: vi.fn() },
+}));
+
+vi.mock('@/lib/db', () => ({ prisma }));
+
+import { GET, POST } from '../route';
+
+const originalGate = process.env.E2E_DASHBOARD_ENABLED;
+
+afterEach(() => {
+    vi.clearAllMocks();
+    if (originalGate === undefined) {
+        delete process.env.E2E_DASHBOARD_ENABLED;
+    } else {
+        process.env.E2E_DASHBOARD_ENABLED = originalGate;
+    }
+});
+
+function postRequest(body = '{not-json'): NextRequest {
+    return new NextRequest('http://localhost/api/test-login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+    });
+}
+
+describe('/api/test-login production gate', () => {
+    it.each([undefined, '0', 'true'])('returns 404 before parsing or persistence when the gate is %s', async (value) => {
+        if (value === undefined) {
+            delete process.env.E2E_DASHBOARD_ENABLED;
+        } else {
+            process.env.E2E_DASHBOARD_ENABLED = value;
+        }
+
+        const response = await POST(postRequest());
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({ error: 'Not found.' });
+        expect(prisma.scheduledSession.findUnique).not.toHaveBeenCalled();
+        expect(prisma.ticketEntitlement.create).not.toHaveBeenCalled();
+        expect(prisma.user.upsert).not.toHaveBeenCalled();
+        expect(prisma.webSession.create).not.toHaveBeenCalled();
+    });
+
+    it('only enables POST for the exact supervised-test value', async () => {
+        process.env.E2E_DASHBOARD_ENABLED = '1';
+
+        const response = await POST(postRequest());
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toEqual({ error: 'Malformed request.' });
+    });
+
+    it('keeps GET indistinguishable from a missing route even during a test window', async () => {
+        process.env.E2E_DASHBOARD_ENABLED = '1';
+
+        const response = await GET();
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({ error: 'Not found.' });
+    });
+});

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -67,6 +67,12 @@ describe('production deploy contract', () => {
     expect(rootHelper).toContain(
       "die 'production E2E dashboard must be disabled before deploy'",
     );
+    expect(workflow).toContain(
+      'https://live.harmonicbeacon.com/api/test-login',
+    );
+    expect(workflow).toContain(
+      'Production test-login $method returned $code instead of 404',
+    );
   });
 
   it('preserves and restores app and tapestry independently', () => {

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -60,6 +60,15 @@ describe('production deploy contract', () => {
     expect(rootHelper).toContain("die 'commerce network is not internal'");
   });
 
+  it('refuses a production deploy while the passwordless E2E dashboard is enabled', () => {
+    expect(rootHelper).toContain(
+      "grep -Fxq 'E2E_DASHBOARD_ENABLED=1' \"$PRODUCTION_ENV\"",
+    );
+    expect(rootHelper).toContain(
+      "die 'production E2E dashboard must be disabled before deploy'",
+    );
+  });
+
   it('preserves and restores app and tapestry independently', () => {
     expect(rootHelper).toContain(
       'harmonic-beacon/app:rollback-${run_id}',


### PR DESCRIPTION
## Diagnosis

The production environment still had `E2E_DASHBOARD_ENABLED=1`. That made the passwordless `/api/test-login` POST route reachable even though the GET page returned 404. The flag has already been disabled in production and the app was recreated on the same known-good image; both GET and POST now return 404.

This PR makes that security state a deploy invariant:

- the privileged deploy helper refuses to deploy if production explicitly enables the E2E dashboard;
- focused route tests prove every value except the exact supervised-test value fails closed before parsing or persistence;
- post-deploy smoke verifies both GET and POST return 404, preventing the asymmetric failure we observed.

## Evidence

- focused endpoint/deploy contract: 15 passed
- full suite: 790 passed, 9 opt-in integration tests skipped
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `bash -n deploy/hb-deploy-root`
- `git diff --check`

## Risk / rollback

Low and fail-closed. Runtime authentication semantics are unchanged; the added workflow smoke only observes public 404s. The helper preflight intentionally prevents a release while the test dashboard is enabled. Rollback is reverting these commits, but production should still keep the E2E dashboard disabled.

## Deployment note

Before promoting the merged SHA, install the exact merged `deploy/hb-deploy-root` as `/usr/local/sbin/hb-deploy` on mona and verify byte identity. The existing production flag is already disabled, so the new preflight should pass.

Refs #27
