### PR TITLE
test: wait for invitation focus effect

### DIFF
--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -570,7 +570,9 @@ describe('SessionRoomPage - stage invitation consent', () => {
         const roomCount = (Room as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
         const { room, dialog } = await receiveInvitation();
 
-        expect(dialog).toHaveFocus();
+        await waitFor(() => {
+            expect(dialog).toHaveFocus();
+        });
         expect(room.localParticipant.setCameraEnabled).not.toHaveBeenCalled();
         expect(room.localParticipant.setMicrophoneEnabled).not.toHaveBeenCalled();
         expect(screen.queryByRole('button', { name: 'Turn camera on' })).not.toBeInTheDocument();


### PR DESCRIPTION
## Diagnosis

Deploy run `30994679659` stopped before preflight or any production mutation because the invitation accessibility test waited for the dialog to exist and then asserted focus synchronously. The component applies focus in a React `useEffect`, so DOM presence and focus are separate observable states. A focused rerun on the same mona checkout passed, confirming an ordering race in the test.

## Change

Wait for the existing dialog to receive focus before asserting the remaining no-device/no-room-lifecycle invariants. This is one test-only synchronization change; `page.tsx`, UI, runtime, audio and data are untouched.

## Evidence

- exact focused assertion: 20/20 consecutive passes
- full suite: 790 passed, 9 opt-in integration tests skipped
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --check`
- mona focused rerun on the failing release checkout: 32/32 file tests passed

## Risk / rollback

Test-only and low risk. It preserves the accessibility requirement rather than deleting or weakening it. Rollback is reverting this commit.

Refs #69
