### PR TITLE
fix(load): preserve evidence on operator abort

### DIFF
--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -21,6 +21,9 @@ and human gates in #24.
   `LIVEKIT_API_SECRET`. They are never arguments or manifest fields.
 - Manifests are mode `0600` and contain no identities, tokens, audio, video,
   email, or raw CLI output.
+- `SIGINT` and `SIGTERM` stop both room generators cooperatively, run the same
+  bounded cleanup check, write an `ABORTED` manifest, and exit non-zero. An
+  interrupted run is evidence of an attempted run, never a PASS.
 
 Preview a run without credentials or LiveKit:
 
@@ -77,6 +80,9 @@ poll-observed join p50/p95/p99, cleanup convergence, packet loss, generator
 CPU/memory/network deltas, and event-loop delay. Each phase fails unless both
 CLI processes exit zero, report every expected track, reach exact room counts,
 clean up to zero, and remain below the configured dropped-packet threshold.
+If an operator or external watchdog aborts a phase, the manifest records only
+the signal and timestamp plus the partial redacted phase metrics. It never
+promotes partial results to FAIL/PASS or continues into another phase.
 Run the full ES and EN profiles twice and attach all four manifests to #24.
 
 ## Tooling

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -222,3 +222,44 @@ export function manifestContainsSecret(value, secrets) {
     const serialized = JSON.stringify(value);
     return secrets.filter(Boolean).some((secret) => serialized.includes(secret));
 }
+
+export function createAbortCoordinator({ terminate = (child) => child.kill('SIGTERM') } = {}) {
+    const children = new Set();
+    let signal = null;
+    let requestedAt = null;
+
+    const terminateChild = (child) => {
+        try {
+            if (!child.killed) terminate(child);
+        } catch {
+            // A child can converge between the signal and this loop. Its close
+            // event still supplies the bounded completion path to the caller.
+        }
+    };
+
+    return {
+        get requested() {
+            return signal !== null;
+        },
+        request(nextSignal) {
+            if (signal !== null) return false;
+            signal = nextSignal;
+            requestedAt = new Date().toISOString();
+            for (const child of children) terminateChild(child);
+            return true;
+        },
+        track(child) {
+            children.add(child);
+            if (signal !== null) terminateChild(child);
+            return () => children.delete(child);
+        },
+        snapshot() {
+            return signal === null ? null : { signal, requestedAt };
+        },
+        exitCode() {
+            if (signal === 'SIGINT') return 130;
+            if (signal === 'SIGTERM') return 143;
+            return 1;
+        },
+    };
+}

--- a/scripts/livekit-load-harness.mjs
+++ b/scripts/livekit-load-harness.mjs
@@ -11,6 +11,7 @@ import { RoomServiceClient } from 'livekit-server-sdk';
 import {
     buildPlan,
     commandFingerprint,
+    createAbortCoordinator,
     manifestContainsSecret,
     parseLoadTestOutput,
     remoteConfirmation,
@@ -87,6 +88,35 @@ function generatedRunId() {
     return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'z').toLowerCase();
 }
 
+function installAbortHandlers(abort) {
+    const onSigint = () => {
+        if (abort.request('SIGINT')) {
+            process.stderr.write('\nSIGINT received; stopping load and preserving an ABORTED manifest.\n');
+        }
+    };
+    const onSigterm = () => {
+        if (abort.request('SIGTERM')) {
+            process.stderr.write('\nSIGTERM received; stopping load and preserving an ABORTED manifest.\n');
+        }
+    };
+    process.on('SIGINT', onSigint);
+    process.on('SIGTERM', onSigterm);
+    return () => {
+        process.off('SIGINT', onSigint);
+        process.off('SIGTERM', onSigterm);
+    };
+}
+
+async function waitBetweenPhases(seconds, abort) {
+    const deadline = Date.now() + seconds * 1000;
+    while (!abort.requested && Date.now() < deadline) {
+        await new Promise((resolvePromise) => setTimeout(
+            resolvePromise,
+            Math.min(250, deadline - Date.now()),
+        ));
+    }
+}
+
 function printHelp() {
     process.stdout.write(`Usage: npm run load:livekit -- [options]\n\n` +
         `  --profile NAME             ci, rehearsal-es, or rehearsal-en\n` +
@@ -110,8 +140,19 @@ async function commandOutput(command, args) {
     });
 }
 
-async function runLoad(lkBinary, args, credentials) {
+async function runLoad(lkBinary, args, credentials, abort) {
     const startedAt = new Date();
+    if (abort.requested) {
+        return {
+            exitCode: abort.exitCode(),
+            operatorAborted: true,
+            terminationSignal: abort.snapshot()?.signal ?? null,
+            startedAt: startedAt.toISOString(),
+            endedAt: startedAt.toISOString(),
+            durationMs: 0,
+            summary: parseLoadTestOutput(''),
+        };
+    }
     return new Promise((resolvePromise) => {
         const child = spawn(lkBinary, args, {
             cwd: repositoryRoot,
@@ -123,7 +164,15 @@ async function runLoad(lkBinary, args, credentials) {
             },
             stdio: ['ignore', 'pipe', 'pipe'],
         });
+        const untrack = abort.track(child);
         let output = '';
+        let settled = false;
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            untrack();
+            resolvePromise(result);
+        };
         child.stdout.on('data', (chunk) => {
             output = appendOutputTail(output, chunk);
             process.stdout.write(chunk);
@@ -133,18 +182,22 @@ async function runLoad(lkBinary, args, credentials) {
             process.stderr.write(chunk);
         });
         child.on('error', (error) => {
-            resolvePromise({
+            finish({
                 exitCode: 127,
                 error: error.message,
+                operatorAborted: abort.requested,
+                terminationSignal: abort.snapshot()?.signal ?? null,
                 startedAt: startedAt.toISOString(),
                 endedAt: new Date().toISOString(),
                 durationMs: Date.now() - startedAt.getTime(),
                 summary: parseLoadTestOutput(output),
             });
         });
-        child.on('close', (exitCode) => {
-            resolvePromise({
-                exitCode: exitCode ?? 1,
+        child.on('close', (exitCode, terminationSignal) => {
+            finish({
+                exitCode: exitCode ?? (abort.requested ? abort.exitCode() : 1),
+                operatorAborted: abort.requested,
+                terminationSignal: terminationSignal ?? null,
                 startedAt: startedAt.toISOString(),
                 endedAt: new Date().toISOString(),
                 durationMs: Date.now() - startedAt.getTime(),
@@ -312,6 +365,7 @@ async function main() {
         ],
         phases: [],
     };
+    let abort = null;
 
     if (!dryRun) {
         const credentials = {
@@ -323,12 +377,15 @@ async function main() {
             throw new Error('LIVEKIT_API_KEY and LIVEKIT_API_SECRET are required');
         }
         if (lk.exitCode !== 0) throw new Error(`LiveKit CLI unavailable: ${lk.output.trim()}`);
+        abort = createAbortCoordinator();
+        const removeAbortHandlers = installAbortHandlers(abort);
         const roomService = new RoomServiceClient(
             url.replace(/^ws:/, 'http:').replace(/^wss:/, 'https:'),
             credentials.apiKey,
             credentials.apiSecret,
         );
         for (const [index, phase] of plan.phases.entries()) {
+            if (abort.requested) break;
             process.stdout.write(`\n[${phase.name}] starting stage and Beacon load\n`);
             const resourceBefore = await readGeneratorResources();
             const eventLoop = monitorEventLoopDelay({ resolution: 20 });
@@ -340,8 +397,8 @@ async function main() {
                 profileBeaconPublishers: profile.beaconPublishers,
             }, stopped);
             const [stage, beacon] = await Promise.all([
-                runLoad(lkBinary, phase.stage.args, credentials),
-                runLoad(lkBinary, phase.beacon.args, credentials),
+                runLoad(lkBinary, phase.stage.args, credentials, abort),
+                runLoad(lkBinary, phase.beacon.args, credentials, abort),
             ]);
             stopped.value = true;
             const observed = await monitor;
@@ -357,7 +414,7 @@ async function main() {
                     max: nanosecondsToMilliseconds(eventLoop.max),
                 },
             };
-            const passed = [stage, beacon].every((result) =>
+            const passed = !abort.requested && [stage, beacon].every((result) =>
                 result.exitCode === 0 &&
                 result.summary.parsed &&
                 result.summary.tracksReceived === result.summary.tracksExpected &&
@@ -373,18 +430,26 @@ async function main() {
             manifest.phases.push({
                 name: phase.name,
                 passed,
+                operatorAborted: abort.requested,
                 stage,
                 beacon,
                 observed,
                 cleanup,
                 generatorResources,
             });
+            if (abort.requested) break;
             if (!passed) manifest.status = 'FAIL';
             if (index < plan.phases.length - 1 && profile.interWaveSeconds > 0) {
-                await new Promise((resolvePromise) => setTimeout(resolvePromise, profile.interWaveSeconds * 1000));
+                await waitBetweenPhases(profile.interWaveSeconds, abort);
             }
         }
-        if (manifest.status !== 'FAIL') manifest.status = 'PASS';
+        removeAbortHandlers();
+        if (abort.requested) {
+            manifest.status = 'ABORTED';
+            manifest.abort = abort.snapshot();
+        } else if (manifest.status !== 'FAIL') {
+            manifest.status = 'PASS';
+        }
         if (manifestContainsSecret(manifest, [credentials.apiKey, credentials.apiSecret])) {
             throw new Error('refusing to write a manifest containing a credential');
         }
@@ -397,6 +462,7 @@ async function main() {
         process.stdout.write(`Remote confirmation used: ${remoteConfirmation(plan.rooms)}\n`);
     }
     if (manifest.status === 'FAIL') process.exitCode = 1;
+    if (manifest.status === 'ABORTED') process.exitCode = abort.exitCode();
 }
 
 main().catch((error) => {

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
     assertSafeTarget,
     buildPlan,
+    createAbortCoordinator,
     manifestContainsSecret,
     parseLoadTestOutput,
     remoteConfirmation,
@@ -127,5 +128,33 @@ describe('LiveKit load harness evidence', () => {
             .toBe(true);
         expect(manifestContainsSecret({ nested: ['safe'] }, ['key', 'secret-value']))
             .toBe(false);
+    });
+
+    it('coordinates the first operator abort across current and late child processes', () => {
+        const terminated: string[] = [];
+        const abort = createAbortCoordinator({
+            terminate: (child: { name: string }) => terminated.push(child.name),
+        });
+        const untrackStage = abort.track({ name: 'stage', killed: false });
+        abort.track({ name: 'beacon', killed: false });
+
+        expect(abort.request('SIGINT')).toBe(true);
+        expect(abort.request('SIGTERM')).toBe(false);
+        abort.track({ name: 'late', killed: false });
+        untrackStage();
+
+        expect(terminated).toEqual(['stage', 'beacon', 'late']);
+        expect(abort.requested).toBe(true);
+        expect(abort.snapshot()).toMatchObject({ signal: 'SIGINT' });
+        expect(abort.exitCode()).toBe(130);
+    });
+
+    it('maps SIGTERM to a non-zero result without inventing an abort beforehand', () => {
+        const abort = createAbortCoordinator();
+        expect(abort.requested).toBe(false);
+        expect(abort.snapshot()).toBeNull();
+        expect(abort.exitCode()).toBe(1);
+        expect(abort.request('SIGTERM')).toBe(true);
+        expect(abort.exitCode()).toBe(143);
     });
 });


### PR DESCRIPTION
## Diagnóstico

El ensayo production-like de #99 respetó el guardrail y fue abortado con SIGINT al perder observabilidad, pero el harness terminó antes de escribir el manifiesto. Eso dejaba una corrida interrumpida sin evidencia redacted ni resultado de cleanup.

## Cambio

- coordina el primer `SIGINT`/`SIGTERM` entre los generadores Stage y Beacon;
- termina ambos procesos cooperativamente y conserva sus resultados parciales;
- ejecuta el cleanup acotado habitual;
- escribe un manifiesto 0600 con estado `ABORTED`, señal/timestamp y métricas parciales sanitizadas;
- sale non-zero y no continúa a otra fase ni transforma una corrida parcial en PASS/FAIL;
- mantiene intacto el camino normal PASS/FAIL.

No cambia la app, LiveKit productivo, rooms reales, audio, pagos ni superficies de Annie.

## Evidencia

- `npm test`: 792 passed, 9 opt-in skipped.
- `npx tsc --noEmit`: green.
- `npm run lint`: green.
- `npm run build`: green.
- dry-run rehearsal EN: `PLANNED`.
- CI local normal: `PASS`, tres fases, 0% Stage/Beacon, cleanup 0/0, manifest 0600 y sin credenciales.
- CI local interrumpido por SIGINT: exit non-zero, `ABORTED`, ambos children exit 130, cleanup 0/0 en 6 ms, manifest 0600 y sin credenciales.

## Riesgo y rollback

El riesgo está aislado al proceso CLI de carga. El cambio sólo instala handlers durante una corrida no-dry y conserva el comportamiento previo cuando no llega una señal. Rollback: revertir el commit de esta PR; no requiere migración ni deploy de producción.

No cierra #99: todavía falta telemetría server-side fuera de banda y repetir los perfiles completos.
