### PR TITLE
ci: isolate pull request checks from mona

### DIFF
--- a/.github/workflows/audio-boundary.yml
+++ b/.github/workflows/audio-boundary.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   frozen-audio-paths:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   lint-and-build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -32,7 +32,7 @@ jobs:
           NEXT_PUBLIC_LIVEKIT_URL: https://placeholder.livekit.cloud
 
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -8,6 +8,9 @@ const readRepositoryFile = (path: string) =>
 describe('production deploy contract', () => {
   const compose = readRepositoryFile('docker-compose.yml');
   const ciWorkflow = readRepositoryFile('.github/workflows/ci.yml');
+  const audioBoundaryWorkflow = readRepositoryFile(
+    '.github/workflows/audio-boundary.yml',
+  );
   const workflow = readRepositoryFile('.github/workflows/deploy.yml');
   const rootHelper = readRepositoryFile('deploy/hb-deploy-root');
   const runnerSudoers = readRepositoryFile('deploy/beacon-runner.sudoers');
@@ -52,6 +55,14 @@ describe('production deploy contract', () => {
       'cmp --silent deploy/hb-deploy-root /usr/local/sbin/hb-deploy',
     );
     expect(workflow).not.toMatch(/runs-on:\s+self-hosted\s*$/m);
+  });
+
+  it('keeps pull-request code off every self-hosted production runner', () => {
+    for (const pullRequestWorkflow of [ciWorkflow, audioBoundaryWorkflow]) {
+      expect(pullRequestWorkflow).toContain('runs-on: ubuntu-latest');
+      expect(pullRequestWorkflow).not.toMatch(/runs-on:.*self-hosted/);
+    }
+    expect(workflow).toContain('runs-on: [self-hosted, mona]');
   });
 
   it('normalizes Docker network templates before the centralized exact membership check', () => {


### PR DESCRIPTION
## Diagnóstico

Los checks `CI` y `Audio boundary` de PR usan `runs-on: self-hosted`. El único runner online es mona, cuyo grupo está correctamente restringido al workflow de deploy en `release`; el runner genérico anterior está offline. Por eso esos tres jobs quedan en cola indefinidamente mientras E2E en GitHub-hosted sí termina.

Dar acceso de PR a mona ejecutaría código no integrado en el host productivo y rompería el aislamiento/least privilege de #112.

## Cambio

- mueve `lint-and-build`, `test` y `frozen-audio-paths` a `ubuntu-latest`;
- conserva `deploy.yml` en `[self-hosted, mona]` sin cambiar el runner group;
- agrega un contract test que impide devolver workflows de PR a `self-hosted` y reafirma el runner exclusivo de deploy.

No agrega secretos, no toca runtime, producción, audio ni pagos.

## Evidencia local

- deploy-contract: 11/11;
- ESLint focalizado: green;
- YAML parse: green;
- diff-check: green.

La evidencia decisiva será esta misma PR: sus cuatro checks deben arrancar y terminar en GitHub-hosted; luego #166 se actualizará sobre main para reemplazar sus checks ya encolados.

## Rollback

Revertir este commit restaura los labels anteriores. No requiere migración ni deploy. No se debe usar ese rollback mientras mona sea el único runner online y permanezca aislado para producción.

Closes #167
