### PR TITLE
feat(load): capture target-side rehearsal telemetry

### DIFF
--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -85,6 +85,44 @@ the signal and timestamp plus the partial redacted phase metrics. It never
 promotes partial results to FAIL/PASS or continues into another phase.
 Run the full ES and EN profiles twice and attach all four manifests to #24.
 
+## Target-local telemetry
+
+The generator's own network path is not a reliable control plane under a large
+subscriber test. Start `scripts/livekit-target-monitor.py` **on the isolated SFU
+host** before traffic. It uses only Python's standard library plus the host's
+Docker CLI, reads no environment credential, probes only a loopback health URL,
+and writes JSONL evidence mode `0600`.
+
+Use a unique synthetic run ID and output path. The monitor refuses to overwrite
+evidence, refuses remote or credential-bearing health URLs, and records no
+response body, Docker ID, environment, command output, token, room identity,
+audio, or video. A typical isolated mona rehearsal monitors both the temporary
+target and the production containers so shared-host impact is visible:
+
+```bash
+python3 scripts/livekit-target-monitor.py \
+  --run-id rehearsal-en-20260805-a \
+  --duration-seconds 1500 \
+  --interval-seconds 1 \
+  --output /tmp/rehearsal-en-20260805-a-target.jsonl \
+  --health-url http://127.0.0.1:3000/api/health/ready \
+  --container hb-load-livekit-isolated \
+  --container beacon-app \
+  --container beacon-livekit
+```
+
+For a remote generator, launch the monitor under a target-local supervisor or
+`nohup` so losing SSH does not lose samples. Send `SIGINT` or `SIGTERM` for a
+cooperative stop; the process writes a final summary and exits non-zero. A
+usable artifact must end with `recordType=summary`. The summary includes health
+failures/latency, peak host and container CPU, minimum available memory,
+physical-interface byte deltas, restart deltas, OOM observation and whether an
+operator interrupted it. Each sample also records its collection duration so a
+slow Docker daemon is visible instead of being mistaken for a one-second cadence.
+Hash the file before copying it to the rehearsal
+record; never weaken a failed load manifest because target telemetry looks
+healthy.
+
 ## Tooling
 
 Install the official `lk` CLI (the CI workflow pins v2.16.3). LiveKit recommends

--- a/scripts/livekit-target-monitor.py
+++ b/scripts/livekit-target-monitor.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Credential-free, target-local telemetry for synthetic LiveKit load runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+SAFE_RUN_ID = re.compile(r"^[a-z0-9][a-z0-9-]{2,63}$")
+LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+BYTE_UNITS = {
+    "b": 1,
+    "kb": 1_000,
+    "mb": 1_000_000,
+    "gb": 1_000_000_000,
+    "tb": 1_000_000_000_000,
+    "kib": 1_024,
+    "mib": 1_048_576,
+    "gib": 1_073_741_824,
+    "tib": 1_099_511_627_776,
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def safe_name(value: str) -> str:
+    if not SAFE_NAME.fullmatch(value):
+        raise argparse.ArgumentTypeError("must be a safe container or interface name")
+    return value
+
+
+def safe_run_id(value: str) -> str:
+    if not SAFE_RUN_ID.fullmatch(value):
+        raise argparse.ArgumentTypeError("must be 3-64 lowercase alphanumeric or hyphen characters")
+    return value
+
+
+def loopback_health_url(value: str) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.hostname not in LOOPBACK_HOSTS
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise argparse.ArgumentTypeError("health URL must be credential-free HTTP(S) on loopback")
+    return value
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Capture target-local, redacted telemetry during a synthetic LiveKit load run.",
+    )
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--run-id", required=True, type=safe_run_id)
+    parser.add_argument("--duration-seconds", required=True, type=positive_float)
+    parser.add_argument("--interval-seconds", default=1.0, type=positive_float)
+    parser.add_argument(
+        "--health-url",
+        default="http://127.0.0.1:3000/api/health/ready",
+        type=loopback_health_url,
+    )
+    parser.add_argument("--container", action="append", required=True, type=safe_name)
+    parser.add_argument("--network-interface", type=safe_name)
+    args = parser.parse_args()
+    if args.interval_seconds > args.duration_seconds:
+        parser.error("interval must not exceed duration")
+    if len(set(args.container)) != len(args.container):
+        parser.error("container names must be unique")
+    return args
+
+
+def default_network_interface() -> str:
+    candidates: list[tuple[int, str]] = []
+    with open("/proc/net/route", encoding="utf-8") as routes:
+        next(routes, None)
+        for line in routes:
+            fields = line.split()
+            if len(fields) < 8 or fields[1] != "00000000":
+                continue
+            try:
+                flags = int(fields[3], 16)
+                metric = int(fields[6])
+            except ValueError:
+                continue
+            if flags & 0x1:
+                candidates.append((metric, fields[0]))
+    if not candidates:
+        raise RuntimeError("no default network interface found")
+    return min(candidates)[1]
+
+
+def read_cpu() -> tuple[int, int]:
+    fields = Path("/proc/stat").read_text(encoding="utf-8").splitlines()[0].split()[1:]
+    counters = [int(value) for value in fields]
+    total = sum(counters)
+    idle = counters[3] + (counters[4] if len(counters) > 4 else 0)
+    return total, idle
+
+
+def cpu_busy_percent(before: tuple[int, int] | None, after: tuple[int, int]) -> float | None:
+    if before is None:
+        return None
+    total_delta = after[0] - before[0]
+    idle_delta = after[1] - before[1]
+    if total_delta <= 0:
+        return None
+    return round((1 - idle_delta / total_delta) * 100, 2)
+
+
+def memory_available_bytes() -> int | None:
+    match = re.search(
+        r"^MemAvailable:\s+(\d+)\s+kB$",
+        Path("/proc/meminfo").read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    return int(match.group(1)) * 1024 if match else None
+
+
+def network_bytes(interface: str) -> tuple[int, int]:
+    root = Path("/sys/class/net") / interface / "statistics"
+    return (
+        int((root / "rx_bytes").read_text(encoding="utf-8")),
+        int((root / "tx_bytes").read_text(encoding="utf-8")),
+    )
+
+
+def parse_bytes(value: str) -> int | None:
+    match = re.fullmatch(r"\s*(\d+(?:\.\d+)?)\s*([KMGT]?i?B)\s*", value, re.IGNORECASE)
+    if not match:
+        return None
+    return round(float(match.group(1)) * BYTE_UNITS[match.group(2).lower()])
+
+
+def parse_pair(value: str) -> tuple[int | None, int | None]:
+    parts = value.split("/", 1)
+    if len(parts) != 2:
+        return None, None
+    return parse_bytes(parts[0]), parse_bytes(parts[1])
+
+
+def run_command(arguments: list[str]) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(
+            arguments,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={
+                "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+                "LC_ALL": "C",
+            },
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def container_samples(names: list[str]) -> list[dict[str, object]]:
+    stats_result = run_command(
+        ["docker", "stats", "--no-stream", "--format", "{{json .}}", *names],
+    )
+    inspect_result = run_command(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{.Name}}\t{{.RestartCount}}\t{{.State.Status}}\t{{.State.OOMKilled}}\t"
+            "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+            *names,
+        ],
+    )
+    if (
+        stats_result is None
+        or stats_result.returncode != 0
+        or inspect_result is None
+        or inspect_result.returncode != 0
+    ):
+        return [
+            {"name": name, "available": False, "error": "docker-unavailable"}
+            for name in names
+        ]
+    try:
+        stats_by_name = {}
+        for line in stats_result.stdout.splitlines():
+            stats = json.loads(line)
+            stats_by_name[str(stats["Name"])] = stats
+        inspect_by_name = {}
+        for line in inspect_result.stdout.splitlines():
+            raw_name, restart_count, state, oom_killed, health = line.split("\t", 4)
+            inspect_by_name[raw_name.removeprefix("/")] = (
+                restart_count,
+                state,
+                oom_killed,
+                health,
+            )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return [
+            {"name": name, "available": False, "error": "docker-output-invalid"}
+            for name in names
+        ]
+
+    samples: list[dict[str, object]] = []
+    for name in names:
+        try:
+            stats = stats_by_name[name]
+            restart_count, state, oom_killed, health = inspect_by_name[name]
+            memory_usage, memory_limit = parse_pair(stats.get("MemUsage", ""))
+            network_rx, network_tx = parse_pair(stats.get("NetIO", ""))
+            samples.append(
+                {
+                    "name": name,
+                    "available": True,
+                    "cpuPercent": float(str(stats.get("CPUPerc", "")).rstrip("%")),
+                    "memoryUsageBytes": memory_usage,
+                    "memoryLimitBytes": memory_limit,
+                    "networkRxBytes": network_rx,
+                    "networkTxBytes": network_tx,
+                    "pids": int(stats.get("PIDs", 0)),
+                    "restartCount": int(restart_count),
+                    "state": state,
+                    "oomKilled": oom_killed.lower() == "true",
+                    "health": None if health == "none" else health,
+                },
+            )
+        except (KeyError, TypeError, ValueError):
+            samples.append(
+                {"name": name, "available": False, "error": "docker-output-invalid"},
+            )
+    return samples
+
+
+def health_sample(url: str, timeout: float) -> dict[str, object]:
+    started = time.monotonic()
+    request = urllib.request.Request(url, headers={"User-Agent": "harmonic-beacon-load-monitor/1"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            response.read(1)
+            return {
+                "ok": 200 <= response.status < 300,
+                "status": response.status,
+                "latencyMs": round((time.monotonic() - started) * 1000, 2),
+            }
+    except urllib.error.HTTPError as error:
+        return {
+            "ok": False,
+            "status": error.code,
+            "latencyMs": round((time.monotonic() - started) * 1000, 2),
+            "error": "http",
+        }
+    except (TimeoutError, socket.timeout):
+        return {
+            "ok": False,
+            "status": None,
+            "latencyMs": round((time.monotonic() - started) * 1000, 2),
+            "error": "timeout",
+        }
+    except (OSError, urllib.error.URLError):
+        return {
+            "ok": False,
+            "status": None,
+            "latencyMs": round((time.monotonic() - started) * 1000, 2),
+            "error": "network",
+        }
+
+
+def write_record(output, record: dict[str, object]) -> None:
+    output.write(json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n")
+    output.flush()
+
+
+def main() -> int:
+    args = parse_args()
+    interface = args.network_interface or default_network_interface()
+    if not (Path("/sys/class/net") / interface).is_dir():
+        raise RuntimeError("network interface does not exist")
+    if args.output.exists():
+        raise RuntimeError("refusing to overwrite an existing telemetry file")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    stop = threading.Event()
+    received_signal: str | None = None
+
+    def request_stop(signum, _frame) -> None:
+        nonlocal received_signal
+        if received_signal is None:
+            received_signal = signal.Signals(signum).name
+            stop.set()
+
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+
+    descriptor = os.open(args.output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    started_at = utc_now()
+    started = time.monotonic()
+    deadline = started + args.duration_seconds
+    next_sample_at = started
+    previous_cpu: tuple[int, int] | None = None
+    first_network: tuple[int, int] | None = None
+    last_network: tuple[int, int] | None = None
+    sample_count = 0
+    health_failures = 0
+    max_health_latency = 0.0
+    max_collection_ms = 0.0
+    max_cpu_busy: float | None = None
+    min_memory_available: int | None = None
+    container_max_cpu = {name: 0.0 for name in args.container}
+    container_first_restarts: dict[str, int] = {}
+    container_last_restarts: dict[str, int] = {}
+    oom_observed = False
+
+    with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+        write_record(
+            output,
+            {
+                "schemaVersion": 1,
+                "kind": "harmonic-beacon-livekit-target-monitor",
+                "recordType": "header",
+                "runId": args.run_id,
+                "startedAt": started_at,
+                "durationSeconds": args.duration_seconds,
+                "intervalSeconds": args.interval_seconds,
+                "healthTarget": "loopback",
+                "networkInterface": interface,
+                "containers": args.container,
+            },
+        )
+        while not stop.is_set():
+            sample_started = time.monotonic()
+            cpu = read_cpu()
+            memory = memory_available_bytes()
+            network = network_bytes(interface)
+            if first_network is None:
+                first_network = network
+            last_network = network
+            busy = cpu_busy_percent(previous_cpu, cpu)
+            previous_cpu = cpu
+            health = health_sample(args.health_url, timeout=min(5.0, args.interval_seconds))
+            containers = container_samples(args.container)
+            sample_count += 1
+            if not health["ok"]:
+                health_failures += 1
+            max_health_latency = max(max_health_latency, float(health["latencyMs"]))
+            if busy is not None:
+                max_cpu_busy = busy if max_cpu_busy is None else max(max_cpu_busy, busy)
+            if memory is not None:
+                min_memory_available = (
+                    memory if min_memory_available is None else min(min_memory_available, memory)
+                )
+            for container in containers:
+                if not container.get("available"):
+                    continue
+                name = str(container["name"])
+                container_max_cpu[name] = max(
+                    container_max_cpu[name],
+                    float(container["cpuPercent"]),
+                )
+                restarts = int(container["restartCount"])
+                container_first_restarts.setdefault(name, restarts)
+                container_last_restarts[name] = restarts
+                oom_observed = oom_observed or bool(container["oomKilled"])
+            collection_ms = round((time.monotonic() - sample_started) * 1000, 2)
+            max_collection_ms = max(max_collection_ms, collection_ms)
+            write_record(
+                output,
+                {
+                    "recordType": "sample",
+                    "at": utc_now(),
+                    "elapsedMs": round((time.monotonic() - started) * 1000),
+                    "collectionMs": collection_ms,
+                    "host": {
+                        "cpuBusyPercent": busy,
+                        "memoryAvailableBytes": memory,
+                        "load1": round(os.getloadavg()[0], 3),
+                        "networkRxBytes": network[0],
+                        "networkTxBytes": network[1],
+                    },
+                    "health": health,
+                    "containers": containers,
+                },
+            )
+            if time.monotonic() >= deadline:
+                break
+            next_sample_at += args.interval_seconds
+            stop.wait(max(0.0, min(next_sample_at, deadline) - time.monotonic()))
+
+        restart_deltas = {
+            name: container_last_restarts.get(name, first) - first
+            for name, first in container_first_restarts.items()
+        }
+        write_record(
+            output,
+            {
+                "recordType": "summary",
+                "endedAt": utc_now(),
+                "samples": sample_count,
+                "interrupted": received_signal is not None,
+                "signal": received_signal,
+                "healthFailures": health_failures,
+                "maxHealthLatencyMs": round(max_health_latency, 2),
+                "maxCollectionMs": round(max_collection_ms, 2),
+                "maxHostCpuBusyPercent": max_cpu_busy,
+                "minMemoryAvailableBytes": min_memory_available,
+                "networkRxBytesDelta": (
+                    last_network[0] - first_network[0] if first_network and last_network else None
+                ),
+                "networkTxBytesDelta": (
+                    last_network[1] - first_network[1] if first_network and last_network else None
+                ),
+                "containerMaxCpuPercent": container_max_cpu,
+                "containerRestartDelta": restart_deltas,
+                "oomObserved": oom_observed,
+            },
+        )
+        os.fsync(output.fileno())
+
+    if received_signal == "SIGINT":
+        return 130
+    if received_signal == "SIGTERM":
+        return 143
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"target monitor refused or failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/livekit-target-monitor.py
+++ b/scripts/livekit-target-monitor.py
@@ -36,6 +36,14 @@ BYTE_UNITS = {
 }
 
 
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        return None
+
+
+NO_REDIRECT_OPENER = urllib.request.build_opener(NoRedirectHandler)
+
+
 def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
@@ -260,7 +268,7 @@ def health_sample(url: str, timeout: float) -> dict[str, object]:
     started = time.monotonic()
     request = urllib.request.Request(url, headers={"User-Agent": "harmonic-beacon-load-monitor/1"})
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        with NO_REDIRECT_OPENER.open(request, timeout=timeout) as response:
             response.read(1)
             return {
                 "ok": 200 <= response.status < 300,

--- a/src/lib/__tests__/livekit-target-monitor.test.ts
+++ b/src/lib/__tests__/livekit-target-monitor.test.ts
@@ -1,0 +1,224 @@
+import { createServer, type Server } from 'node:http';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const script = join(process.cwd(), 'scripts/livekit-target-monitor.py');
+const temporaryRoots: string[] = [];
+
+function temporaryRoot() {
+  const root = mkdtempSync(join(tmpdir(), 'hb-target-monitor-'));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function fakeDocker(root: string) {
+  const bin = join(root, 'bin');
+  mkdirSync(bin);
+  const executable = join(bin, 'docker');
+  const environmentCapture = join(root, 'docker-environment');
+  writeFileSync(executable, [
+    '#!/bin/sh',
+    `env > '${environmentCapture}'`,
+    'case "$1" in',
+    '  stats)',
+    "    printf '%s\\n' '{\"Name\":\"beacon-app\",\"CPUPerc\":\"12.50%\",\"MemUsage\":\"1MiB / 2GiB\",\"NetIO\":\"3MB / 4MB\",\"PIDs\":\"7\"}'",
+    "    printf '%s\\n' '{\"Name\":\"beacon-livekit\",\"CPUPerc\":\"4.25%\",\"MemUsage\":\"2MiB / 2GiB\",\"NetIO\":\"5MB / 6MB\",\"PIDs\":\"9\"}'",
+    '    ;;',
+    '  inspect)',
+    "    printf '/beacon-app\\t2\\trunning\\tfalse\\thealthy\\n'",
+    "    printf '/beacon-livekit\\t3\\trunning\\tfalse\\tnone\\n'",
+    '    ;;',
+    '  *) exit 9 ;;',
+    'esac',
+  ].join('\n'));
+  chmodSync(executable, 0o755);
+  return { bin, environmentCapture };
+}
+
+async function healthyServer(): Promise<{ server: Server; url: string }> {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{"status":"ok"}');
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address === null || typeof address === 'string') throw new Error('missing test server port');
+  return { server, url: `http://127.0.0.1:${address.port}/ready` };
+}
+
+function records(path: string) {
+  return readFileSync(path, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 4_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('timed out waiting for monitor evidence');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+async function runPython(args: string[], env: NodeJS.ProcessEnv) {
+  const child = spawn('python3', args, {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+  child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+  const status = await new Promise<number | null>((resolve) => child.on('close', resolve));
+  return { status, stdout, stderr };
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('LiveKit target-side monitor', () => {
+  it('writes bounded, credential-free target telemetry and a final summary', async () => {
+    const root = temporaryRoot();
+    const { bin, environmentCapture } = fakeDocker(root);
+    const output = join(root, 'evidence', 'monitor.jsonl');
+    const { server, url } = await healthyServer();
+    try {
+      const result = await runPython([
+        script,
+        '--output', output,
+        '--run-id', 'target-monitor-test',
+        '--duration-seconds', '0.65',
+        '--interval-seconds', '0.2',
+        '--health-url', url,
+        '--network-interface', 'lo',
+        '--container', 'beacon-app',
+        '--container', 'beacon-livekit',
+      ], {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        TARGET_MONITOR_SECRET_SENTINEL: 'must-not-appear',
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(statSync(output).mode & 0o777).toBe(0o600);
+      const raw = readFileSync(output, 'utf8');
+      expect(raw).not.toContain('must-not-appear');
+      expect(readFileSync(environmentCapture, 'utf8')).not.toContain(
+        'TARGET_MONITOR_SECRET_SENTINEL',
+      );
+      const evidence = records(output);
+      expect(evidence[0]).toMatchObject({
+        schemaVersion: 1,
+        kind: 'harmonic-beacon-livekit-target-monitor',
+        recordType: 'header',
+        healthTarget: 'loopback',
+        containers: ['beacon-app', 'beacon-livekit'],
+      });
+      const samples = evidence.filter((record) => record.recordType === 'sample');
+      expect(samples.length).toBeGreaterThanOrEqual(2);
+      expect(samples[0].health).toMatchObject({ ok: true, status: 200 });
+      expect(samples[0].containers[0]).toMatchObject({
+        name: 'beacon-app',
+        available: true,
+        cpuPercent: 12.5,
+        memoryUsageBytes: 1_048_576,
+        memoryLimitBytes: 2_147_483_648,
+        networkRxBytes: 3_000_000,
+        networkTxBytes: 4_000_000,
+        restartCount: 2,
+        oomKilled: false,
+        health: 'healthy',
+      });
+      expect(samples[0].containers[1]).toMatchObject({
+        name: 'beacon-livekit',
+        available: true,
+        cpuPercent: 4.25,
+        restartCount: 3,
+        health: null,
+      });
+      expect(evidence.at(-1)).toMatchObject({
+        recordType: 'summary',
+        interrupted: false,
+        signal: null,
+        healthFailures: 0,
+        containerMaxCpuPercent: { 'beacon-app': 12.5, 'beacon-livekit': 4.25 },
+        containerRestartDelta: { 'beacon-app': 0, 'beacon-livekit': 0 },
+        oomObserved: false,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  }, 10_000);
+
+  it.each([
+    ['SIGINT', 130],
+    ['SIGTERM', 143],
+  ] as const)('preserves a summary for %s with exit %i', async (sentSignal, expectedExit) => {
+    const root = temporaryRoot();
+    const { bin } = fakeDocker(root);
+    const output = join(root, 'interrupted.jsonl');
+    const { server, url } = await healthyServer();
+    try {
+      const child = spawn('python3', [
+        script,
+        '--output', output,
+        '--run-id', 'target-monitor-interrupt',
+        '--duration-seconds', '20',
+        '--interval-seconds', '0.2',
+        '--health-url', url,
+        '--network-interface', 'lo',
+        '--container', 'beacon-app',
+      ], {
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stderr = '';
+      child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+      await waitUntil(() => existsSync(output) && readFileSync(output, 'utf8').includes('"recordType":"sample"'));
+      child.kill(sentSignal);
+      const exitCode = await new Promise<number | null>((resolve) => child.on('close', resolve));
+
+      expect(exitCode, stderr).toBe(expectedExit);
+      const evidence = records(output);
+      expect(evidence.at(-1)).toMatchObject({
+        recordType: 'summary',
+        interrupted: true,
+        signal: sentSignal,
+        healthFailures: 0,
+      });
+      expect(statSync(output).mode & 0o777).toBe(0o600);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  }, 10_000);
+
+  it.each([
+    'https://user:password@example.com/ready',
+    'http://127.0.0.1/ready?token=secret',
+  ])('refuses remote or credential-bearing health URL %s before opening evidence', (url) => {
+    const root = temporaryRoot();
+    const output = join(root, 'refused.jsonl');
+    const result = spawnSync('python3', [
+      script,
+      '--output', output,
+      '--run-id', 'target-monitor-refusal',
+      '--duration-seconds', '1',
+      '--health-url', url,
+      '--container', 'beacon-app',
+    ], { encoding: 'utf8', timeout: 5_000 });
+
+    expect(result.status).toBe(2);
+    expect(existsSync(output)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/livekit-target-monitor.test.ts
+++ b/src/lib/__tests__/livekit-target-monitor.test.ts
@@ -47,15 +47,22 @@ function fakeDocker(root: string) {
   return { bin, environmentCapture };
 }
 
-async function healthyServer(): Promise<{ server: Server; url: string }> {
-  const server = createServer((_request, response) => {
+async function healthyServer(): Promise<{ server: Server; url: string; requests: string[] }> {
+  const requests: string[] = [];
+  const server = createServer((request, response) => {
+    requests.push(request.url ?? '');
+    if (request.url === '/redirect') {
+      response.writeHead(302, { location: '/redirect-target' });
+      response.end();
+      return;
+    }
     response.writeHead(200, { 'content-type': 'application/json' });
     response.end('{"status":"ok"}');
   });
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   const address = server.address();
   if (address === null || typeof address === 'string') throw new Error('missing test server port');
-  return { server, url: `http://127.0.0.1:${address.port}/ready` };
+  return { server, url: `http://127.0.0.1:${address.port}/ready`, requests };
 }
 
 function records(path: string) {
@@ -202,6 +209,34 @@ describe('LiveKit target-side monitor', () => {
       await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     }
   }, 10_000);
+
+  it('records a loopback redirect as unhealthy without following it', async () => {
+    const root = temporaryRoot();
+    const { bin } = fakeDocker(root);
+    const output = join(root, 'redirect.jsonl');
+    const { server, url, requests } = await healthyServer();
+    try {
+      const result = await runPython([
+        script,
+        '--output', output,
+        '--run-id', 'target-monitor-redirect',
+        '--duration-seconds', '0.25',
+        '--interval-seconds', '0.2',
+        '--health-url', url.replace('/ready', '/redirect'),
+        '--network-interface', 'lo',
+        '--container', 'beacon-app',
+      ], { ...process.env, PATH: `${bin}:${process.env.PATH}` });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(requests.length).toBeGreaterThanOrEqual(2);
+      expect(new Set(requests)).toEqual(new Set(['/redirect']));
+      const evidence = records(output);
+      expect(evidence[1].health).toMatchObject({ ok: false, status: 302, error: 'http' });
+      expect(evidence.at(-1)).toMatchObject({ healthFailures: requests.length });
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
 
   it.each([
     'https://user:password@example.com/ready',


### PR DESCRIPTION
## Diagnóstico

El perfil completo de #99 perdió readiness y el canal SSH del generador durante la rampa. Como ambos compartían la ruta que estaba siendo saturada, el ensayo quedó sin evidencia del host del SFU y tuvo que abortarse.

## Cambio

- agrega un monitor Python estándar que corre en el host objetivo y escribe JSONL 0600;
- captura readiness loopback sin body, CPU/memoria/red física, Docker CPU/mem/net/PIDs, reinicios, OOM y salud;
- consulta todos los containers en un solo batch y registra la duración real de recolección;
- no hereda secretos al Docker CLI y rechaza URLs remotas, con credenciales o query;
- preserva summary y salida 130/143 ante SIGINT/SIGTERM;
- documenta uso target-local y la relación con el manifest autoritativo del harness.

## Evidencia

- 5 tests focalizados: normal, batch multi-container, 0600, no-leak, SIGINT, SIGTERM y URLs rechazadas;
- ejecución con Docker real sobre dos containers locales: 3 muestras, readiness 0 fallos, reinicios 0, OOM false y collectionMs observable;
- suite completa: 798 tests verdes, 9 opt-in skipped;
- TypeScript, ESLint y build verdes.

## Riesgo y rollback

No cambia runtime, rooms, señal de audio, pagos, DB ni producción. El monitor es opt-in. Rollback: revertir este único commit. No cierra #99: luego faltan sharding y repetir el perfil completo con esta telemetría.