### PR TITLE
feat(load): distribute rehearsal generators safely

### DIFF
--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -55,6 +55,62 @@ npm run load:livekit -- \
 Never point this command at an active event. The remote rooms must be synthetic
 and the operator must monitor LiveKit, CPU, memory, and network on the target.
 
+## Distributed generators
+
+A single generator receiving six simulcast publishers can saturate its own
+network path before the SFU reaches capacity. Split a rehearsal across two or
+more **distinct generator hosts** with the same committed harness, LiveKit CLI,
+profile, run ID, confirmation and UTC start. Choose a start at least 30 seconds
+in the future; two minutes gives operators time to launch every shard. Verify
+NTP/chrony on every generator first and keep reported clock offset below one
+second; synchronized manifest timestamps cannot correct a drifting host clock.
+
+Example for two hosts (run shard 0 on the first and shard 1 on the second):
+
+```bash
+npm run load:livekit -- \
+  --profile rehearsal-en \
+  --run-id rehearsal-en-20260805-a \
+  --shard-count 2 \
+  --shard-index 0 \
+  --start-at 2026-08-05T18:00:00Z \
+  --url wss://test-live.example.invalid \
+  --allow-remote \
+  --confirm-test-rooms 'LOADTEST:hb-load-rehearsal-en-20260805-a-en-stage:hb-load-rehearsal-en-20260805-a-en-beacon'
+```
+
+Sharding partitions attendees, publishers and the declared global ramp rate
+without rounding anything away. Every identity prefix includes its shard, all
+shards join the same two synthetic rooms, and every shard independently observes
+the exact **global** participant/publisher counts. Synchronized phases use a
+minimum 15-second gap so cleanup can converge before the next absolute start.
+The schedule includes the CLI connection ramp because LiveKit starts its
+`--duration` timer only after those connections finish.
+Missing coordinates, duplicate identities, a late phase, API sampling errors,
+extra/missing joins or incomplete cleanup fail closed.
+
+LiveKit CLI reports its track denominator from publishers created by that one
+process, so that denominator is incomplete in a shared room. The harness keeps
+the raw parsed value for diagnosis but gates each shard against the independently
+calculated `local subscribers × global publishers` count. A shard with zero
+local Beacon publishers must still receive the one global Beacon track.
+
+Copy the redacted manifests to one trusted operator machine and aggregate them:
+
+```bash
+node scripts/livekit-load-aggregate.mjs \
+  --output artifacts/load-test/rehearsal-en-20260805-a-aggregate.json \
+  artifacts/load-test/rehearsal-en-20260805-a-rehearsal-en-shard-0-of-2.json \
+  artifacts/load-test/rehearsal-en-20260805-a-rehearsal-en-shard-1-of-2.json
+```
+
+The aggregator writes mode `0600` and refuses overwrite. It emits PASS only
+when every index is present, the partitions sum to the profile exactly, every
+phase proves the global counts and clean teardown, the harness/CLI/run contract
+is byte-equivalent, worktrees are clean and generator host hashes are distinct.
+Keep every source manifest and its aggregate; the aggregate does not replace
+target-local telemetry or physical browser evidence.
+
 ## Profiles and evidence
 
 - `ci`: four attendees, two stage publishers, one Beacon publisher, short

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -60,6 +60,43 @@ export function validateProfile(profile) {
     return profile;
 }
 
+export function validateShard({ shardIndex, shardCount }, profile) {
+    if (!Number.isInteger(shardCount) || shardCount < 1) {
+        throw new Error('shardCount must be a positive integer');
+    }
+    if (!Number.isInteger(shardIndex) || shardIndex < 0 || shardIndex >= shardCount) {
+        throw new Error('shardIndex must be an integer between zero and shardCount - 1');
+    }
+    if (shardCount > profile.attendees) {
+        throw new Error('shardCount cannot exceed attendee count');
+    }
+    if (shardCount > profile.rampPerSecond) {
+        throw new Error('shardCount cannot exceed the global ramp rate');
+    }
+    return { shardIndex, shardCount };
+}
+
+export function partitionCount(total, shardIndex, shardCount) {
+    const base = Math.floor(total / shardCount);
+    return base + (shardIndex < total % shardCount ? 1 : 0);
+}
+
+export function connectionRampSeconds(connections, rampPerSecond) {
+    if (connections <= 1) return 0;
+    return Math.ceil((connections - 1) / Math.min(rampPerSecond, 10));
+}
+
+export function normalizeScheduledStart(value) {
+    if (value === undefined || value === null || value === '') return null;
+    const text = String(value);
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/.test(text)) {
+        throw new Error('startAt must be an explicit UTC timestamp ending in Z');
+    }
+    const milliseconds = Date.parse(text);
+    if (!Number.isFinite(milliseconds)) throw new Error('startAt is not a valid timestamp');
+    return new Date(milliseconds).toISOString();
+}
+
 export function roomNames(runId) {
     const safeRunId = sanitizeRunId(runId);
     return {
@@ -125,23 +162,88 @@ function commandFor({
     return args;
 }
 
-export function buildPlan({ profileName, profile, runId, url, allowRemote = false, confirmation = '' }) {
+export function buildPlan({
+    profileName,
+    profile,
+    runId,
+    url,
+    allowRemote = false,
+    confirmation = '',
+    shardIndex = 0,
+    shardCount = 1,
+    startAt = /** @type {string | null | undefined} */ (undefined),
+}) {
     validateProfile(profile);
+    validateShard({ shardIndex, shardCount }, profile);
+    const scheduledStartAt = normalizeScheduledStart(startAt);
+    if (shardCount > 1 && scheduledStartAt === null) {
+        throw new Error('sharded runs require a shared startAt timestamp');
+    }
     const rooms = roomNames(`${sanitizeRunId(runId)}-${profile.eventLanguage}`);
     const safety = assertSafeTarget({ url, rooms, allowRemote, confirmation });
+    const localAttendees = partitionCount(profile.attendees, shardIndex, shardCount);
+    const localStagePublishers = partitionCount(
+        profile.stagePublishers,
+        shardIndex,
+        shardCount,
+    );
+    const localBeaconPublishers = partitionCount(
+        profile.beaconPublishers,
+        shardIndex,
+        shardCount,
+    );
+    const localRampPerSecond = partitionCount(
+        profile.rampPerSecond,
+        shardIndex,
+        shardCount,
+    );
+    const shardIdentity = shardCount === 1 ? '' : `-s${shardIndex}`;
+    const phaseGapSeconds = shardCount === 1
+        ? profile.interWaveSeconds
+        : Math.max(profile.interWaveSeconds, 15);
     const phases = [
-        { name: 'ramp', durationSeconds: profile.rampDurationSeconds, rampPerSecond: profile.rampPerSecond },
-        { name: 'soak', durationSeconds: profile.soakDurationSeconds, rampPerSecond: profile.rampPerSecond },
+        {
+            name: 'ramp',
+            durationSeconds: profile.rampDurationSeconds,
+            stageRampPerSecond: localRampPerSecond,
+            beaconRampPerSecond: localRampPerSecond,
+        },
+        {
+            name: 'soak',
+            durationSeconds: profile.soakDurationSeconds,
+            stageRampPerSecond: localRampPerSecond,
+            beaconRampPerSecond: localRampPerSecond,
+        },
     ];
     for (let wave = 1; wave <= profile.reconnectWaves; wave += 1) {
         phases.push({
             name: `reconnect-${wave}`,
             durationSeconds: profile.reconnectDurationSeconds,
-            rampPerSecond: profile.reconnectMode === 'simultaneous'
-                ? profile.attendees + profile.stagePublishers
-                : profile.rampPerSecond,
+            stageRampPerSecond: profile.reconnectMode === 'simultaneous'
+                ? localAttendees + localStagePublishers
+                : localRampPerSecond,
+            beaconRampPerSecond: profile.reconnectMode === 'simultaneous'
+                ? localAttendees + localBeaconPublishers
+                : localRampPerSecond,
         });
     }
+    let scheduledOffsetSeconds = 0;
+    const scheduledPhases = phases.map((phase, index) => {
+        const expectedConnectSeconds = Math.max(
+            connectionRampSeconds(
+                localAttendees + localStagePublishers,
+                phase.stageRampPerSecond,
+            ),
+            connectionRampSeconds(
+                localAttendees + localBeaconPublishers,
+                phase.beaconRampPerSecond,
+            ),
+        );
+        const scheduled = { ...phase, scheduledOffsetSeconds, expectedConnectSeconds };
+        scheduledOffsetSeconds += expectedConnectSeconds + phase.durationSeconds;
+        if (index < phases.length - 1) scheduledOffsetSeconds += phaseGapSeconds;
+        return scheduled;
+    });
     return {
         schemaVersion: 1,
         profileName,
@@ -150,34 +252,52 @@ export function buildPlan({ profileName, profile, runId, url, allowRemote = fals
         urlHost: safety.host,
         target: safety.target,
         rooms,
-        phases: phases.map((phase) => ({
+        scheduledStartAt,
+        shard: {
+            index: shardIndex,
+            count: shardCount,
+            localAttendees,
+            localStagePublishers,
+            localBeaconPublishers,
+            localRampPerSecond,
+            phaseGapSeconds,
+        },
+        phases: scheduledPhases.map((phase) => ({
             ...phase,
             stage: {
                 roomName: rooms.stage,
-                requestedConnections: profile.attendees + profile.stagePublishers,
+                requestedConnections: localAttendees + localStagePublishers,
+                expectedGlobalConnections: profile.attendees + profile.stagePublishers,
+                localPublishers: localStagePublishers,
+                expectedGlobalPublishers: profile.stagePublishers,
+                expectedSubscriberTracks: localAttendees * profile.stagePublishers,
                 args: commandFor({
                     room: rooms.stage,
-                    identityPrefix: `hbload-${sanitizeRunId(runId)}-stage`,
+                    identityPrefix: `hbload-${sanitizeRunId(runId)}${shardIdentity}-stage`,
                     durationSeconds: phase.durationSeconds,
-                    publishers: profile.stagePublishers,
+                    publishers: localStagePublishers,
                     publisherKind: 'video',
-                    attendees: profile.attendees,
-                    rampPerSecond: phase.rampPerSecond,
+                    attendees: localAttendees,
+                    rampPerSecond: phase.stageRampPerSecond,
                     videoCodec: profile.stageVideoCodec,
                     layout: profile.stageLayout,
                 }),
             },
             beacon: {
                 roomName: rooms.beacon,
-                requestedConnections: profile.attendees + profile.beaconPublishers,
+                requestedConnections: localAttendees + localBeaconPublishers,
+                expectedGlobalConnections: profile.attendees + profile.beaconPublishers,
+                localPublishers: localBeaconPublishers,
+                expectedGlobalPublishers: profile.beaconPublishers,
+                expectedSubscriberTracks: localAttendees * profile.beaconPublishers,
                 args: commandFor({
                     room: rooms.beacon,
-                    identityPrefix: `hbload-${sanitizeRunId(runId)}-beacon`,
+                    identityPrefix: `hbload-${sanitizeRunId(runId)}${shardIdentity}-beacon`,
                     durationSeconds: phase.durationSeconds,
-                    publishers: profile.beaconPublishers,
+                    publishers: localBeaconPublishers,
                     publisherKind: 'audio',
-                    attendees: profile.attendees,
-                    rampPerSecond: phase.rampPerSecond,
+                    attendees: localAttendees,
+                    rampPerSecond: phase.beaconRampPerSecond,
                 }),
             },
         })),
@@ -221,6 +341,274 @@ export function commandFingerprint(args) {
 export function manifestContainsSecret(value, secrets) {
     const serialized = JSON.stringify(value);
     return secrets.filter(Boolean).some((secret) => serialized.includes(secret));
+}
+
+function sameJson(left, right) {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function assertAggregate(condition, message) {
+    if (!condition) throw new Error(`shard aggregate refused: ${message}`);
+}
+
+function phasePassedIndependently(phase, plannedPhase, profile) {
+    const streams = ['stage', 'beacon'];
+    if (
+        !phase.passed ||
+        phase.operatorAborted ||
+        !phase.synchronization?.passed ||
+        !phase.cleanup?.passed
+    ) return false;
+    if (phase.observed?.apiErrors !== 0 || phase.observed?.successfulSamples < 1) return false;
+    const scheduledFor = phase.synchronization.scheduledFor;
+    for (const stream of streams) {
+        const result = phase[stream];
+        const observed = phase.observed?.[stream];
+        const planned = plannedPhase[stream];
+        if (
+            result?.exitCode !== 0 ||
+            (scheduledFor !== null && (
+                !Number.isFinite(Date.parse(result?.startedAt)) ||
+                Math.abs(Date.parse(result.startedAt) - Date.parse(scheduledFor)) > 5_000
+            )) ||
+            !result.summary?.parsed ||
+            result.summary.tracksReceived !== planned.expectedSubscriberTracks ||
+            result.summary.droppedPercent > profile.maxDroppedPercent ||
+            (result.summary.errorCount !== null && result.summary.errorCount !== 0) ||
+            observed?.expectedConnections !== planned.expectedGlobalConnections ||
+            observed?.peakConnections !== planned.expectedGlobalConnections ||
+            observed?.joinObserved !== planned.expectedGlobalConnections ||
+            observed?.expectedPublishers !== planned.expectedGlobalPublishers ||
+            observed?.peakPublishers !== planned.expectedGlobalPublishers
+        ) return false;
+    }
+    return true;
+}
+
+function shardPlanIsDeterministic(plan, index, shardCount) {
+    const profile = plan.profile;
+    const localAttendees = partitionCount(profile.attendees, index, shardCount);
+    const localStagePublishers = partitionCount(profile.stagePublishers, index, shardCount);
+    const localBeaconPublishers = partitionCount(profile.beaconPublishers, index, shardCount);
+    const localRampPerSecond = partitionCount(profile.rampPerSecond, index, shardCount);
+    const expectedGap = Math.max(profile.interWaveSeconds, 15);
+    if (
+        plan.shard.localAttendees !== localAttendees ||
+        plan.shard.localStagePublishers !== localStagePublishers ||
+        plan.shard.localBeaconPublishers !== localBeaconPublishers ||
+        plan.shard.localRampPerSecond !== localRampPerSecond ||
+        plan.shard.phaseGapSeconds !== expectedGap
+    ) return false;
+
+    let offset = 0;
+    return plan.phases.every((phase, phaseIndex) => {
+        const stageRamp = phaseIndex >= 2 && profile.reconnectMode === 'simultaneous'
+            ? localAttendees + localStagePublishers
+            : localRampPerSecond;
+        const beaconRamp = phaseIndex >= 2 && profile.reconnectMode === 'simultaneous'
+            ? localAttendees + localBeaconPublishers
+            : localRampPerSecond;
+        const expectedConnectSeconds = Math.max(
+            connectionRampSeconds(localAttendees + localStagePublishers, stageRamp),
+            connectionRampSeconds(localAttendees + localBeaconPublishers, beaconRamp),
+        );
+        const valid =
+            phase.scheduledOffsetSeconds === offset &&
+            phase.expectedConnectSeconds === expectedConnectSeconds &&
+            phase.stageRampPerSecond === stageRamp &&
+            phase.beaconRampPerSecond === beaconRamp &&
+            phase.stage.requestedConnections === localAttendees + localStagePublishers &&
+            phase.stage.expectedGlobalConnections === profile.attendees + profile.stagePublishers &&
+            phase.stage.localPublishers === localStagePublishers &&
+            phase.stage.expectedGlobalPublishers === profile.stagePublishers &&
+            phase.stage.expectedSubscriberTracks === localAttendees * profile.stagePublishers &&
+            phase.beacon.requestedConnections === localAttendees + localBeaconPublishers &&
+            phase.beacon.expectedGlobalConnections === profile.attendees + profile.beaconPublishers &&
+            phase.beacon.localPublishers === localBeaconPublishers &&
+            phase.beacon.expectedGlobalPublishers === profile.beaconPublishers &&
+            phase.beacon.expectedSubscriberTracks === localAttendees * profile.beaconPublishers;
+        offset += expectedConnectSeconds + phase.durationSeconds;
+        if (phaseIndex < plan.phases.length - 1) offset += expectedGap;
+        return valid;
+    });
+}
+
+export function aggregateShardManifests(entries) {
+    assertAggregate(Array.isArray(entries) && entries.length >= 2, 'at least two shards are required');
+    const first = entries[0]?.manifest;
+    const shardCount = first?.plan?.shard?.count;
+    assertAggregate(Number.isInteger(shardCount) && shardCount >= 2, 'invalid shard count');
+    assertAggregate(entries.length === shardCount, 'manifest count does not match shard count');
+
+    const expectedCore = {
+        schemaVersion: first.schemaVersion,
+        kind: first.kind,
+        harnessSha: first.harnessSha,
+        livekitCliVersion: first.livekitCliVersion,
+        profileName: first.plan.profileName,
+        profile: first.plan.profile,
+        runId: first.plan.runId,
+        rooms: first.plan.rooms,
+        scheduledStartAt: first.plan.scheduledStartAt,
+        target: first.plan.target,
+        urlHost: first.plan.urlHost,
+        phaseNames: first.plan.phases.map((phase) => phase.name),
+        phaseOffsets: first.plan.phases.map((phase) => phase.scheduledOffsetSeconds),
+    };
+    assertAggregate(first.schemaVersion === 1, 'unexpected manifest schema');
+    assertAggregate(first.kind === 'harmonic-beacon-livekit-load', 'unexpected manifest kind');
+    assertAggregate(/^[a-f0-9]{40}$/.test(first.harnessSha), 'invalid harness SHA');
+    assertAggregate(first.plan.scheduledStartAt !== null, 'shared start timestamp is missing');
+    try {
+        validateProfile(first.plan.profile);
+        validateShard({ shardIndex: first.plan.shard.index, shardCount }, first.plan.profile);
+    } catch {
+        assertAggregate(false, 'invalid profile or shard contract');
+    }
+
+    const indices = new Set();
+    const hosts = new Set();
+    const sourceHashes = new Set();
+    let attendeeTotal = 0;
+    let stagePublisherTotal = 0;
+    let beaconPublisherTotal = 0;
+    const sources = [];
+
+    for (const entry of entries) {
+        const manifest = entry.manifest;
+        const core = {
+            schemaVersion: manifest.schemaVersion,
+            kind: manifest.kind,
+            harnessSha: manifest.harnessSha,
+            livekitCliVersion: manifest.livekitCliVersion,
+            profileName: manifest.plan?.profileName,
+            profile: manifest.plan?.profile,
+            runId: manifest.plan?.runId,
+            rooms: manifest.plan?.rooms,
+            scheduledStartAt: manifest.plan?.scheduledStartAt,
+            target: manifest.plan?.target,
+            urlHost: manifest.plan?.urlHost,
+            phaseNames: manifest.plan?.phases?.map((phase) => phase.name),
+            phaseOffsets: manifest.plan?.phases?.map((phase) => phase.scheduledOffsetSeconds),
+        };
+        assertAggregate(sameJson(core, expectedCore), 'shards do not describe the same run');
+        assertAggregate(manifest.status === 'PASS', 'every shard must have status PASS');
+        assertAggregate(manifest.harnessDirty === false, 'dirty harness evidence is not admissible');
+        assertAggregate(manifest.plan.shard.count === shardCount, 'inconsistent shard count');
+        const index = manifest.plan.shard.index;
+        assertAggregate(Number.isInteger(index) && index >= 0 && index < shardCount, 'invalid shard index');
+        assertAggregate(!indices.has(index), 'duplicate shard index');
+        indices.add(index);
+        assertAggregate(
+            typeof entry.sha256 === 'string' && /^[a-f0-9]{64}$/.test(entry.sha256),
+            'invalid source manifest hash',
+        );
+        assertAggregate(!sourceHashes.has(entry.sha256), 'duplicate source manifest');
+        sourceHashes.add(entry.sha256);
+        assertAggregate(
+            typeof manifest.generatorHostHash === 'string' &&
+            /^[a-f0-9]{12}$/.test(manifest.generatorHostHash),
+            'invalid generator host hash',
+        );
+        assertAggregate(!hosts.has(manifest.generatorHostHash), 'shards must run on distinct hosts');
+        hosts.add(manifest.generatorHostHash);
+        assertAggregate(
+            shardPlanIsDeterministic(manifest.plan, index, shardCount),
+            `shard ${index} is not the deterministic partition`,
+        );
+        assertAggregate(
+            manifest.phases.length === manifest.plan.phases.length &&
+            manifest.phases.every((phase, phaseIndex) => phasePassedIndependently(
+                phase,
+                manifest.plan.phases[phaseIndex],
+                manifest.plan.profile,
+            )),
+            `shard ${index} contains an unproven phase`,
+        );
+        attendeeTotal += manifest.plan.shard.localAttendees;
+        stagePublisherTotal += manifest.plan.shard.localStagePublishers;
+        beaconPublisherTotal += manifest.plan.shard.localBeaconPublishers;
+        sources.push({
+            index,
+            sha256: entry.sha256,
+            generatorHostHash: manifest.generatorHostHash,
+            status: manifest.status,
+        });
+    }
+
+    assertAggregate(indices.size === shardCount, 'not every shard index is present');
+    assertAggregate(attendeeTotal === first.plan.profile.attendees, 'attendee partition is incomplete');
+    assertAggregate(
+        stagePublisherTotal === first.plan.profile.stagePublishers,
+        'stage publisher partition is incomplete',
+    );
+    assertAggregate(
+        beaconPublisherTotal === first.plan.profile.beaconPublishers,
+        'Beacon publisher partition is incomplete',
+    );
+
+    const phaseEvidence = first.plan.phases.map((plannedPhase, phaseIndex) => {
+        const phases = entries.map((entry) => entry.manifest.phases[phaseIndex]);
+        const startTimes = phases.flatMap((phase) => [
+            Date.parse(phase.stage.startedAt),
+            Date.parse(phase.beacon.startedAt),
+        ]);
+        const streamEvidence = (stream) => ({
+            expectedConnections: plannedPhase[stream].expectedGlobalConnections,
+            peakConnections: Math.max(...phases.map(
+                (phase) => phase.observed[stream].peakConnections,
+            )),
+            expectedPublishers: plannedPhase[stream].expectedGlobalPublishers,
+            peakPublishers: Math.max(...phases.map(
+                (phase) => phase.observed[stream].peakPublishers,
+            )),
+            subscriberTracksExpected: entries.reduce(
+                (total, entry) => total +
+                    entry.manifest.plan.phases[phaseIndex][stream].expectedSubscriberTracks,
+                0,
+            ),
+            subscriberTracksReceived: phases.reduce(
+                (total, phase) => total + phase[stream].summary.tracksReceived,
+                0,
+            ),
+            maxDroppedPercent: Math.max(...phases.map(
+                (phase) => phase[stream].summary.droppedPercent,
+            )),
+        });
+        const cleanupTimes = phases
+            .map((phase) => phase.cleanup.convergenceMs)
+            .filter(Number.isFinite);
+        return {
+            name: plannedPhase.name,
+            shardsPassed: shardCount,
+            startSkewMs: Math.max(...startTimes) - Math.min(...startTimes),
+            apiErrors: phases.reduce((total, phase) => total + phase.observed.apiErrors, 0),
+            cleanupMaxConvergenceMs: cleanupTimes.length > 0 ? Math.max(...cleanupTimes) : null,
+            stage: streamEvidence('stage'),
+            beacon: streamEvidence('beacon'),
+        };
+    });
+
+    return {
+        schemaVersion: 1,
+        kind: 'harmonic-beacon-livekit-load-aggregate',
+        status: 'PASS',
+        generatedAt: new Date().toISOString(),
+        harnessSha: first.harnessSha,
+        livekitCliVersion: first.livekitCliVersion,
+        runId: first.plan.runId,
+        profileName: first.plan.profileName,
+        rooms: first.plan.rooms,
+        scheduledStartAt: first.plan.scheduledStartAt,
+        shardCount,
+        totals: {
+            attendees: attendeeTotal,
+            stagePublishers: stagePublisherTotal,
+            beaconPublishers: beaconPublisherTotal,
+        },
+        phases: phaseEvidence,
+        sources: sources.sort((left, right) => left.index - right.index),
+    };
 }
 
 export function createAbortCoordinator({ terminate = (child) => child.kill('SIGTERM') } = {}) {

--- a/scripts/livekit-load-aggregate.mjs
+++ b/scripts/livekit-load-aggregate.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { aggregateShardManifests } from './lib/livekit-load-harness.mjs';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function printHelp() {
+    process.stdout.write(
+        'Usage: node scripts/livekit-load-aggregate.mjs --output PATH SHARD_MANIFEST...\n',
+    );
+}
+
+function parseArguments() {
+    const args = process.argv.slice(2);
+    if (args.includes('--help') || args.includes('-h')) return { help: true };
+    const outputIndex = args.indexOf('--output');
+    if (outputIndex < 0 || !args[outputIndex + 1]) {
+        throw new Error('--output is required');
+    }
+    const output = resolve(repositoryRoot, args[outputIndex + 1]);
+    const manifests = args.filter((_, index) => index !== outputIndex && index !== outputIndex + 1);
+    if (manifests.some((argument) => argument.startsWith('-'))) {
+        throw new Error('unknown option');
+    }
+    if (manifests.length < 2) throw new Error('at least two shard manifests are required');
+    return {
+        help: false,
+        output,
+        manifests: manifests.map((path) => resolve(repositoryRoot, path)),
+    };
+}
+
+async function main() {
+    const options = parseArguments();
+    if (options.help) {
+        printHelp();
+        return;
+    }
+    try {
+        await access(options.output, constants.F_OK);
+        throw new Error('refusing to overwrite an existing aggregate');
+    } catch (error) {
+        if (error?.code !== 'ENOENT') throw error;
+    }
+    const entries = await Promise.all(options.manifests.map(async (path) => {
+        const bytes = await readFile(path);
+        return {
+            sha256: createHash('sha256').update(bytes).digest('hex'),
+            manifest: JSON.parse(bytes.toString('utf8')),
+        };
+    }));
+    const aggregate = aggregateShardManifests(entries);
+    await mkdir(dirname(options.output), { recursive: true });
+    await writeFile(options.output, `${JSON.stringify(aggregate, null, 2)}\n`, {
+        mode: 0o600,
+        flag: 'wx',
+    });
+    process.stdout.write(`Aggregate: ${options.output}\nStatus: ${aggregate.status}\n`);
+}
+
+main().catch((error) => {
+    process.stderr.write(
+        `load aggregate refused or failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+});

--- a/scripts/livekit-load-harness.mjs
+++ b/scripts/livekit-load-harness.mjs
@@ -88,6 +88,17 @@ function generatedRunId() {
     return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'z').toLowerCase();
 }
 
+async function generatorHostFingerprint() {
+    let machineId = '';
+    try {
+        machineId = (await readFile('/etc/machine-id', 'utf8')).trim();
+    } catch {
+        // Hostname-only fallback remains opaque; the aggregate still refuses
+        // duplicate hashes rather than claiming independent generators.
+    }
+    return commandFingerprint([hostname(), machineId]).slice(0, 12);
+}
+
 function installAbortHandlers(abort) {
     const onSigint = () => {
         if (abort.request('SIGINT')) {
@@ -117,6 +128,26 @@ async function waitBetweenPhases(seconds, abort) {
     }
 }
 
+async function waitForScheduledPhase(startAt, offsetSeconds, abort) {
+    if (startAt === null) {
+        return { passed: true, scheduledFor: null, observedAt: null, lateByMs: null };
+    }
+    const target = Date.parse(startAt) + offsetSeconds * 1000;
+    while (!abort.requested && Date.now() < target) {
+        await new Promise((resolvePromise) => setTimeout(
+            resolvePromise,
+            Math.min(250, target - Date.now()),
+        ));
+    }
+    const lateByMs = Date.now() - target;
+    return {
+        passed: abort.requested || lateByMs <= 5_000,
+        scheduledFor: new Date(target).toISOString(),
+        observedAt: new Date().toISOString(),
+        lateByMs,
+    };
+}
+
 function printHelp() {
     process.stdout.write(`Usage: npm run load:livekit -- [options]\n\n` +
         `  --profile NAME             ci, rehearsal-es, or rehearsal-en\n` +
@@ -124,6 +155,9 @@ function printHelp() {
         `  --url URL                  LiveKit URL (default LIVEKIT_URL or localhost)\n` +
         `  --lk-bin PATH              pinned LiveKit CLI executable (default lk)\n` +
         `  --manifest PATH            output JSON path\n` +
+        `  --shard-index NUMBER       zero-based generator shard (default 0)\n` +
+        `  --shard-count NUMBER       total generator shards (default 1)\n` +
+        `  --start-at UTC             shared future UTC start required for sharding\n` +
         `  --dry-run                  validate and write a PLANNED manifest only\n` +
         `  --allow-remote             acknowledge a non-local target\n` +
         `  --confirm-test-rooms VALUE exact room confirmation required remotely\n`);
@@ -229,6 +263,14 @@ function summarizeObservedRoom(observed, expectedConnections, expectedPublishers
     };
 }
 
+function loadResultPassed(result, expectedSubscriberTracks, profile) {
+    return result.exitCode === 0 &&
+        result.summary.parsed &&
+        result.summary.tracksReceived === expectedSubscriberTracks &&
+        result.summary.droppedPercent <= profile.maxDroppedPercent &&
+        (result.summary.errorCount === null || result.summary.errorCount === 0);
+}
+
 async function monitorRooms(roomService, phase, stopped) {
     const startedAt = Date.now();
     const rooms = {
@@ -270,8 +312,16 @@ async function monitorRooms(roomService, phase, stopped) {
     return {
         apiErrors,
         successfulSamples,
-        stage: summarizeObservedRoom(rooms.stage, phase.stage.requestedConnections, phase.profileStagePublishers),
-        beacon: summarizeObservedRoom(rooms.beacon, phase.beacon.requestedConnections, phase.profileBeaconPublishers),
+        stage: summarizeObservedRoom(
+            rooms.stage,
+            phase.stage.expectedGlobalConnections,
+            phase.profileStagePublishers,
+        ),
+        beacon: summarizeObservedRoom(
+            rooms.beacon,
+            phase.beacon.expectedGlobalConnections,
+            phase.profileBeaconPublishers,
+        ),
     };
 }
 
@@ -305,11 +355,19 @@ function publicPlan(plan, lkBinary) {
             ...phase,
             stage: {
                 requestedConnections: phase.stage.requestedConnections,
+                expectedGlobalConnections: phase.stage.expectedGlobalConnections,
+                localPublishers: phase.stage.localPublishers,
+                expectedGlobalPublishers: phase.stage.expectedGlobalPublishers,
+                expectedSubscriberTracks: phase.stage.expectedSubscriberTracks,
                 command: `${executable} ${phase.stage.args.join(' ')}`,
                 fingerprint: commandFingerprint(phase.stage.args),
             },
             beacon: {
                 requestedConnections: phase.beacon.requestedConnections,
+                expectedGlobalConnections: phase.beacon.expectedGlobalConnections,
+                localPublishers: phase.beacon.localPublishers,
+                expectedGlobalPublishers: phase.beacon.expectedGlobalPublishers,
+                expectedSubscriberTracks: phase.beacon.expectedSubscriberTracks,
                 command: `${executable} ${phase.beacon.args.join(' ')}`,
                 fingerprint: commandFingerprint(phase.beacon.args),
             },
@@ -327,6 +385,9 @@ async function main() {
     const url = option('--url', process.env.LIVEKIT_URL ?? 'ws://localhost:7880');
     const lkBinary = option('--lk-bin', process.env.LK_BIN ?? 'lk');
     const dryRun = hasFlag('--dry-run');
+    const shardIndex = Number(option('--shard-index', '0'));
+    const shardCount = Number(option('--shard-count', '1'));
+    const startAt = option('--start-at', '');
     const profilesPath = resolve(repositoryRoot, 'config/livekit-load-profiles.json');
     const profilesDocument = JSON.parse(await readFile(profilesPath, 'utf8'));
     const profile = profilesDocument.profiles?.[profileName];
@@ -338,10 +399,19 @@ async function main() {
         url,
         allowRemote: hasFlag('--allow-remote'),
         confirmation: option('--confirm-test-rooms', ''),
+        shardIndex,
+        shardCount,
+        startAt,
     });
+    if (!dryRun && plan.scheduledStartAt !== null && Date.parse(plan.scheduledStartAt) - Date.now() < 30_000) {
+        throw new Error('startAt must be at least 30 seconds in the future');
+    }
+    const shardFileSuffix = plan.shard.count === 1
+        ? ''
+        : `-shard-${plan.shard.index}-of-${plan.shard.count}`;
     const manifestPath = resolve(
         repositoryRoot,
-        option('--manifest', `artifacts/load-test/${plan.runId}-${profileName}.json`),
+        option('--manifest', `artifacts/load-test/${plan.runId}-${profileName}${shardFileSuffix}.json`),
     );
     const [git, gitStatus, lk] = await Promise.all([
         commandOutput('git', ['rev-parse', 'HEAD']),
@@ -356,7 +426,7 @@ async function main() {
         harnessSha: git.output.trim() || 'unknown',
         livekitCliVersion: lk.output.trim() || 'unknown',
         harnessDirty: gitStatus.output.trim().length > 0,
-        generatorHostHash: commandFingerprint([hostname()]).slice(0, 12),
+        generatorHostHash: await generatorHostFingerprint(),
         plan: publicPlan(plan, lkBinary),
         limitations: [
             'Protocol clients measure SFU capacity; they do not certify browser DOM, decode, physical speaker routing, or perceived audio quality.',
@@ -386,6 +456,22 @@ async function main() {
         );
         for (const [index, phase] of plan.phases.entries()) {
             if (abort.requested) break;
+            const synchronization = await waitForScheduledPhase(
+                plan.scheduledStartAt,
+                phase.scheduledOffsetSeconds,
+                abort,
+            );
+            if (abort.requested) break;
+            if (!synchronization.passed) {
+                manifest.status = 'FAIL';
+                manifest.phases.push({
+                    name: phase.name,
+                    passed: false,
+                    reason: 'missed-synchronized-start',
+                    synchronization,
+                });
+                break;
+            }
             process.stdout.write(`\n[${phase.name}] starting stage and Beacon load\n`);
             const resourceBefore = await readGeneratorResources();
             const eventLoop = monitorEventLoopDelay({ resolution: 20 });
@@ -414,23 +500,23 @@ async function main() {
                     max: nanosecondsToMilliseconds(eventLoop.max),
                 },
             };
-            const passed = !abort.requested && [stage, beacon].every((result) =>
-                result.exitCode === 0 &&
-                result.summary.parsed &&
-                result.summary.tracksReceived === result.summary.tracksExpected &&
-                result.summary.droppedPercent <= profile.maxDroppedPercent &&
-                (result.summary.errorCount === null || result.summary.errorCount === 0),
-            ) &&
+            const passed = !abort.requested &&
+                loadResultPassed(stage, phase.stage.expectedSubscriberTracks, profile) &&
+                loadResultPassed(beacon, phase.beacon.expectedSubscriberTracks, profile) &&
+                observed.apiErrors === 0 &&
                 observed.successfulSamples > 0 &&
-                observed.stage.peakConnections === phase.stage.requestedConnections &&
+                observed.stage.peakConnections === phase.stage.expectedGlobalConnections &&
+                observed.stage.joinObserved === phase.stage.expectedGlobalConnections &&
                 observed.stage.peakPublishers === profile.stagePublishers &&
-                observed.beacon.peakConnections === phase.beacon.requestedConnections &&
+                observed.beacon.peakConnections === phase.beacon.expectedGlobalConnections &&
+                observed.beacon.joinObserved === phase.beacon.expectedGlobalConnections &&
                 observed.beacon.peakPublishers === profile.beaconPublishers &&
                 cleanup.passed;
             manifest.phases.push({
                 name: phase.name,
                 passed,
                 operatorAborted: abort.requested,
+                synchronization,
                 stage,
                 beacon,
                 observed,
@@ -439,7 +525,7 @@ async function main() {
             });
             if (abort.requested) break;
             if (!passed) manifest.status = 'FAIL';
-            if (index < plan.phases.length - 1 && profile.interWaveSeconds > 0) {
+            if (index < plan.phases.length - 1 && plan.scheduledStartAt === null && profile.interWaveSeconds > 0) {
                 await waitBetweenPhases(profile.interWaveSeconds, abort);
             }
         }

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -1,14 +1,29 @@
-import { describe, expect, it } from 'vitest';
+import {
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+    aggregateShardManifests,
     assertSafeTarget,
     buildPlan,
+    connectionRampSeconds,
     createAbortCoordinator,
     manifestContainsSecret,
+    normalizeScheduledStart,
+    partitionCount,
     parseLoadTestOutput,
     remoteConfirmation,
     roomNames,
     validateProfile,
+    validateShard,
 } from '../../../scripts/lib/livekit-load-harness.mjs';
 
 const profile = {
@@ -27,6 +42,88 @@ const profile = {
     interWaveSeconds: 10,
     maxDroppedPercent: 0.1,
 };
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+    for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function passingShardManifest(plan: ReturnType<typeof buildPlan>, hostIndex: number) {
+    return {
+        schemaVersion: 1,
+        kind: 'harmonic-beacon-livekit-load',
+        status: 'PASS',
+        harnessSha: '0123456789abcdef0123456789abcdef01234567',
+        livekitCliVersion: 'lk 2.16.3',
+        harnessDirty: false,
+        generatorHostHash: String(hostIndex).padStart(12, '0'),
+        plan,
+        phases: plan.phases.map((plannedPhase) => ({
+            name: plannedPhase.name,
+            passed: true,
+            operatorAborted: false,
+            synchronization: {
+                passed: true,
+                scheduledFor: new Date(
+                    Date.parse(plan.scheduledStartAt ?? '') +
+                    plannedPhase.scheduledOffsetSeconds * 1000,
+                ).toISOString(),
+                observedAt: new Date(
+                    Date.parse(plan.scheduledStartAt ?? '') +
+                    plannedPhase.scheduledOffsetSeconds * 1000,
+                ).toISOString(),
+                lateByMs: 0,
+            },
+            stage: {
+                exitCode: 0,
+                startedAt: new Date(
+                    Date.parse(plan.scheduledStartAt ?? '') +
+                    plannedPhase.scheduledOffsetSeconds * 1000,
+                ).toISOString(),
+                summary: {
+                    parsed: true,
+                    tracksReceived: plannedPhase.stage.expectedSubscriberTracks,
+                    tracksExpected: plan.shard.localAttendees * plan.shard.localStagePublishers,
+                    droppedPercent: 0,
+                    errorCount: 0,
+                },
+            },
+            beacon: {
+                exitCode: 0,
+                startedAt: new Date(
+                    Date.parse(plan.scheduledStartAt ?? '') +
+                    plannedPhase.scheduledOffsetSeconds * 1000,
+                ).toISOString(),
+                summary: {
+                    parsed: true,
+                    tracksReceived: plannedPhase.beacon.expectedSubscriberTracks,
+                    tracksExpected: plan.shard.localAttendees * plan.shard.localBeaconPublishers,
+                    droppedPercent: 0,
+                    errorCount: 0,
+                },
+            },
+            observed: {
+                apiErrors: 0,
+                successfulSamples: 2,
+                stage: {
+                    expectedConnections: plannedPhase.stage.expectedGlobalConnections,
+                    peakConnections: plannedPhase.stage.expectedGlobalConnections,
+                    joinObserved: plannedPhase.stage.expectedGlobalConnections,
+                    expectedPublishers: plannedPhase.stage.expectedGlobalPublishers,
+                    peakPublishers: plannedPhase.stage.expectedGlobalPublishers,
+                },
+                beacon: {
+                    expectedConnections: plannedPhase.beacon.expectedGlobalConnections,
+                    peakConnections: plannedPhase.beacon.expectedGlobalConnections,
+                    joinObserved: plannedPhase.beacon.expectedGlobalConnections,
+                    expectedPublishers: plannedPhase.beacon.expectedGlobalPublishers,
+                    peakPublishers: plannedPhase.beacon.expectedGlobalPublishers,
+                },
+            },
+            cleanup: { passed: true },
+        })),
+    };
+}
 
 describe('LiveKit load harness safety', () => {
     it('builds two synthetic connections per attendee and caps the stage at six publishers', () => {
@@ -51,6 +148,71 @@ describe('LiveKit load harness safety', () => {
         expect(plan.phases[0].stage.args).toContain('vp8');
         expect(plan.phases[0].stage.args).toContain('speaker');
         expect(plan.phases[2].stage.args).toContain('hbload-event-weekend-stage');
+    });
+
+    it('partitions attendees, publishers and ramp exactly across synchronized shards', () => {
+        const startAt = '2026-08-06T12:00:00.000Z';
+        const shards = [0, 1].map((shardIndex) => buildPlan({
+            profileName: 'rehearsal-es',
+            profile,
+            runId: 'event-weekend',
+            url: 'ws://localhost:7880',
+            shardIndex,
+            shardCount: 2,
+            startAt,
+        }));
+
+        expect(shards[0].rooms).toEqual(shards[1].rooms);
+        expect(shards.map((plan) => plan.scheduledStartAt)).toEqual([startAt, startAt]);
+        expect(shards.map((plan) => plan.shard.localAttendees)).toEqual([75, 75]);
+        expect(shards.map((plan) => plan.shard.localStagePublishers)).toEqual([3, 3]);
+        expect(shards.map((plan) => plan.shard.localBeaconPublishers)).toEqual([1, 0]);
+        expect(shards.map((plan) => plan.shard.localRampPerSecond)).toEqual([5, 5]);
+        expect(shards.map((plan) => plan.phases[0].stage.requestedConnections)).toEqual([78, 78]);
+        expect(shards.map((plan) => plan.phases[0].beacon.requestedConnections)).toEqual([76, 75]);
+        expect(shards[0].phases[0].stage.expectedGlobalConnections).toBe(156);
+        expect(shards[1].phases[0].beacon.expectedGlobalConnections).toBe(151);
+        expect(shards[0].phases[0].stage.expectedSubscriberTracks).toBe(450);
+        expect(shards[1].phases[0].beacon.expectedSubscriberTracks).toBe(75);
+        expect(shards[0].phases[0].stage.args).toContain('hbload-event-weekend-s0-stage');
+        expect(shards[1].phases[0].stage.args).toContain('hbload-event-weekend-s1-stage');
+        expect(shards[0].phases.map((phase) => phase.scheduledOffsetSeconds)).toEqual([
+            0, 91, 1322, 1413,
+        ]);
+    });
+
+    it('partitions uneven totals deterministically without dropping work', () => {
+        expect([0, 1, 2].map((index) => partitionCount(10, index, 3))).toEqual([4, 3, 3]);
+        expect([0, 1, 2].map((index) => partitionCount(2, index, 3))).toEqual([1, 1, 0]);
+    });
+
+    it('accounts for the LiveKit CLI connection ramp before its duration timer', () => {
+        expect(connectionRampSeconds(78, 5)).toBe(16);
+        expect(connectionRampSeconds(6, 6)).toBe(1);
+        expect(connectionRampSeconds(151, 100)).toBe(15);
+    });
+
+    it('fails closed on incomplete or unsynchronized shard coordinates', () => {
+        expect(() => validateShard({ shardIndex: 2, shardCount: 2 }, profile))
+            .toThrow(/shardIndex/);
+        expect(() => validateShard({ shardIndex: 0, shardCount: 11 }, profile))
+            .toThrow(/ramp rate/);
+        expect(() => buildPlan({
+            profileName: 'rehearsal-es',
+            profile,
+            runId: 'event-weekend',
+            url: 'ws://localhost:7880',
+            shardIndex: 0,
+            shardCount: 2,
+        })).toThrow(/shared startAt/);
+    });
+
+    it('accepts only explicit UTC scheduled starts', () => {
+        expect(normalizeScheduledStart('2026-08-06T12:00:00Z'))
+            .toBe('2026-08-06T12:00:00.000Z');
+        expect(() => normalizeScheduledStart('2026-08-06T12:00:00-03:00'))
+            .toThrow(/UTC/);
+        expect(() => normalizeScheduledStart('not-a-date')).toThrow(/UTC/);
     });
 
     it('rejects a seventh stage publisher before starting traffic', () => {
@@ -92,6 +254,114 @@ describe('LiveKit load harness safety', () => {
 });
 
 describe('LiveKit load harness evidence', () => {
+    it('aggregates only exact, clean shard coverage from distinct generator hosts', () => {
+        const startAt = '2026-08-06T12:00:00.000Z';
+        const entries = [0, 1].map((shardIndex) => ({
+            sha256: String(shardIndex).padStart(64, 'a'),
+            manifest: passingShardManifest(buildPlan({
+                profileName: 'rehearsal-es',
+                profile,
+                runId: 'aggregate-test',
+                url: 'ws://localhost:7880',
+                shardIndex,
+                shardCount: 2,
+                startAt,
+            }), shardIndex),
+        }));
+
+        const aggregate = aggregateShardManifests(entries);
+        expect(aggregate).toMatchObject({
+            kind: 'harmonic-beacon-livekit-load-aggregate',
+            status: 'PASS',
+            runId: 'aggregate-test',
+            shardCount: 2,
+            totals: { attendees: 150, stagePublishers: 6, beaconPublishers: 1 },
+            sources: [
+                { index: 0, generatorHostHash: '000000000000' },
+                { index: 1, generatorHostHash: '000000000001' },
+            ],
+        });
+        expect(aggregate.phases[0]).toMatchObject({
+            name: 'ramp',
+            shardsPassed: 2,
+            startSkewMs: 0,
+            apiErrors: 0,
+            stage: {
+                expectedConnections: 156,
+                subscriberTracksExpected: 900,
+                subscriberTracksReceived: 900,
+            },
+            beacon: {
+                expectedConnections: 151,
+                subscriberTracksExpected: 150,
+                subscriberTracksReceived: 150,
+            },
+        });
+    });
+
+    it('refuses duplicate hosts, dirty evidence and unproven global observations', () => {
+        const startAt = '2026-08-06T12:00:00.000Z';
+        const entries = [0, 1].map((shardIndex) => ({
+            sha256: String(shardIndex).padStart(64, 'a'),
+            manifest: passingShardManifest(buildPlan({
+                profileName: 'rehearsal-es',
+                profile,
+                runId: 'aggregate-refusal',
+                url: 'ws://localhost:7880',
+                shardIndex,
+                shardCount: 2,
+                startAt,
+            }), shardIndex),
+        }));
+
+        entries[1].manifest.generatorHostHash = entries[0].manifest.generatorHostHash;
+        expect(() => aggregateShardManifests(entries)).toThrow(/distinct hosts/);
+        entries[1].manifest.generatorHostHash = '000000000001';
+        entries[1].manifest.harnessDirty = true;
+        expect(() => aggregateShardManifests(entries)).toThrow(/dirty harness/);
+        entries[1].manifest.harnessDirty = false;
+        entries[1].manifest.phases[0].observed.stage.peakConnections -= 1;
+        expect(() => aggregateShardManifests(entries)).toThrow(/unproven phase/);
+    });
+
+    it('writes a 0600 aggregate once and refuses to overwrite it', () => {
+        const root = mkdtempSync(join(tmpdir(), 'hb-load-aggregate-'));
+        temporaryRoots.push(root);
+        const startAt = '2026-08-06T12:00:00.000Z';
+        const manifestPaths = [0, 1].map((shardIndex) => {
+            const path = join(root, `shard-${shardIndex}.json`);
+            writeFileSync(path, JSON.stringify(passingShardManifest(buildPlan({
+                profileName: 'rehearsal-es',
+                profile,
+                runId: 'aggregate-cli',
+                url: 'ws://localhost:7880',
+                shardIndex,
+                shardCount: 2,
+                startAt,
+            }), shardIndex)));
+            return path;
+        });
+        const output = join(root, 'aggregate.json');
+        const args = [
+            'scripts/livekit-load-aggregate.mjs',
+            '--output', output,
+            ...manifestPaths,
+        ];
+
+        const first = spawnSync('node', args, { encoding: 'utf8', timeout: 5_000 });
+        expect(first.status, first.stderr).toBe(0);
+        expect(statSync(output).mode & 0o777).toBe(0o600);
+        expect(JSON.parse(readFileSync(output, 'utf8'))).toMatchObject({
+            status: 'PASS',
+            shardCount: 2,
+        });
+        const before = readFileSync(output, 'utf8');
+        const second = spawnSync('node', args, { encoding: 'utf8', timeout: 5_000 });
+        expect(second.status).toBe(1);
+        expect(second.stderr).toMatch(/refusing to overwrite/);
+        expect(readFileSync(output, 'utf8')).toBe(before);
+    });
+
     it('parses the official CLI total summary without retaining participant rows', () => {
         const output = 'Summary | Tester | Tracks | Bitrate | Latency | Total Dropped\n' +
             '        | Total | 5000/5000 | 678.7mbps | 79.923769ms | 0 (0%)\n';


### PR DESCRIPTION
## Diagnóstico

El ensayo de 150 × 2 conexiones saturó la ruta del generador antes de producir evidencia concluyente del SFU. Repartir procesos sin contrato tampoco era correcto: `lk v2.16.3` inicia `--duration` después de la rampa y calcula el denominador de tracks sólo con publishers locales.

## Cambio

- particiona attendees, Stage/Beacon publishers y ramp global sin pérdida ni duplicación;
- exige índice/count válidos, identidades únicas y un inicio UTC común;
- agenda cada fase incluyendo la rampa real del CLI y un gap mínimo de cleanup;
- cada shard exige counts/publishers globales, joins exactos, cero API errors y tracks `subscribers locales × publishers globales`;
- preserva FAIL si pierde una ventana sincronizada y mantiene ABORTED ante señales;
- agrega manifests con nombres por shard y fingerprint de host opaco;
- agrega agregador 0600/no-overwrite que exige todos los índices, SHAs/CLI/contrato idénticos, worktrees limpios, hosts distintos, fases PASS y particiones exactas;
- documenta NTP, lanzamiento y agregación.

## Evidencia

- 19 tests focalizados de partición, schedule, tracks globales, refusals y agregado;
- dry-run rehearsal EN: 75+75 attendees, 3+3 Stage publishers, 1+0 Beacon publisher y ramp 5+5;
- perfil CI real unsharded: ramp/soak/reconnect PASS, 0% loss, 0 API errors, joins 6/5 y cleanup 0/0;
- perfil CI real dual-shard sincronizado: ambos manifests PASS/clean; skew 0–1 ms; Stage recibió 4 tracks por shard aunque CLI esperaba 2; Beacon shard sin publisher local recibió 2 aunque CLI esperaba 0; counts globales 6/5, publishers 2/1 y cleanup 0/0 en las tres fases;
- el agregador rechazó correctamente esos dos manifests locales por compartir host;
- suite standalone: 807 tests verdes + 9 opt-in skipped; TypeScript, lint y build verdes. Un primer run con tests y build compitiendo tuvo un único timing failure ajeno en ThumbnailSender; el archivo pasó 20/20 aislado y la suite standalone pasó completa sin tocar esa superficie.

## Riesgo y rollback

Opt-in tooling/docs only. No cambia app, producción, rooms reales, DB, pagos ni audio. Rollback: revertir este commit. No cierra #99/#24: todavía hay que ejecutar dos hosts reales contra el SFU aislado con target telemetry y repetir EN/ES según el runbook.