### PR TITLE
ci(load): orchestrate isolated distributed rehearsal

### DIFF
--- a/.github/workflows/livekit-capacity.yml
+++ b/.github/workflows/livekit-capacity.yml
@@ -1,0 +1,165 @@
+name: Distributed LiveKit capacity rehearsal
+
+# Manual only. The capacity-rehearsal environment must be restricted to main
+# and provisioned with credentials for an isolated, disposable LiveKit target.
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Synthetic load profile
+        required: true
+        type: choice
+        options:
+          - ci
+          - rehearsal-es
+          - rehearsal-en
+      run_id:
+        description: Unique synthetic run identifier (no event-room name)
+        required: true
+        type: string
+      start_delay_seconds:
+        description: Delay before synchronized traffic begins
+        required: true
+        default: '1200'
+        type: choice
+        options:
+          - '900'
+          - '1200'
+          - '1800'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: livekit-capacity-rehearsal
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    environment: capacity-rehearsal
+    outputs:
+      run_id: ${{ steps.plan.outputs.run_id }}
+      start_at: ${{ steps.plan.outputs.start_at }}
+      expected_end_at: ${{ steps.plan.outputs.expected_end_at }}
+      confirmation: ${{ steps.plan.outputs.confirmation }}
+      shard_count: ${{ steps.plan.outputs.shard_count }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.22'
+
+      - name: Validate isolated target and derive the synchronized plan
+        id: plan
+        env:
+          LOAD_TEST_URL: ${{ secrets.LOAD_TEST_URL }}
+          LOAD_TEST_API_KEY: ${{ secrets.LOAD_TEST_API_KEY }}
+          LOAD_TEST_API_SECRET: ${{ secrets.LOAD_TEST_API_SECRET }}
+          LOAD_PROFILE: ${{ inputs.profile }}
+          LOAD_RUN_ID: ${{ inputs.run_id }}
+          LOAD_START_DELAY_SECONDS: ${{ inputs.start_delay_seconds }}
+        run: |
+          test -n "$LOAD_TEST_URL"
+          test -n "$LOAD_TEST_API_KEY"
+          test -n "$LOAD_TEST_API_SECRET"
+          node scripts/livekit-load-dispatch-plan.mjs \
+            --profile "$LOAD_PROFILE" \
+            --run-id "$LOAD_RUN_ID" \
+            --start-delay-seconds "$LOAD_START_DELAY_SECONDS"
+
+  generator:
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: capacity-rehearsal
+    timeout-minutes: 55
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [0, 1]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.22'
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install pinned LiveKit load tester
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/lk.tar.gz" \
+            https://github.com/livekit/livekit-cli/releases/download/v2.16.3/lk_2.16.3_linux_amd64.tar.gz
+          echo "57935ce348a634a1e12769b9eaf7e684cf46920ad65e4b6d88f87a9cd01de2d6  $RUNNER_TEMP/lk.tar.gz" \
+            | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/lk.tar.gz" -C "$RUNNER_TEMP" lk
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - name: Run shard ${{ matrix.shard_index }} of ${{ needs.prepare.outputs.shard_count }}
+        env:
+          LIVEKIT_URL: ${{ secrets.LOAD_TEST_URL }}
+          LIVEKIT_API_KEY: ${{ secrets.LOAD_TEST_API_KEY }}
+          LIVEKIT_API_SECRET: ${{ secrets.LOAD_TEST_API_SECRET }}
+          LOAD_PROFILE: ${{ inputs.profile }}
+          LOAD_RUN_ID: ${{ needs.prepare.outputs.run_id }}
+          LOAD_SHARD_COUNT: ${{ needs.prepare.outputs.shard_count }}
+          LOAD_SHARD_INDEX: ${{ matrix.shard_index }}
+          LOAD_START_AT: ${{ needs.prepare.outputs.start_at }}
+          LOAD_CONFIRMATION: ${{ needs.prepare.outputs.confirmation }}
+        run: |
+          npm run load:livekit -- \
+            --profile "$LOAD_PROFILE" \
+            --run-id "$LOAD_RUN_ID" \
+            --shard-count "$LOAD_SHARD_COUNT" \
+            --shard-index "$LOAD_SHARD_INDEX" \
+            --start-at "$LOAD_START_AT" \
+            --allow-remote \
+            --confirm-test-rooms "$LOAD_CONFIRMATION" \
+            --manifest "artifacts/load-test/shard-${LOAD_SHARD_INDEX}.json"
+
+      - name: Upload redacted shard evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: livekit-capacity-${{ needs.prepare.outputs.run_id }}-shard-${{ matrix.shard_index }}
+          path: artifacts/load-test/shard-${{ matrix.shard_index }}.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  aggregate:
+    if: always()
+    needs: [prepare, generator]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download all shard evidence
+        uses: actions/download-artifact@v4
+        with:
+          pattern: livekit-capacity-${{ needs.prepare.outputs.run_id }}-shard-*
+          path: artifacts/load-test/shards
+          merge-multiple: true
+
+      - name: Aggregate only complete, distinct-host PASS evidence
+        run: |
+          node scripts/livekit-load-aggregate.mjs \
+            --output 'artifacts/load-test/${{ needs.prepare.outputs.run_id }}-aggregate.json' \
+            artifacts/load-test/shards/shard-0.json \
+            artifacts/load-test/shards/shard-1.json
+
+      - name: Upload aggregate and source manifests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: livekit-capacity-${{ needs.prepare.outputs.run_id }}-aggregate
+          path: artifacts/load-test/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -111,6 +111,42 @@ is byte-equivalent, worktrees are clean and generator host hashes are distinct.
 Keep every source manifest and its aggregate; the aggregate does not replace
 target-local telemetry or physical browser evidence.
 
+### GitHub-hosted generators
+
+`.github/workflows/livekit-capacity.yml` is a manual-only two-generator
+orchestrator for the case where no two trusted standalone hosts are available.
+It runs each shard on a different ephemeral GitHub-hosted runner, pins and
+verifies `lk` v2.16.3, schedules both against the same future UTC boundary, and
+uploads the redacted source manifests before aggregating them fail-closed.
+
+The workflow uses the `capacity-rehearsal` environment. Restrict that
+environment to the `main` branch and provision these environment secrets only
+for the lifetime of one isolated target:
+
+- `LOAD_TEST_URL`: credential-free `ws://` or `wss://` URL of the disposable
+  LiveKit node. Paths, query strings, fragments, localhost and embedded
+  credentials are rejected.
+- `LOAD_TEST_API_KEY` and `LOAD_TEST_API_SECRET`: credentials generated only
+  for that disposable node. Never copy production LiveKit credentials.
+
+Start the target-local monitor first, then dispatch with a unique synthetic run
+ID and at least a 15-minute setup delay:
+
+```bash
+gh workflow run livekit-capacity.yml --ref main \
+  -f profile=rehearsal-en \
+  -f run_id=capacity-en-20260805-a \
+  -f start_delay_seconds=1200
+```
+
+The target must stay isolated from event rooms and the production LiveKit
+process. After downloading and hashing the aggregate plus target telemetry,
+remove the disposable container, its exact firewall rules/config files, and
+all three environment secrets. Confirm production readiness and restart/OOM
+counters after cleanup. A GitHub PASS still does not close #24: physical
+browsers, mobile routing, TURN, acoustic quality and the human rehearsal remain
+separate gates.
+
 ## Profiles and evidence
 
 - `ci`: four attendees, two stage publishers, one Beacon publisher, short

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -109,6 +109,28 @@ export function remoteConfirmation(rooms) {
     return `LOADTEST:${rooms.stage}:${rooms.beacon}`;
 }
 
+export function validateDistributedTargetUrl(value) {
+    let parsed;
+    try {
+        parsed = new URL(String(value ?? ''));
+    } catch {
+        throw new Error('distributed target URL must be a valid ws:// or wss:// URL');
+    }
+    if (!['ws:', 'wss:'].includes(parsed.protocol)) {
+        throw new Error('distributed target URL must use ws:// or wss://');
+    }
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+        throw new Error('distributed target URL must not contain credentials, query, or fragment');
+    }
+    if (LOCAL_HOSTS.has(parsed.hostname)) {
+        throw new Error('distributed target URL must be remote');
+    }
+    if (parsed.pathname !== '/' && parsed.pathname !== '') {
+        throw new Error('distributed target URL must not contain a path');
+    }
+    return parsed.toString().replace(/\/$/, '');
+}
+
 export function assertSafeTarget({ url, rooms, allowRemote, confirmation }) {
     const parsed = new URL(url.replace(/^ws:/, 'http:').replace(/^wss:/, 'https:'));
     for (const room of Object.values(rooms)) {
@@ -301,6 +323,57 @@ export function buildPlan({
                 }),
             },
         })),
+    };
+}
+
+export function buildDistributedDispatchPlan({
+    profileName,
+    profile,
+    runId,
+    targetUrl,
+    startDelaySeconds,
+    shardCount = 2,
+    nowMs = Date.now(),
+}) {
+    const url = validateDistributedTargetUrl(targetUrl);
+    if (!Number.isInteger(startDelaySeconds) ||
+        startDelaySeconds < 600 || startDelaySeconds > 3600) {
+        throw new Error('start delay must be an integer between 600 and 3600 seconds');
+    }
+    if (shardCount !== 2) {
+        throw new Error('the GitHub-hosted rehearsal requires exactly two shards');
+    }
+    const safeRunId = sanitizeRunId(runId);
+    const startAt = new Date(nowMs + startDelaySeconds * 1000).toISOString();
+    const rooms = roomNames(`${safeRunId}-${profile.eventLanguage}`);
+    const confirmation = remoteConfirmation(rooms);
+    const plans = Array.from({ length: shardCount }, (_, shardIndex) => buildPlan({
+        profileName,
+        profile,
+        runId: safeRunId,
+        url,
+        allowRemote: true,
+        confirmation,
+        shardIndex,
+        shardCount,
+        startAt,
+    }));
+    const finalPhase = plans[0].phases.at(-1);
+    const expectedEndAt = new Date(
+        Date.parse(startAt) +
+        (finalPhase.scheduledOffsetSeconds +
+            finalPhase.expectedConnectSeconds +
+            finalPhase.durationSeconds) * 1000,
+    ).toISOString();
+    return {
+        profileName,
+        runId: safeRunId,
+        shardCount,
+        startAt,
+        expectedEndAt,
+        confirmation,
+        rooms,
+        targetHost: plans[0].urlHost,
     };
 }
 

--- a/scripts/livekit-load-dispatch-plan.mjs
+++ b/scripts/livekit-load-dispatch-plan.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { appendFile, readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildDistributedDispatchPlan } from './lib/livekit-load-harness.mjs';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function option(name) {
+    const index = process.argv.indexOf(name);
+    if (index < 0 || !process.argv[index + 1]) throw new Error(`${name} is required`);
+    return process.argv[index + 1];
+}
+
+async function main() {
+    const profilesDocument = JSON.parse(await readFile(
+        resolve(repositoryRoot, 'config/livekit-load-profiles.json'),
+        'utf8',
+    ));
+    const profileName = option('--profile');
+    const profile = profilesDocument.profiles?.[profileName];
+    if (!profile) throw new Error(`unknown profile: ${profileName}`);
+    const targetUrl = process.env.LOAD_TEST_URL;
+    if (!targetUrl) throw new Error('LOAD_TEST_URL is required');
+    const plan = buildDistributedDispatchPlan({
+        profileName,
+        profile,
+        runId: option('--run-id'),
+        targetUrl,
+        startDelaySeconds: Number(option('--start-delay-seconds')),
+    });
+    const outputPath = process.env.GITHUB_OUTPUT;
+    if (!outputPath) throw new Error('GITHUB_OUTPUT is required');
+    const outputs = {
+        run_id: plan.runId,
+        start_at: plan.startAt,
+        expected_end_at: plan.expectedEndAt,
+        confirmation: plan.confirmation,
+        shard_count: String(plan.shardCount),
+    };
+    await appendFile(
+        outputPath,
+        Object.entries(outputs).map(([key, value]) => `${key}=${value}\n`).join(''),
+        { mode: 0o600 },
+    );
+    process.stdout.write(
+        `Validated ${plan.profileName} run ${plan.runId}: ` +
+        `${plan.shardCount} shards, ${plan.startAt} to ${plan.expectedEndAt}, ` +
+        `target host ${plan.targetHost}.\n`,
+    );
+}
+
+main().catch((error) => {
+    process.stderr.write(
+        `distributed load plan refused: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+});

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
     aggregateShardManifests,
     assertSafeTarget,
+    buildDistributedDispatchPlan,
     buildPlan,
     connectionRampSeconds,
     createAbortCoordinator,
@@ -24,6 +25,7 @@ import {
     roomNames,
     validateProfile,
     validateShard,
+    validateDistributedTargetUrl,
 } from '../../../scripts/lib/livekit-load-harness.mjs';
 
 const profile = {
@@ -126,6 +128,55 @@ function passingShardManifest(plan: ReturnType<typeof buildPlan>, hostIndex: num
 }
 
 describe('LiveKit load harness safety', () => {
+    it('builds a bounded two-host dispatch without exposing target credentials', () => {
+        const dispatch = buildDistributedDispatchPlan({
+            profileName: 'rehearsal-es',
+            profile,
+            runId: 'github-run-a',
+            targetUrl: 'ws://144.217.90.60:7890',
+            startDelaySeconds: 1200,
+            nowMs: Date.parse('2026-08-05T12:00:00Z'),
+        });
+        expect(dispatch).toMatchObject({
+            runId: 'github-run-a',
+            shardCount: 2,
+            startAt: '2026-08-05T12:20:00.000Z',
+            targetHost: '144.217.90.60',
+            rooms: {
+                stage: 'hb-load-github-run-a-es-stage',
+                beacon: 'hb-load-github-run-a-es-beacon',
+            },
+        });
+        expect(dispatch.expectedEndAt).toBe('2026-08-05T12:44:49.000Z');
+        expect(JSON.stringify(dispatch)).not.toContain('secret');
+        expect(dispatch.confirmation).toBe(
+            'LOADTEST:hb-load-github-run-a-es-stage:hb-load-github-run-a-es-beacon',
+        );
+    });
+
+    it('refuses unsafe distributed targets, timing and topology', () => {
+        for (const unsafe of [
+            'https://example.test',
+            'ws://localhost:7890',
+            'ws://key:secret@example.test:7890',
+            'ws://example.test:7890/path',
+            'ws://example.test:7890?token=secret',
+            'ws://example.test:7890#fragment',
+        ]) {
+            expect(() => validateDistributedTargetUrl(unsafe)).toThrow();
+        }
+        expect(validateDistributedTargetUrl('wss://load.example.test'))
+            .toBe('wss://load.example.test');
+        expect(() => buildDistributedDispatchPlan({
+            profileName: 'rehearsal-es', profile, runId: 'github-run-a',
+            targetUrl: 'ws://example.test:7890', startDelaySeconds: 599,
+        })).toThrow(/start delay/);
+        expect(() => buildDistributedDispatchPlan({
+            profileName: 'rehearsal-es', profile, runId: 'github-run-a',
+            targetUrl: 'ws://example.test:7890', startDelaySeconds: 1200, shardCount: 3,
+        })).toThrow(/exactly two shards/);
+    });
+
     it('builds two synthetic connections per attendee and caps the stage at six publishers', () => {
         const plan = buildPlan({
             profileName: 'rehearsal-es',

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+    resolve(process.cwd(), '.github/workflows/livekit-capacity.yml'),
+    'utf8',
+);
+
+describe('distributed LiveKit capacity workflow contract', () => {
+    it('is manual, least-privilege and cannot receive an arbitrary target input', () => {
+        expect(workflow).toContain('workflow_dispatch:');
+        expect(workflow).not.toMatch(/^\s+pull_request:/m);
+        expect(workflow).not.toMatch(/^\s+push:/m);
+        expect(workflow).toContain('contents: read');
+        expect(workflow).not.toContain('target_url:');
+        expect(workflow).toContain('secrets.LOAD_TEST_URL');
+        expect(workflow).not.toContain('secrets.LIVEKIT_API_SECRET');
+        expect(workflow).not.toMatch(/--(?:profile|run-id|start-at) '\$\{\{/);
+        expect(workflow).toContain('--run-id "$LOAD_RUN_ID"');
+    });
+
+    it('uses two independent hosted runners and always preserves shard evidence', () => {
+        expect(workflow).toContain('shard_index: [0, 1]');
+        expect(workflow).toContain('fail-fast: false');
+        expect(workflow.match(/environment: capacity-rehearsal/g)).toHaveLength(2);
+        expect(workflow).toContain('if: always()');
+        expect(workflow).toContain('livekit-load-aggregate.mjs');
+        expect(workflow).toContain('ref: ${{ github.sha }}');
+    });
+
+    it('pins and verifies the official LiveKit CLI artifact', () => {
+        expect(workflow).toContain('releases/download/v2.16.3/');
+        expect(workflow).toContain(
+            '57935ce348a634a1e12769b9eaf7e684cf46920ad65e4b6d88f87a9cd01de2d6',
+        );
+        expect(workflow).toContain('sha256sum -c -');
+    });
+});


### PR DESCRIPTION
## Diagnóstico

El harness de #99 ya exige manifests de hosts distintos, pero sólo existían instrucciones manuales. La ejecución completa anterior quedó limitada por un único generador y una ruta de observabilidad compartida; usar mona o daimonmatrix como segundo generador falsearía o pondría en riesgo la evidencia.

## Cambio

- workflow manual `livekit-capacity.yml` con dos runners GitHub-hosted efímeros y shards deterministas;
- ambiente `capacity-rehearsal`, credenciales exclusivas del target desechable y permisos `contents: read`;
- target fijado por secret de ambiente: no existe input de URL arbitraria y no se reutilizan secretos productivos;
- derivación validada de run ID, confirmación de rooms, start UTC y end esperado;
- inputs del dispatch pasan por environment, sin interpolación shell;
- `lk` v2.16.3 fijado y verificado por SHA-256;
- upload por shard aun ante fallo y agregación fail-closed de dos manifests distintos;
- URL remota rechaza credenciales, query, fragment, path y localhost;
- runbook de provisión y cleanup efímero.

## Evidencia local

- 24 pruebas focalizadas;
- suite completa: 812 tests verdes, 9 integraciones opt-in omitidas;
- TypeScript, ESLint y build productivo verdes;
- `actionlint` v1.7.7 oficial verificado por checksum: verde;
- smoke del plan CI: dos shards, UTC/end determinísticos, outputs sin credenciales;
- `git diff --check`: verde.

## Riesgo y guardrails

El workflow no corre por push ni PR. No es utilizable hasta configurar el ambiente, restringirlo a `main` y cargar tres secretos efímeros de un LiveKit aislado. La prueba real debe correr con telemetría target-local #169, abortar ante degradación productiva y retirar container, reglas y secretos al finalizar. No toca runtime, DB, pagos, participantes ni audio.

## Rollback

Revertir este commit elimina el workflow y el planner. Antes o después de un ensayo, borrar los tres secretos del ambiente y retirar el target/reglas temporales deja producción igual que antes.

Closes no issue: #99 sólo debe cerrar después de un aggregate PASS real y evidencia target-local.
