### PR TITLE
fix(load): fingerprint generator VM boots

### DIFF
--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -108,6 +108,9 @@ The aggregator writes mode `0600` and refuses overwrite. It emits PASS only
 when every index is present, the partitions sum to the profile exactly, every
 phase proves the global counts and clean teardown, the harness/CLI/run contract
 is byte-equivalent, worktrees are clean and generator host hashes are distinct.
+The opaque host hash includes the kernel boot ID: processes on the same running
+host remain identical, while separately booted hosted-runner VMs remain
+distinct even when their image clones hostname and machine ID.
 Keep every source manifest and its aggregate; the aggregate does not replace
 target-local telemetry or physical browser evidence.
 

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -411,6 +411,10 @@ export function commandFingerprint(args) {
     return createHash('sha256').update(JSON.stringify(args)).digest('hex');
 }
 
+export function generatorHostFingerprint({ hostName, machineId = '', bootId = '' }) {
+    return commandFingerprint([hostName, machineId, bootId]).slice(0, 12);
+}
+
 export function manifestContainsSecret(value, secrets) {
     const serialized = JSON.stringify(value);
     return secrets.filter(Boolean).some((secret) => serialized.includes(secret));

--- a/scripts/livekit-load-harness.mjs
+++ b/scripts/livekit-load-harness.mjs
@@ -12,6 +12,7 @@ import {
     buildPlan,
     commandFingerprint,
     createAbortCoordinator,
+    generatorHostFingerprint,
     manifestContainsSecret,
     parseLoadTestOutput,
     remoteConfirmation,
@@ -88,15 +89,22 @@ function generatedRunId() {
     return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'z').toLowerCase();
 }
 
-async function generatorHostFingerprint() {
-    let machineId = '';
-    try {
-        machineId = (await readFile('/etc/machine-id', 'utf8')).trim();
-    } catch {
-        // Hostname-only fallback remains opaque; the aggregate still refuses
-        // duplicate hashes rather than claiming independent generators.
-    }
-    return commandFingerprint([hostname(), machineId]).slice(0, 12);
+async function readGeneratorHostFingerprint() {
+    const readOpaqueHostPart = async (path) => {
+        try {
+            return (await readFile(path, 'utf8')).trim();
+        } catch {
+            return '';
+        }
+    };
+    const [machineId, bootId] = await Promise.all([
+        readOpaqueHostPart('/etc/machine-id'),
+        readOpaqueHostPart('/proc/sys/kernel/random/boot_id'),
+    ]);
+    // boot_id is stable for processes sharing one running kernel, but differs
+    // across separately booted VMs even when a runner image clones hostname
+    // and machine-id. Only the truncated hash enters the manifest.
+    return generatorHostFingerprint({ hostName: hostname(), machineId, bootId });
 }
 
 function installAbortHandlers(abort) {
@@ -426,7 +434,7 @@ async function main() {
         harnessSha: git.output.trim() || 'unknown',
         livekitCliVersion: lk.output.trim() || 'unknown',
         harnessDirty: gitStatus.output.trim().length > 0,
-        generatorHostHash: await generatorHostFingerprint(),
+        generatorHostHash: await readGeneratorHostFingerprint(),
         plan: publicPlan(plan, lkBinary),
         limitations: [
             'Protocol clients measure SFU capacity; they do not certify browser DOM, decode, physical speaker routing, or perceived audio quality.',

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -17,6 +17,7 @@ import {
     buildPlan,
     connectionRampSeconds,
     createAbortCoordinator,
+    generatorHostFingerprint,
     manifestContainsSecret,
     normalizeScheduledStart,
     partitionCount,
@@ -305,6 +306,25 @@ describe('LiveKit load harness safety', () => {
 });
 
 describe('LiveKit load harness evidence', () => {
+    it('distinguishes separate VM boots while keeping same-kernel processes identical', () => {
+        const first = generatorHostFingerprint({
+            hostName: 'runner',
+            machineId: 'cloned-image',
+            bootId: 'boot-a',
+        });
+        expect(generatorHostFingerprint({
+            hostName: 'runner',
+            machineId: 'cloned-image',
+            bootId: 'boot-a',
+        })).toBe(first);
+        expect(generatorHostFingerprint({
+            hostName: 'runner',
+            machineId: 'cloned-image',
+            bootId: 'boot-b',
+        })).not.toBe(first);
+        expect(first).toMatch(/^[a-f0-9]{12}$/);
+    });
+
     it('aggregates only exact, clean shard coverage from distinct generator hosts', () => {
         const startAt = '2026-08-06T12:00:00.000Z';
         const entries = [0, 1].map((shardIndex) => ({


### PR DESCRIPTION
## Causa demostrada

El primer ensayo real del workflow #171 (`31008650406`) produjo dos manifests shard PASS sobre jobs GitHub-hosted concurrentes, pero ambos tenían el mismo `generatorHostHash`. GitHub clonó hostname y `/etc/machine-id` en esas VMs; el aggregate se negó correctamente con `shards must run on distinct hosts`.

## Corrección

El fingerprint opaco incorpora `/proc/sys/kernel/random/boot_id` además de hostname/machine-id. El boot ID:

- permanece idéntico para procesos que comparten el mismo kernel/host;
- cambia entre VMs arrancadas independientemente aunque clonen la imagen;
- nunca se escribe en crudo: sólo entra al hash truncado de 12 hex.

No se usa shard index, job ID ni otro valor que fabricaría independencia por configuración.

## Evidencia

- reproducción remota: ambos shards PASS, mismo hash antiguo `aea7cdfb47da`, aggregate FAIL seguro;
- test nuevo prueba misma VM boot → mismo hash; boot distinto → hash distinto;
- suite completa del commit hook: 813 verdes, 9 opt-in skips;
- prueba focalizada 22/22, TypeScript y ESLint verdes;
- producción permaneció ready, 0 restart/OOM durante la carga CI.

## Riesgo / rollback

Sólo cambia provenance del manifiesto; no cambia tráfico, codec, señal, runtime web, DB ni producción. Revertir el commit restaura el fingerprint conservador anterior y vuelve a rechazar estas VMs clonadas.
