### PR TITLE
feat(load): abort if production readiness degrades

### DIFF
--- a/.github/workflows/livekit-capacity.yml
+++ b/.github/workflows/livekit-capacity.yml
@@ -120,6 +120,7 @@ jobs:
             --shard-index "$LOAD_SHARD_INDEX" \
             --start-at "$LOAD_START_AT" \
             --allow-remote \
+            --guard-production-ready \
             --confirm-test-rooms "$LOAD_CONFIRMATION" \
             --manifest "artifacts/load-test/shard-${LOAD_SHARD_INDEX}.json"
 

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -121,6 +121,10 @@ orchestrator for the case where no two trusted standalone hosts are available.
 It runs each shard on a different ephemeral GitHub-hosted runner, pins and
 verifies `lk` v2.16.3, schedules both against the same future UTC boundary, and
 uploads the redacted source manifests before aggregating them fail-closed.
+Each generator also probes the fixed public production readiness endpoint. Two
+consecutive failures abort its current Stage and Beacon processes, preserve an
+`ABORTED` source manifest and prevent a global PASS. The probe never reads a
+response body and cannot be redirected to an operator-supplied URL.
 
 The workflow uses the `capacity-rehearsal` environment. Restrict that
 environment to the `main` branch and provision these environment secrets only

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -2,6 +2,52 @@ import { createHash } from 'node:crypto';
 
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 const ROOM_PATTERN = /^hb-load-[a-z0-9][a-z0-9-]{2,47}-(stage|beacon)$/;
+export const PRODUCTION_READINESS_URL =
+    'https://live.harmonicbeacon.com/api/health/ready';
+
+export async function probeProductionReadiness({
+    fetchImpl = fetch,
+    timeoutMs = 2_500,
+} = {}) {
+    try {
+        const response = await fetchImpl(PRODUCTION_READINESS_URL, {
+            method: 'GET',
+            cache: 'no-store',
+            redirect: 'manual',
+            signal: AbortSignal.timeout(timeoutMs),
+        });
+        const healthy = response.status === 200;
+        await response.body?.cancel();
+        return healthy;
+    } catch {
+        return false;
+    }
+}
+
+export function createConsecutiveFailureGuard({ maxFailures = 2, onTrip }) {
+    if (!Number.isInteger(maxFailures) || maxFailures < 1) {
+        throw new Error('maxFailures must be a positive integer');
+    }
+    let failures = 0;
+    let tripped = false;
+    return {
+        record(healthy) {
+            if (tripped) return true;
+            failures = healthy ? 0 : failures + 1;
+            if (failures >= maxFailures) {
+                tripped = true;
+                onTrip();
+            }
+            return tripped;
+        },
+        get failures() {
+            return failures;
+        },
+        get tripped() {
+            return tripped;
+        },
+    };
+}
 
 export function sanitizeRunId(value) {
     const runId = String(value ?? '')

--- a/scripts/livekit-load-harness.mjs
+++ b/scripts/livekit-load-harness.mjs
@@ -12,9 +12,11 @@ import {
     buildPlan,
     commandFingerprint,
     createAbortCoordinator,
+    createConsecutiveFailureGuard,
     generatorHostFingerprint,
     manifestContainsSecret,
     parseLoadTestOutput,
+    probeProductionReadiness,
     remoteConfirmation,
 } from './lib/livekit-load-harness.mjs';
 
@@ -126,6 +128,31 @@ function installAbortHandlers(abort) {
     };
 }
 
+function startProductionReadinessGuard(abort) {
+    let stopped = false;
+    const failures = createConsecutiveFailureGuard({
+        maxFailures: 2,
+        onTrip: () => {
+            if (abort.request('PRODUCTION_READINESS_GUARD')) {
+                process.stderr.write(
+                    '\nPublic production readiness failed twice; stopping load and preserving an ABORTED manifest.\n',
+                );
+            }
+        },
+    });
+    const completion = (async () => {
+        while (!stopped && !abort.requested) {
+            const healthy = await probeProductionReadiness();
+            if (failures.record(healthy)) break;
+            await new Promise((resolvePromise) => setTimeout(resolvePromise, 2_000));
+        }
+    })();
+    return async () => {
+        stopped = true;
+        await completion;
+    };
+}
+
 async function waitBetweenPhases(seconds, abort) {
     const deadline = Date.now() + seconds * 1000;
     while (!abort.requested && Date.now() < deadline) {
@@ -168,6 +195,7 @@ function printHelp() {
         `  --start-at UTC             shared future UTC start required for sharding\n` +
         `  --dry-run                  validate and write a PLANNED manifest only\n` +
         `  --allow-remote             acknowledge a non-local target\n` +
+        `  --guard-production-ready   abort after two failed public readiness probes\n` +
         `  --confirm-test-rooms VALUE exact room confirmation required remotely\n`);
 }
 
@@ -393,6 +421,7 @@ async function main() {
     const url = option('--url', process.env.LIVEKIT_URL ?? 'ws://localhost:7880');
     const lkBinary = option('--lk-bin', process.env.LK_BIN ?? 'lk');
     const dryRun = hasFlag('--dry-run');
+    const guardProductionReadiness = hasFlag('--guard-production-ready');
     const shardIndex = Number(option('--shard-index', '0'));
     const shardCount = Number(option('--shard-count', '1'));
     const startAt = option('--start-at', '');
@@ -441,6 +470,9 @@ async function main() {
             'Load-test summary latency is media latency, not per-user application login latency.',
             'Physical iOS, Android, Bluetooth, TURN, and six-camera evidence remains in issue #24.',
         ],
+        safety: {
+            productionReadinessGuard: guardProductionReadiness,
+        },
         phases: [],
     };
     let abort = null;
@@ -457,6 +489,9 @@ async function main() {
         if (lk.exitCode !== 0) throw new Error(`LiveKit CLI unavailable: ${lk.output.trim()}`);
         abort = createAbortCoordinator();
         const removeAbortHandlers = installAbortHandlers(abort);
+        const stopProductionReadinessGuard = guardProductionReadiness
+            ? startProductionReadinessGuard(abort)
+            : async () => {};
         const roomService = new RoomServiceClient(
             url.replace(/^ws:/, 'http:').replace(/^wss:/, 'https:'),
             credentials.apiKey,
@@ -537,6 +572,7 @@ async function main() {
                 await waitBetweenPhases(profile.interWaveSeconds, abort);
             }
         }
+        await stopProductionReadinessGuard();
         removeAbortHandlers();
         if (abort.requested) {
             manifest.status = 'ABORTED';

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -17,11 +17,14 @@ import {
     buildPlan,
     connectionRampSeconds,
     createAbortCoordinator,
+    createConsecutiveFailureGuard,
     generatorHostFingerprint,
     manifestContainsSecret,
     normalizeScheduledStart,
     partitionCount,
     parseLoadTestOutput,
+    probeProductionReadiness,
+    PRODUCTION_READINESS_URL,
     remoteConfirmation,
     roomNames,
     validateProfile,
@@ -129,6 +132,48 @@ function passingShardManifest(plan: ReturnType<typeof buildPlan>, hostIndex: num
 }
 
 describe('LiveKit load harness safety', () => {
+    it('probes only the fixed public production readiness boundary', async () => {
+        const calls: Array<{ url: string; init: RequestInit }> = [];
+        const fetchImpl = async (url: string | URL | Request, init?: RequestInit) => {
+            calls.push({ url: String(url), init: init ?? {} });
+            return { status: 200 } as Response;
+        };
+
+        await expect(probeProductionReadiness({ fetchImpl })).resolves.toBe(true);
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({
+            url: PRODUCTION_READINESS_URL,
+            init: { method: 'GET', cache: 'no-store', redirect: 'manual' },
+        });
+        expect(calls[0].init.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('fails closed on non-200 responses and probe errors', async () => {
+        await expect(probeProductionReadiness({
+            fetchImpl: async () => ({ status: 503 }) as Response,
+        })).resolves.toBe(false);
+        await expect(probeProductionReadiness({
+            fetchImpl: async () => { throw new Error('network unavailable'); },
+        })).resolves.toBe(false);
+    });
+
+    it('trips after two consecutive failures but resets after a success', () => {
+        let trips = 0;
+        const guard = createConsecutiveFailureGuard({
+            maxFailures: 2,
+            onTrip: () => { trips += 1; },
+        });
+
+        expect(guard.record(false)).toBe(false);
+        expect(guard.failures).toBe(1);
+        expect(guard.record(true)).toBe(false);
+        expect(guard.failures).toBe(0);
+        expect(guard.record(false)).toBe(false);
+        expect(guard.record(false)).toBe(true);
+        expect(guard.record(true)).toBe(true);
+        expect(trips).toBe(1);
+    });
+
     it('builds a bounded two-host dispatch without exposing target credentials', () => {
         const dispatch = buildDistributedDispatchPlan({
             profileName: 'rehearsal-es',

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -14,10 +14,12 @@ describe('distributed LiveKit capacity workflow contract', () => {
         expect(workflow).not.toMatch(/^\s+push:/m);
         expect(workflow).toContain('contents: read');
         expect(workflow).not.toContain('target_url:');
+        expect(workflow).not.toContain('readiness_url:');
         expect(workflow).toContain('secrets.LOAD_TEST_URL');
         expect(workflow).not.toContain('secrets.LIVEKIT_API_SECRET');
         expect(workflow).not.toMatch(/--(?:profile|run-id|start-at) '\$\{\{/);
         expect(workflow).toContain('--run-id "$LOAD_RUN_ID"');
+        expect(workflow.match(/--guard-production-ready/g)).toHaveLength(1);
     });
 
     it('uses two independent hosted runners and always preserves shard evidence', () => {


### PR DESCRIPTION
## Result

The manual distributed capacity workflow now fails closed when the shared production boundary degrades. Each generator probes only the fixed public readiness URL; two consecutive non-200/timeouts terminate both current load children through the existing cooperative abort path, preserve a redacted `ABORTED` manifest, and prevent aggregate PASS. A success between failures resets the counter.

This directly addresses the earlier production-like abort where the public path and SSH observability disappeared under load. It complements, rather than replaces, target-local telemetry and the mona guard.

## Safety

- fixed HTTPS endpoint; no operator-supplied URL or redirect following
- response body is never read and is cancelled
- 2.5 s bounded probe; two consecutive failures required
- no production credential, room, database, runtime, payment or audio change
- workflow remains manual, main-only and isolated-target-only

## Evidence

- full unit suite: 816 passed, 9 opt-in skipped
- focused harness/workflow: 28 passed
- TypeScript and ESLint: green
- diff check: green

## Rollback

Revert this commit. The previous workflow continues to aggregate fail-closed but loses the independent public production guard.

Contributes to #99 and #24; neither closes until the full manifests and physical rehearsal exist.