### PR TITLE
ci(deploy): gate exact release SHA with E2E

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # The reusable workflow checks the exact release commit in a throwaway
+  # Postgres + LiveKit + browser stack before mona can run any release step.
+  release-e2e:
+    uses: ./.github/workflows/e2e.yml
+
   deploy:
+    needs: release-e2e
     runs-on: [self-hosted, mona]
     steps:
       - name: Verify deploy runner identity

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ name: E2E quality gates
 on:
   pull_request:
     branches: [main, release]
+  workflow_call:
 
 concurrency:
   group: e2e-${{ github.head_ref || github.run_id }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,14 +28,16 @@ only the public application and LiveKit signaling ports.
 
 A push to `release` runs `.github/workflows/deploy.yml` on the managed host. It:
 
-1. runs contract, unit, type and lint gates;
-2. verifies both root-owned env files and the private network membership;
-3. preserves the currently running app and tapestry images under independent
+1. runs the exact release commit through the reusable browser E2E workflow on
+   a throwaway Postgres + LiveKit stack, including synthetic attendee access;
+2. runs contract, unit, type and lint gates;
+3. verifies both root-owned env files and the private network membership;
+4. preserves the currently running app and tapestry images under independent
    immutable rollback tags;
-4. builds commit-tagged app and tapestry images;
-5. applies additive Prisma migrations and verifies migration status;
-6. replaces only app, commerce reconciler and tapestry; and
-7. waits for app readiness plus reconciler and tapestry health.
+5. builds commit-tagged app and tapestry images;
+6. applies additive Prisma migrations and verifies migration status;
+7. replaces only app, commerce reconciler and tapestry; and
+8. waits for app readiness plus reconciler and tapestry health.
 
 On failure it restores the preserved app and tapestry images independently. It
 never uses `compose down`, deletes data or pretends that rebuilding the same tag

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -11,6 +11,7 @@ describe('production deploy contract', () => {
   const audioBoundaryWorkflow = readRepositoryFile(
     '.github/workflows/audio-boundary.yml',
   );
+  const e2eWorkflow = readRepositoryFile('.github/workflows/e2e.yml');
   const workflow = readRepositoryFile('.github/workflows/deploy.yml');
   const rootHelper = readRepositoryFile('deploy/hb-deploy-root');
   const runnerSudoers = readRepositoryFile('deploy/beacon-runner.sudoers');
@@ -55,6 +56,13 @@ describe('production deploy contract', () => {
       'cmp --silent deploy/hb-deploy-root /usr/local/sbin/hb-deploy',
     );
     expect(workflow).not.toMatch(/runs-on:\s+self-hosted\s*$/m);
+  });
+
+  it('runs the exact release SHA through the reusable synthetic browser gate before mona', () => {
+    expect(e2eWorkflow).toContain('workflow_call:');
+    expect(workflow).toContain('release-e2e:');
+    expect(workflow).toContain('uses: ./.github/workflows/e2e.yml');
+    expect(workflow).toMatch(/deploy:\n\s+needs: release-e2e\n\s+runs-on: \[self-hosted, mona\]/);
   });
 
   it('keeps pull-request code off every self-hosted production runner', () => {


### PR DESCRIPTION
## Result

Every push to `release` now calls the reusable E2E workflow on the exact release SHA before the self-hosted mona deploy job can start. The called workflow uses only throwaway Postgres, LiveKit, synthetic identities and hosted runners; a failed attendee ticket journey, canonical redirect, browser gate or media continuity check leaves production completely untouched.

This closes the remaining safe design gap in #124 without creating a synthetic identity in the production database. Unit/contract/form-encoded checks still run inside the deploy job before preflight/preserve/build, and the existing public provenance check still rejects an old SHA after replacement.

## Safety

- no production secret or data enters the reusable workflow
- pull-request code remains off mona
- deploy waits through `needs: release-e2e`
- rollback behavior and privileged helper are unchanged
- no runtime, schema, payment or audio change

## Evidence

- full unit suite: 817 passed, 9 opt-in skipped
- deploy/workflow focused: 15 passed
- TypeScript, ESLint and diff check: green
- actionlint 1.7.7: green for both workflows

## Rollback

Revert this commit. Deploys return to running unit/type/lint on mona without an exact-SHA browser pre-gate.

Contributes to #124; merge does not deploy or move `release`.