### PR TITLE
fix(load): preserve synchronization after delayed completion

### DIFF
--- a/config/livekit-load-profiles.json
+++ b/config/livekit-load-profiles.json
@@ -15,6 +15,7 @@
       "reconnectWaves": 1,
       "reconnectMode": "simultaneous",
       "interWaveSeconds": 1,
+      "phaseCompletionBufferSeconds": 15,
       "maxDroppedPercent": 0
     },
     "rehearsal-es": {
@@ -31,6 +32,7 @@
       "reconnectWaves": 2,
       "reconnectMode": "staggered",
       "interWaveSeconds": 10,
+      "phaseCompletionBufferSeconds": 300,
       "maxDroppedPercent": 0.1
     },
     "rehearsal-en": {
@@ -47,6 +49,7 @@
       "reconnectWaves": 2,
       "reconnectMode": "staggered",
       "interWaveSeconds": 10,
+      "phaseCompletionBufferSeconds": 300,
       "maxDroppedPercent": 0.1
     }
   }

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -83,9 +83,14 @@ Sharding partitions attendees, publishers and the declared global ramp rate
 without rounding anything away. Every identity prefix includes its shard, all
 shards join the same two synthetic rooms, and every shard independently observes
 the exact **global** participant/publisher counts. Synchronized phases use a
-minimum 15-second gap so cleanup can converge before the next absolute start.
-The schedule includes the CLI connection ramp because LiveKit starts its
-`--duration` timer only after those connections finish.
+minimum 15-second cleanup gap. Each profile also declares a
+`phaseCompletionBufferSeconds` tail before the next absolute start. This tail
+is not load duration and does not excuse a timeout: it keeps both hosts at the
+same later barrier when the CLI spends time reporting failed/late connection
+attempts after its nominal ramp. The rehearsal profiles reserve five minutes;
+the small CI profile reserves 15 seconds. The schedule separately includes the
+ideal CLI connection ramp because LiveKit starts its `--duration` timer only
+after those connections finish.
 Missing coordinates, duplicate identities, a late phase, API sampling errors,
 extra/missing joins or incomplete cleanup fail closed.
 

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -73,6 +73,7 @@ export function validateProfile(profile) {
         'reconnectDurationSeconds',
         'reconnectWaves',
         'interWaveSeconds',
+        'phaseCompletionBufferSeconds',
     ];
     for (const field of integerFields) {
         if (!Number.isInteger(profile[field]) || profile[field] < 0) {
@@ -309,7 +310,9 @@ export function buildPlan({
         );
         const scheduled = { ...phase, scheduledOffsetSeconds, expectedConnectSeconds };
         scheduledOffsetSeconds += expectedConnectSeconds + phase.durationSeconds;
-        if (index < phases.length - 1) scheduledOffsetSeconds += phaseGapSeconds;
+        if (index < phases.length - 1) {
+            scheduledOffsetSeconds += profile.phaseCompletionBufferSeconds + phaseGapSeconds;
+        }
         return scheduled;
     });
     return {
@@ -329,6 +332,7 @@ export function buildPlan({
             localBeaconPublishers,
             localRampPerSecond,
             phaseGapSeconds,
+            phaseCompletionBufferSeconds: profile.phaseCompletionBufferSeconds,
         },
         phases: scheduledPhases.map((phase) => ({
             ...phase,
@@ -520,7 +524,8 @@ function shardPlanIsDeterministic(plan, index, shardCount) {
         plan.shard.localStagePublishers !== localStagePublishers ||
         plan.shard.localBeaconPublishers !== localBeaconPublishers ||
         plan.shard.localRampPerSecond !== localRampPerSecond ||
-        plan.shard.phaseGapSeconds !== expectedGap
+        plan.shard.phaseGapSeconds !== expectedGap ||
+        plan.shard.phaseCompletionBufferSeconds !== profile.phaseCompletionBufferSeconds
     ) return false;
 
     let offset = 0;
@@ -551,7 +556,9 @@ function shardPlanIsDeterministic(plan, index, shardCount) {
             phase.beacon.expectedGlobalPublishers === profile.beaconPublishers &&
             phase.beacon.expectedSubscriberTracks === localAttendees * profile.beaconPublishers;
         offset += expectedConnectSeconds + phase.durationSeconds;
-        if (phaseIndex < plan.phases.length - 1) offset += expectedGap;
+        if (phaseIndex < plan.phases.length - 1) {
+            offset += profile.phaseCompletionBufferSeconds + expectedGap;
+        }
         return valid;
     });
 }

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -46,6 +46,7 @@ const profile = {
     reconnectWaves: 2,
     reconnectMode: 'staggered',
     interWaveSeconds: 10,
+    phaseCompletionBufferSeconds: 300,
     maxDroppedPercent: 0.1,
 };
 const temporaryRoots: string[] = [];
@@ -193,7 +194,7 @@ describe('LiveKit load harness safety', () => {
                 beacon: 'hb-load-github-run-a-es-beacon',
             },
         });
-        expect(dispatch.expectedEndAt).toBe('2026-08-05T12:44:49.000Z');
+        expect(dispatch.expectedEndAt).toBe('2026-08-05T12:59:49.000Z');
         expect(JSON.stringify(dispatch)).not.toContain('secret');
         expect(dispatch.confirmation).toBe(
             'LOADTEST:hb-load-github-run-a-es-stage:hb-load-github-run-a-es-beacon',
@@ -265,6 +266,7 @@ describe('LiveKit load harness safety', () => {
         expect(shards.map((plan) => plan.shard.localStagePublishers)).toEqual([3, 3]);
         expect(shards.map((plan) => plan.shard.localBeaconPublishers)).toEqual([1, 0]);
         expect(shards.map((plan) => plan.shard.localRampPerSecond)).toEqual([5, 5]);
+        expect(shards.map((plan) => plan.shard.phaseCompletionBufferSeconds)).toEqual([300, 300]);
         expect(shards.map((plan) => plan.phases[0].stage.requestedConnections)).toEqual([78, 78]);
         expect(shards.map((plan) => plan.phases[0].beacon.requestedConnections)).toEqual([76, 75]);
         expect(shards[0].phases[0].stage.expectedGlobalConnections).toBe(156);
@@ -274,7 +276,7 @@ describe('LiveKit load harness safety', () => {
         expect(shards[0].phases[0].stage.args).toContain('hbload-event-weekend-s0-stage');
         expect(shards[1].phases[0].stage.args).toContain('hbload-event-weekend-s1-stage');
         expect(shards[0].phases.map((phase) => phase.scheduledOffsetSeconds)).toEqual([
-            0, 91, 1322, 1413,
+            0, 391, 1922, 2313,
         ]);
     });
 
@@ -287,6 +289,35 @@ describe('LiveKit load harness safety', () => {
         expect(connectionRampSeconds(78, 5)).toBe(16);
         expect(connectionRampSeconds(6, 6)).toBe(1);
         expect(connectionRampSeconds(151, 100)).toBe(15);
+    });
+
+    it('reserves an explicit completion tail before every later synchronized phase', () => {
+        const withoutBuffer = buildPlan({
+            profileName: 'rehearsal-es',
+            profile: { ...profile, phaseCompletionBufferSeconds: 0 },
+            runId: 'schedule-without-buffer',
+            url: 'ws://localhost:7880',
+            shardIndex: 0,
+            shardCount: 2,
+            startAt: '2026-08-06T12:00:00.000Z',
+        });
+        const withBuffer = buildPlan({
+            profileName: 'rehearsal-es',
+            profile,
+            runId: 'schedule-with-buffer',
+            url: 'ws://localhost:7880',
+            shardIndex: 0,
+            shardCount: 2,
+            startAt: '2026-08-06T12:00:00.000Z',
+        });
+
+        expect(withBuffer.phases.map((phase, index) =>
+            phase.scheduledOffsetSeconds - withoutBuffer.phases[index].scheduledOffsetSeconds,
+        )).toEqual([0, 300, 600, 900]);
+        expect(() => validateProfile({
+            ...profile,
+            phaseCompletionBufferSeconds: -1,
+        })).toThrow(/phaseCompletionBufferSeconds/);
     });
 
     it('fails closed on incomplete or unsynchronized shard coordinates', () => {


### PR DESCRIPTION
## Outcome

Keeps distributed full-profile phases synchronized even when the official LiveKit CLI spends several minutes reporting connection timeouts after its ideal ramp.

- adds an explicit, validated `phaseCompletionBufferSeconds` to every profile;
- reserves 15 seconds in CI and five minutes in full rehearsals before each later absolute barrier;
- binds the buffer into each shard plan and aggregate determinism checks;
- does not change requested connections, publishers, phase duration, codec/layout, packet-loss threshold or PASS criteria.

## Reproduction / cause

Full run [`capacity-en-20260805a`](https://github.com/AlterMundi/harmonic-beacon-webapp/actions/runs/31014771845) synchronized its first phases at 0–1 ms, but the 20-minute CLI process spent another ~146 seconds finishing timeout reports. Both shards therefore reached reconnect-1 ~146 seconds after the precomputed absolute barrier and failed closed with `missed-synchronized-start`.

The run remains a genuine FAIL independent of this scheduler defect: Stage ramp loss was 21.323% / 21.661%; soak reported incomplete tracks and connection errors even though its received-track packet loss was 0.036% / 0.015%. Beacon loss stayed 0%. This PR neither hides nor weakens those results; it lets a later run preserve reconnect evidence after an earlier phase fails.

## Evidence

- focused harness tests: 26/26;
- full Vitest: 818 passed, 9 opt-in skipped;
- TypeScript: pass;
- ESLint: pass;
- production build: pass;
- diff check: pass.

## Risk / rollback

Tooling/config/docs/tests only. Full distributed rehearsals wait longer between phases and their predicted end moves from 24m49s to 39m49s after the shared start. Local non-scheduled runs are unchanged. Revert the merge commit to restore the prior schedule; no production runtime, data, commerce, UI or audio path is touched.

Refs #99 and #24. Does not close either issue.
