### PR TITLE
feat(load): support six-host fan-in diagnostics

### DIFF
--- a/.github/workflows/livekit-capacity.yml
+++ b/.github/workflows/livekit-capacity.yml
@@ -26,6 +26,14 @@ on:
           - '900'
           - '1200'
           - '1800'
+      shard_count:
+        description: Independent generator hosts (2 baseline, 6 fan-in diagnostic)
+        required: true
+        default: '2'
+        type: choice
+        options:
+          - '2'
+          - '6'
 
 permissions:
   contents: read
@@ -44,6 +52,7 @@ jobs:
       expected_end_at: ${{ steps.plan.outputs.expected_end_at }}
       confirmation: ${{ steps.plan.outputs.confirmation }}
       shard_count: ${{ steps.plan.outputs.shard_count }}
+      shard_indices: ${{ steps.plan.outputs.shard_indices }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,6 +71,7 @@ jobs:
           LOAD_PROFILE: ${{ inputs.profile }}
           LOAD_RUN_ID: ${{ inputs.run_id }}
           LOAD_START_DELAY_SECONDS: ${{ inputs.start_delay_seconds }}
+          LOAD_SHARD_COUNT: ${{ inputs.shard_count }}
         run: |
           test -n "$LOAD_TEST_URL"
           test -n "$LOAD_TEST_API_KEY"
@@ -69,7 +79,8 @@ jobs:
           node scripts/livekit-load-dispatch-plan.mjs \
             --profile "$LOAD_PROFILE" \
             --run-id "$LOAD_RUN_ID" \
-            --start-delay-seconds "$LOAD_START_DELAY_SECONDS"
+            --start-delay-seconds "$LOAD_START_DELAY_SECONDS" \
+            --shard-count "$LOAD_SHARD_COUNT"
 
   generator:
     needs: prepare
@@ -81,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard_index: [0, 1]
+        shard_index: ${{ fromJSON(needs.prepare.outputs.shard_indices) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -152,11 +163,19 @@ jobs:
           merge-multiple: true
 
       - name: Aggregate only complete, distinct-host PASS evidence
+        env:
+          LOAD_SHARD_COUNT: ${{ needs.prepare.outputs.shard_count }}
         run: |
+          set -euo pipefail
+          shard_paths=()
+          for ((shard_index = 0; shard_index < LOAD_SHARD_COUNT; shard_index++)); do
+            shard_path="artifacts/load-test/shards/shard-${shard_index}.json"
+            test -f "$shard_path"
+            shard_paths+=("$shard_path")
+          done
           node scripts/livekit-load-aggregate.mjs \
             --output 'artifacts/load-test/${{ needs.prepare.outputs.run_id }}-aggregate.json' \
-            artifacts/load-test/shards/shard-0.json \
-            artifacts/load-test/shards/shard-1.json
+            "${shard_paths[@]}"
 
       - name: Upload aggregate and source manifests
         if: always()

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -123,6 +123,12 @@ target-local telemetry or physical browser evidence.
 
 `.github/workflows/livekit-capacity.yml` is a manual-only two-generator
 orchestrator for the case where no two trusted standalone hosts are available.
+The default remains two hosts so consecutive baselines stay comparable. A
+bounded six-host option partitions the same 150 attendees, six Stage publishers,
+one Beacon publisher and global ramp across six independent runners. Use it to
+diagnose generator fan-in after a two-host failure; it does not increase the
+declared load or relax any acceptance threshold. The aggregate still requires
+every planned shard, distinct boot provenance and byte-equivalent plans.
 It runs each shard on a different ephemeral GitHub-hosted runner, pins and
 verifies `lk` v2.16.3, schedules both against the same future UTC boundary, and
 uploads the redacted source manifests before aggregating them fail-closed.
@@ -156,6 +162,11 @@ gh workflow run livekit-capacity.yml --ref main \
   -f run_id=capacity-en-20260805-a \
   -f start_delay_seconds=1200
 ```
+
+Keep the default two-host baseline for comparisons. After a failed baseline
+whose generator fan-in remains a plausible cause, repeat with the same profile,
+target and thresholds plus `-f shard_count=6`; use a new run ID and preserve
+both manifests as separate evidence.
 
 The target must stay isolated from event rooms and the production LiveKit
 process. After downloading and hashing the aggregate plus target telemetry,

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -128,6 +128,37 @@ export function partitionCount(total, shardIndex, shardCount) {
     return base + (shardIndex < total % shardCount ? 1 : 0);
 }
 
+function shardExpectedConnectSeconds(profile, shardIndex, shardCount, phaseName) {
+    const attendees = partitionCount(profile.attendees, shardIndex, shardCount);
+    const stagePublishers = partitionCount(profile.stagePublishers, shardIndex, shardCount);
+    const beaconPublishers = partitionCount(profile.beaconPublishers, shardIndex, shardCount);
+    const rampPerSecond = partitionCount(profile.rampPerSecond, shardIndex, shardCount);
+    const simultaneousReconnect = phaseName.startsWith('reconnect-') &&
+        profile.reconnectMode === 'simultaneous';
+    const stageRampPerSecond = simultaneousReconnect
+        ? attendees + stagePublishers
+        : rampPerSecond;
+    const beaconRampPerSecond = simultaneousReconnect
+        ? attendees + beaconPublishers
+        : rampPerSecond;
+    return Math.max(
+        connectionRampSeconds(attendees + stagePublishers, stageRampPerSecond),
+        connectionRampSeconds(attendees + beaconPublishers, beaconRampPerSecond),
+    );
+}
+
+function distributedExpectedConnectSeconds(profile, shardCount, phaseName) {
+    return Math.max(...Array.from(
+        { length: shardCount },
+        (_, shardIndex) => shardExpectedConnectSeconds(
+            profile,
+            shardIndex,
+            shardCount,
+            phaseName,
+        ),
+    ));
+}
+
 export function connectionRampSeconds(connections, rampPerSecond) {
     if (connections <= 1) return 0;
     return Math.ceil((connections - 1) / Math.min(rampPerSecond, 10));
@@ -298,16 +329,9 @@ export function buildPlan({
     }
     let scheduledOffsetSeconds = 0;
     const scheduledPhases = phases.map((phase, index) => {
-        const expectedConnectSeconds = Math.max(
-            connectionRampSeconds(
-                localAttendees + localStagePublishers,
-                phase.stageRampPerSecond,
-            ),
-            connectionRampSeconds(
-                localAttendees + localBeaconPublishers,
-                phase.beaconRampPerSecond,
-            ),
-        );
+        const expectedConnectSeconds = shardCount === 1
+            ? shardExpectedConnectSeconds(profile, shardIndex, shardCount, phase.name)
+            : distributedExpectedConnectSeconds(profile, shardCount, phase.name);
         const scheduled = { ...phase, scheduledOffsetSeconds, expectedConnectSeconds };
         scheduledOffsetSeconds += expectedConnectSeconds + phase.durationSeconds;
         if (index < phases.length - 1) {
@@ -390,8 +414,8 @@ export function buildDistributedDispatchPlan({
         startDelaySeconds < 600 || startDelaySeconds > 3600) {
         throw new Error('start delay must be an integer between 600 and 3600 seconds');
     }
-    if (shardCount !== 2) {
-        throw new Error('the GitHub-hosted rehearsal requires exactly two shards');
+    if (![2, 6].includes(shardCount)) {
+        throw new Error('the GitHub-hosted rehearsal requires two or six shards');
     }
     const safeRunId = sanitizeRunId(runId);
     const startAt = new Date(nowMs + startDelaySeconds * 1000).toISOString();
@@ -536,9 +560,10 @@ function shardPlanIsDeterministic(plan, index, shardCount) {
         const beaconRamp = phaseIndex >= 2 && profile.reconnectMode === 'simultaneous'
             ? localAttendees + localBeaconPublishers
             : localRampPerSecond;
-        const expectedConnectSeconds = Math.max(
-            connectionRampSeconds(localAttendees + localStagePublishers, stageRamp),
-            connectionRampSeconds(localAttendees + localBeaconPublishers, beaconRamp),
+        const expectedConnectSeconds = distributedExpectedConnectSeconds(
+            profile,
+            shardCount,
+            phase.name,
         );
         const valid =
             phase.scheduledOffsetSeconds === offset &&

--- a/scripts/livekit-load-dispatch-plan.mjs
+++ b/scripts/livekit-load-dispatch-plan.mjs
@@ -30,6 +30,7 @@ async function main() {
         runId: option('--run-id'),
         targetUrl,
         startDelaySeconds: Number(option('--start-delay-seconds')),
+        shardCount: Number(option('--shard-count')),
     });
     const outputPath = process.env.GITHUB_OUTPUT;
     if (!outputPath) throw new Error('GITHUB_OUTPUT is required');
@@ -39,6 +40,10 @@ async function main() {
         expected_end_at: plan.expectedEndAt,
         confirmation: plan.confirmation,
         shard_count: String(plan.shardCount),
+        shard_indices: JSON.stringify(Array.from(
+            { length: plan.shardCount },
+            (_, shardIndex) => shardIndex,
+        )),
     };
     await appendFile(
         outputPath,

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -201,6 +201,60 @@ describe('LiveKit load harness safety', () => {
         );
     });
 
+    it('supports the bounded six-host diagnostic without changing global load', () => {
+        const dispatch = buildDistributedDispatchPlan({
+            profileName: 'rehearsal-es',
+            profile,
+            runId: 'github-run-six',
+            targetUrl: 'ws://144.217.90.60:7890',
+            startDelaySeconds: 1200,
+            shardCount: 6,
+            nowMs: Date.parse('2026-08-05T12:00:00Z'),
+        });
+
+        expect(dispatch).toMatchObject({
+            runId: 'github-run-six',
+            shardCount: 6,
+            startAt: '2026-08-05T12:20:00.000Z',
+            expectedEndAt: '2026-08-05T13:00:25.000Z',
+        });
+
+        const plans = Array.from({ length: 6 }, (_, shardIndex) => buildPlan({
+            profileName: 'rehearsal-es',
+            profile,
+            runId: 'github-run-six',
+            url: 'ws://144.217.90.60:7890',
+            allowRemote: true,
+            confirmation: dispatch.confirmation,
+            shardIndex,
+            shardCount: 6,
+            startAt: dispatch.startAt,
+        }));
+        expect(plans.map((plan) => plan.shard.localAttendees))
+            .toEqual([25, 25, 25, 25, 25, 25]);
+        expect(plans.reduce((total, plan) => total + plan.shard.localStagePublishers, 0))
+            .toBe(6);
+        expect(plans.reduce((total, plan) => total + plan.shard.localBeaconPublishers, 0))
+            .toBe(1);
+        expect(plans.map((plan) => plan.shard.localRampPerSecond))
+            .toEqual([2, 2, 2, 2, 1, 1]);
+        expect(plans.map((plan) => plan.phases.map((phase) => phase.scheduledOffsetSeconds)))
+            .toEqual(Array(6).fill([0, 400, 1940, 2340]));
+        expect(plans.map((plan) => plan.phases[0].expectedConnectSeconds))
+            .toEqual([25, 25, 25, 25, 25, 25]);
+
+        const aggregate = aggregateShardManifests(plans.map((plan, shardIndex) => ({
+            sha256: String(shardIndex).padStart(64, 'b'),
+            manifest: passingShardManifest(plan, shardIndex),
+        })));
+        expect(aggregate).toMatchObject({
+            status: 'PASS',
+            shardCount: 6,
+            totals: { attendees: 150, stagePublishers: 6, beaconPublishers: 1 },
+        });
+        expect(aggregate.sources).toHaveLength(6);
+    });
+
     it('refuses unsafe distributed targets, timing and topology', () => {
         for (const unsafe of [
             'https://example.test',
@@ -221,7 +275,7 @@ describe('LiveKit load harness safety', () => {
         expect(() => buildDistributedDispatchPlan({
             profileName: 'rehearsal-es', profile, runId: 'github-run-a',
             targetUrl: 'ws://example.test:7890', startDelaySeconds: 1200, shardCount: 3,
-        })).toThrow(/exactly two shards/);
+        })).toThrow(/two or six shards/);
     });
 
     it('builds two synthetic connections per attendee and caps the stage at six publishers', () => {

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -28,8 +28,12 @@ describe('distributed LiveKit capacity workflow contract', () => {
         expect(workflow.match(/--guard-production-ready/g)).toHaveLength(1);
     });
 
-    it('uses two independent hosted runners and always preserves shard evidence', () => {
-        expect(workflow).toContain('shard_index: [0, 1]');
+    it('uses a bounded dynamic hosted-runner matrix and always preserves shard evidence', () => {
+        expect(workflow).toContain("default: '2'");
+        expect(workflow).toContain("- '6'");
+        expect(workflow).toContain('fromJSON(needs.prepare.outputs.shard_indices)');
+        expect(workflow).toContain('--shard-count "$LOAD_SHARD_COUNT"');
+        expect(workflow).toContain('shard_paths+=("$shard_path")');
         expect(workflow).toContain('fail-fast: false');
         expect(workflow.match(/environment: capacity-rehearsal/g)).toHaveLength(2);
         expect(workflow).toContain('if: always()');


### PR DESCRIPTION
## Outcome

Adds a bounded six-host diagnostic mode to the existing distributed LiveKit capacity workflow. The default remains the comparable two-host baseline; six hosts partition the same 150 attendees, six Stage publishers, one Beacon publisher and global ramp without changing codec, load, duration or acceptance thresholds.

## Why

The first two-host production-like run showed heavy VP8 loss and target RTP-buffer backlog while each hosted generator concentrated 75 subscriber clients. Six hosts reduce that synthetic fan-in to 25 clients per host so a follow-up can distinguish generator-path concentration from SFU capacity.

## Safety

- workflow_dispatch only, main-only protected environment
- allowed shard counts are exactly 2 or 6
- every shard uses a distinct hosted runner and exact SHA
- common phase barriers use the slowest deterministic partition
- aggregate refuses missing/duplicate hosts, dirty plans or failed invariants
- no runtime, production deploy, LiveKit config, codec, buffer or audio change

## Evidence

- focused harness/workflow tests: 30 passed
- complete unit suite: 819 passed, 9 opt-in skipped
- TypeScript, ESLint, diff check and production build: green
- full commit hook suite: 819 passed, 9 opt-in skipped

## Rollback

Revert this tooling-only commit; the current two-shard default and production runtime are otherwise unchanged.

Draft until the active two-host rerun 31020053573 completes and demonstrates whether the six-host diagnostic is necessary.
