### PR TITLE
fix(load): budget full generator job runtime

### DIFF
--- a/.github/workflows/livekit-capacity.yml
+++ b/.github/workflows/livekit-capacity.yml
@@ -75,7 +75,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     environment: capacity-rehearsal
-    timeout-minutes: 55
+    # Includes the longest selectable synchronization delay, every absolute
+    # phase barrier/completion tail, and a bounded setup/evidence margin.
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -131,6 +131,12 @@ consecutive failures abort its current Stage and Beacon processes, preserve an
 `ABORTED` source manifest and prevent a global PASS. The probe never reads a
 response body and cannot be redirected to an operator-supplied URL.
 
+The generator job has a 75-minute hard timeout. A workflow contract test proves
+that this covers the longest selectable synchronization delay, the complete
+rehearsal schedule (including delayed CLI completion tails), and a five-minute
+setup/evidence margin. Do not shorten it independently of the committed profile
+timings: a job timeout cannot emit an admissible manifest.
+
 The workflow uses the `capacity-rehearsal` environment. Restrict that
 environment to the `main` branch and provision these environment secrets only
 for the lifetime of one isolated target:

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -2,10 +2,16 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { buildDistributedDispatchPlan } from '../../../scripts/lib/livekit-load-harness.mjs';
+
 const workflow = readFileSync(
     resolve(process.cwd(), '.github/workflows/livekit-capacity.yml'),
     'utf8',
 );
+const profiles = JSON.parse(readFileSync(
+    resolve(process.cwd(), 'config/livekit-load-profiles.json'),
+    'utf8',
+)).profiles;
 
 describe('distributed LiveKit capacity workflow contract', () => {
     it('is manual, least-privilege and cannot receive an arbitrary target input', () => {
@@ -29,6 +35,30 @@ describe('distributed LiveKit capacity workflow contract', () => {
         expect(workflow).toContain('if: always()');
         expect(workflow).toContain('livekit-load-aggregate.mjs');
         expect(workflow).toContain('ref: ${{ github.sha }}');
+    });
+
+    it('budgets the longest dispatch plan plus bounded runner overhead', () => {
+        const timeoutMinutes = Number(workflow.match(/timeout-minutes:\s*(\d+)/)?.[1]);
+        const startDelayChoices = [...workflow.matchAll(/^\s+- '(\d+)'$/gm)]
+            .map((match) => Number(match[1]));
+        const maxStartDelaySeconds = Math.max(...startDelayChoices);
+        const nowMs = Date.parse('2026-08-05T00:00:00.000Z');
+        const setupAndEvidenceMarginSeconds = 300;
+
+        for (const [profileName, profile] of Object.entries(profiles)) {
+            const plan = buildDistributedDispatchPlan({
+                profileName,
+                profile,
+                runId: `timeout-${profileName}`,
+                targetUrl: 'ws://example.test:7890',
+                startDelaySeconds: maxStartDelaySeconds,
+                nowMs,
+            });
+            const requiredSeconds =
+                (Date.parse(plan.expectedEndAt) - nowMs) / 1000 +
+                setupAndEvidenceMarginSeconds;
+            expect(timeoutMinutes * 60, profileName).toBeGreaterThanOrEqual(requiredSeconds);
+        }
     });
 
     it('pins and verifies the official LiveKit CLI artifact', () => {


### PR DESCRIPTION
## Cause

Full run `capacity-en-20260805b` (Actions 31020053573) was canceled by GitHub's 55-minute job limit after reconnect-1 and before reconnect-2. Both generators started at the exact synchronized boundary and production remained ready, but the workflow could never emit manifests because PR #176 correctly added phase-completion tails without updating the enclosing job budget.

At the longest selectable 1,800-second start delay, the committed rehearsal plan requires 4,189 seconds from dispatch planning through its expected final phase. A five-minute setup/evidence allowance raises the required bound to 4,489 seconds; 55 minutes is impossible and 75 minutes provides a bounded 4,500 seconds.

## Change

- raise only the generator job timeout from 55 to 75 minutes;
- derive a contract test from every committed profile and the workflow's longest selectable delay;
- document why the timeout must evolve with profile timing.

No load, phase duration, threshold, target, codec, buffer, bitrate, audio path or production behavior changes.

## Verification

- focused load/workflow tests: 30/30;
- full suite: 819 passed, 9 opt-in integration tests skipped;
- TypeScript: green;
- ESLint: green;
- actionlint: green;
- production build: green;
- diff-check: green.

## Risk / rollback

This only permits an already-bounded manual rehearsal to reach its committed end. Concurrency remains serialized, environment-protected and manual-only. Rollback is reverting `cb9e9a9`, though that restores a deterministically impossible full run.
