### PR TITLE
fix(load): budget every selectable shard count

### DIFF
--- a/.github/workflows/livekit-capacity.yml
+++ b/.github/workflows/livekit-capacity.yml
@@ -88,7 +88,7 @@ jobs:
     environment: capacity-rehearsal
     # Includes the longest selectable synchronization delay, every absolute
     # phase barrier/completion tail, and a bounded setup/evidence margin.
-    timeout-minutes: 75
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -137,11 +137,12 @@ consecutive failures abort its current Stage and Beacon processes, preserve an
 `ABORTED` source manifest and prevent a global PASS. The probe never reads a
 response body and cannot be redirected to an operator-supplied URL.
 
-The generator job has a 75-minute hard timeout. A workflow contract test proves
+The generator job has an 80-minute hard timeout. A workflow contract test proves
 that this covers the longest selectable synchronization delay, the complete
-rehearsal schedule (including delayed CLI completion tails), and a five-minute
-setup/evidence margin. Do not shorten it independently of the committed profile
-timings: a job timeout cannot emit an admissible manifest.
+rehearsal schedule (including delayed CLI completion tails), every selectable
+valid shard count, and a five-minute setup/evidence margin. Do not shorten it
+independently of the committed profile timings: a job timeout cannot emit an
+admissible manifest.
 
 The workflow uses the `capacity-rehearsal` environment. Restrict that
 environment to the `main` branch and provision these environment secrets only

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -45,23 +45,40 @@ describe('distributed LiveKit capacity workflow contract', () => {
         const timeoutMinutes = Number(workflow.match(/timeout-minutes:\s*(\d+)/)?.[1]);
         const startDelayChoices = [...workflow.matchAll(/^\s+- '(\d+)'$/gm)]
             .map((match) => Number(match[1]));
+        const shardCountOptions = workflow.match(
+            /shard_count:[\s\S]*?options:\n((?:\s+- '\d+'\n)+)/,
+        )?.[1] ?? '';
+        const shardCountChoices = [...shardCountOptions.matchAll(/- '(\d+)'/g)]
+            .map((match) => Number(match[1]));
         const maxStartDelaySeconds = Math.max(...startDelayChoices);
         const nowMs = Date.parse('2026-08-05T00:00:00.000Z');
         const setupAndEvidenceMarginSeconds = 300;
 
+        expect(shardCountChoices).toEqual([2, 6]);
         for (const [profileName, profile] of Object.entries(profiles)) {
-            const plan = buildDistributedDispatchPlan({
-                profileName,
-                profile,
-                runId: `timeout-${profileName}`,
-                targetUrl: 'ws://example.test:7890',
-                startDelaySeconds: maxStartDelaySeconds,
-                nowMs,
-            });
-            const requiredSeconds =
-                (Date.parse(plan.expectedEndAt) - nowMs) / 1000 +
-                setupAndEvidenceMarginSeconds;
-            expect(timeoutMinutes * 60, profileName).toBeGreaterThanOrEqual(requiredSeconds);
+            const { attendees, rampPerSecond } = profile as {
+                attendees: number;
+                rampPerSecond: number;
+            };
+            for (const shardCount of shardCountChoices) {
+                if (shardCount > attendees || shardCount > rampPerSecond) continue;
+                const plan = buildDistributedDispatchPlan({
+                    profileName,
+                    profile,
+                    runId: `timeout-${profileName}-${shardCount}`,
+                    targetUrl: 'ws://example.test:7890',
+                    startDelaySeconds: maxStartDelaySeconds,
+                    shardCount,
+                    nowMs,
+                });
+                const requiredSeconds =
+                    (Date.parse(plan.expectedEndAt) - nowMs) / 1000 +
+                    setupAndEvidenceMarginSeconds;
+                expect(
+                    timeoutMinutes * 60,
+                    `${profileName}/${shardCount} shards`,
+                ).toBeGreaterThanOrEqual(requiredSeconds);
+            }
         }
     });
 


### PR DESCRIPTION
## Cause

PR #177 made six hosted generators selectable, but the timeout contract still built only the default two-shard plan. At the longest selectable 1,800-second synchronization delay:

- two shards + five-minute setup/evidence margin require 4,489 seconds;
- six shards + the same margin require 4,525 seconds;
- the existing 75-minute job limit provides only 4,500 seconds.

The six-host plan can therefore be canceled 25 seconds before its bounded evidence margin ends.

## Change

- derive every selectable shard count from the workflow contract;
- prove every valid profile × shard-count plan against the longest selectable delay;
- raise only the generator job ceiling from 75 to 80 minutes;
- document that the timeout covers every valid selectable shard count.

No profile, load, phase, threshold, codec, layout, audio path, target or production behavior changes.

## Verification

- focused workflow/harness tests: 31/31;
- full suite: 820 passed, 9 opt-in integration tests skipped;
- TypeScript: green;
- ESLint: green;
- production build: green;
- diff-check: green.

## Risk / rollback

This only prevents a valid manual six-host rehearsal from losing its final evidence margin. Concurrency remains serialized, main-only, environment-protected and manual. Rollback is reverting `7017f9e`, which restores the known 25-second shortfall at the maximum delay.