### PR TITLE
fix(load): synchronize distributed shard completion

### DIFF
--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -137,6 +137,13 @@ consecutive failures abort its current Stage and Beacon processes, preserve an
 `ABORTED` source manifest and prevent a global PASS. The probe never reads a
 response body and cannot be redirected to an operator-supplied URL.
 
+Every shard pads its local CLI duration by the difference between its own
+connection ramp and the slowest planned ramp. Stage and Beacon therefore remain
+connected through one shared completion barrier even when attendee, publisher,
+or global ramp partitions are uneven. Cleanup is checked only after that
+barrier; an aggregate refuses a shard whose recorded command could disconnect
+early.
+
 The generator job has an 80-minute hard timeout. A workflow contract test proves
 that this covers the longest selectable synchronization delay, the complete
 rehearsal schedule (including delayed CLI completion tails), every selectable

--- a/docs/ops/rehearsals/2026-08-04-livekit-load-local.md
+++ b/docs/ops/rehearsals/2026-08-04-livekit-load-local.md
@@ -165,15 +165,45 @@ failure, LiveKit `v1.13.4` logged packet-bucket overflow/eviction warnings. The
 subsequent upstream `v1.13.5` release includes a
 [forwarded-padding fix](https://github.com/livekit/livekit/commit/366cadcd96b8b09c7212e27693a25f3a88e6c8be)
 that its maintainer explicitly describes as affecting special clients and
-bandwidth estimation. A controlled isolated comparison on `v1.13.5` is
-therefore the next diagnostic; changing the 0.1% threshold is not.
+bandwidth estimation.
+
+### Isolated `v1.13.4` versus `v1.13.5` control
+
+Three non-debug 60-second controls then used the same mona host, pinned CLI
+`v2.16.3`, six VP8 simulcast publishers, 150 subscribers, speaker layout,
+synthetic rooms and loopback-only ports. All three received 900/900 tracks with
+zero CLI errors:
+
+| Server | Run | Loss | Packet-bucket lookup warnings | Extended-packet overflow warnings |
+|---|---|---:|---:|---:|
+| `v1.13.4` | control | 5.051% | 429 | 88 |
+| `v1.13.5` | control A | 0.274% | 24 | 6 |
+| `v1.13.5` | control B | 11.261% | 767 | 154 |
+
+The first `v1.13.5` run improved sharply but remained above the 0.1% gate; the
+immediate identical repetition regressed beyond `v1.13.4`. The padding fix is
+therefore relevant but not sufficient or deterministic evidence for a server
+upgrade. Loss continues to correlate with the SFU packet-bucket warnings.
+Production must not be upgraded on this result, and the threshold remains
+unchanged. The next comparison must keep target and generators on separate
+hosts, capture target resource/packet telemetry, and repeat `v1.13.5` before a
+release decision.
+
+Artifact SHA-256:
+
+- `v1.13.4` CLI: `97b090b50afcdc473890a93e0ce2d031c96dc929ae7c70ed46f7824f5371167f`;
+- `v1.13.4` server: `230bbc940781f79dd539893dcde796369292322580688fa82077e5551a2555e2`;
+- `v1.13.5` control A CLI: `a427685500fbb8e2ab403dfc43cc1005464e847c2a9e8e6a4458a645a835f49a`;
+- `v1.13.5` control A server: `75d9e3fef0fcd80b7e55957e9f36d0323ecf055b990135e2e614dc9c7f172b99`;
+- `v1.13.5` control B CLI: `52ac72bd4ad2b64f6c51f05d84d36b18110f796120f01e6c93cedaad0c33c047`;
+- `v1.13.5` control B server: `dd0d733f06dff685c5b96de371f0ab4dc309a0458ee0dd2b137fe493634e5b46`.
 
 ## Decision
 
 - Do not close #99 or use this run as GO evidence for #24.
 - Keep the 0.1% loss threshold; do not normalize the failure away.
-- Compare the explicit VP8 topology on an isolated LiveKit `v1.13.5` target
-  before changing production or classifying the remaining loss.
+- Repeat the explicit VP8 topology from separate generators against isolated
+  LiveKit `v1.13.5`; neither local result authorizes a production upgrade.
 - Run the explicit H264 path as supporting Safari evidence, never as a
   substitute for VP8.
 - Physical browser, TURN, mobile routing, six-camera, and listening gates remain

--- a/docs/ops/rehearsals/2026-08-04-livekit-load-local.md
+++ b/docs/ops/rehearsals/2026-08-04-livekit-load-local.md
@@ -110,12 +110,70 @@ in all eight. This establishes repeatability on the local same-host topology,
 but does not distinguish SFU capacity from generator contention or certify
 mona/external network capacity.
 
+## Six-generator production-like diagnostic
+
+Run `capacity-en-20260805d` completed all four phases against an isolated
+LiveKit `v1.13.4` target on mona from six distinct GitHub-hosted generators and
+exact `main@505cc9506bd734d89914635d71c028b6009bbb37`. Actions run:
+`31032518240`.
+
+Every phase reached the exact global topology: 156 Stage connections with six
+publishers and 151 Beacon connections with one publisher. Each shard received
+150 Stage subscriber tracks and 25 Beacon subscriber tracks, every API poll
+succeeded, phase synchronization was 0--1 ms, and all containers remained at
+restart delta zero with no OOM. The source manifest hashes are:
+
+- shard 0: `ed535bec5a1d416f8e17a4da46d12a1c033a5a9b6dd01ec51193fa8f62a72994`;
+- shard 1: `de4c737dba64c10743456d2e73b49b0e9d4a41a5a8b3c7cc3923006350d7deb4`;
+- shard 2: `8084edd4532d61319af4e28c79015bd2d2a1c115c47601bf423ba5478a084d99`;
+- shard 3: `93f8c283b95220012a97832fcc5fc2593e217473b69ec82dd9ddf50fb199ffb9`;
+- shard 4: `3fe8f31e54e87ec00ab77d12af49ada8cfffc0532cc05f39de3ebe7d13b68af2`;
+- shard 5: `2ba8d47e62a193dc1cfe952cb3cae7224cdb6f408f0a73991d1b874ba1cbfeb3`.
+
+The result remained a real packet-loss failure:
+
+| Shard | Stage ramp | Stage soak | Stage reconnect 1 | Stage reconnect 2 | Beacon max |
+|---:|---:|---:|---:|---:|---:|
+| 0 | 15.841% | 34.396% | 26.931% | 16.921% | 6.435% |
+| 1 | 16.542% | 34.837% | 27.900% | 19.221% | 6.294% |
+| 2 | 15.724% | 33.840% | 29.198% | 18.310% | 6.333% |
+| 3 | 15.735% | 33.832% | 26.903% | 16.997% | 6.257% |
+| 4 | 8.742% | 21.370% | 15.757% | 8.523% | 4.006% |
+| 5 | 8.706% | 22.138% | 15.213% | 8.850% | 4.003% |
+
+Splitting subscriber fan-in over six machines did not remove the failure, so
+the earlier two-host result must not be classified as generator contention
+alone. Target telemetry also rules out simple host or NIC saturation: 1,936
+samples completed normally, public readiness failures were zero, host CPU
+peaked at 60.67%, available memory stayed above 15,340,625,920 bytes, and soak
+traffic averaged 310.19 Mbps outbound with a 355.72 Mbps maximum interval. The
+telemetry SHA-256 is
+`311e9c73cfdce640ac35fd34f0c4fc3b24b282226bfdd2ffba25cb31c482465f`.
+
+The run also exposed a harness defect independent of packet loss. Shards 0--3
+had a faster local ramp and disconnected before shards 4--5; their ten-second
+cleanup polls therefore ended with 52 Stage and 50 Beacon participants still
+present. The two slowest shards subsequently observed exact zero. The harness
+now pads each local command to one shared completion barrier and validates that
+contract before aggregation.
+
+The pinned CLI `v2.16.3` computes `Pkt. Loss` from the Pion sample builder's
+dropped-packet callback with a 100-packet late window. It is a receiver-visible
+RTP sequence-gap metric, not an acoustic or browser decode test, and it cannot
+by itself distinguish network loss from an SFU forwarding defect. During the
+failure, LiveKit `v1.13.4` logged packet-bucket overflow/eviction warnings. The
+subsequent upstream `v1.13.5` release includes a
+[forwarded-padding fix](https://github.com/livekit/livekit/commit/366cadcd96b8b09c7212e27693a25f3a88e6c8be)
+that its maintainer explicitly describes as affecting special clients and
+bandwidth estimation. A controlled isolated comparison on `v1.13.5` is
+therefore the next diagnostic; changing the 0.1% threshold is not.
+
 ## Decision
 
 - Do not close #99 or use this run as GO evidence for #24.
 - Keep the 0.1% loss threshold; do not normalize the failure away.
-- Repeat the explicit VP8 profile on a separately provisioned generator or
-  mona-safe production-like target before classifying server versus generator.
+- Compare the explicit VP8 topology on an isolated LiveKit `v1.13.5` target
+  before changing production or classifying the remaining loss.
 - Run the explicit H264 path as supporting Safari evidence, never as a
   substitute for VP8.
 - Physical browser, TURN, mobile routing, six-camera, and listening gates remain

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -159,6 +159,10 @@ function distributedExpectedConnectSeconds(profile, shardCount, phaseName) {
     ));
 }
 
+function streamExpectedConnectSeconds(connections, rampPerSecond) {
+    return connectionRampSeconds(connections, rampPerSecond);
+}
+
 export function connectionRampSeconds(connections, rampPerSecond) {
     if (connections <= 1) return 0;
     return Math.ceil((connections - 1) / Math.min(rampPerSecond, 10));
@@ -173,6 +177,15 @@ export function normalizeScheduledStart(value) {
     const milliseconds = Date.parse(text);
     if (!Number.isFinite(milliseconds)) throw new Error('startAt is not a valid timestamp');
     return new Date(milliseconds).toISOString();
+}
+
+export function scheduledCompletionDelayMs(startAt, phase, nowMs = Date.now()) {
+    if (startAt === null) return 0;
+    return Math.max(0,
+        Date.parse(startAt) +
+        (phase.scheduledOffsetSeconds + phase.expectedConnectSeconds + phase.durationSeconds) * 1000 -
+        nowMs,
+    );
 }
 
 export function roomNames(runId) {
@@ -332,7 +345,21 @@ export function buildPlan({
         const expectedConnectSeconds = shardCount === 1
             ? shardExpectedConnectSeconds(profile, shardIndex, shardCount, phase.name)
             : distributedExpectedConnectSeconds(profile, shardCount, phase.name);
-        const scheduled = { ...phase, scheduledOffsetSeconds, expectedConnectSeconds };
+        const stageExpectedConnectSeconds = streamExpectedConnectSeconds(
+            localAttendees + localStagePublishers,
+            phase.stageRampPerSecond,
+        );
+        const beaconExpectedConnectSeconds = streamExpectedConnectSeconds(
+            localAttendees + localBeaconPublishers,
+            phase.beaconRampPerSecond,
+        );
+        const scheduled = {
+            ...phase,
+            scheduledOffsetSeconds,
+            expectedConnectSeconds,
+            stageExpectedConnectSeconds,
+            beaconExpectedConnectSeconds,
+        };
         scheduledOffsetSeconds += expectedConnectSeconds + phase.durationSeconds;
         if (index < phases.length - 1) {
             scheduledOffsetSeconds += profile.phaseCompletionBufferSeconds + phaseGapSeconds;
@@ -367,10 +394,14 @@ export function buildPlan({
                 localPublishers: localStagePublishers,
                 expectedGlobalPublishers: profile.stagePublishers,
                 expectedSubscriberTracks: localAttendees * profile.stagePublishers,
+                localExpectedConnectSeconds: phase.stageExpectedConnectSeconds,
+                commandDurationSeconds: phase.durationSeconds +
+                    phase.expectedConnectSeconds - phase.stageExpectedConnectSeconds,
                 args: commandFor({
                     room: rooms.stage,
                     identityPrefix: `hbload-${sanitizeRunId(runId)}${shardIdentity}-stage`,
-                    durationSeconds: phase.durationSeconds,
+                    durationSeconds: phase.durationSeconds +
+                        phase.expectedConnectSeconds - phase.stageExpectedConnectSeconds,
                     publishers: localStagePublishers,
                     publisherKind: 'video',
                     attendees: localAttendees,
@@ -386,10 +417,14 @@ export function buildPlan({
                 localPublishers: localBeaconPublishers,
                 expectedGlobalPublishers: profile.beaconPublishers,
                 expectedSubscriberTracks: localAttendees * profile.beaconPublishers,
+                localExpectedConnectSeconds: phase.beaconExpectedConnectSeconds,
+                commandDurationSeconds: phase.durationSeconds +
+                    phase.expectedConnectSeconds - phase.beaconExpectedConnectSeconds,
                 args: commandFor({
                     room: rooms.beacon,
                     identityPrefix: `hbload-${sanitizeRunId(runId)}${shardIdentity}-beacon`,
-                    durationSeconds: phase.durationSeconds,
+                    durationSeconds: phase.durationSeconds +
+                        phase.expectedConnectSeconds - phase.beaconExpectedConnectSeconds,
                     publishers: localBeaconPublishers,
                     publisherKind: 'audio',
                     attendees: localAttendees,
@@ -485,6 +520,39 @@ export function commandFingerprint(args) {
     return createHash('sha256').update(JSON.stringify(args)).digest('hex');
 }
 
+export function publicLoadPlan(plan, executable = 'lk') {
+    return {
+        ...plan,
+        phases: plan.phases.map((phase) => ({
+            ...phase,
+            stage: {
+                roomName: phase.stage.roomName,
+                requestedConnections: phase.stage.requestedConnections,
+                expectedGlobalConnections: phase.stage.expectedGlobalConnections,
+                localPublishers: phase.stage.localPublishers,
+                expectedGlobalPublishers: phase.stage.expectedGlobalPublishers,
+                expectedSubscriberTracks: phase.stage.expectedSubscriberTracks,
+                localExpectedConnectSeconds: phase.stage.localExpectedConnectSeconds,
+                commandDurationSeconds: phase.stage.commandDurationSeconds,
+                command: `${executable} ${phase.stage.args.join(' ')}`,
+                fingerprint: commandFingerprint(phase.stage.args),
+            },
+            beacon: {
+                roomName: phase.beacon.roomName,
+                requestedConnections: phase.beacon.requestedConnections,
+                expectedGlobalConnections: phase.beacon.expectedGlobalConnections,
+                localPublishers: phase.beacon.localPublishers,
+                expectedGlobalPublishers: phase.beacon.expectedGlobalPublishers,
+                expectedSubscriberTracks: phase.beacon.expectedSubscriberTracks,
+                localExpectedConnectSeconds: phase.beacon.localExpectedConnectSeconds,
+                commandDurationSeconds: phase.beacon.commandDurationSeconds,
+                command: `${executable} ${phase.beacon.args.join(' ')}`,
+                fingerprint: commandFingerprint(phase.beacon.args),
+            },
+        })),
+    };
+}
+
 export function generatorHostFingerprint({ hostName, machineId = '', bootId = '' }) {
     return commandFingerprint([hostName, machineId, bootId]).slice(0, 12);
 }
@@ -565,21 +633,61 @@ function shardPlanIsDeterministic(plan, index, shardCount) {
             shardCount,
             phase.name,
         );
+        const stageExpectedConnectSeconds = streamExpectedConnectSeconds(
+            localAttendees + localStagePublishers,
+            stageRamp,
+        );
+        const beaconExpectedConnectSeconds = streamExpectedConnectSeconds(
+            localAttendees + localBeaconPublishers,
+            beaconRamp,
+        );
+        const stageCommandDurationSeconds = phase.durationSeconds +
+            expectedConnectSeconds - stageExpectedConnectSeconds;
+        const beaconCommandDurationSeconds = phase.durationSeconds +
+            expectedConnectSeconds - beaconExpectedConnectSeconds;
         const valid =
             phase.scheduledOffsetSeconds === offset &&
             phase.expectedConnectSeconds === expectedConnectSeconds &&
+            phase.stageExpectedConnectSeconds === stageExpectedConnectSeconds &&
+            phase.beaconExpectedConnectSeconds === beaconExpectedConnectSeconds &&
             phase.stageRampPerSecond === stageRamp &&
             phase.beaconRampPerSecond === beaconRamp &&
+            phase.stage.roomName === plan.rooms.stage &&
             phase.stage.requestedConnections === localAttendees + localStagePublishers &&
             phase.stage.expectedGlobalConnections === profile.attendees + profile.stagePublishers &&
             phase.stage.localPublishers === localStagePublishers &&
             phase.stage.expectedGlobalPublishers === profile.stagePublishers &&
             phase.stage.expectedSubscriberTracks === localAttendees * profile.stagePublishers &&
+            phase.stage.localExpectedConnectSeconds === stageExpectedConnectSeconds &&
+            phase.stage.commandDurationSeconds === stageCommandDurationSeconds &&
+            phase.stage.fingerprint === commandFingerprint(commandFor({
+                room: plan.rooms.stage,
+                identityPrefix: `hbload-${sanitizeRunId(plan.runId)}-s${index}-stage`,
+                durationSeconds: stageCommandDurationSeconds,
+                publishers: localStagePublishers,
+                publisherKind: 'video',
+                attendees: localAttendees,
+                rampPerSecond: stageRamp,
+                videoCodec: profile.stageVideoCodec,
+                layout: profile.stageLayout,
+            })) &&
+            phase.beacon.roomName === plan.rooms.beacon &&
             phase.beacon.requestedConnections === localAttendees + localBeaconPublishers &&
             phase.beacon.expectedGlobalConnections === profile.attendees + profile.beaconPublishers &&
             phase.beacon.localPublishers === localBeaconPublishers &&
             phase.beacon.expectedGlobalPublishers === profile.beaconPublishers &&
-            phase.beacon.expectedSubscriberTracks === localAttendees * profile.beaconPublishers;
+            phase.beacon.expectedSubscriberTracks === localAttendees * profile.beaconPublishers &&
+            phase.beacon.localExpectedConnectSeconds === beaconExpectedConnectSeconds &&
+            phase.beacon.commandDurationSeconds === beaconCommandDurationSeconds &&
+            phase.beacon.fingerprint === commandFingerprint(commandFor({
+                room: plan.rooms.beacon,
+                identityPrefix: `hbload-${sanitizeRunId(plan.runId)}-s${index}-beacon`,
+                durationSeconds: beaconCommandDurationSeconds,
+                publishers: localBeaconPublishers,
+                publisherKind: 'audio',
+                attendees: localAttendees,
+                rampPerSecond: beaconRamp,
+            }));
         offset += expectedConnectSeconds + phase.durationSeconds;
         if (phaseIndex < plan.phases.length - 1) {
             offset += profile.phaseCompletionBufferSeconds + expectedGap;

--- a/scripts/livekit-load-harness.mjs
+++ b/scripts/livekit-load-harness.mjs
@@ -10,14 +10,15 @@ import { RoomServiceClient } from 'livekit-server-sdk';
 
 import {
     buildPlan,
-    commandFingerprint,
     createAbortCoordinator,
     createConsecutiveFailureGuard,
     generatorHostFingerprint,
     manifestContainsSecret,
     parseLoadTestOutput,
     probeProductionReadiness,
+    publicLoadPlan,
     remoteConfirmation,
+    scheduledCompletionDelayMs,
 } from './lib/livekit-load-harness.mjs';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -181,6 +182,10 @@ async function waitForScheduledPhase(startAt, offsetSeconds, abort) {
         observedAt: new Date().toISOString(),
         lateByMs,
     };
+}
+
+async function waitForScheduledCompletion(startAt, phase, abort) {
+    await waitBetweenPhases(scheduledCompletionDelayMs(startAt, phase) / 1000, abort);
 }
 
 function printHelp() {
@@ -383,34 +388,6 @@ async function waitForCleanup(roomService, roomNames, timeoutMs = 10_000) {
     return { passed: false, convergenceMs: Date.now() - startedAt, remaining };
 }
 
-function publicPlan(plan, lkBinary) {
-    const executable = basename(lkBinary);
-    return {
-        ...plan,
-        phases: plan.phases.map((phase) => ({
-            ...phase,
-            stage: {
-                requestedConnections: phase.stage.requestedConnections,
-                expectedGlobalConnections: phase.stage.expectedGlobalConnections,
-                localPublishers: phase.stage.localPublishers,
-                expectedGlobalPublishers: phase.stage.expectedGlobalPublishers,
-                expectedSubscriberTracks: phase.stage.expectedSubscriberTracks,
-                command: `${executable} ${phase.stage.args.join(' ')}`,
-                fingerprint: commandFingerprint(phase.stage.args),
-            },
-            beacon: {
-                requestedConnections: phase.beacon.requestedConnections,
-                expectedGlobalConnections: phase.beacon.expectedGlobalConnections,
-                localPublishers: phase.beacon.localPublishers,
-                expectedGlobalPublishers: phase.beacon.expectedGlobalPublishers,
-                expectedSubscriberTracks: phase.beacon.expectedSubscriberTracks,
-                command: `${executable} ${phase.beacon.args.join(' ')}`,
-                fingerprint: commandFingerprint(phase.beacon.args),
-            },
-        })),
-    };
-}
-
 async function main() {
     if (hasFlag('--help') || hasFlag('-h')) {
         printHelp();
@@ -464,7 +441,7 @@ async function main() {
         livekitCliVersion: lk.output.trim() || 'unknown',
         harnessDirty: gitStatus.output.trim().length > 0,
         generatorHostHash: await readGeneratorHostFingerprint(),
-        plan: publicPlan(plan, lkBinary),
+        plan: publicLoadPlan(plan, basename(lkBinary)),
         limitations: [
             'Protocol clients measure SFU capacity; they do not certify browser DOM, decode, physical speaker routing, or perceived audio quality.',
             'Load-test summary latency is media latency, not per-user application login latency.',
@@ -529,6 +506,7 @@ async function main() {
                 runLoad(lkBinary, phase.stage.args, credentials, abort),
                 runLoad(lkBinary, phase.beacon.args, credentials, abort),
             ]);
+            await waitForScheduledCompletion(plan.scheduledStartAt, phase, abort);
             stopped.value = true;
             const observed = await monitor;
             const cleanup = await waitForCleanup(roomService, plan.rooms);

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -25,8 +25,10 @@ import {
     parseLoadTestOutput,
     probeProductionReadiness,
     PRODUCTION_READINESS_URL,
+    publicLoadPlan,
     remoteConfirmation,
     roomNames,
+    scheduledCompletionDelayMs,
     validateProfile,
     validateShard,
     validateDistributedTargetUrl,
@@ -56,6 +58,7 @@ afterEach(() => {
 });
 
 function passingShardManifest(plan: ReturnType<typeof buildPlan>, hostIndex: number) {
+    const manifestPlan = publicLoadPlan(plan);
     return {
         schemaVersion: 1,
         kind: 'harmonic-beacon-livekit-load',
@@ -64,7 +67,7 @@ function passingShardManifest(plan: ReturnType<typeof buildPlan>, hostIndex: num
         livekitCliVersion: 'lk 2.16.3',
         harnessDirty: false,
         generatorHostHash: String(hostIndex).padStart(12, '0'),
-        plan,
+        plan: manifestPlan,
         phases: plan.phases.map((plannedPhase) => ({
             name: plannedPhase.name,
             passed: true,
@@ -242,6 +245,25 @@ describe('LiveKit load harness safety', () => {
             .toEqual(Array(6).fill([0, 400, 1940, 2340]));
         expect(plans.map((plan) => plan.phases[0].expectedConnectSeconds))
             .toEqual([25, 25, 25, 25, 25, 25]);
+        expect(plans.map((plan) => plan.phases[0].stage.localExpectedConnectSeconds))
+            .toEqual([13, 13, 13, 13, 25, 25]);
+        expect(plans.map((plan) => plan.phases[0].stage.commandDurationSeconds))
+            .toEqual([72, 72, 72, 72, 60, 60]);
+        expect(plans.map((plan) => plan.phases[0].beacon.localExpectedConnectSeconds))
+            .toEqual([13, 12, 12, 12, 24, 24]);
+        expect(plans.map((plan) => plan.phases[0].beacon.commandDurationSeconds))
+            .toEqual([72, 73, 73, 73, 61, 61]);
+        for (const plan of plans) {
+            const phase = plan.phases[0];
+            expect(phase.stage.localExpectedConnectSeconds + phase.stage.commandDurationSeconds)
+                .toBe(phase.expectedConnectSeconds + phase.durationSeconds);
+            expect(phase.beacon.localExpectedConnectSeconds + phase.beacon.commandDurationSeconds)
+                .toBe(phase.expectedConnectSeconds + phase.durationSeconds);
+            expect(phase.stage.args[phase.stage.args.indexOf('--duration') + 1])
+                .toBe(`${phase.stage.commandDurationSeconds}s`);
+            expect(phase.beacon.args[phase.beacon.args.indexOf('--duration') + 1])
+                .toBe(`${phase.beacon.commandDurationSeconds}s`);
+        }
 
         const aggregate = aggregateShardManifests(plans.map((plan, shardIndex) => ({
             sha256: String(shardIndex).padStart(64, 'b'),
@@ -253,6 +275,26 @@ describe('LiveKit load harness safety', () => {
             totals: { attendees: 150, stagePublishers: 6, beaconPublishers: 1 },
         });
         expect(aggregate.sources).toHaveLength(6);
+    });
+
+    it('holds cleanup until the shared planned completion barrier', () => {
+        const phase = {
+            scheduledOffsetSeconds: 400,
+            expectedConnectSeconds: 25,
+            durationSeconds: 1200,
+        };
+        const startAt = '2026-08-05T18:00:00.000Z';
+        expect(scheduledCompletionDelayMs(
+            startAt,
+            phase,
+            Date.parse('2026-08-05T18:26:40.000Z'),
+        )).toBe(25_000);
+        expect(scheduledCompletionDelayMs(
+            startAt,
+            phase,
+            Date.parse('2026-08-05T18:27:06.000Z'),
+        )).toBe(0);
+        expect(scheduledCompletionDelayMs(null, phase, 0)).toBe(0);
     });
 
     it('refuses unsafe distributed targets, timing and topology', () => {
@@ -523,6 +565,25 @@ describe('LiveKit load harness evidence', () => {
         entries[1].manifest.harnessDirty = false;
         entries[1].manifest.phases[0].observed.stage.peakConnections -= 1;
         expect(() => aggregateShardManifests(entries)).toThrow(/unproven phase/);
+    });
+
+    it('refuses a shard plan that can disconnect before the shared completion barrier', () => {
+        const startAt = '2026-08-06T12:00:00.000Z';
+        const entries = [0, 1].map((shardIndex) => ({
+            sha256: String(shardIndex).padStart(64, 'c'),
+            manifest: passingShardManifest(buildPlan({
+                profileName: 'rehearsal-es',
+                profile,
+                runId: 'aggregate-early-cleanup',
+                url: 'ws://localhost:7880',
+                shardIndex,
+                shardCount: 2,
+                startAt,
+            }), shardIndex),
+        }));
+
+        entries[0].manifest.plan.phases[0].stage.commandDurationSeconds -= 1;
+        expect(() => aggregateShardManifests(entries)).toThrow(/deterministic partition/);
     });
 
     it('writes a 0600 aggregate once and refuses to overwrite it', () => {


### PR DESCRIPTION
Refs #99 and #24.

## Diagnosis

The six-generator run `capacity-en-20260805d` exposed two independent facts:

- the global 156 Stage / 151 Beacon topology and all tracks/reconnect phases completed, but VP8 Stage packet loss remained well above the 0.1% gate;
- shards with the faster local partition exited before the two one-client-per-second shards, so they polled cleanup while 52 Stage / 50 Beacon participants were still legitimately running.

The previous plan gave every CLI process the same post-connect duration even though local ramp times differed.

## Change

- pad each Stage and Beacon CLI duration by the difference between its local ramp and the slowest distributed ramp;
- wait for the absolute shared completion boundary before checking cleanup;
- record the local ramp and compensated duration in the redacted plan;
- validate room, duration, and exact command fingerprint before accepting a shard aggregate;
- make fixtures use the real redacted manifest shape;
- preserve the complete six-generator evidence and the source-based packet-loss diagnosis.

No profile size, codec, threshold, production path, or audio behavior changes.

## Evidence

- focused load-harness tests: 29/29
- full unit/component suite: 822 passed, 9 opt-in integration tests skipped
- TypeScript: pass
- ESLint: pass
- production build: pass
- diff check: pass
- production remained ready; temporary target, ports, UFW rules, services/files, and all three environment secrets were removed after evidence capture

## Risk / rollback

Risk is limited to manual synthetic load orchestration. Revert commit `79205a7` to restore the previous scheduling. No production deployment is part of this PR.