### PR TITLE
test(load): add bounded VP8 server diagnostic

### DIFF
--- a/.github/workflows/livekit-capacity.yml
+++ b/.github/workflows/livekit-capacity.yml
@@ -13,6 +13,7 @@ on:
           - ci
           - rehearsal-es
           - rehearsal-en
+          - diagnostic-en-vp8
       run_id:
         description: Unique synthetic run identifier (no event-room name)
         required: true

--- a/config/livekit-load-profiles.json
+++ b/config/livekit-load-profiles.json
@@ -51,6 +51,23 @@
       "interWaveSeconds": 10,
       "phaseCompletionBufferSeconds": 300,
       "maxDroppedPercent": 0.1
+    },
+    "diagnostic-en-vp8": {
+      "eventLanguage": "en",
+      "attendees": 150,
+      "stagePublishers": 6,
+      "beaconPublishers": 1,
+      "stageVideoCodec": "vp8",
+      "stageLayout": "speaker",
+      "rampPerSecond": 10,
+      "rampDurationSeconds": 60,
+      "soakDurationSeconds": 60,
+      "reconnectDurationSeconds": 0,
+      "reconnectWaves": 0,
+      "reconnectMode": "staggered",
+      "interWaveSeconds": 10,
+      "phaseCompletionBufferSeconds": 60,
+      "maxDroppedPercent": 0.1
     }
   }
 }

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -188,6 +188,10 @@ separate gates.
 
 - `ci`: four attendees, two stage publishers, one Beacon publisher, short
   ramp/soak/reconnect.
+- `diagnostic-en-vp8`: the full 150-attendee, six-publisher VP8/speaker
+  topology with two 60-second phases and no reconnect wave. It exists only for
+  bounded server/generator comparisons; it cannot satisfy the 20-minute soak,
+  reconnect, repeated-run, browser or listening gates.
 - `rehearsal-es` and `rehearsal-en`: 150 dual-room attendees, six simulcast
   stage publishers, one Beacon audio publisher, 20-minute soak, and two
   staggered reconnect waves.

--- a/scripts/livekit-load-harness.mjs
+++ b/scripts/livekit-load-harness.mjs
@@ -190,7 +190,7 @@ async function waitForScheduledCompletion(startAt, phase, abort) {
 
 function printHelp() {
     process.stdout.write(`Usage: npm run load:livekit -- [options]\n\n` +
-        `  --profile NAME             ci, rehearsal-es, or rehearsal-en\n` +
+        `  --profile NAME             ci, rehearsal-es, rehearsal-en, or diagnostic-en-vp8\n` +
         `  --run-id ID                synthetic namespace recorded in the manifest\n` +
         `  --url URL                  LiveKit URL (default LIVEKIT_URL or localhost)\n` +
         `  --lk-bin PATH              pinned LiveKit CLI executable (default lk)\n` +

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -89,4 +89,36 @@ describe('distributed LiveKit capacity workflow contract', () => {
         );
         expect(workflow).toContain('sha256sum -c -');
     });
+
+    it('offers a bounded full-topology VP8 diagnostic without weakening rehearsal profiles', () => {
+        expect(workflow).toContain('- diagnostic-en-vp8');
+        expect(profiles['diagnostic-en-vp8']).toMatchObject({
+            attendees: 150,
+            stagePublishers: 6,
+            beaconPublishers: 1,
+            stageVideoCodec: 'vp8',
+            stageLayout: 'speaker',
+            rampDurationSeconds: 60,
+            soakDurationSeconds: 60,
+            reconnectWaves: 0,
+            maxDroppedPercent: 0.1,
+        });
+        expect(profiles['rehearsal-en']).toMatchObject({
+            soakDurationSeconds: 1200,
+            reconnectWaves: 2,
+            maxDroppedPercent: 0.1,
+        });
+
+        const plan = buildDistributedDispatchPlan({
+            profileName: 'diagnostic-en-vp8',
+            profile: profiles['diagnostic-en-vp8'],
+            runId: 'server-version-control',
+            targetUrl: 'ws://example.test:7890',
+            startDelaySeconds: 900,
+            shardCount: 6,
+            nowMs: Date.parse('2026-08-05T00:00:00.000Z'),
+        });
+        expect(plan.shardCount).toBe(6);
+        expect(plan.expectedEndAt).toBe('2026-08-05T00:19:05.000Z');
+    });
 });


### PR DESCRIPTION
Refs #99 and #24.

## Why

The full six-host v1.13.4 rehearsal disproved generator fan-in as the sole cause of packet loss. Same-host v1.13.5 controls were highly variable (0.274% then 11.261%), so another same-host repetition cannot separate SFU behavior from generator contention.

## Change

- add manual-only `diagnostic-en-vp8` with the real 150 dual-room attendees, six VP8 Stage publishers, one Beacon publisher and unchanged 0.1% loss gate;
- keep two bounded 60-second phases and no reconnect waves so version comparisons finish quickly;
- expose it only through the existing protected, secret-scoped capacity workflow;
- document explicitly that it cannot satisfy the 20-minute soak, reconnect, browser, listening or repeated-run acceptance gates;
- test exact topology, duration, workflow exposure and preservation of the full rehearsal profile.

No codec, threshold, production runtime or audio-path change.

## Evidence

- load workflow + harness tests: 34/34
- TypeScript: pass
- ESLint: pass
- actionlint 1.7.7: pass
- diff check: pass

## Risk / rollback

Only a manually selected synthetic profile is added. Revert `174713f` to remove it. It does not deploy or upgrade LiveKit; target setup, monitoring and cleanup remain separate operator actions.