### PR TITLE
ci: skip heavy E2E for docs-only PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,12 @@ name: E2E quality gates
 on:
   pull_request:
     branches: [main, release]
+    # Documentation-only PRs cannot affect the browser/runtime contract. Keep
+    # this filter scoped to pull_request: release deploys invoke workflow_call
+    # and must always run the complete gate.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   workflow_call:
 
 concurrency:


### PR DESCRIPTION
## Summary

- skip the expensive dual-LiveKit/browser E2E workflow when a pull request changes only `docs/**` or Markdown files
- keep code, tests, packages, config and workflow changes covered
- keep every `workflow_call` invocation unconditional, so release/deploy gates are unchanged

## Evidence

- `git diff --check`
- parsed the workflow with the repository-installed `js-yaml`
- asserted the ignore list is scoped to `pull_request` and `workflow_call` remains present and unfiltered
- this PR changes the workflow itself, so its normal remote quality gates still run

## Risk / rollback

Low-risk CI-only change; no application, UI, audio or deploy behavior changes. Roll back by reverting this single commit. The filter is intentionally conservative: any non-Markdown file still launches full E2E.

Refs #69.