### PR TITLE
ci: run heavy E2E when drafts are ready

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ name: E2E quality gates
 on:
   pull_request:
     branches: [main, release]
+    types: [opened, synchronize, reopened, ready_for_review]
     # Documentation-only PRs cannot affect the browser/runtime contract. Keep
     # this filter scoped to pull_request: release deploys invoke workflow_call
     # and must always run the complete gate.
@@ -31,6 +32,10 @@ concurrency:
 
 jobs:
   e2e:
+    # Drafts use focused checks while they are moving quickly. The
+    # ready_for_review event above runs this complete matrix before review;
+    # workflow_call (release/deploy) remains unconditional.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
## Summary

- skip the expensive E2E job while a pull request remains draft
- trigger the complete matrix automatically when the author marks it ready for review
- preserve every opened/reopened/synchronized non-draft PR and every release/deploy `workflow_call`

## Evidence

- `git diff --check`
- parsed the workflow with the repository-installed `js-yaml`
- asserted exact PR event types, draft guard, and an unfiltered `workflow_call`
- this PR is non-draft and changes the workflow, so it runs the complete remote matrix once

## Risk / rollback

CI-only. A draft can accumulate focused evidence without spending ~10 minutes per push, but cannot merge while draft. Moving it to Ready automatically launches the full gate. Revert this commit to restore E2E on every draft synchronization.

Refs #69.