### PR TITLE
test(load): reject unverified VP8 loss metrics

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,6 +63,11 @@ jobs:
           node-version: '22.22'
           cache: 'npm'
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.8'
+          cache: false
+
       - run: npm ci
 
       - run: npx playwright install --with-deps chromium
@@ -78,13 +83,9 @@ jobs:
           echo "LiveKit did not become ready" >&2
           exit 1
 
-      - name: Install pinned LiveKit load tester
+      - name: Build verified LiveKit load tester
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/lk.tar.gz" \
-            https://github.com/livekit/livekit-cli/releases/download/v2.16.3/lk_2.16.3_linux_amd64.tar.gz
-          echo "57935ce348a634a1e12769b9eaf7e684cf46920ad65e4b6d88f87a9cd01de2d6  $RUNNER_TEMP/lk.tar.gz" \
-            | sha256sum -c -
-          tar -xzf "$RUNNER_TEMP/lk.tar.gz" -C "$RUNNER_TEMP" lk
+          scripts/install-livekit-load-cli.sh "$RUNNER_TEMP/lk"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
       - name: Run small dual-LiveKit load profile

--- a/.github/workflows/livekit-capacity.yml
+++ b/.github/workflows/livekit-capacity.yml
@@ -63,6 +63,11 @@ jobs:
         with:
           node-version: '22.22'
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.8'
+          cache: false
+
       - name: Validate isolated target and derive the synchronized plan
         id: plan
         env:
@@ -82,6 +87,17 @@ jobs:
             --run-id "$LOAD_RUN_ID" \
             --start-delay-seconds "$LOAD_START_DELAY_SECONDS" \
             --shard-count "$LOAD_SHARD_COUNT"
+
+      - name: Build verified LiveKit load tester once
+        run: scripts/install-livekit-load-cli.sh "$RUNNER_TEMP/livekit-load-cli/lk"
+
+      - name: Share the verified load tester with every shard
+        uses: actions/upload-artifact@v4
+        with:
+          name: livekit-load-cli-${{ github.run_id }}
+          path: ${{ runner.temp }}/livekit-load-cli/lk
+          if-no-files-found: error
+          retention-days: 1
 
   generator:
     needs: prepare
@@ -106,14 +122,18 @@ jobs:
 
       - run: npm ci
 
-      - name: Install pinned LiveKit load tester
+      - name: Install the verified load tester built by prepare
+        uses: actions/download-artifact@v4
+        with:
+          name: livekit-load-cli-${{ github.run_id }}
+          path: ${{ runner.temp }}/livekit-load-cli
+
+      - name: Expose the verified load tester
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/lk.tar.gz" \
-            https://github.com/livekit/livekit-cli/releases/download/v2.16.3/lk_2.16.3_linux_amd64.tar.gz
-          echo "57935ce348a634a1e12769b9eaf7e684cf46920ad65e4b6d88f87a9cd01de2d6  $RUNNER_TEMP/lk.tar.gz" \
-            | sha256sum -c -
-          tar -xzf "$RUNNER_TEMP/lk.tar.gz" -C "$RUNNER_TEMP" lk
-          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+          chmod 0755 "$RUNNER_TEMP/livekit-load-cli/lk"
+          test "$("$RUNNER_TEMP/livekit-load-cli/lk" --version)" = \
+            'lk version 2.16.3-hb-vp8.1'
+          echo "$RUNNER_TEMP/livekit-load-cli" >> "$GITHUB_PATH"
 
       - name: Run shard ${{ matrix.shard_index }} of ${{ needs.prepare.outputs.shard_count }}
         env:

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -258,8 +258,22 @@ healthy.
 
 ## Tooling
 
-Install the official `lk` CLI (the CI workflow pins v2.16.3). LiveKit recommends
-running large tests from a well-provisioned host and raising file-descriptor and
+The CI workflow still pins the checksum-verified official `lk` v2.16.3 binary,
+but the harness now refuses to classify VP8 packet-loss evidence from it. The
+[pinned v2.16.3 source](https://github.com/livekit/livekit-cli/blob/e90c82ab4467cafd4fabe3affd348f474c312280/pkg/loadtester/loadtester.go#L377-L399)
+constructs an H264 depacketizer for every video track, including VP8; under an
+identical synthetic VP8 sequence gap this counted 18 dropped frames versus 8
+with the correct VP8 depacketizer and also requested a PLI for every count. The
+previous VP8 manifests therefore remain useful topology/cleanup evidence but
+their packet-loss magnitudes are not admissible capacity evidence. H264 controls
+remain runnable and cannot certify the production VP8 browser path.
+
+Do not bypass this fail-closed guard. Re-enable VP8 runs only after a pinned CLI
+source selects the depacketizer from the negotiated codec and a focused
+loss-control proves the reported drops match VP8 packet boundaries. Then add
+that exact CLI version to the verified allowlist with its test and provenance.
+
+LiveKit recommends running large tests from a well-provisioned host and raising file-descriptor and
 network limits; do that on the load-generator host before a 150-person run. See
 the official [LiveKit benchmarking guide](https://docs.livekit.io/transport/self-hosting/benchmark)
 and [LiveKit CLI repository](https://github.com/livekit/livekit-cli).

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -258,8 +258,11 @@ healthy.
 
 ## Tooling
 
-The CI workflow still pins the checksum-verified official `lk` v2.16.3 binary,
-but the harness now refuses to classify VP8 packet-loss evidence from it. The
+The CI and distributed workflows build their load tester once from exact
+official source commit `e90c82ab4467cafd4fabe3affd348f474c312280`, verify its
+Git LFS objects, apply the repository-owned codec-selection patch, and require
+the provenance version `2.16.3-hb-vp8.1`. The harness refuses to classify VP8
+packet-loss evidence from any other build. The unpatched
 [pinned v2.16.3 source](https://github.com/livekit/livekit-cli/blob/e90c82ab4467cafd4fabe3affd348f474c312280/pkg/loadtester/loadtester.go#L377-L399)
 constructs an H264 depacketizer for every video track, including VP8; under an
 identical synthetic VP8 sequence gap this counted 18 dropped frames versus 8

--- a/scripts/install-livekit-load-cli.sh
+++ b/scripts/install-livekit-load-cli.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SOURCE_REPOSITORY='https://github.com/livekit/livekit-cli.git'
+readonly SOURCE_COMMIT='e90c82ab4467cafd4fabe3affd348f474c312280'
+readonly EXPECTED_VERSION='lk version 2.16.3-hb-vp8.1'
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly PATCH_FILE="$SCRIPT_DIR/patches/livekit-cli-v2.16.3-vp8-depacketizer.patch"
+
+if [[ $# -ne 1 || -z "$1" ]]; then
+    echo 'usage: scripts/install-livekit-load-cli.sh OUTPUT_PATH' >&2
+    exit 2
+fi
+
+readonly OUTPUT_PATH="$(realpath -m -- "$1")"
+readonly BUILD_ROOT="$(mktemp -d)"
+readonly SOURCE_ROOT="$BUILD_ROOT/livekit-cli"
+
+cleanup() {
+    rm -rf -- "$BUILD_ROOT"
+}
+trap cleanup EXIT
+
+command -v git >/dev/null
+command -v go >/dev/null
+command -v git-lfs >/dev/null
+
+GIT_LFS_SKIP_SMUDGE=1 git clone --quiet --no-checkout --filter=blob:none \
+    "$SOURCE_REPOSITORY" "$SOURCE_ROOT"
+git -C "$SOURCE_ROOT" fetch --quiet --depth=1 origin "$SOURCE_COMMIT"
+git -C "$SOURCE_ROOT" checkout --quiet --detach FETCH_HEAD
+test "$(git -C "$SOURCE_ROOT" rev-parse HEAD)" = "$SOURCE_COMMIT"
+
+git -C "$SOURCE_ROOT" lfs pull --include='pkg/provider/resources/**'
+git -C "$SOURCE_ROOT" lfs fsck
+git -C "$SOURCE_ROOT" apply --check "$PATCH_FILE"
+git -C "$SOURCE_ROOT" apply "$PATCH_FILE"
+
+mkdir -p -- "$(dirname -- "$OUTPUT_PATH")"
+(
+    cd "$SOURCE_ROOT"
+    go build -trimpath -ldflags='-s -w' -o "$OUTPUT_PATH" ./cmd/lk
+)
+test "$($OUTPUT_PATH --version)" = "$EXPECTED_VERSION"
+sha256sum "$OUTPUT_PATH"

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -5,6 +5,35 @@ const ROOM_PATTERN = /^hb-load-[a-z0-9][a-z0-9-]{2,47}-(stage|beacon)$/;
 export const PRODUCTION_READINESS_URL =
     'https://live.harmonicbeacon.com/api/health/ready';
 
+// No released CLI version has yet been verified against the VP8 depacketizer
+// invariant. Add a version only after its source selects codecs.VP8Packet for
+// VP8 tracks and the focused loss-control test has passed.
+const VERIFIED_VP8_MEASUREMENT_CLI_VERSIONS = new Set();
+
+export function assertLiveKitCliMeasurementCompatibility({
+    stageVideoCodec,
+    livekitCliVersion,
+}) {
+    if (stageVideoCodec !== 'vp8') {
+        return { codec: stageVideoCodec, version: null, verified: true };
+    }
+
+    const match = String(livekitCliVersion ?? '').match(/\bversion\s+(\d+\.\d+\.\d+(?:[-+][\w.-]+)?)\b/i);
+    const version = match?.[1] ?? null;
+    if (!version) {
+        throw new Error(
+            'VP8 capacity evidence requires a parseable and explicitly verified LiveKit CLI version',
+        );
+    }
+    if (!VERIFIED_VP8_MEASUREMENT_CLI_VERSIONS.has(version)) {
+        throw new Error(
+            `LiveKit CLI ${version} is not verified for VP8 packet-loss evidence; ` +
+            'v2.16.3 depacketizes every video track as H264 and can overcount VP8 drops',
+        );
+    }
+    return { codec: stageVideoCodec, version, verified: true };
+}
+
 export async function probeProductionReadiness({
     fetchImpl = fetch,
     timeoutMs = 2_500,

--- a/scripts/lib/livekit-load-harness.mjs
+++ b/scripts/lib/livekit-load-harness.mjs
@@ -8,7 +8,9 @@ export const PRODUCTION_READINESS_URL =
 // No released CLI version has yet been verified against the VP8 depacketizer
 // invariant. Add a version only after its source selects codecs.VP8Packet for
 // VP8 tracks and the focused loss-control test has passed.
-const VERIFIED_VP8_MEASUREMENT_CLI_VERSIONS = new Set();
+const VERIFIED_VP8_MEASUREMENT_CLI_VERSIONS = new Set([
+    '2.16.3-hb-vp8.1',
+]);
 
 export function assertLiveKitCliMeasurementCompatibility({
     stageVideoCodec,

--- a/scripts/livekit-load-harness.mjs
+++ b/scripts/livekit-load-harness.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 import { RoomServiceClient } from 'livekit-server-sdk';
 
 import {
+    assertLiveKitCliMeasurementCompatibility,
     buildPlan,
     createAbortCoordinator,
     createConsecutiveFailureGuard,
@@ -455,6 +456,11 @@ async function main() {
     let abort = null;
 
     if (!dryRun) {
+        if (lk.exitCode !== 0) throw new Error(`LiveKit CLI unavailable: ${lk.output.trim()}`);
+        assertLiveKitCliMeasurementCompatibility({
+            stageVideoCodec: profile.stageVideoCodec,
+            livekitCliVersion: lk.output,
+        });
         const credentials = {
             url,
             apiKey: process.env.LIVEKIT_API_KEY ?? '',
@@ -463,7 +469,6 @@ async function main() {
         if (!credentials.apiKey || !credentials.apiSecret) {
             throw new Error('LIVEKIT_API_KEY and LIVEKIT_API_SECRET are required');
         }
-        if (lk.exitCode !== 0) throw new Error(`LiveKit CLI unavailable: ${lk.output.trim()}`);
         abort = createAbortCoordinator();
         const removeAbortHandlers = installAbortHandlers(abort);
         const stopProductionReadinessGuard = guardProductionReadiness

--- a/scripts/patches/livekit-cli-v2.16.3-vp8-depacketizer.patch
+++ b/scripts/patches/livekit-cli-v2.16.3-vp8-depacketizer.patch
@@ -1,0 +1,39 @@
+diff --git a/pkg/loadtester/loadtester.go b/pkg/loadtester/loadtester.go
+index f10177d..31f995f 100644
+--- a/pkg/loadtester/loadtester.go
++++ b/pkg/loadtester/loadtester.go
+@@ -17,5 +17,6 @@ package loadtester
+ import (
+ 	"fmt"
++	"strings"
+ 	"sync"
+ 	"time"
+ 
+@@ -386,7 +387,15 @@ func (t *LoadTester) consumeTrack(track *webrtc.TrackRemote, pub *lksdk.RemoteT
+ 	var dpkt rtp.Depacketizer
+ 	isVideo := false
+ 	if pub.Kind() == lksdk.TrackKindVideo {
+-		dpkt = &codecs.H264Packet{}
++		switch {
++		case strings.EqualFold(track.Codec().MimeType, webrtc.MimeTypeVP8):
++			dpkt = &codecs.VP8Packet{}
++		case strings.EqualFold(track.Codec().MimeType, webrtc.MimeTypeH264):
++			dpkt = &codecs.H264Packet{}
++		default:
++			fmt.Println("unsupported video codec in load tester", track.Codec().MimeType)
++			return
++		}
+ 		isVideo = true
+ 	} else {
+ 		dpkt = &codecs.OpusPacket{}
+diff --git a/version.go b/version.go
+index bb27038..0671ee0 100644
+--- a/version.go
++++ b/version.go
+@@ -15,5 +15,5 @@
+ package livekitcli
+ 
+ const (
+-	Version = "2.16.3"
++	Version = "2.16.3-hb-vp8.1"
+ )

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
     aggregateShardManifests,
+    assertLiveKitCliMeasurementCompatibility,
     assertSafeTarget,
     buildDistributedDispatchPlan,
     buildPlan,
@@ -136,6 +137,24 @@ function passingShardManifest(plan: ReturnType<typeof buildPlan>, hostIndex: num
 }
 
 describe('LiveKit load harness safety', () => {
+    it('fails closed when VP8 packet-loss metrics come from an unverified CLI', () => {
+        expect(() => assertLiveKitCliMeasurementCompatibility({
+            stageVideoCodec: 'vp8',
+            livekitCliVersion: 'lk version 2.16.3',
+        })).toThrow(/not verified for VP8 packet-loss evidence/);
+        expect(() => assertLiveKitCliMeasurementCompatibility({
+            stageVideoCodec: 'vp8',
+            livekitCliVersion: 'unexpected output',
+        })).toThrow(/parseable and explicitly verified/);
+    });
+
+    it('does not apply the VP8 measurement guard to an H264 control', () => {
+        expect(assertLiveKitCliMeasurementCompatibility({
+            stageVideoCodec: 'h264',
+            livekitCliVersion: 'lk version 2.16.3',
+        })).toEqual({ codec: 'h264', version: null, verified: true });
+    });
+
     it('probes only the fixed public production readiness boundary', async () => {
         const calls: Array<{ url: string; init: RequestInit }> = [];
         const fetchImpl = async (url: string | URL | Request, init?: RequestInit) => {

--- a/src/lib/__tests__/livekit-load-harness.test.ts
+++ b/src/lib/__tests__/livekit-load-harness.test.ts
@@ -155,6 +155,13 @@ describe('LiveKit load harness safety', () => {
         })).toEqual({ codec: 'h264', version: null, verified: true });
     });
 
+    it('admits only the provenance-marked VP8 load tester', () => {
+        expect(assertLiveKitCliMeasurementCompatibility({
+            stageVideoCodec: 'vp8',
+            livekitCliVersion: 'lk version 2.16.3-hb-vp8.1',
+        })).toEqual({ codec: 'vp8', version: '2.16.3-hb-vp8.1', verified: true });
+    });
+
     it('probes only the fixed public production readiness boundary', async () => {
         const calls: Array<{ url: string; init: RequestInit }> = [];
         const fetchImpl = async (url: string | URL | Request, init?: RequestInit) => {

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -11,6 +11,18 @@ const workflow = readFileSync(
     resolve(process.cwd(), '.github/workflows/livekit-capacity.yml'),
     'utf8',
 );
+const e2eWorkflow = readFileSync(
+    resolve(process.cwd(), '.github/workflows/e2e.yml'),
+    'utf8',
+);
+const installer = readFileSync(
+    resolve(process.cwd(), 'scripts/install-livekit-load-cli.sh'),
+    'utf8',
+);
+const livekitPatch = readFileSync(
+    resolve(process.cwd(), 'scripts/patches/livekit-cli-v2.16.3-vp8-depacketizer.patch'),
+    'utf8',
+);
 const profiles = JSON.parse(readFileSync(
     resolve(process.cwd(), 'config/livekit-load-profiles.json'),
     'utf8',
@@ -85,17 +97,22 @@ describe('distributed LiveKit capacity workflow contract', () => {
         }
     });
 
-    it('pins and verifies the official LiveKit CLI artifact whose VP8 metrics fail closed', () => {
-        const pinnedVersion = workflow.match(/releases\/download\/v([^/]+)\//)?.[1];
-        expect(pinnedVersion).toBe('2.16.3');
-        expect(workflow).toContain(
-            '57935ce348a634a1e12769b9eaf7e684cf46920ad65e4b6d88f87a9cd01de2d6',
-        );
-        expect(workflow).toContain('sha256sum -c -');
-        expect(() => assertLiveKitCliMeasurementCompatibility({
+    it('builds one provenance-marked VP8 tester and shares it with every shard', () => {
+        expect(installer).toContain('e90c82ab4467cafd4fabe3affd348f474c312280');
+        expect(installer).toContain('git -C "$SOURCE_ROOT" lfs fsck');
+        expect(installer).toContain('git -C "$SOURCE_ROOT" apply --check "$PATCH_FILE"');
+        expect(livekitPatch).toContain('dpkt = &codecs.VP8Packet{}');
+        expect(livekitPatch).toContain('Version = "2.16.3-hb-vp8.1"');
+        expect(workflow.match(/install-livekit-load-cli\.sh/g)).toHaveLength(1);
+        expect(workflow).toContain('actions/upload-artifact@v4');
+        expect(workflow).toContain('actions/download-artifact@v4');
+        expect(workflow).toContain('livekit-load-cli-${{ github.run_id }}');
+        expect(e2eWorkflow).toContain('install-livekit-load-cli.sh "$RUNNER_TEMP/lk"');
+        expect(workflow).not.toContain('releases/download/v2.16.3/');
+        expect(assertLiveKitCliMeasurementCompatibility({
             stageVideoCodec: 'vp8',
-            livekitCliVersion: `lk version ${pinnedVersion}`,
-        })).toThrow(/not verified for VP8 packet-loss evidence/);
+            livekitCliVersion: 'lk version 2.16.3-hb-vp8.1',
+        })).toMatchObject({ verified: true });
     });
 
     it('offers a bounded full-topology VP8 diagnostic without weakening rehearsal profiles', () => {

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { buildDistributedDispatchPlan } from '../../../scripts/lib/livekit-load-harness.mjs';
+import {
+    assertLiveKitCliMeasurementCompatibility,
+    buildDistributedDispatchPlan,
+} from '../../../scripts/lib/livekit-load-harness.mjs';
 
 const workflow = readFileSync(
     resolve(process.cwd(), '.github/workflows/livekit-capacity.yml'),
@@ -82,12 +85,17 @@ describe('distributed LiveKit capacity workflow contract', () => {
         }
     });
 
-    it('pins and verifies the official LiveKit CLI artifact', () => {
-        expect(workflow).toContain('releases/download/v2.16.3/');
+    it('pins and verifies the official LiveKit CLI artifact whose VP8 metrics fail closed', () => {
+        const pinnedVersion = workflow.match(/releases\/download\/v([^/]+)\//)?.[1];
+        expect(pinnedVersion).toBe('2.16.3');
         expect(workflow).toContain(
             '57935ce348a634a1e12769b9eaf7e684cf46920ad65e4b6d88f87a9cd01de2d6',
         );
         expect(workflow).toContain('sha256sum -c -');
+        expect(() => assertLiveKitCliMeasurementCompatibility({
+            stageVideoCodec: 'vp8',
+            livekitCliVersion: `lk version ${pinnedVersion}`,
+        })).toThrow(/not verified for VP8 packet-loss evidence/);
     });
 
     it('offers a bounded full-topology VP8 diagnostic without weakening rehearsal profiles', () => {


### PR DESCRIPTION
## Outcome

Makes VP8 capacity evidence trustworthy again instead of accepting inflated packet-loss figures from the stock load tester.

## Root cause and control

The pinned official `lk` v2.16.3 source constructs `codecs.H264Packet` for every video track, even when the negotiated/profile codec is VP8. A focused control using the same pinned LiveKit samplebuilder and one identical synthetic VP8 sequence gap per 101 RTP packets reported:

- correct `VP8Packet`: 8 dropped frames;
- mismatched `H264Packet`: 18 dropped frames;
- zero injected loss: 0 drops for both paths (with one trailing H264 packet buffered).

The load tester requests a PLI on every counted video drop, so the mismatch can both overstate loss and amplify feedback. Previous runs remain valid for topology, counts, cleanup and host-health observations, but their VP8 packet-loss magnitudes cannot certify capacity.

## Change

- fail closed before credentials, synchronization or load whenever a VP8 profile uses a CLI build that has not been explicitly verified;
- build from exact upstream source commit `e90c82ab4467cafd4fabe3affd348f474c312280`, verify Git LFS media, apply a two-file repository-owned patch and mark the artifact `2.16.3-hb-vp8.1`;
- select `VP8Packet` or `H264Packet` from the negotiated MIME type; unknown video codecs fail closed;
- build once in the distributed prepare job and share the same artifact with every shard;
- keep codec, simulcast, layout and the 0.1% rehearsal threshold unchanged;
- document the source, provenance, evidence correction and rollback.

## Verification

- clean Docker build from the pinned source: PASS, LFS fsck PASS, artifact SHA-256 `aa7c33ee6c0d86c4e6fff2f7b492698198f28029af5d28dce35419b145e0d77c`;
- real local dual-room VP8 profile on LiveKit v1.13.4: PASS across ramp, soak and reconnect; Stage/Beacon loss 0%, all expected tracks present, cleanup exact zero in 2–3 ms;
- focused Vitest: 37/37 passing;
- ESLint on all changed JS/TS files and `bash -n`: passing;
- unpatched official `lk v2.16.3` invocation: exits before load with the expected compatibility error;
- `git diff --check`: passing.

## Risk / rollback

Tooling only: no app runtime, production, database, credentials, product audio path or deployment changes. Building the tester adds setup time to E2E; the distributed workflow builds it once rather than six times. Revert both commits to restore the official binary, but its VP8 loss metric would again be inadmissible.

Advances #99 and corrects evidence consumed by #24; it does not by itself satisfy the 150-user or physical-device gates.
