### PR TITLE
fix(auth): prevent caching LiveKit token responses

### DIFF
--- a/src/app/api/livekit/token/__tests__/route.test.ts
+++ b/src/app/api/livekit/token/__tests__/route.test.ts
@@ -25,12 +25,12 @@ describe('GET /api/livekit/token', () => {
 
     it('requires an event scope before resolving authorization', async () => {
         const { GET } = await import('../route');
-        const { status, body } = await parseResponse(
-            await GET(createRequest('/api/livekit/token')),
-        );
+        const response = await GET(createRequest('/api/livekit/token'));
+        const { status, body } = await parseResponse(response);
 
         expect(status).toBe(400);
         expect(body).toEqual({ error: 'sessionId is required' });
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
         expect(resolveRoomPrincipal).not.toHaveBeenCalled();
     });
 
@@ -49,6 +49,7 @@ describe('GET /api/livekit/token', () => {
         );
 
         expect((await parseResponse(response)).status).toBe(status);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
         expect(createBedToken).not.toHaveBeenCalled();
     });
 
@@ -59,13 +60,15 @@ describe('GET /api/livekit/token', () => {
         });
 
         const { GET } = await import('../route');
-        const { status, body } = await parseResponse(await GET(
+        const response = await GET(
             createRequest('/api/livekit/token', {
                 searchParams: { sessionId: 'event-1' },
             }),
-        ));
+        );
+        const { status, body } = await parseResponse(response);
 
         expect(status).toBe(200);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
         expect(resolveRoomPrincipal).toHaveBeenCalledWith(
             expect.anything(),
             'event-1',

--- a/src/app/api/livekit/token/route.ts
+++ b/src/app/api/livekit/token/route.ts
@@ -14,6 +14,11 @@ import { SESSION_COOKIE_NAME } from '@/lib/session-auth';
 export const dynamic = 'force-dynamic';
 
 const BED_ROOM_NAME = process.env.LIVEKIT_ROOM_NAME || 'beacon';
+const PRIVATE_NO_STORE = { 'Cache-Control': 'private, no-store' };
+
+function tokenResponse(body: unknown, status = 200) {
+    return NextResponse.json(body, { status, headers: PRIVATE_NO_STORE });
+}
 
 /**
  * Issue an audio-only, subscribe-only connection to the configured Beacon bed.
@@ -23,18 +28,12 @@ const BED_ROOM_NAME = process.env.LIVEKIT_ROOM_NAME || 'beacon';
 export async function GET(request: NextRequest) {
     const sessionId = request.nextUrl.searchParams.get('sessionId')?.trim();
     if (!sessionId) {
-        return NextResponse.json(
-            { error: 'sessionId is required' },
-            { status: 400 },
-        );
+        return tokenResponse({ error: 'sessionId is required' }, 400);
     }
 
     const entitlement = await resolveRoomPrincipal(request, sessionId);
     if (!entitlement.ok) {
-        return NextResponse.json(
-            { error: entitlement.error },
-            { status: entitlement.status },
-        );
+        return tokenResponse({ error: entitlement.error }, entitlement.status);
     }
 
     try {
@@ -51,19 +50,16 @@ export async function GET(request: NextRequest) {
             const cookieValue = request.cookies.get(SESSION_COOKIE_NAME)?.value;
             const tokenExpiresAt = new Date(Date.now() + TICKET_LIVEKIT_TOKEN_TTL_SECONDS * 1000);
             if (!cookieValue || !await finalizeTicketTokenIssue(cookieValue, ticketId, tokenExpiresAt)) {
-                return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+                return tokenResponse({ error: 'Not authorized' }, 403);
             }
         }
-        return NextResponse.json({
+        return tokenResponse({
             token,
             identity,
             room: BED_ROOM_NAME,
             canPublish: false,
         });
     } catch {
-        return NextResponse.json(
-            { error: 'LiveKit API credentials not configured' },
-            { status: 500 },
-        );
+        return tokenResponse({ error: 'LiveKit API credentials not configured' }, 500);
     }
 }

--- a/src/app/api/scheduled-sessions/[id]/token/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/token/__tests__/route.test.ts
@@ -54,6 +54,7 @@ describe('GET /api/scheduled-sessions/[id]/token', () => {
         );
 
         expect((await parseResponse(response)).status).toBe(status);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
         expect(createSessionToken).not.toHaveBeenCalled();
     });
 
@@ -61,12 +62,14 @@ describe('GET /api/scheduled-sessions/[id]/token', () => {
         resolveRoomPrincipal.mockResolvedValue({ ok: true, principal });
 
         const { GET } = await import('../route');
-        const { status, body } = await parseResponse(await GET(
+        const response = await GET(
             createRequest('/api/scheduled-sessions/event-1/token'),
             mockParams({ id: 'event-1' }),
-        ));
+        );
+        const { status, body } = await parseResponse(response);
 
         expect(status).toBe(200);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
         expect(createSessionToken).toHaveBeenCalledWith(
             'weekend-stage',
             'event-stable-opaque',

--- a/src/app/api/scheduled-sessions/[id]/token/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/token/route.ts
@@ -10,6 +10,12 @@ import { SESSION_COOKIE_NAME } from '@/lib/session-auth';
 
 export const dynamic = 'force-dynamic';
 
+const PRIVATE_NO_STORE = { 'Cache-Control': 'private, no-store' };
+
+function tokenResponse(body: unknown, status = 200) {
+    return NextResponse.json(body, { status, headers: PRIVATE_NO_STORE });
+}
+
 /**
  * Issue the event stage token from the current weekend WebSession entitlement.
  * The stable identity deliberately makes a new connection replace an older
@@ -22,10 +28,7 @@ export async function GET(
     const { id } = await params;
     const entitlement = await resolveRoomPrincipal(request, id);
     if (!entitlement.ok) {
-        return NextResponse.json(
-            { error: entitlement.error },
-            { status: entitlement.status },
-        );
+        return tokenResponse({ error: entitlement.error }, entitlement.status);
     }
 
     const { principal } = entitlement;
@@ -60,11 +63,11 @@ export async function GET(
                 principal.ticketEntitlementId,
                 tokenExpiresAt,
             )) {
-                return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+                return tokenResponse({ error: 'Not authorized' }, 403);
             }
         }
 
-        return NextResponse.json({
+        return tokenResponse({
             token,
             identity: principal.identity,
             room: principal.session.roomName,
@@ -83,9 +86,6 @@ export async function GET(
             },
         });
     } catch {
-        return NextResponse.json(
-            { error: 'LiveKit API credentials not configured' },
-            { status: 500 },
-        );
+        return tokenResponse({ error: 'LiveKit API credentials not configured' }, 500);
     }
 }


### PR DESCRIPTION
## Outcome

Every Stage and Beacon LiveKit token response now carries `Cache-Control: private, no-store`, including validation, authentication, entitlement, finalization and credential errors.

`dynamic = force-dynamic` prevents Next.js server caching but did not emit a client/intermediary cache directive: public probes returned 400/401 without `Cache-Control`. Successful responses contain bearer credentials, so the route contract should be explicit at every exit.

## Scope

- one local response helper in each of the two token routes;
- no authorization, identity, TTL, room, grant, metadata, token creation or audio behavior changes;
- focused assertions cover 400, 401/403 and successful responses for both rooms.

## Verification

- focused Vitest: 14/14 passing;
- ESLint on all four changed files: passing;
- `git diff --check`: passing;
- draft checks passed (unit, lint/build, frozen-audio; heavy E2E skipped as designed);
- rebased onto current `main@a0e4c2e`, head `01c36e5`, and marked ready to run the one full pre-merge checkpoint.

## Risk / rollback

Very low: clients must not rely on caching short-lived bearer credentials. Revert this commit to restore the prior headers. No deployment is included.

Advances the API-cache acceptance slice of #27; DNS/staff/fallback/external operations remain separate.
