### PR TITLE
release: add isolated private LOGOS session

### DIFF
--- a/prisma/migrations/20260806233000_add_logos_private_session/migration.sql
+++ b/prisma/migrations/20260806233000_add_logos_private_session/migration.sql
@@ -1,0 +1,61 @@
+-- LOGOS is a private, free Ticket Tailor event whose attendees still require
+-- a normal Beacon entitlement. Create a fresh production session; do not
+-- reuse the historical internal Testing row or any public-event access.
+INSERT INTO "scheduled_sessions" (
+    "id",
+    "title",
+    "description",
+    "room_name",
+    "language",
+    "scheduled_at",
+    "status",
+    "is_test",
+    "paid_mode",
+    "attendee_cap",
+    "max_publishers",
+    "facilitator_id",
+    "updated_at"
+)
+SELECT
+    '40000000-0000-4000-8000-202608070001'::uuid,
+    'Harmonic Myth Projection — LOGOS — 7 de agosto',
+    'Sesión virtual privada en español · 16:00 Costa Rica',
+    'hmp-logos-2026-08-07-es',
+    'SPANISH'::"SessionLanguage",
+    '2026-08-07 22:00:00'::timestamp,
+    'SCHEDULED'::"ScheduledSessionStatus",
+    false,
+    true,
+    150,
+    6,
+    "facilitator_id",
+    CURRENT_TIMESTAMP
+FROM "scheduled_sessions"
+WHERE "id" = '20000000-0000-4000-8000-202608080001'::uuid;
+
+DO $$
+DECLARE
+    source_count integer;
+    target_count integer;
+BEGIN
+    SELECT count(*) INTO source_count
+    FROM "scheduled_sessions"
+    WHERE "id" = '20000000-0000-4000-8000-202608080001'::uuid;
+
+    SELECT count(*) INTO target_count
+    FROM "scheduled_sessions"
+    WHERE
+        "id" = '40000000-0000-4000-8000-202608070001'::uuid
+        AND "status" = 'SCHEDULED'::"ScheduledSessionStatus"
+        AND "scheduled_at" = '2026-08-07 22:00:00'::timestamp
+        AND "is_test" = false
+        AND "paid_mode" = true
+        AND "attendee_cap" = 150;
+
+    IF source_count NOT IN (0, 1) THEN
+        RAISE EXCEPTION 'LOGOS facilitator source is ambiguous';
+    END IF;
+    IF target_count <> source_count THEN
+        RAISE EXCEPTION 'LOGOS private session could not be created';
+    END IF;
+END $$;

--- a/src/lib/__tests__/seed-contract.test.ts
+++ b/src/lib/__tests__/seed-contract.test.ts
@@ -197,4 +197,25 @@ describe('weekend seed contract', () => {
         expect(migration).toContain('old_count NOT IN (0, 1)');
         expect(migration).toContain('new_count <> old_count');
     });
+
+    it('creates LOGOS as a fresh entitlement-gated production session', () => {
+        const migration = readFileSync(
+            new URL(
+                '../../../prisma/migrations/20260806233000_add_logos_private_session/migration.sql',
+                import.meta.url,
+            ),
+            'utf8',
+        );
+
+        expect(migration).toContain('40000000-0000-4000-8000-202608070001');
+        expect(migration).toContain('20000000-0000-4000-8000-202608080001');
+        expect(migration).toContain("'2026-08-07 22:00:00'::timestamp");
+        expect(migration).toContain("'SPANISH'::\"SessionLanguage\"");
+        expect(migration).toContain("'SCHEDULED'::\"ScheduledSessionStatus\"");
+        expect(migration).toContain('"is_test" = false');
+        expect(migration).toContain('"paid_mode" = true');
+        expect(migration).toContain('source_count NOT IN (0, 1)');
+        expect(migration).toContain('target_count <> source_count');
+        expect(migration).not.toMatch(/UPDATE\s+"scheduled_sessions"/i);
+    });
 });


### PR DESCRIPTION
## Alcance exacto\nEste release parte de la revisión hoy desplegada y agrega únicamente:\n- la migración aditiva de la sesión privada LOGOS\n- su prueba de contrato\n\nNo incorpora los 21 commits adicionales de main.\n\n## Verificación local\n- seed contract: 16/16\n- eslint y diff-check pasan\n\nAl fusionar, el workflow de release ejecutará E2E, backup, build, migración, reemplazo, readiness, revisión pública, límites privados y rollback automático ante fallo.