### PR TITLE
fix(listener): preserve iPhone intro-to-Beacon handoff

### DIFF
--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -858,19 +858,17 @@ export default function ListenerPlayer({
     async function playWithIntro(language: DropLanguage) {
         const selected = dropAudio[language].current;
         if (!selected || !dropIns[language]) return;
-        // The intro already contains the Beacon. Stop the live source before
-        // the first intro frame so the two sources can never overlap.
-        wantsLivePlayback.current = false;
-        cancelRecovery(true);
+        // The intro already contains the Beacon, so the shared stream must stay
+        // inaudible underneath it. Starting both prepared elements inside this
+        // gesture preserves iOS authorization for the later automatic handoff.
+        // Pausing the live element here would make Safari require another tap.
         cancelLiveFade();
         pendingLiveFade.current = false;
-        liveSuppressedForDrop.current = false;
-        liveAudio.current?.pause();
         if (liveAudio.current) {
-            liveAudio.current.muted = false;
-            liveAudio.current.volume = volumeRef.current;
+            liveAudio.current.muted = true;
+            liveSuppressedForDrop.current = true;
+            if (volumeSupported) liveAudio.current.volume = 0;
         }
-        updateLiveState('paused');
         const other: DropLanguage = language === 'es' ? 'en' : 'es';
         dropAudio[other].current?.pause();
         cancelDropFade();
@@ -881,8 +879,41 @@ export default function ListenerPlayer({
         activeDrop.current = language;
         const isCurrent = () => dropGeneration.current === generation && activeDrop.current === language;
         try {
-            await selected.play();
+            let liveStarted: Promise<void> | null = null;
+            if (!wantsLivePlayback.current && livePreparedRef.current && liveAudio.current) {
+                wantsLivePlayback.current = true;
+                cancelRecovery(true);
+                updateLiveState('loading');
+                seekNativeAudioToLiveEdge(liveAudio.current);
+                // Promote the already prepared same-device lease without
+                // delaying either media play() call beyond this user gesture.
+                void requestLease('play').then((grant) => {
+                    leaseId.current = grant.leaseId;
+                    manifestExpiresAt.current = Date.parse(grant.stream.expiresAt);
+                }).catch(() => {
+                    // The prepared source remains authorized. Heartbeat/recovery
+                    // will retry without interrupting the introduction.
+                });
+                liveStarted = liveAudio.current.play();
+            }
+            const introStarted = selected.play();
+            if (!wantsLivePlayback.current) {
+                wantsLivePlayback.current = true;
+                cancelRecovery(true);
+                updateLiveState('loading');
+                void attemptLivePlayback().then((played) => {
+                    if (!wantsLivePlayback.current) return;
+                    if (played) updateLiveState('playing');
+                    else scheduleAutomaticRecovery(STALL_RECOVERY_DELAY_MS);
+                });
+            }
+            await introStarted;
             if (!isCurrent()) return;
+            if (liveStarted) {
+                void liveStarted.then(() => updateLiveState('playing')).catch(() => {
+                    scheduleAutomaticRecovery(STALL_RECOVERY_DELAY_MS);
+                });
+            }
             setHasStarted(true);
             setTransportStopped(false);
             setTransportPaused(false);
@@ -892,6 +923,13 @@ export default function ListenerPlayer({
             activeDrop.current = null;
             setTransportStopped(true);
             setPlayingDrop(null);
+            wantsLivePlayback.current = false;
+            liveAudio.current?.pause();
+            if (liveAudio.current) {
+                liveAudio.current.muted = false;
+                liveAudio.current.volume = volumeRef.current;
+            }
+            liveSuppressedForDrop.current = false;
         }
     }
 
@@ -917,6 +955,14 @@ export default function ListenerPlayer({
             [language]: { current: 0, duration: current[language].duration },
         }));
         audio!.currentTime = 0;
+        if (liveAudio.current && !liveAudio.current.paused) {
+            cancelRecovery(true);
+            setTransportPaused(false);
+            updateLiveState('playing');
+            pendingLiveFade.current = true;
+            beginLiveFade();
+            return;
+        }
         void playLive(false, dropGeneration.current);
     }
 

--- a/src/components/early-birds/__tests__/ListenerTransport.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerTransport.test.tsx
@@ -221,16 +221,26 @@ describe('Listener one-action playlist transport', () => {
         const live = screen.getByLabelText('Beacon') as HTMLAudioElement;
         const intro = screen.getByLabelText('Warm-up · English') as HTMLAudioElement;
         await waitForListen();
+        play.mockClear();
         fireEvent.click(screen.getByRole('button', { name: 'Listen' }));
         await waitFor(() => expectPhase('intro'));
+        // Safari authorizes each media element independently. The live element
+        // must begin muted in the original gesture; starting it only from the
+        // later ended event is rejected on physical iPhones.
+        expect(play.mock.instances).toContain(live);
+        expect(play.mock.instances).toContain(intro);
+        expect(live.muted).toBe(true);
+        Object.defineProperty(live, 'paused', { value: false, configurable: true });
+        fireEvent.playing(live);
+        expect(live.muted).toBe(true);
+        play.mockClear();
 
         Object.defineProperty(intro, 'ended', { value: true, configurable: true });
         fireEvent.ended(intro);
-        await waitFor(() => expect(play.mock.instances).toContain(live));
-        Object.defineProperty(live, 'paused', { value: false, configurable: true });
-        fireEvent.playing(live);
+        expect(play.mock.instances).not.toContain(live);
         frames.shift()?.(3_000);
         expect(live.volume).toBeCloseTo(1);
+        expect(live.muted).toBe(false);
         expectPhase('beacon');
     });
 


### PR DESCRIPTION
## Finding

Physical iPhone Safari played the introduction but natural completion did not start audible Beacon playback. **Skip to Beacon** and **Beacon only** worked, isolating the defect to the automatic handoff.

The refactor had begun the live element only from the intro `ended` event. Safari authorizes media elements independently and rejects that second element when its first `play()` occurs outside the original gesture.

## Change

- Start the already-prepared Beacon element muted inside the same click that starts the introduction.
- Keep it inaudible underneath the intro, which already contains Beacon.
- At natural completion, reveal the already-playing current live edge with the approved fade; do not issue a new `play()`.
- Preserve explicit Skip, Beacon-only, Stop, leases and bounded recovery.
- Add a regression that proves both elements start in the original gesture, live remains muted during intro and no second live `play()` occurs on `ended`.

## Guardrail

No asset, codec, bitrate, sample rate, channels, gain constants, fade duration, HLS buffer, routing or event audio changed.

## Evidence

- ListenerPlayer + ListenerTransport: 24 tests passed.
- Focused ESLint passed.
- TypeScript passed.
- Diff check passed.

## Human acceptance

Deploy only to isolated Listener, then repeat on physical iPhone Safari:
1. With introduction → natural completion → audible Beacon.
2. Stop, Beacon-only, Skip.
3. Lock/unlock and one network transition.
4. Observe whether transient Reconnecting remains; that symptom is recorded separately in #219 and should not be guessed from automation.

Rollback is the current Listener image `575b75a`.

Closes the handoff portion of #219; physical reconnect evidence remains.