### PR TITLE
docs(listener): record iPhone acceptance

### DIFF
--- a/docs/operations/EARLY_BIRDS_FREE_ACCEPTANCE.md
+++ b/docs/operations/EARLY_BIRDS_FREE_ACCEPTANCE.md
@@ -130,7 +130,7 @@ instant revocation.
 | _pending_ | Desktop | Chromium | ES/EN | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | |
 | _pending_ | Desktop | Firefox | ES/EN | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | |
 | _pending_ | Android physical | Chrome | ES/EN | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | |
-| _pending_ | iPhone physical | Safari | ES/EN | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | |
+| 2026-08-07 | iPhone physical | Safari | ES/EN | Previously proven | Tested flow passed | PASS | PASS | Not separately recorded | PASS | PASS | Nico confirmed the deployed iPhone Listener flow worked correctly; #219 closed. |
 
 Run one 60-minute physical listen covering intro, handoff, Stop/restart,
 background/foreground and a network transition. Report audible glitches as a
@@ -152,6 +152,6 @@ pasted into GitHub. A normal Apple Account on an iPhone is sufficient for the
 physical login test only after this developer configuration exists.
 
 If the isolated Listener degrades, restore root-only
-`/etc/harmonic-beacon/earlybirds-preview.env.pre-575b75a`, select Listener image
-`d7ed952`, retain both preview databases and origin media, and run the preview
-health smoke. Do not touch the event runtime.
+`/etc/harmonic-beacon/earlybirds-preview.env.pre-dad29d4`, select Listener image
+`55bf282`, retain the preview database, additive welcome-access table and origin
+media, and run the preview health smoke. Do not touch the event runtime.

--- a/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
+++ b/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
@@ -17,7 +17,7 @@ an event-stack deployment or an acoustic change.
 | Artifact | Exact value |
 |---|---|
 | Deployed Listener application | `dad29d4dc5010603a5bbc7ed309c8f78e7c0f384` |
-| Branch/documentation head | `dad29d4` |
+| Branch/documentation head | `4cd9968` (documentation may advance independently) |
 | Listener database schema | `20260807100000_early_bird_welcome_access` |
 | Authority application | `21c3637ee0f520ee79d20c247e2914699ed8a73a` |
 | Public mode | Free for All OFF during coordinated registered-Free acceptance |
@@ -49,7 +49,7 @@ test-only branch head.
 | Free/FFA never fabricate membership or Purchase | Proven | Separate schedule/technical-account tables and route-level override; no payment/Meta event is emitted by Listener paths. |
 | FFA reversible | Proven | OFF denied anonymous lease; ON restored anonymous lease 200 without schema or membership mutation. |
 | ES/EN and override | Proven | Locale default, explicit intro override, private byte ranges and distinct immutable assets pass tests/runtime. |
-| Intro to Beacon lifecycle | Automated/browser proven; physical pending | Intro play/pause/seek, natural handoff, mutual exclusion, live-edge Stop/rejoin and duplicate guards pass. Acoustic/device acceptance remains human. |
+| Intro to Beacon lifecycle | Automated/browser and iPhone human proven | Intro play/pause/seek, natural handoff, mutual exclusion, live-edge Stop/rejoin and duplicate guards pass. Nico confirmed the deployed iPhone flow worked correctly after the gesture-safe fix. |
 | Mobile one-screen interaction | Browser proven; physical pending | Chromium 390x844 has no overflow; mode targets are 52 px and primary action 56 px. Physical keyboard/screen-reader/touch review remains. |
 | Audio guardrail | Proven | Frozen-audio gate is green; this registration slice changed no asset, codec, rate, channel, gain, fade, buffer, routing or event audio. |
 | App/origin/DB/canary | Proven | Public readiness, exact schema/SHA, stream health and decoded canary are green. |
@@ -101,8 +101,8 @@ deployed image; later documentation-only commits do not require rebuilding it.
   physical start/end confirmation.
 - #217 remains open on the external Gmail delivery endpoint #44.
 - #218 is closed/Done with deployed runtime evidence.
-- #219 remains In Progress for physical iPhone natural-handoff/reconnect
-  acceptance; the gesture-safe implementation is deployed.
+- #219 is closed/Done after positive physical iPhone acceptance of the deployed
+  gesture-safe handoff.
 - #213 is Todo; #211/#212 and the larger campaign/cosmic-campfire journey are
   post-MVP and do not block this bounded test.
 
@@ -112,7 +112,8 @@ Use `docs/operations/EARLY_BIRDS_FREE_ACCEPTANCE.md` as the authoritative
 worksheet.
 
 1. Finish playback/reconnect checks in the already active FFA-OFF interval.
-2. Complete physical Chrome, Firefox, Android Chrome and iPhone Safari rows.
+2. Complete the remaining physical Chrome, Firefox and Android Chrome rows;
+   retain the accepted iPhone result.
 3. Run one 60-minute physical listen with intro, handoff, background/foreground,
    network transition and Stop/rejoin.
 4. Restore FFA ON and verify anonymous playback before public sharing.


### PR DESCRIPTION
## Outcome

Records Nico's positive physical iPhone acceptance against deployed Listener
`dad29d4`, closes the stale #219 gate in the release handoff and updates the
immediate rollback from the pre-welcome candidate to `55bf282`.

## Scope

- documentation only;
- no runtime, audio, payment or event change;
- remaining Chrome, Firefox, Android, #216 timing, 60-minute and external-load
  rows stay explicitly open.

## Verification

- `git diff --check`
- exact two-file review

Targets the shared `early-birds` integration branch.
