### PR TITLE
feat(listener): anonymous regional presence

### DIFF
--- a/docs/operations/LISTENER_REGIONAL_PRESENCE.md
+++ b/docs/operations/LISTENER_REGIONAL_PRESENCE.md
@@ -1,0 +1,60 @@
+# Listener regional presence
+
+Founding Listener exposes a deliberately imprecise public presence signal at
+`GET /api/listener/presence`. The response contains fixed macro-regions and one
+of five qualitative bands (`none`, `trace`, `cluster`, `field`, `radiant`). It
+never contains exact counts, identities, countries, cities, coordinates, IP
+addresses, account IDs, or device IDs.
+
+## Runtime configuration
+
+Set `BEACON_LISTENER_GEOIP_DB_PATH` to a local GeoIP2/GeoLite2 **Country** MMDB
+file readable by the Listener container. Keep the file on the secondary data
+volume and mount it read-only into the container; do not commit it to Git or
+download it during a request. A missing, unreadable, or unmatched database
+maps the request to `UNKNOWN` and never blocks listening.
+
+The application derives the client address only after the configured trusted
+proxy chain. Keep `TRUSTED_PROXY_HOPS` aligned with nginx/the edge topology.
+Caller-supplied forwarding prefixes are ignored. Do not expose the app port
+directly to the Internet.
+
+## Semantics
+
+- A prepared lease is `IDLE`.
+- An audible introduction and the Beacon are both `LISTENING`.
+- Pause, Stop, terminal playback failure, logout/page close, and lease
+  displacement report `IDLE` immediately on a best-effort basis.
+- Ordinary heartbeats reconcile the state every minute; expired or abruptly
+  disconnected leases disappear after the existing short lease TTL.
+- Two devices belonging to one signed-in account count once.
+- Free-for-All devices use their ephemeral HMAC device digest as the private
+  grouping key because they intentionally share one technical account.
+
+Only the macro-region and ephemeral playback timestamps are persisted. The
+source address is used for the local lookup and discarded.
+
+## Public cache and failure behavior
+
+Successful responses are cacheable for five seconds with a short stale window.
+If PostgreSQL briefly fails, the process serves only its last known public
+bands. With no last-known snapshot it returns `503` instead of inventing an
+empty crowd. Exact counts remain available only to private operational metrics.
+
+## Deploy check
+
+1. Apply the forward-only Prisma migration.
+2. Mount the Country MMDB read-only and set `BEACON_LISTENER_GEOIP_DB_PATH`.
+3. Start one synthetic listener from two devices and confirm it produces one
+   qualitative presence unit.
+4. Confirm a Free-for-All synthetic device appears independently.
+5. Stop playback and confirm the region returns to its previous band without
+   waiting for lease expiry.
+6. Send a forged left-most `X-Forwarded-For` entry through nginx and verify it
+   cannot select a region.
+7. Remove the MMDB mount in staging and verify listening stays healthy while
+   presence falls back to `UNKNOWN`.
+
+Rollback is operational: deploy the previous app image. The additive columns,
+enums, and index can remain in place safely; do not reverse the migration during
+an incident.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@maxmind/geoip2-node": "^7.1.0",
         "@prisma/adapter-pg": "^7.9.1",
         "@prisma/client": "^7.9.1",
         "better-auth": "1.6.26",
@@ -1511,6 +1512,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@maxmind/geoip2-node": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@maxmind/geoip2-node/-/geoip2-node-7.1.0.tgz",
+      "integrity": "sha512-tOXoITRIPLQdUPf9JEU5ZRsFjO1guKba7kkhoUnZUsDGpS6gX3xcJLQBQgeW4nXL6Ko0LACdbL1aAGY5sgPMmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "maxmind": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -7941,6 +7954,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/maxmind": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-5.0.7.tgz",
+      "integrity": "sha512-+w637dwfv01MKjkrp4sKDBTEKHLPvWLYb647QTjiz3wG/teSemqudIKNShaS6eqZ7ffxC9oZlQQgIqY0rGojog==",
+      "license": "MIT",
+      "dependencies": {
+        "mmdb-lib": "3.0.3",
+        "tiny-lru": "13.0.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -8016,6 +8043,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mmdb-lib": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-3.0.3.tgz",
+      "integrity": "sha512-xQPoBXcNjjHiOvOraFBKtA++uNWF6aCVHL9dRKFXEov8eI3QJwtgiw3qApsonFT5SpoqsEVISUTg3HIDs2DiXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
       }
     },
     "node_modules/ms": {
@@ -9966,6 +10003,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-13.0.0.tgz",
+      "integrity": "sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "load:livekit": "node scripts/livekit-load-harness.mjs"
   },
   "dependencies": {
+    "@maxmind/geoip2-node": "^7.1.0",
     "@prisma/adapter-pg": "^7.9.1",
     "@prisma/client": "^7.9.1",
     "better-auth": "1.6.26",

--- a/prisma/migrations/20260807200000_listener_regional_presence/migration.sql
+++ b/prisma/migrations/20260807200000_listener_regional_presence/migration.sql
@@ -1,0 +1,19 @@
+CREATE TYPE "ListenerMacroRegion" AS ENUM (
+  'NORTH_AMERICA',
+  'LATIN_AMERICA',
+  'EUROPE',
+  'AFRICA',
+  'ASIA',
+  'OCEANIA',
+  'UNKNOWN'
+);
+
+CREATE TYPE "ListenerPresenceState" AS ENUM ('IDLE', 'LISTENING');
+
+ALTER TABLE "early_bird_stream_leases"
+  ADD COLUMN "presence" "ListenerPresenceState" NOT NULL DEFAULT 'IDLE',
+  ADD COLUMN "macro_region" "ListenerMacroRegion" NOT NULL DEFAULT 'UNKNOWN',
+  ADD COLUMN "presence_updated_at" TIMESTAMP(3);
+
+CREATE INDEX "early_bird_stream_leases_presence_presence_updated_at_expires_idx"
+  ON "early_bird_stream_leases"("presence", "presence_updated_at", "expires_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,6 +99,23 @@ enum EarlyBirdMembershipSource {
   MERCADO_PAGO
 }
 
+// Coarse, non-identifying regions used only for Listener presence. Exact
+// locations never enter the application database.
+enum ListenerMacroRegion {
+  NORTH_AMERICA
+  LATIN_AMERICA
+  EUROPE
+  AFRICA
+  ASIA
+  OCEANIA
+  UNKNOWN
+}
+
+enum ListenerPresenceState {
+  IDLE
+  LISTENING
+}
+
 model User {
   id             String    @id @default(uuid()) @db.Uuid
   email          String    @unique
@@ -563,16 +580,20 @@ model EarlyBirdWelcomeAccess {
 }
 
 model EarlyBirdStreamLease {
-  id           String        @id @default(uuid()) @db.Uuid
-  accountId    String        @map("account_id")
-  account      EarlyBirdUser @relation(fields: [accountId], references: [id], onDelete: Cascade)
-  deviceDigest String        @map("device_digest") @db.Char(64)
-  createdAt    DateTime      @default(now()) @map("created_at")
-  lastSeenAt   DateTime      @map("last_seen_at")
-  expiresAt    DateTime      @map("expires_at")
-  evictedAt    DateTime?     @map("evicted_at")
+  id                String                @id @default(uuid()) @db.Uuid
+  accountId         String                @map("account_id")
+  account           EarlyBirdUser         @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  deviceDigest      String                @map("device_digest") @db.Char(64)
+  presence          ListenerPresenceState @default(IDLE)
+  macroRegion       ListenerMacroRegion   @default(UNKNOWN) @map("macro_region")
+  presenceUpdatedAt DateTime?             @map("presence_updated_at")
+  createdAt         DateTime              @default(now()) @map("created_at")
+  lastSeenAt        DateTime              @map("last_seen_at")
+  expiresAt         DateTime              @map("expires_at")
+  evictedAt         DateTime?             @map("evicted_at")
 
   @@unique([accountId, deviceDigest])
   @@index([accountId, evictedAt, expiresAt, lastSeenAt])
+  @@index([presence, presenceUpdatedAt, expiresAt])
   @@map("early_bird_stream_leases")
 }

--- a/src/app/api/early-birds/stream/heartbeat/__tests__/route.test.ts
+++ b/src/app/api/early-birds/stream/heartbeat/__tests__/route.test.ts
@@ -27,11 +27,11 @@ import { POST } from '../route';
 
 const LEASE_ID = '00000000-0000-4000-8000-000000000003';
 
-function request(intent?: 'play' | 'prepare') {
+function request(intent?: 'play' | 'prepare', presence?: 'idle' | 'listening') {
     return new NextRequest('https://listener.example.test/api/early-birds/stream/heartbeat', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ leaseId: LEASE_ID, intent }),
+        body: JSON.stringify({ leaseId: LEASE_ID, intent, presence }),
     });
 }
 
@@ -81,6 +81,7 @@ describe('EarlyBird stream heartbeat route', () => {
         });
         expect(mocks.heartbeatEarlyBirdStreamLease).toHaveBeenCalledWith(
             'listener-1', LEASE_ID, undefined, undefined, true,
+            { state: 'LISTENING', macroRegion: 'UNKNOWN' },
         );
     });
 
@@ -96,7 +97,12 @@ describe('EarlyBird stream heartbeat route', () => {
         });
 
         expect((await POST(request())).status).toBe(200);
-        expect(mocks.heartbeatFreeForAllStreamLease).toHaveBeenCalledWith(LEASE_ID);
+        expect(mocks.heartbeatFreeForAllStreamLease).toHaveBeenCalledWith(
+            LEASE_ID,
+            undefined,
+            undefined,
+            { state: 'LISTENING', macroRegion: 'UNKNOWN' },
+        );
         expect(mocks.currentEarlyBirdSession).not.toHaveBeenCalled();
         expect(mocks.heartbeatEarlyBirdStreamLease).not.toHaveBeenCalled();
     });
@@ -110,9 +116,38 @@ describe('EarlyBird stream heartbeat route', () => {
             },
         });
 
-        expect((await POST(request('prepare'))).status).toBe(200);
+        expect((await POST(request('prepare', 'idle'))).status).toBe(200);
         expect(mocks.heartbeatEarlyBirdStreamLease).toHaveBeenCalledWith(
             'listener-1', LEASE_ID, undefined, undefined, false,
+            { state: 'IDLE', macroRegion: 'UNKNOWN' },
+        );
+    });
+
+    it('does not let an unknown presence value manufacture listening state', async () => {
+        mocks.heartbeatEarlyBirdStreamLease.mockResolvedValue({
+            leaseExpiresAt: new Date('2026-08-06T12:03:00.000Z'),
+            stream: {
+                manifestUrl: `/api/early-birds/stream/manifest?leaseId=${LEASE_ID}`,
+                expiresAt: new Date('2026-08-06T12:03:00.000Z'),
+            },
+        });
+        const malformedPresence = new NextRequest(
+            'https://listener.example.test/api/early-birds/stream/heartbeat',
+            {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                    leaseId: LEASE_ID,
+                    intent: 'prepare',
+                    presence: 'radiant',
+                }),
+            },
+        );
+
+        expect((await POST(malformedPresence)).status).toBe(200);
+        expect(mocks.heartbeatEarlyBirdStreamLease).toHaveBeenCalledWith(
+            'listener-1', LEASE_ID, undefined, undefined, false,
+            { state: 'IDLE', macroRegion: 'UNKNOWN' },
         );
     });
 });

--- a/src/app/api/early-birds/stream/heartbeat/route.ts
+++ b/src/app/api/early-birds/stream/heartbeat/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
+import { clientAddress } from '@/lib/client-address';
 import { currentEarlyBirdSession } from '@/lib/early-birds/auth';
 import {
     earlyBirdsEnabled,
@@ -12,6 +13,7 @@ import {
     heartbeatFreeForAllStreamLease,
     heartbeatEarlyBirdStreamLease,
 } from '@/lib/early-birds/stream';
+import { resolveListenerMacroRegion } from '@/lib/listener/presence';
 
 export const dynamic = 'force-dynamic';
 
@@ -28,10 +30,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     let leaseId: string;
     let intent: 'play' | 'prepare';
+    let presence: 'IDLE' | 'LISTENING';
     try {
-        const body = await request.json() as { leaseId?: unknown; intent?: unknown };
+        const body = await request.json() as {
+            leaseId?: unknown;
+            intent?: unknown;
+            presence?: unknown;
+        };
         leaseId = typeof body.leaseId === 'string' ? body.leaseId : '';
         intent = body.intent === 'prepare' ? 'prepare' : 'play';
+        presence = body.presence === 'idle'
+            ? 'IDLE'
+            : body.presence === 'listening'
+                ? 'LISTENING'
+                // Backward compatibility for a browser tab loaded before the
+                // presence-aware deploy. `play` was already its real intent.
+                : intent === 'play' ? 'LISTENING' : 'IDLE';
     } catch {
         return NextResponse.json({ error: 'Malformed request.' }, { status: 400 });
     }
@@ -40,14 +54,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     try {
+        const macroRegion = await resolveListenerMacroRegion(clientAddress(request.headers));
+        const reportedPresence = { state: presence, macroRegion } as const;
         const grant = freeForAll
-            ? await heartbeatFreeForAllStreamLease(leaseId)
+            ? await heartbeatFreeForAllStreamLease(
+                leaseId,
+                undefined,
+                undefined,
+                reportedPresence,
+            )
             : await heartbeatEarlyBirdStreamLease(
                 session!.user.id,
                 leaseId,
                 undefined,
                 undefined,
                 intent === 'play',
+                reportedPresence,
             );
         return NextResponse.json({
             leaseExpiresAt: grant.leaseExpiresAt.toISOString(),

--- a/src/app/api/listener/presence/__tests__/route.test.ts
+++ b/src/app/api/listener/presence/__tests__/route.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const currentRegionalPresence = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/listener/presence', () => ({ currentRegionalPresence }));
+
+import { resetListenerPresenceRouteCacheForTests } from '@/lib/listener/presence-route-cache';
+import { GET } from '../route';
+
+const snapshot = {
+    schema: 'listener-presence.v1' as const,
+    observedAt: '2026-08-07T20:00:00.000Z',
+    regions: [{ region: 'EUROPE' as const, level: 'cluster' as const }],
+};
+
+beforeEach(() => {
+    resetListenerPresenceRouteCacheForTests();
+    currentRegionalPresence.mockResolvedValue(snapshot);
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('public Listener presence route', () => {
+    it('returns only the coarse cacheable public snapshot', async () => {
+        const response = await GET();
+        expect(response.status).toBe(200);
+        expect(response.headers.get('cache-control')).toContain('max-age=5');
+        await expect(response.json()).resolves.toEqual(snapshot);
+    });
+
+    it('serves the last known public bands when storage is temporarily unavailable', async () => {
+        await GET();
+        currentRegionalPresence.mockRejectedValue(new Error('db down'));
+        const response = await GET();
+        expect(response.status).toBe(200);
+        expect(response.headers.get('warning')).toContain('stale');
+        await expect(response.json()).resolves.toEqual(snapshot);
+    });
+
+    it('fails explicitly instead of inventing an empty crowd without evidence', async () => {
+        resetListenerPresenceRouteCacheForTests();
+        currentRegionalPresence.mockRejectedValue(new Error('db down'));
+        const response = await GET();
+        expect(response.status).toBe(503);
+        expect(response.headers.get('cache-control')).toBe('no-store');
+    });
+});

--- a/src/app/api/listener/presence/route.ts
+++ b/src/app/api/listener/presence/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+import {
+    currentRegionalPresence,
+} from '@/lib/listener/presence';
+import {
+    cachedListenerPresence,
+    rememberListenerPresence,
+} from '@/lib/listener/presence-route-cache';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<NextResponse> {
+    try {
+        const snapshot = await currentRegionalPresence();
+        rememberListenerPresence(snapshot);
+        return NextResponse.json(snapshot, {
+            headers: {
+                'cache-control': 'public, max-age=5, stale-while-revalidate=20',
+            },
+        });
+    } catch {
+        const lastGood = cachedListenerPresence();
+        if (lastGood) {
+            return NextResponse.json(lastGood, {
+                headers: {
+                    'cache-control': 'public, max-age=0, stale-while-revalidate=20',
+                    warning: '110 - "Response is stale"',
+                },
+            });
+        }
+        return NextResponse.json(
+            { error: 'Presence temporarily unavailable.' },
+            { status: 503, headers: { 'cache-control': 'no-store' } },
+        );
+    }
+}

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -130,6 +130,7 @@ export default function ListenerPlayer({
     const recoveryTimer = useRef<number | null>(null);
     const queuedRecoveryDelay = useRef<number | null>(null);
     const nativeSuspendObserved = useRef(false);
+    const listenerPresence = useRef<'idle' | 'listening'>('idle');
     const automaticRecovery = useRef<(initialDelayMs?: number) => void>(() => undefined);
     const deferLiveFadeForRecovery = useRef<() => void>(() => undefined);
     const [liveState, setLiveState] = useState<LiveState>('idle');
@@ -221,7 +222,9 @@ export default function ListenerPlayer({
         return response.json() as Promise<LeasePayload>;
     }, []);
 
-    const probeExistingLease = useCallback(async (): Promise<LeaseProbeResult> => {
+    const probeExistingLease = useCallback(async (
+        presence = listenerPresence.current,
+    ): Promise<LeaseProbeResult> => {
         if (!leaseId.current) return { kind: 'reacquire' };
         try {
             const response = await fetch('/api/early-birds/stream/heartbeat', {
@@ -230,6 +233,7 @@ export default function ListenerPlayer({
                 body: JSON.stringify({
                     leaseId: leaseId.current,
                     intent: wantsLivePlayback.current ? 'play' : 'prepare',
+                    presence,
                 }),
             });
             if (response.status === 410) {
@@ -244,6 +248,22 @@ export default function ListenerPlayer({
         } catch {
             return { kind: 'retry' };
         }
+    }, []);
+
+    const reportPresence = useCallback((presence: 'idle' | 'listening') => {
+        listenerPresence.current = presence;
+        const currentLeaseId = leaseId.current;
+        if (!currentLeaseId || typeof navigator.sendBeacon !== 'function') return;
+        const body = new Blob([
+            JSON.stringify({
+                leaseId: currentLeaseId,
+                intent: wantsLivePlayback.current ? 'play' : 'prepare',
+                presence,
+            }),
+        ], { type: 'application/json' });
+        // sendBeacon survives pagehide and does not compete with playback or
+        // recovery fetches. The ordinary heartbeat remains the reliable retry.
+        navigator.sendBeacon('/api/early-birds/stream/heartbeat', body);
     }, []);
 
     const cancelLiveFade = useCallback(() => {
@@ -581,6 +601,7 @@ export default function ListenerPlayer({
             if (recoveryAttempts.current >= RECOVERY_DELAYS_MS.length) {
                 wantsLivePlayback.current = false;
                 liveAudio.current?.pause();
+                reportPresence('idle');
                 updateLiveState('error');
                 return;
             }
@@ -605,7 +626,7 @@ export default function ListenerPlayer({
             }, delayMs);
         };
         runAttempt(Math.max(0, initialDelayMs));
-    }, [attemptLivePlayback, updateLiveState]);
+    }, [attemptLivePlayback, reportPresence, updateLiveState]);
 
     useEffect(() => {
         automaticRecovery.current = scheduleAutomaticRecovery;
@@ -631,11 +652,12 @@ export default function ListenerPlayer({
         }
         if (played) {
             setTransportPaused(false);
+            reportPresence('listening');
             updateLiveState('playing');
             return;
         }
         scheduleAutomaticRecovery(STALL_RECOVERY_DELAY_MS);
-    }, [armLiveFadeIn, attemptLivePlayback, cancelRecovery, pauseDropIns, scheduleAutomaticRecovery, updateLiveState]);
+    }, [armLiveFadeIn, attemptLivePlayback, cancelRecovery, pauseDropIns, reportPresence, scheduleAutomaticRecovery, updateLiveState]);
 
     function playBeaconOnly() {
         dropGeneration.current += 1;
@@ -662,6 +684,7 @@ export default function ListenerPlayer({
             try {
                 await intro.play();
                 setTransportPaused(false);
+                reportPresence('listening');
             } catch {
                 // Keep the paused state visible when the browser rejects resume.
             }
@@ -673,6 +696,7 @@ export default function ListenerPlayer({
         intro?.pause();
         storeProgress(language);
         setTransportPaused(true);
+        reportPresence('idle');
     }
 
     function stopTransport() {
@@ -680,6 +704,7 @@ export default function ListenerPlayer({
         setTransportStopped(true);
         setTransportPaused(false);
         wantsLivePlayback.current = false;
+        reportPresence('idle');
         cancelRecovery(true);
         pendingLiveFade.current = false;
         liveSuppressedForDrop.current = false;
@@ -712,17 +737,25 @@ export default function ListenerPlayer({
             nativeSuspendObserved.current = true;
             return;
         }
+        reportPresence('idle');
         deferLiveFade();
         scheduleAutomaticRecovery(kind === 'error' ? 0 : STALL_RECOVERY_DELAY_MS);
-    }, [deferLiveFade, scheduleAutomaticRecovery]);
+    }, [deferLiveFade, reportPresence, scheduleAutomaticRecovery]);
 
-    const handleNativePlaying = useCallback(() => {
+    function handleNativePlaying() {
         if (!wantsLivePlayback.current) return;
         nativeSuspendObserved.current = false;
         cancelRecovery(true);
+        const introduction = activeDrop.current
+            ? dropAudio[activeDrop.current].current
+            : null;
+        // The live element remains muted and playing behind an introduction
+        // so Safari can hand off without another gesture. A paused intro is
+        // therefore idle even if that hidden element emits `playing`.
+        if (!introduction || !introduction.paused) reportPresence('listening');
         updateLiveState('playing');
         if (pendingLiveFade.current) beginLiveFade();
-    }, [beginLiveFade, cancelRecovery, updateLiveState]);
+    }
 
     useEffect(() => {
         const probe = document.createElement('audio');
@@ -783,6 +816,7 @@ export default function ListenerPlayer({
             const probe = await probeExistingLease();
             if (probe.kind === 'displaced' || probe.kind === 'denied') {
                 wantsLivePlayback.current = false;
+                reportPresence('idle');
                 cancelRecovery(true);
                 liveAudio.current?.pause();
                 stopHls();
@@ -810,10 +844,11 @@ export default function ListenerPlayer({
             }
         }, 60_000);
         return () => window.clearInterval(interval);
-    }, [cancelRecovery, prepareLiveSource, probeExistingLease, scheduleAutomaticRecovery, stopHls, updateLiveState]);
+    }, [cancelRecovery, prepareLiveSource, probeExistingLease, reportPresence, scheduleAutomaticRecovery, stopHls, updateLiveState]);
 
     useEffect(() => () => {
         wantsLivePlayback.current = false;
+        reportPresence('idle');
         cancelRecovery(true);
         cancelLiveFade();
         cancelDropFade();
@@ -821,7 +856,7 @@ export default function ListenerPlayer({
         activeDrop.current = null;
         liveAudio.current?.pause();
         stopHls();
-    }, [cancelDropFade, cancelLiveFade, cancelRecovery, stopHls]);
+    }, [cancelDropFade, cancelLiveFade, cancelRecovery, reportPresence, stopHls]);
 
     function restoreProgress(language: DropLanguage) {
         const audio = dropAudio[language].current;
@@ -918,6 +953,7 @@ export default function ListenerPlayer({
             setTransportStopped(false);
             setTransportPaused(false);
             setPlayingDrop(language);
+            reportPresence('listening');
         } catch {
             if (!isCurrent()) return;
             activeDrop.current = null;
@@ -930,6 +966,7 @@ export default function ListenerPlayer({
                 liveAudio.current.volume = volumeRef.current;
             }
             liveSuppressedForDrop.current = false;
+            reportPresence('idle');
         }
     }
 

--- a/src/lib/early-birds/stream.ts
+++ b/src/lib/early-birds/stream.ts
@@ -12,6 +12,11 @@ export const EARLY_BIRD_ORIGIN_MANIFEST_TTL_SECONDS = 60;
 export const EARLY_BIRD_LEASE_MANIFEST_PATH = '/api/early-birds/stream/manifest';
 export const EARLY_BIRD_FREE_FOR_ALL_ACCOUNT_ID = 'early-birds-free-for-all';
 
+export type ListenerLeasePresence = {
+    state: 'IDLE' | 'LISTENING';
+    macroRegion: 'NORTH_AMERICA' | 'LATIN_AMERICA' | 'EUROPE' | 'AFRICA' | 'ASIA' | 'OCEANIA' | 'UNKNOWN';
+};
+
 const EARLY_BIRD_FREE_FOR_ALL_ACCOUNT = {
     id: EARLY_BIRD_FREE_FOR_ALL_ACCOUNT_ID,
     name: 'Public Listener',
@@ -306,10 +311,24 @@ export async function acquireEarlyBirdStreamLease(
         const current = previous
             ? await tx.earlyBirdStreamLease.update({
                 where: { id: previous.id },
-                data: { createdAt: now, lastSeenAt: prioritySeenAt, expiresAt: leaseExpiresAt, evictedAt: null },
+                data: {
+                    createdAt: now,
+                    lastSeenAt: prioritySeenAt,
+                    expiresAt: leaseExpiresAt,
+                    evictedAt: null,
+                    presence: 'IDLE',
+                    presenceUpdatedAt: now,
+                },
             })
             : await tx.earlyBirdStreamLease.create({
-                data: { accountId, deviceDigest, lastSeenAt: prioritySeenAt, expiresAt: leaseExpiresAt },
+                data: {
+                    accountId,
+                    deviceDigest,
+                    lastSeenAt: prioritySeenAt,
+                    expiresAt: leaseExpiresAt,
+                    presence: 'IDLE',
+                    presenceUpdatedAt: now,
+                },
             });
         return { current, evictedLeaseId: evicted[0]?.id ?? null, leaseExpiresAt };
     });
@@ -351,6 +370,7 @@ export async function heartbeatEarlyBirdStreamLease(
     now = new Date(),
     issuer = earlyBirdStreamUrlIssuer(),
     refreshPriority = true,
+    presence?: ListenerLeasePresence,
 ): Promise<{ leaseExpiresAt: Date; stream: StreamUrlGrant }> {
     const lease = await prisma.$transaction(async (tx) => {
         const [projection, schedule, welcome] = await Promise.all([
@@ -372,9 +392,15 @@ export async function heartbeatEarlyBirdStreamLease(
         if (current.expiresAt <= now) throw new EarlyBirdLeaseInactiveError('expired');
         const updated = await tx.earlyBirdStreamLease.update({
             where: { id: current.id },
-            data: refreshPriority
-                ? { lastSeenAt: now, expiresAt: leaseExpiresAt }
-                : { expiresAt: leaseExpiresAt },
+            data: {
+                ...(refreshPriority ? { lastSeenAt: now } : {}),
+                expiresAt: leaseExpiresAt,
+                ...(presence ? {
+                    presence: presence.state,
+                    macroRegion: presence.macroRegion,
+                    presenceUpdatedAt: now,
+                } : {}),
+            },
         });
         return { updated, leaseExpiresAt };
     });
@@ -425,6 +451,8 @@ export async function acquireFreeForAllStreamLease(
             lastSeenAt: now,
             expiresAt: leaseExpiresAt,
             evictedAt: null,
+            presence: 'IDLE',
+            presenceUpdatedAt: now,
         },
     });
 
@@ -467,12 +495,21 @@ export async function heartbeatFreeForAllStreamLease(
     leaseId: string,
     now = new Date(),
     issuer = earlyBirdStreamUrlIssuer(),
+    presence?: ListenerLeasePresence,
 ): Promise<{ leaseExpiresAt: Date; stream: StreamUrlGrant }> {
     const leaseExpiresAt = new Date(now.getTime() + EARLY_BIRD_LEASE_TTL_MS);
     const current = await authorizeFreeForAllStreamLease(leaseId, now);
     const lease = await prisma.earlyBirdStreamLease.update({
         where: { id: current.id },
-        data: { lastSeenAt: now, expiresAt: leaseExpiresAt },
+        data: {
+            lastSeenAt: now,
+            expiresAt: leaseExpiresAt,
+            ...(presence ? {
+                presence: presence.state,
+                macroRegion: presence.macroRegion,
+                presenceUpdatedAt: now,
+            } : {}),
+        },
     });
     const stream = await issuer.issue({
         accountId: EARLY_BIRD_FREE_FOR_ALL_ACCOUNT_ID,

--- a/src/lib/listener/__tests__/presence.test.ts
+++ b/src/lib/listener/__tests__/presence.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const prisma = vi.hoisted(() => ({ $queryRaw: vi.fn() }));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+import {
+    currentRegionalPresence,
+    macroRegionFromCountry,
+    presenceLevel,
+    publicPresenceSnapshot,
+    resolveListenerMacroRegion,
+} from '../presence';
+
+describe('anonymous Listener regional presence', () => {
+    it('maps only to intentionally coarse macro-regions', () => {
+        expect(macroRegionFromCountry('NA', 'MX')).toBe('LATIN_AMERICA');
+        expect(macroRegionFromCountry('NA', 'US')).toBe('NORTH_AMERICA');
+        expect(macroRegionFromCountry('SA', 'AR')).toBe('LATIN_AMERICA');
+        expect(macroRegionFromCountry('EU', 'DE')).toBe('EUROPE');
+        expect(macroRegionFromCountry('AS', 'JP')).toBe('ASIA');
+        expect(macroRegionFromCountry(undefined, undefined)).toBe('UNKNOWN');
+    });
+
+    it('fails soft for unattributed, invalid, missing and failed GeoIP data', async () => {
+        const factory = vi.fn();
+        expect(await resolveListenerMacroRegion('unattributed', factory)).toBe('UNKNOWN');
+        expect(factory).not.toHaveBeenCalled();
+        await expect(resolveListenerMacroRegion('203.0.113.7', async () => null))
+            .resolves.toBe('UNKNOWN');
+        await expect(resolveListenerMacroRegion('203.0.113.7', async () => {
+            throw new Error('database unavailable');
+        })).resolves.toBe('UNKNOWN');
+    });
+
+    it('exposes bands rather than precise counts', () => {
+        expect([0, 1, 2, 5, 16].map(presenceLevel)).toEqual([
+            'none', 'trace', 'cluster', 'field', 'radiant',
+        ]);
+        const snapshot = publicPresenceSnapshot([
+            { macroRegion: 'EUROPE', listeners: 19 },
+            { macroRegion: 'LATIN_AMERICA', listeners: 3 },
+        ], new Date('2026-08-07T20:00:00.000Z'));
+
+        expect(snapshot).toMatchObject({
+            schema: 'listener-presence.v1',
+            observedAt: '2026-08-07T20:00:00.000Z',
+        });
+        expect(snapshot.regions.find(({ region }) => region === 'EUROPE')?.level).toBe('radiant');
+        expect(snapshot.regions.find(({ region }) => region === 'LATIN_AMERICA')?.level).toBe('cluster');
+        expect(JSON.stringify(snapshot)).not.toContain('19');
+        expect(Object.keys(snapshot.regions[0] ?? {})).toEqual(['region', 'level']);
+    });
+
+    it('converts private grouped counts to the public schema', async () => {
+        prisma.$queryRaw.mockResolvedValue([
+            { macroRegion: 'OCEANIA', listeners: 1 },
+        ]);
+        const snapshot = await currentRegionalPresence(new Date('2026-08-07T20:00:00.000Z'));
+        expect(snapshot.regions.find(({ region }) => region === 'OCEANIA')?.level).toBe('trace');
+        expect(prisma.$queryRaw).toHaveBeenCalledOnce();
+    });
+});

--- a/src/lib/listener/presence-route-cache.ts
+++ b/src/lib/listener/presence-route-cache.ts
@@ -1,0 +1,15 @@
+import type { ListenerPresenceSnapshot } from './presence';
+
+let lastGood: ListenerPresenceSnapshot | null = null;
+
+export function cachedListenerPresence(): ListenerPresenceSnapshot | null {
+    return lastGood;
+}
+
+export function rememberListenerPresence(snapshot: ListenerPresenceSnapshot): void {
+    lastGood = snapshot;
+}
+
+export function resetListenerPresenceRouteCacheForTests(): void {
+    lastGood = null;
+}

--- a/src/lib/listener/presence.ts
+++ b/src/lib/listener/presence.ts
@@ -1,0 +1,137 @@
+import { isIP } from 'node:net';
+
+import { Reader, type ReaderModel } from '@maxmind/geoip2-node';
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/db';
+import { EARLY_BIRD_FREE_FOR_ALL_ACCOUNT_ID } from '@/lib/early-birds/stream';
+
+export const LISTENER_MACRO_REGIONS = [
+    'NORTH_AMERICA',
+    'LATIN_AMERICA',
+    'EUROPE',
+    'AFRICA',
+    'ASIA',
+    'OCEANIA',
+    'UNKNOWN',
+] as const;
+
+export type ListenerMacroRegion = typeof LISTENER_MACRO_REGIONS[number];
+export type ListenerPresenceLevel = 'none' | 'trace' | 'cluster' | 'field' | 'radiant';
+
+export type ListenerPresenceSnapshot = {
+    schema: 'listener-presence.v1';
+    observedAt: string;
+    regions: Array<{
+        region: ListenerMacroRegion;
+        level: ListenerPresenceLevel;
+    }>;
+};
+
+type RegionalCount = { macroRegion: ListenerMacroRegion; listeners: number };
+
+const LATIN_AMERICAN_COUNTRIES = new Set([
+    'AR', 'BO', 'BR', 'BZ', 'CL', 'CO', 'CR', 'CU', 'DO', 'EC', 'SV', 'GF',
+    'GT', 'GY', 'HT', 'HN', 'MX', 'NI', 'PA', 'PY', 'PE', 'PR', 'SR', 'UY',
+    'VE', 'AG', 'BS', 'BB', 'DM', 'GD', 'JM', 'KN', 'LC', 'VC', 'TT',
+    'AW', 'BQ', 'CW', 'GP', 'MQ', 'MF', 'SX', 'TC', 'VI', 'VG', 'KY', 'MS',
+]);
+
+let geoReaderPromise: Promise<ReaderModel | null> | null = null;
+
+async function configuredGeoReader(): Promise<ReaderModel | null> {
+    const path = process.env.BEACON_LISTENER_GEOIP_DB_PATH?.trim();
+    if (!path) return null;
+    if (!geoReaderPromise) {
+        geoReaderPromise = Reader.open(path).catch(() => null);
+    }
+    return geoReaderPromise;
+}
+
+export function macroRegionFromCountry(
+    continentCode?: string,
+    countryCode?: string,
+): ListenerMacroRegion {
+    const country = countryCode?.toUpperCase();
+    if (country && LATIN_AMERICAN_COUNTRIES.has(country)) return 'LATIN_AMERICA';
+    switch (continentCode?.toUpperCase()) {
+        case 'NA': return 'NORTH_AMERICA';
+        case 'SA': return 'LATIN_AMERICA';
+        case 'EU': return 'EUROPE';
+        case 'AF': return 'AFRICA';
+        case 'AS': return 'ASIA';
+        case 'OC': return 'OCEANIA';
+        default: return 'UNKNOWN';
+    }
+}
+
+export async function resolveListenerMacroRegion(
+    address: string,
+    readerFactory: () => Promise<ReaderModel | null> = configuredGeoReader,
+): Promise<ListenerMacroRegion> {
+    if (!isIP(address)) return 'UNKNOWN';
+    try {
+        const reader = await readerFactory();
+        if (!reader) return 'UNKNOWN';
+        const match = reader.country(address);
+        return macroRegionFromCountry(match.continent?.code, match.country?.isoCode);
+    } catch {
+        return 'UNKNOWN';
+    }
+}
+
+export function presenceLevel(listeners: number): ListenerPresenceLevel {
+    if (listeners <= 0) return 'none';
+    if (listeners === 1) return 'trace';
+    if (listeners <= 4) return 'cluster';
+    if (listeners <= 15) return 'field';
+    return 'radiant';
+}
+
+export function publicPresenceSnapshot(
+    rows: RegionalCount[],
+    observedAt = new Date(),
+): ListenerPresenceSnapshot {
+    const counts = new Map(rows.map((row) => [row.macroRegion, row.listeners]));
+    return {
+        schema: 'listener-presence.v1',
+        observedAt: observedAt.toISOString(),
+        regions: LISTENER_MACRO_REGIONS.map((region) => ({
+            region,
+            level: presenceLevel(counts.get(region) ?? 0),
+        })),
+    };
+}
+
+export async function currentRegionalPresence(
+    now = new Date(),
+): Promise<ListenerPresenceSnapshot> {
+    const freshAfter = new Date(now.getTime() - 4 * 60 * 1000);
+    // Registered accounts count once even when using two leases. Anonymous
+    // Free-for-All devices share a technical account, so their HMAC digest is
+    // the ephemeral grouping key. Neither key leaves this private query.
+    const rows = await prisma.$queryRaw<RegionalCount[]>(Prisma.sql`
+        SELECT grouped."macroRegion", COUNT(*)::int AS "listeners"
+        FROM (
+            SELECT
+                "macro_region"::text AS "macroRegion",
+                CASE
+                    WHEN "account_id" = ${EARLY_BIRD_FREE_FOR_ALL_ACCOUNT_ID}
+                    THEN "device_digest"
+                    ELSE "account_id"
+                END AS "listenerKey"
+            FROM "early_bird_stream_leases"
+            WHERE "presence" = 'LISTENING'::"ListenerPresenceState"
+              AND "presence_updated_at" >= ${freshAfter}
+              AND "expires_at" > ${now}
+              AND "evicted_at" IS NULL
+            GROUP BY "macro_region", "listenerKey"
+        ) grouped
+        GROUP BY grouped."macroRegion"
+    `);
+    return publicPresenceSnapshot(rows, now);
+}
+
+export function resetListenerGeoReaderForTests(): void {
+    geoReaderPromise = null;
+}


### PR DESCRIPTION
## Outcome

Adds privacy-preserving Listener presence for #211 without changing playback or the approved audio path.

- fixed macro-regions and qualitative public bands only
- local Country MMDB lookup; raw addresses are discarded
- one signed-in account counts once across two leases
- Free-for-All devices remain independent without public identifiers
- prepared/paused/stopped leases are idle; intro and Beacon playback are listening
- cacheable fail-soft public endpoint at `/api/listener/presence`
- forward-only additive migration and operational runbook

## Evidence

- 37 focused tests green
- TypeScript and focused ESLint green
- Prisma schema valid
- all 15 migrations applied cleanly to fresh PostgreSQL 16
- live SQL smoke confirmed account dedupe and anonymous-device grouping

## Risk / rollback

The feature is additive and not yet rendered in the default UI. Missing GeoIP data resolves to `UNKNOWN` and never blocks audio. Roll back the app image/commit; the additive columns and index can safely remain.

No deploy in this PR.