### PR TITLE
fix(listener): enter and leave Free windows without reload

### DIFF
--- a/e2e/fixtures/listener-boundary.ts
+++ b/e2e/fixtures/listener-boundary.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from 'node:crypto';
+
+import type { APIRequestContext, TestInfo } from '@playwright/test';
+import pg from 'pg';
+
+import { requireDirectDb } from './db';
+
+export type SyntheticListener = {
+    accountId: string;
+    email: string;
+};
+
+function localStartMinute(date: Date): number {
+    return date.getUTCHours() * 60 + date.getUTCMinutes();
+}
+
+export function minuteOffset(date: Date, offset: number): number {
+    return (localStartMinute(date) + offset + 1_440) % 1_440;
+}
+
+/**
+ * Create an auth-only Listener session through the production-shaped,
+ * local-E2E-only seam. The credential is read from process env and is never
+ * returned, logged or stored in browser storage by this helper.
+ */
+export async function signInSyntheticListener(
+    request: APIRequestContext,
+    email: string,
+): Promise<void> {
+    // This value is the committed local fixture credential already used by
+    // playwright.config.ts. It authorizes no deployed environment and is
+    // never written to logs, browser storage or test attachments.
+    const secret = process.env.EARLY_BIRDS_TEST_LOGIN_SECRET
+        ?? 'early-birds-e2e-login-secret-not-for-production';
+    const response = await request.post('/api/early-birds/test-login', {
+        headers: {
+            authorization: `Bearer ${secret}`,
+            'x-forwarded-proto': 'https',
+        },
+        data: { email, name: 'Boundary Listener', authOnly: true },
+    });
+    if (!response.ok()) throw new Error(`synthetic Listener login failed with ${response.status()}`);
+}
+
+export async function syntheticListenerByEmail(
+    testInfo: TestInfo,
+    email: string,
+): Promise<SyntheticListener> {
+    const databaseUrl = requireDirectDb(testInfo);
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        const result = await client.query<{ id: string }>(
+            'select id from early_bird_users where email = $1',
+            [email],
+        );
+        if (result.rows.length !== 1) throw new Error('synthetic Listener account was not created');
+        return { accountId: result.rows[0].id, email };
+    } finally {
+        await client.end();
+    }
+}
+
+export async function putSyntheticFreeSchedule(
+    testInfo: TestInfo,
+    listener: SyntheticListener,
+    startMinute: number,
+): Promise<void> {
+    const databaseUrl = requireDirectDb(testInfo);
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        const now = new Date();
+        await client.query(
+            `insert into early_bird_free_schedules (
+                account_id, time_zone, local_start_minute, selected_at,
+                change_allowed_at, selection_request_id, revision, updated_at
+            ) values ($1, 'UTC', $2, $3, $3, $4, 1, $3)
+            on conflict (account_id) do update set
+                local_start_minute = excluded.local_start_minute,
+                selection_request_id = excluded.selection_request_id,
+                revision = early_bird_free_schedules.revision + 1,
+                updated_at = excluded.updated_at`,
+            [listener.accountId, startMinute, now, randomUUID()],
+        );
+    } finally {
+        await client.end();
+    }
+}
+
+/** Delete only the unique @e2e.invalid identities created by this test. */
+export async function deleteSyntheticListenerEmails(
+    testInfo: TestInfo,
+    emails: readonly string[],
+): Promise<void> {
+    const databaseUrl = requireDirectDb(testInfo);
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        for (const email of emails) {
+            if (!email.endsWith('@e2e.invalid')) {
+                throw new Error('refusing to delete a non-synthetic Listener');
+            }
+            await client.query(
+                'delete from early_bird_users where email = $1',
+                [email],
+            );
+        }
+    } finally {
+        await client.end();
+    }
+}

--- a/e2e/tests/early-birds-boundary.spec.ts
+++ b/e2e/tests/early-birds-boundary.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+import {
+    deleteSyntheticListenerEmails,
+    minuteOffset,
+    putSyntheticFreeSchedule,
+    signInSyntheticListener,
+    syntheticListenerByEmail,
+} from '../fixtures/listener-boundary';
+import { requireDirectDb } from '../fixtures/db';
+
+async function documentEpoch(page: Page): Promise<number> {
+    return page.evaluate(() => Number(sessionStorage.getItem('listener-boundary-document-epoch')));
+}
+
+async function installDocumentEpoch(context: BrowserContext): Promise<void> {
+    await context.addInitScript(() => {
+        const key = 'listener-boundary-document-epoch';
+        const next = Number(sessionStorage.getItem(key) ?? 0) + 1;
+        sessionStorage.setItem(key, String(next));
+    });
+}
+
+// A failed run must not persist the ephemeral Listener cookie or the local
+// synthetic-login request headers in a Playwright trace artifact.
+test.use({ trace: 'off' });
+
+test.describe('Listener scheduled Free browser boundary', () => {
+    test('enters and leaves without document reload, polling or client authorization', async ({ browser }, testInfo) => {
+        test.setTimeout(90_000);
+        // Refuse before creating a session or browser context unless both the
+        // app and database are the dedicated local fixture stack.
+        requireDirectDb(testInfo);
+        const baseURL = new URL(String(testInfo.project.use.baseURL));
+        if (!['localhost', '127.0.0.1', '[::1]'].includes(baseURL.hostname)) {
+            throw new Error('refusing to run Listener boundary E2E against a non-local application');
+        }
+        const nonce = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const enteringEmail = `boundary-enter-${nonce}@e2e.invalid`;
+        const leavingEmail = `boundary-leave-${nonce}@e2e.invalid`;
+        const contexts: BrowserContext[] = [];
+
+        try {
+            const enteringContext = await browser.newContext();
+            const leavingContext = await browser.newContext();
+            contexts.push(enteringContext, leavingContext);
+            await Promise.all([installDocumentEpoch(enteringContext), installDocumentEpoch(leavingContext)]);
+
+            await Promise.all([
+                signInSyntheticListener(enteringContext.request, enteringEmail),
+                signInSyntheticListener(leavingContext.request, leavingEmail),
+            ]);
+            const entering = await syntheticListenerByEmail(testInfo, enteringEmail);
+            const leaving = await syntheticListenerByEmail(testInfo, leavingEmail);
+
+            const now = new Date();
+            // Entering starts at the next UTC wall minute. Leaving starts now,
+            // so its truthful boundary is two hours away in browser time.
+            await Promise.all([
+                putSyntheticFreeSchedule(testInfo, entering, minuteOffset(now, 1)),
+                putSyntheticFreeSchedule(testInfo, leaving, minuteOffset(now, 0)),
+            ]);
+
+            const enteringPage = await enteringContext.newPage();
+            const leavingPage = await leavingContext.newPage();
+            await Promise.all([enteringPage.clock.install(), leavingPage.clock.install()]);
+
+            let enteringStateRequests = 0;
+            let leavingStateRequests = 0;
+            let enteringLeaseRequests = 0;
+            let failEnteringOnce = true;
+            await enteringPage.route('**/api/early-birds/access-state', async (route) => {
+                enteringStateRequests += 1;
+                if (failEnteringOnce) {
+                    failEnteringOnce = false;
+                    await route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"synthetic outage"}' });
+                    return;
+                }
+                await route.continue();
+            });
+            await enteringPage.route('**/api/early-birds/stream/lease', async (route) => {
+                enteringLeaseRequests += 1;
+                await route.continue();
+            });
+            await leavingPage.route('**/api/early-birds/access-state', async (route) => {
+                leavingStateRequests += 1;
+                await route.continue();
+            });
+
+            await Promise.all([
+                enteringPage.goto('/early-birds'),
+                leavingPage.goto('/early-birds'),
+            ]);
+            await expect(enteringPage.locator('.listener-shell--public')).toBeVisible();
+            await expect(enteringPage.locator('.listener-experience')).toHaveCount(0);
+            await expect(leavingPage.locator('.listener-experience')).toBeVisible();
+
+            const enteringEpoch = await documentEpoch(enteringPage);
+            const leavingEpoch = await documentEpoch(leavingPage);
+            const enteringState = await enteringPage.request.get('/api/early-birds/access-state');
+            const leavingState = await leavingPage.request.get('/api/early-birds/access-state');
+            const enteringPayload = await enteringState.json() as { serverNow: string; freeWindow: { nextStart: string } };
+            const leavingPayload = await leavingState.json() as { serverNow: string; access: { allowedUntil: string } };
+
+            // Move only synthetic database truth across both boundaries. The
+            // browser clock then runs the real setTimeout path immediately;
+            // no test-only public clock or authorization endpoint is needed.
+            const transitionNow = new Date();
+            await Promise.all([
+                putSyntheticFreeSchedule(testInfo, entering, minuteOffset(transitionNow, 0)),
+                putSyntheticFreeSchedule(testInfo, leaving, minuteOffset(transitionNow, -121)),
+            ]);
+
+            const enterDelay = new Date(enteringPayload.freeWindow.nextStart).getTime()
+                - new Date(enteringPayload.serverNow).getTime() + 1_000;
+            const leaveDelay = new Date(leavingPayload.access.allowedUntil).getTime()
+                - new Date(leavingPayload.serverNow).getTime() + 1_000;
+            await Promise.all([
+                enteringPage.clock.fastForward(Math.max(1_000, enterDelay)),
+                leavingPage.clock.fastForward(Math.max(1_000, leaveDelay)),
+            ]);
+
+            // The failed start revalidation cannot grant UI or media access.
+            await expect.poll(() => enteringStateRequests).toBe(1);
+            await expect(enteringPage.locator('.listener-shell--public')).toBeVisible();
+            expect(enteringLeaseRequests).toBe(0);
+
+            // A resume/visibility signal supplies one bounded retry.
+            await enteringPage.evaluate(() => document.dispatchEvent(new Event('visibilitychange')));
+            await expect.poll(() => enteringStateRequests).toBe(2);
+            await expect(enteringPage.locator('.listener-experience')).toBeVisible();
+            await expect(leavingPage.locator('.listener-experience')).toHaveCount(0);
+            await expect(leavingPage.locator('.listener-shell--public')).toBeVisible();
+
+            expect(await documentEpoch(enteringPage)).toBe(enteringEpoch);
+            expect(await documentEpoch(leavingPage)).toBe(leavingEpoch);
+            expect(leavingStateRequests).toBe(1);
+
+            // Once the refreshed server tree is stable, a full minute of
+            // browser time produces no extra access-state polling.
+            await Promise.all([
+                enteringPage.clock.fastForward(60_000),
+                leavingPage.clock.fastForward(60_000),
+            ]);
+            expect(enteringStateRequests).toBe(2);
+            expect(leavingStateRequests).toBe(1);
+        } finally {
+            await Promise.all(contexts.map((context) => context.close()));
+            await deleteSyntheticListenerEmails(testInfo, [enteringEmail, leavingEmail]);
+        }
+    });
+});

--- a/src/components/early-birds/AccessBoundarySync.tsx
+++ b/src/components/early-birds/AccessBoundarySync.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 type AccessKind = 'membership' | 'free-window' | 'welcome' | 'denied';
-const reloadPage = () => window.location.reload();
 
 /**
  * Revalidates once at a server-computed authorization boundary. Stream grants
@@ -14,13 +14,15 @@ export default function AccessBoundarySync({
     expectedKind,
     boundaryAt,
     serverNow,
-    onAccessChanged = reloadPage,
+    onAccessChanged,
 }: {
     expectedKind: AccessKind;
     boundaryAt: string | null;
     serverNow: string;
     onAccessChanged?: () => void;
 }) {
+    const router = useRouter();
+
     useEffect(() => {
         if (!boundaryAt) return;
         let cancelled = false;
@@ -47,7 +49,11 @@ export default function AccessBoundarySync({
                     payload.access?.kind !== expectedKind
                     || (expectedKind !== 'denied' && payload.access?.allowedUntil !== boundaryAt)
                 ) {
-                    onAccessChanged();
+                    // Refresh the server component tree without replacing the
+                    // browser document. The new tree authoritatively enters
+                    // or leaves Listener while the browser session survives.
+                    if (onAccessChanged) onAccessChanged();
+                    else router.refresh();
                     return;
                 }
                 // A client clock may be ahead of the server by a few seconds.
@@ -82,7 +88,7 @@ export default function AccessBoundarySync({
             window.removeEventListener('pageshow', revalidateAfterResume);
             document.removeEventListener('visibilitychange', revalidateAfterResume);
         };
-    }, [boundaryAt, expectedKind, onAccessChanged, serverNow]);
+    }, [boundaryAt, expectedKind, onAccessChanged, router, serverNow]);
 
     return null;
 }

--- a/src/components/early-birds/__tests__/AccessBoundarySync.test.tsx
+++ b/src/components/early-birds/__tests__/AccessBoundarySync.test.tsx
@@ -4,10 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AccessBoundarySync from '../AccessBoundarySync';
 
+const navigation = vi.hoisted(() => ({ refresh: vi.fn() }));
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ refresh: navigation.refresh }),
+}));
+
 describe('Listener access boundary synchronization', () => {
     beforeEach(() => vi.useFakeTimers());
     afterEach(() => {
         cleanup();
+        navigation.refresh.mockReset();
         vi.restoreAllMocks();
         vi.useRealTimers();
     });
@@ -49,5 +55,22 @@ describe('Listener access boundary synchronization', () => {
         await act(async () => { await vi.advanceTimersByTimeAsync(1_750); });
 
         expect(changed).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes the server component tree without reloading the document', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+            access: { kind: 'free-window', allowedUntil: '2026-08-07T17:00:00.000Z' },
+        }), { status: 200 }));
+        render(
+            <AccessBoundarySync
+                expectedKind="denied"
+                boundaryAt="2026-08-07T15:01:00.000Z"
+                serverNow="2026-08-07T15:00:00.000Z"
+            />,
+        );
+
+        await act(async () => { await vi.advanceTimersByTimeAsync(60_750); });
+
+        expect(navigation.refresh).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Outcome

Closes the remaining technical gate in #216.

The default boundary transition now uses `router.refresh()` instead of `window.location.reload()`: the authoritative server component tree changes at the Free-window boundary without replacing the document or losing the browser session.

Adds a guarded local-only Chromium scenario with two independent contexts that proves:

- denied → Free active and Free active → denied
- same document epoch across both transitions
- start failure remains denied and requests no stream lease
- one visibility/resume event performs the bounded retry
- no continuous polling after the boundary
- all synthetic accounts are `@e2e.invalid` and removed in `finally`

## Evidence

- Chromium integration 1/1 green
- unit tests 3/3 green
- TypeScript, focused ESLint, build and diff check green
- throwaway PostgreSQL fixture removed after execution

## Risk / rollback

No audio, media, lease authority or public fixture route changed. Revert this commit to restore the old document reload behavior. No deploy in this PR.