### PR TITLE
feat(listener): prototype the cosmic campfire

### DIFF
--- a/docs/design/LISTENER_COSMIC_CAMPFIRE_PROTOTYPE.md
+++ b/docs/design/LISTENER_COSMIC_CAMPFIRE_PROTOTYPE.md
@@ -1,0 +1,37 @@
+# Listener cosmic campfire prototype
+
+Status: isolated, presentation-only prototype for #212. It is disabled by
+default and is not part of the accepted Listener MVP.
+
+## Boundary
+
+- No presence endpoint, network request, location input or account data.
+- No Web Audio, media-element, HLS, lease, transport or event-audio integration.
+- The canvas is decorative, has no pointer interaction and stays outside the
+  accessibility tree.
+- `prefers-reduced-motion`, Save-Data and a hidden document produce a static or
+  paused scene. Animated rendering is capped at 20 frames per second and device
+  pixel ratio is capped at 1.5.
+- The only data is one of four deterministic fixtures: `empty`, `near`,
+  `middle` or `far`. They represent anonymous distance bands, not real people.
+
+## Explicit preview opt-in
+
+Both values are server-side runtime configuration. Nothing is enabled when
+they are absent.
+
+```text
+LISTENER_CAMPFIRE_PROTOTYPE=1
+LISTENER_CAMPFIRE_FIXTURE=empty|near|middle|far
+```
+
+An invalid fixture fails to `empty`; any flag value other than the exact `1`
+keeps the established blank MVP. No production or staging configuration in the
+repository enables the prototype.
+
+## Review gate
+
+Review all four fixtures at 320, 390, 768, 1024 and 1440 CSS pixels. The
+prototype may connect to the future privacy-preserving #211 contract only
+after that contract exists and after an explicit product/performance review.
+Until then it must not replace `BeaconField` or imply a real crowd.

--- a/src/app/early-birds/__tests__/page.test.tsx
+++ b/src/app/early-birds/__tests__/page.test.tsx
@@ -73,6 +73,21 @@ describe('EarlyBird Listener page', () => {
         expect(mocks.getEarlyBirdListeningAccess).not.toHaveBeenCalled();
     });
 
+    it('passes the campfire fixture only behind the exact server-side prototype flag', async () => {
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '1');
+        vi.stubEnv('LISTENER_CAMPFIRE_PROTOTYPE', '1');
+        vi.stubEnv('LISTENER_CAMPFIRE_FIXTURE', 'near');
+
+        const result = await EarlyBirdsPage({ searchParams: Promise.resolve({}) });
+
+        expect(result.type).toBe(EarlyBirdHome);
+        expect(result.props).toMatchObject({
+            campfirePrototype: true,
+            campfireFixture: 'near',
+        });
+    });
+
     it('renders an authenticated Listener during an active Free window', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');

--- a/src/app/early-birds/page.tsx
+++ b/src/app/early-birds/page.tsx
@@ -19,6 +19,7 @@ import { configuredEarlyBirdDropIn } from '@/lib/early-birds/drop-ins';
 import { freeWindowState, serializeFreeWindowState } from '@/lib/early-birds/free-window';
 import { serializeWelcomeAccessState, welcomeAccessState } from '@/lib/early-birds/welcome-access';
 import { earlyBirdMagicLinkAvailable } from '@/lib/early-birds/magic-link';
+import { listenerCampfirePrototypeConfig } from '@/lib/early-birds/campfire-prototype';
 
 export const dynamic = 'force-dynamic';
 
@@ -33,11 +34,14 @@ export default async function EarlyBirdsPage({
     searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
     if (!earlyBirdsEnabled()) return <EarlyBirdUnavailable />;
+    const campfire = listenerCampfirePrototypeConfig();
 
     if (earlyBirdsFreeForAll()) {
         return (
             <EarlyBirdHome
                 publicAccess
+                campfirePrototype={campfire.enabled}
+                campfireFixture={campfire.fixture}
                 displayName=""
                 membershipSource={null}
                 dropIns={{
@@ -64,6 +68,8 @@ export default async function EarlyBirdsPage({
         return (
             <EarlyBirdHome
                 displayName={session.user.name}
+                campfirePrototype={campfire.enabled}
+                campfireFixture={campfire.fixture}
                 membershipSource={access.membership.projection?.source ?? null}
                 accessKind={access.kind === 'free-window'
                     ? 'free-window'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1158,6 +1158,31 @@ body {
   opacity: 0.34;
 }
 
+.listener-campfire {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+  contain: strict;
+  opacity: 0.82;
+}
+
+.listener-campfire::after {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(to bottom, rgba(5, 11, 12, 0.08), transparent 24%, transparent 72%, rgba(5, 11, 12, 0.42)),
+    radial-gradient(ellipse at 50% 55%, transparent 0%, transparent 31%, rgba(5, 11, 12, 0.2) 74%);
+  content: '';
+}
+
+.listener-campfire canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .listener-shell__frame {
   width: min(100%, 1180px);
   min-height: 100vh;
@@ -1803,6 +1828,7 @@ body {
 }
 
 @media (max-width: 760px) {
+  .listener-campfire { opacity: 0.72; }
   .listener-shell__frame { padding-inline: 1rem; }
   .listener-rail .brand-lockup { font-size: 0.72rem; }
   .listener-experience { margin-top: 0.55rem; }
@@ -1836,6 +1862,7 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .listener-campfire { opacity: 0.74; }
   .listener-field__aurora,
   .listener-field__orbit,
   .listener-field__core,

--- a/src/components/early-birds/CosmicCampfire.tsx
+++ b/src/components/early-birds/CosmicCampfire.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import type { ListenerCampfireFixture } from '@/lib/early-birds/campfire-prototype';
+
+import { buildCampfireFrame, type CampfireFrame } from './cosmic-campfire-scene';
+
+type NavigatorWithConnection = Navigator & {
+    connection?: { saveData?: boolean };
+};
+
+const MAX_DEVICE_PIXEL_RATIO = 1.5;
+const FRAME_INTERVAL_MS = 50;
+
+function drawGlow(
+    context: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    radius: number,
+    inner: string,
+    outer: string,
+) {
+    const gradient = context.createRadialGradient(x, y, 0, x, y, radius);
+    gradient.addColorStop(0, inner);
+    gradient.addColorStop(1, outer);
+    context.fillStyle = gradient;
+    context.beginPath();
+    context.arc(x, y, radius, 0, Math.PI * 2);
+    context.fill();
+}
+
+export function drawCampfireFrame(
+    context: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    frame: CampfireFrame,
+) {
+    context.clearRect(0, 0, width, height);
+    const scale = Math.min(width, height);
+    const fireX = frame.fire.x * width;
+    const fireY = frame.fire.y * height;
+    const fireRadius = frame.fire.radius * scale * frame.fire.breath;
+
+    context.save();
+    context.globalCompositeOperation = 'screen';
+
+    for (const [radius, alpha] of [[0.37, 0.032], [0.25, 0.052], [0.15, 0.075]] as const) {
+        context.strokeStyle = `rgba(255, 216, 117, ${alpha})`;
+        context.lineWidth = 1;
+        context.beginPath();
+        context.ellipse(fireX, fireY, radius * width, radius * height * 0.48, 0, 0, Math.PI * 2);
+        context.stroke();
+    }
+
+    drawGlow(
+        context,
+        fireX,
+        fireY,
+        fireRadius * 3.4,
+        'rgba(255, 216, 117, 0.24)',
+        'rgba(255, 143, 200, 0)',
+    );
+    drawGlow(
+        context,
+        fireX,
+        fireY,
+        fireRadius,
+        'rgba(255, 249, 233, 0.92)',
+        'rgba(255, 143, 200, 0.04)',
+    );
+
+    context.fillStyle = 'rgba(255, 216, 117, 0.44)';
+    context.beginPath();
+    context.moveTo(fireX, fireY - fireRadius * 1.22);
+    context.bezierCurveTo(
+        fireX + fireRadius * 0.78,
+        fireY - fireRadius * 0.45,
+        fireX + fireRadius * 0.58,
+        fireY + fireRadius * 0.72,
+        fireX,
+        fireY + fireRadius,
+    );
+    context.bezierCurveTo(
+        fireX - fireRadius * 0.58,
+        fireY + fireRadius * 0.72,
+        fireX - fireRadius * 0.72,
+        fireY - fireRadius * 0.36,
+        fireX,
+        fireY - fireRadius * 1.22,
+    );
+    context.fill();
+
+    for (const ember of frame.embers) {
+        context.globalAlpha = ember.alpha;
+        drawGlow(
+            context,
+            ember.x * width,
+            ember.y * height,
+            ember.radius * scale * 2.5,
+            'rgba(255, 216, 117, 0.88)',
+            'rgba(255, 143, 200, 0)',
+        );
+    }
+    context.globalAlpha = 1;
+
+    for (const listener of frame.listeners) {
+        const color = listener.band === 'near'
+            ? 'rgba(255, 216, 117, 0.72)'
+            : listener.band === 'middle'
+                ? 'rgba(255, 143, 200, 0.54)'
+                : 'rgba(124, 234, 255, 0.43)';
+        drawGlow(
+            context,
+            listener.x * width,
+            listener.y * height,
+            listener.radius * scale * 4.5,
+            color,
+            'rgba(124, 234, 255, 0)',
+        );
+        context.fillStyle = color;
+        context.beginPath();
+        context.arc(
+            listener.x * width,
+            listener.y * height,
+            Math.max(1.5, listener.radius * scale),
+            0,
+            Math.PI * 2,
+        );
+        context.fill();
+    }
+
+    drawGlow(
+        context,
+        frame.self.x * width,
+        frame.self.y * height,
+        frame.self.radius * scale * 5,
+        'rgba(124, 234, 255, 0.66)',
+        'rgba(124, 234, 255, 0)',
+    );
+    context.fillStyle = 'rgba(255, 249, 233, 0.84)';
+    context.beginPath();
+    context.arc(
+        frame.self.x * width,
+        frame.self.y * height,
+        Math.max(1.8, frame.self.radius * scale),
+        0,
+        Math.PI * 2,
+    );
+    context.fill();
+    context.restore();
+}
+
+export default function CosmicCampfire({ fixture }: { fixture: ListenerCampfireFixture }) {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const context = canvas.getContext('2d');
+        if (!context) return;
+
+        const reducedMotion = typeof window.matchMedia === 'function'
+            && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const saveData = Boolean((navigator as NavigatorWithConnection).connection?.saveData);
+        const motion = !reducedMotion && !saveData;
+        let animationFrame: number | null = null;
+        let lastFrameAt = -FRAME_INTERVAL_MS;
+        let startAt = performance.now();
+
+        const render = (now: number) => {
+            const bounds = canvas.getBoundingClientRect();
+            const ratio = Math.min(window.devicePixelRatio || 1, MAX_DEVICE_PIXEL_RATIO);
+            const width = Math.max(1, Math.round(bounds.width * ratio));
+            const height = Math.max(1, Math.round(bounds.height * ratio));
+            if (canvas.width !== width || canvas.height !== height) {
+                canvas.width = width;
+                canvas.height = height;
+            }
+            drawCampfireFrame(context, width, height, buildCampfireFrame(fixture, now - startAt, motion));
+        };
+
+        const tick = (now: number) => {
+            if (now - lastFrameAt >= FRAME_INTERVAL_MS) {
+                lastFrameAt = now;
+                render(now);
+            }
+            animationFrame = window.requestAnimationFrame(tick);
+        };
+
+        const start = () => {
+            if (!motion || document.visibilityState === 'hidden' || animationFrame !== null) return;
+            startAt = performance.now();
+            animationFrame = window.requestAnimationFrame(tick);
+        };
+        const stop = () => {
+            if (animationFrame !== null) window.cancelAnimationFrame(animationFrame);
+            animationFrame = null;
+        };
+        const handleVisibility = () => {
+            if (document.visibilityState === 'hidden') stop();
+            else {
+                render(performance.now());
+                start();
+            }
+        };
+
+        const observer = typeof ResizeObserver === 'function'
+            ? new ResizeObserver(() => render(performance.now()))
+            : null;
+        observer?.observe(canvas);
+        window.addEventListener('resize', handleVisibility, { passive: true });
+        document.addEventListener('visibilitychange', handleVisibility);
+        render(startAt);
+        start();
+
+        return () => {
+            stop();
+            observer?.disconnect();
+            window.removeEventListener('resize', handleVisibility);
+            document.removeEventListener('visibilitychange', handleVisibility);
+        };
+    }, [fixture]);
+
+    return (
+        <div
+            className="listener-campfire"
+            data-fixture={fixture}
+            data-testid="listener-campfire"
+            aria-hidden="true"
+        >
+            <canvas ref={canvasRef} />
+        </div>
+    );
+}

--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -3,10 +3,12 @@
 import BrandLockup from '@/components/brand/BrandLockup';
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdAuthClient } from '@/lib/early-birds/auth-client';
+import type { ListenerCampfireFixture } from '@/lib/early-birds/campfire-prototype';
 import { earlyBirdHomeCopy } from '@/lib/early-birds/copy';
 
 import ListenerPlayer from './ListenerPlayer';
 import AccessBoundarySync from './AccessBoundarySync';
+import CosmicCampfire from './CosmicCampfire';
 
 export default function EarlyBirdHome({
     displayName,
@@ -16,6 +18,8 @@ export default function EarlyBirdHome({
     serverNow = new Date(0).toISOString(),
     dropIns,
     publicAccess = false,
+    campfirePrototype = false,
+    campfireFixture = 'empty',
 }: {
     displayName: string;
     membershipSource: string | null;
@@ -24,6 +28,8 @@ export default function EarlyBirdHome({
     serverNow?: string;
     dropIns: { es: string | null; en: string | null };
     publicAccess?: boolean;
+    campfirePrototype?: boolean;
+    campfireFixture?: ListenerCampfireFixture;
 }) {
     const { locale } = useLocale();
     const copy = earlyBirdHomeCopy[locale];
@@ -35,6 +41,7 @@ export default function EarlyBirdHome({
 
     return (
         <main className="listener-shell">
+            {campfirePrototype && <CosmicCampfire fixture={campfireFixture} />}
             {accessKind !== 'membership' && (
                 <AccessBoundarySync
                     expectedKind={accessKind}

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -7,6 +7,11 @@ import { LocaleProvider } from '@/context/LocaleContext';
 vi.mock('../ListenerPlayer', () => ({
     default: () => <section aria-label="listener-player" />,
 }));
+vi.mock('../CosmicCampfire', () => ({
+    default: ({ fixture }: { fixture: string }) => (
+        <div data-testid="listener-campfire" data-fixture={fixture} aria-hidden="true" />
+    ),
+}));
 import EarlyBirdHome from '../EarlyBirdHome';
 
 afterEach(cleanup);
@@ -43,5 +48,33 @@ describe('EarlyBird Listener home access chrome', () => {
         expect(screen.queryByText('Sign out')).not.toBeInTheDocument();
         expect(screen.queryByRole('group', { name: /language|idioma/i })).not.toBeInTheDocument();
         expect(screen.getByLabelText('listener-player')).toBeInTheDocument();
+    });
+
+    it('keeps the campfire prototype absent unless its exact server flag is passed', () => {
+        const view = render(
+            <LocaleProvider initialLocale="en">
+                <EarlyBirdHome
+                    displayName="Nico"
+                    membershipSource="FREE"
+                    dropIns={{ es: null, en: null }}
+                />
+            </LocaleProvider>,
+        );
+
+        expect(screen.queryByTestId('listener-campfire')).not.toBeInTheDocument();
+        view.rerender(
+            <LocaleProvider initialLocale="en">
+                <EarlyBirdHome
+                    campfirePrototype
+                    campfireFixture="far"
+                    displayName="Nico"
+                    membershipSource="FREE"
+                    dropIns={{ es: null, en: null }}
+                />
+            </LocaleProvider>,
+        );
+
+        expect(screen.getByTestId('listener-campfire')).toHaveAttribute('data-fixture', 'far');
+        expect(screen.getByTestId('listener-campfire')).toHaveAttribute('aria-hidden', 'true');
     });
 });

--- a/src/components/early-birds/__tests__/cosmic-campfire-scene.test.ts
+++ b/src/components/early-birds/__tests__/cosmic-campfire-scene.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCampfireFrame, CAMPFIRE_FIXTURE_LISTENERS } from '../cosmic-campfire-scene';
+
+describe('cosmic campfire deterministic fixtures', () => {
+    it('keeps presence fixtures cumulative, bounded and anonymous', () => {
+        expect(Object.fromEntries(Object.entries(CAMPFIRE_FIXTURE_LISTENERS).map(
+            ([fixture, listeners]) => [
+                fixture,
+                listeners.map(({ id, band }) => `${id}:${band}`),
+            ],
+        ))).toMatchInlineSnapshot(`
+          {
+            "empty": [],
+            "far": [
+              "near-west:near",
+              "near-east:near",
+              "middle-west:middle",
+              "middle-east:middle",
+              "middle-north:middle",
+              "far-west:far",
+              "far-east:far",
+              "far-north-west:far",
+              "far-north-east:far",
+            ],
+            "middle": [
+              "near-west:near",
+              "near-east:near",
+              "middle-west:middle",
+              "middle-east:middle",
+              "middle-north:middle",
+            ],
+            "near": [
+              "near-west:near",
+              "near-east:near",
+            ],
+          }
+        `);
+
+        for (const listeners of Object.values(CAMPFIRE_FIXTURE_LISTENERS)) {
+            for (const listener of listeners) {
+                expect(listener.x).toBeGreaterThanOrEqual(0);
+                expect(listener.x).toBeLessThanOrEqual(1);
+                expect(listener.y).toBeGreaterThanOrEqual(0);
+                expect(listener.y).toBeLessThanOrEqual(1);
+                expect(listener).not.toHaveProperty('name');
+                expect(listener).not.toHaveProperty('location');
+            }
+        }
+    });
+
+    it('renders a stable static frame for reduced-motion and Save-Data paths', () => {
+        const first = buildCampfireFrame('far', 0, false);
+        const later = buildCampfireFrame('far', 600_000, false);
+        const signature = [
+            `fire:${Object.values(first.fire).join(',')}`,
+            `self:${Object.values(first.self).join(',')}`,
+            `listeners:${first.listeners.map(({ id, band, x, y, radius }) => (
+                [id, band, x, y, radius].join(',')
+            )).join('|')}`,
+            `embers:${first.embers.map(({ x, y, radius, alpha }) => (
+                [x.toFixed(3), y.toFixed(3), radius, alpha].join(',')
+            )).join('|')}`,
+        ];
+
+        expect(later).toEqual(first);
+        expect(signature).toMatchInlineSnapshot(`
+          [
+            "fire:0.5,0.55,0.074,1",
+            "self:0.5,0.87,0.0075",
+            "listeners:near-west,near,0.42,0.64,0.007|near-east,near,0.58,0.63,0.007|middle-west,middle,0.29,0.7,0.0055|middle-east,middle,0.72,0.69,0.0055|middle-north,middle,0.52,0.37,0.0055|far-west,far,0.12,0.54,0.0045|far-east,far,0.88,0.49,0.0045|far-north-west,far,0.25,0.24,0.0045|far-north-east,far,0.78,0.23,0.0045",
+            "embers:0.482,0.494,0.006,0.48|0.522,0.467,0.004,0.48|0.464,0.438,0.003,0.48|0.509,0.405,0.0035,0.48",
+          ]
+        `);
+    });
+
+    it('keeps every fixture point in bounds across the review viewports', () => {
+        const viewports = [
+            { width: 320, height: 720 },
+            { width: 390, height: 844 },
+            { width: 768, height: 1024 },
+            { width: 1024, height: 768 },
+            { width: 1440, height: 900 },
+        ];
+
+        for (const fixture of ['empty', 'near', 'middle', 'far'] as const) {
+            const frame = buildCampfireFrame(fixture, 0, false);
+            for (const viewport of viewports) {
+                for (const point of [frame.fire, frame.self, ...frame.listeners, ...frame.embers]) {
+                    expect(point.x * viewport.width).toBeGreaterThanOrEqual(0);
+                    expect(point.x * viewport.width).toBeLessThanOrEqual(viewport.width);
+                    expect(point.y * viewport.height).toBeGreaterThanOrEqual(0);
+                    expect(point.y * viewport.height).toBeLessThanOrEqual(viewport.height);
+                }
+            }
+        }
+    });
+});

--- a/src/components/early-birds/cosmic-campfire-scene.ts
+++ b/src/components/early-birds/cosmic-campfire-scene.ts
@@ -1,0 +1,88 @@
+import type { ListenerCampfireFixture } from '@/lib/early-birds/campfire-prototype';
+
+export type CampfireBand = 'near' | 'middle' | 'far';
+
+type NormalizedListener = {
+    id: string;
+    x: number;
+    y: number;
+    band: CampfireBand;
+};
+
+export type CampfireFrame = {
+    fire: {
+        x: number;
+        y: number;
+        radius: number;
+        breath: number;
+    };
+    self: {
+        x: number;
+        y: number;
+        radius: number;
+    };
+    listeners: Array<NormalizedListener & { radius: number }>;
+    embers: Array<{
+        x: number;
+        y: number;
+        radius: number;
+        alpha: number;
+    }>;
+};
+
+const NEAR: NormalizedListener[] = [
+    { id: 'near-west', x: 0.42, y: 0.64, band: 'near' },
+    { id: 'near-east', x: 0.58, y: 0.63, band: 'near' },
+];
+
+const MIDDLE: NormalizedListener[] = [
+    { id: 'middle-west', x: 0.29, y: 0.70, band: 'middle' },
+    { id: 'middle-east', x: 0.72, y: 0.69, band: 'middle' },
+    { id: 'middle-north', x: 0.52, y: 0.37, band: 'middle' },
+];
+
+const FAR: NormalizedListener[] = [
+    { id: 'far-west', x: 0.12, y: 0.54, band: 'far' },
+    { id: 'far-east', x: 0.88, y: 0.49, band: 'far' },
+    { id: 'far-north-west', x: 0.25, y: 0.24, band: 'far' },
+    { id: 'far-north-east', x: 0.78, y: 0.23, band: 'far' },
+];
+
+export const CAMPFIRE_FIXTURE_LISTENERS: Record<ListenerCampfireFixture, NormalizedListener[]> = {
+    empty: [],
+    near: NEAR,
+    middle: [...NEAR, ...MIDDLE],
+    far: [...NEAR, ...MIDDLE, ...FAR],
+};
+
+const EMBERS = [
+    { x: -0.018, y: -0.056, radius: 0.006, phase: 0.3 },
+    { x: 0.022, y: -0.083, radius: 0.004, phase: 1.4 },
+    { x: -0.036, y: -0.112, radius: 0.003, phase: 2.5 },
+    { x: 0.009, y: -0.145, radius: 0.0035, phase: 3.2 },
+] as const;
+
+export function buildCampfireFrame(
+    fixture: ListenerCampfireFixture,
+    elapsedMs: number,
+    motion: boolean,
+): CampfireFrame {
+    const time = motion ? elapsedMs / 1_000 : 0;
+    const breath = 1 + Math.sin(time * 0.72) * 0.045;
+
+    return {
+        fire: { x: 0.5, y: 0.55, radius: 0.074, breath },
+        self: { x: 0.5, y: 0.87, radius: 0.0075 },
+        listeners: CAMPFIRE_FIXTURE_LISTENERS[fixture].map((listener) => ({
+            ...listener,
+            radius: listener.band === 'near' ? 0.007
+                : listener.band === 'middle' ? 0.0055 : 0.0045,
+        })),
+        embers: EMBERS.map((ember) => ({
+            x: 0.5 + ember.x + (motion ? Math.sin(time * 0.8 + ember.phase) * 0.006 : 0),
+            y: 0.55 + ember.y - (motion ? ((time * 0.018 + ember.phase * 0.004) % 0.07) : 0),
+            radius: ember.radius,
+            alpha: motion ? 0.42 + Math.sin(time * 1.1 + ember.phase) * 0.16 : 0.48,
+        })),
+    };
+}

--- a/src/lib/early-birds/__tests__/campfire-prototype.test.ts
+++ b/src/lib/early-birds/__tests__/campfire-prototype.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { listenerCampfirePrototypeConfig } from '../campfire-prototype';
+
+describe('Listener cosmic campfire prototype flag', () => {
+    it('is absent by default and keeps the empty fixture', () => {
+        expect(listenerCampfirePrototypeConfig({})).toEqual({
+            enabled: false,
+            fixture: 'empty',
+        });
+    });
+
+    it('requires exact opt-in and accepts only deterministic fixtures', () => {
+        expect(listenerCampfirePrototypeConfig({
+            LISTENER_CAMPFIRE_PROTOTYPE: '1',
+            LISTENER_CAMPFIRE_FIXTURE: 'middle',
+        })).toEqual({ enabled: true, fixture: 'middle' });
+
+        expect(listenerCampfirePrototypeConfig({
+            LISTENER_CAMPFIRE_PROTOTYPE: 'true',
+            LISTENER_CAMPFIRE_FIXTURE: 'live-presence',
+        })).toEqual({ enabled: false, fixture: 'empty' });
+    });
+});

--- a/src/lib/early-birds/campfire-prototype.ts
+++ b/src/lib/early-birds/campfire-prototype.ts
@@ -1,0 +1,24 @@
+export const LISTENER_CAMPFIRE_FIXTURES = ['empty', 'near', 'middle', 'far'] as const;
+
+export type ListenerCampfireFixture = typeof LISTENER_CAMPFIRE_FIXTURES[number];
+
+export type ListenerCampfirePrototypeConfig = {
+    enabled: boolean;
+    fixture: ListenerCampfireFixture;
+};
+
+export function listenerCampfirePrototypeConfig(
+    env: Readonly<Record<string, string | undefined>> = process.env,
+): ListenerCampfirePrototypeConfig {
+    const requestedFixture = env.LISTENER_CAMPFIRE_FIXTURE;
+    const fixture = LISTENER_CAMPFIRE_FIXTURES.find((candidate) => candidate === requestedFixture)
+        ?? 'empty';
+
+    return {
+        // Exact opt-in. The isolated preview and production remain on the
+        // established blank Listener unless an operator deliberately enables
+        // this presentation-only prototype.
+        enabled: env.LISTENER_CAMPFIRE_PROTOTYPE === '1',
+        fixture,
+    };
+}


### PR DESCRIPTION
## Outcome

Implements the review-only prototype for #212 without changing the accepted minimal Listener by default.

- Canvas 2D cosmic campfire with deterministic `empty|near|middle|far` fixtures
- exact server-side opt-in: `LISTENER_CAMPFIRE_PROTOTYPE=1`
- absent by default in every environment
- decorative/non-interactive and outside the accessibility tree
- 20 FPS and DPR 1.5 caps
- static under reduced-motion or Save-Data; paused while hidden
- no network, location, account, presence, lease, media, Web Audio or audio integration

## Evidence

- full suite: 1,130 green, 19 expected skips
- focal: 13/13 green
- TypeScript, ESLint and production build green
- deterministic scene snapshots and bounded viewport fixtures
- ListenerPlayer/audio boundary untouched

## Review gate

This PR makes the prototype available only behind the flag. It does not enable or deploy it. Human visual acceptance at 320/390/768/1024/1440 remains required before it can replace the blank MVP.

Rollback: revert the commit or leave the flag absent.