### PR TITLE
ops(listener): mount verified local country data

### DIFF
--- a/docs/operations/LISTENER_REGIONAL_PRESENCE.md
+++ b/docs/operations/LISTENER_REGIONAL_PRESENCE.md
@@ -8,11 +8,13 @@ addresses, account IDs, or device IDs.
 
 ## Runtime configuration
 
-Set `BEACON_LISTENER_GEOIP_DB_PATH` to a local GeoIP2/GeoLite2 **Country** MMDB
-file readable by the Listener container. Keep the file on the secondary data
-volume and mount it read-only into the container; do not commit it to Git or
-download it during a request. A missing, unreadable, or unmatched database
-maps the request to `UNKNOWN` and never blocks listening.
+The reviewed data source is DB-IP Country Lite July 2026 in MMDB format,
+distributed under CC BY 4.0. Install it with
+`scripts/early-birds-preview/install-geoip-country.sh`, keep it on the
+secondary data volume, and mount it read-only into the container. The public
+response includes the required DB-IP attribution link. Do not commit the
+database to Git or download it during a request. A missing, unreadable, or
+unmatched database maps the request to `UNKNOWN` and never blocks listening.
 
 The application derives the client address only after the configured trusted
 proxy chain. Keep `TRUSTED_PROXY_HOPS` aligned with nginx/the edge topology.

--- a/ops/early-birds-preview/compose.yml
+++ b/ops/early-birds-preview/compose.yml
@@ -91,11 +91,13 @@ services:
       EARLY_BIRDS_TEST_LOGIN_SECRET: ${EARLY_BIRDS_TEST_LOGIN_SECRET:-}
       EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED: ${EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED:-0}
       EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS: ${EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS:?set_in_preview.env}
+      BEACON_LISTENER_GEOIP_DB_PATH: /data/geoip/dbip-country-lite.mmdb
       TRUSTED_PROXY_HOPS: "1"
     ports:
       - "127.0.0.1:${EARLYBIRDS_PREVIEW_APP_PORT:-13000}:3000"
     volumes:
       - ${BEACON_STREAM_ARTIFACTS_HOST_PATH:?set_in_preview.env}:/media/artifacts:ro
+      - ${BEACON_LISTENER_GEOIP_HOST_PATH:?set_in_preview.env}:/data/geoip/dbip-country-lite.mmdb:ro
     networks:
       - preview_db
       - listener_egress

--- a/ops/early-birds-preview/preview.env.synthetic.example
+++ b/ops/early-birds-preview/preview.env.synthetic.example
@@ -9,7 +9,7 @@ EARLYBIRDS_PREVIEW_APP_PORT=13000
 EARLYBIRDS_PREVIEW_IMAGE_TAG=synthetic
 EARLYBIRDS_PREVIEW_GIT_SHA=synthetic-preview
 EARLYBIRDS_PREVIEW_BUILD_TIME=synthetic-preview
-EARLYBIRDS_PREVIEW_SCHEMA_VERSION=20260806040000_early_birds_listener
+EARLYBIRDS_PREVIEW_SCHEMA_VERSION=20260807200000_listener_regional_presence
 # Leave empty for the default disconnected fixture. The guarded optional value
 # is earlybirds_authority_private; see the runbook before joining it.
 EARLYBIRDS_PREVIEW_AUTHORITY_NETWORK=
@@ -38,6 +38,10 @@ EARLY_BIRDS_TEST_LOGIN_SECRET=synthetic-preview-login-secret-at-least-32-charact
 # window, then enable it together with EARLY_BIRDS_ENABLED.
 EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=0
 EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS=earlybirds-staging.harmonicbeacon.com
+
+# Local country-only GeoIP data. The reviewed July 2026 DB-IP Lite artifact is
+# installed by install-geoip-country.sh and mounted read-only into Listener.
+BEACON_LISTENER_GEOIP_HOST_PATH=/mnt/beacon-data/listener/geoip/dbip-country-lite-2026-07.mmdb
 
 # No real authority/provider is contacted by the synthetic fixture. The
 # example.invalid authority remains non-routable and its credentials are fake.

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -32,6 +32,7 @@ test('synthetic guard accepts the example and rejects unsafe effective values', 
     ['unsafe free-for-all switch', 'EARLY_BIRDS_FREE_FOR_ALL=true', /must be 0 or 1/],
     ['unsafe team-entry switch', 'EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=true', /must be 0 or 1/],
     ['wrong team-entry host', 'EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS=staging.example.invalid', /must be earlybirds-staging/],
+    ['unreviewed GeoIP path', 'BEACON_LISTENER_GEOIP_HOST_PATH=/tmp/random.mmdb', /reviewed absolute July 2026/],
     ['non-synthetic secret', 'EARLY_BIRDS_AUTH_SECRET=not-a-real-but-long-enough-secret-value', /visibly synthetic/],
   ];
 
@@ -121,6 +122,8 @@ test('compose gates the loopback Listener on a forward-only isolated database mi
   assert.doesNotMatch(postgresBlock, /ports:/, 'preview PostgreSQL must stay container-private');
   assert.match(postgresBlock, /earlybirds-preview-postgres/, 'preview PostgreSQL needs a collision-proof alias');
   assert.match(source, /@earlybirds-preview-postgres:5432/, 'database URLs must use the collision-proof alias');
+  assert.match(source, /BEACON_LISTENER_GEOIP_DB_PATH: \/data\/geoip\/dbip-country-lite\.mmdb/);
+  assert.match(source, /BEACON_LISTENER_GEOIP_HOST_PATH[^\n]*:\/data\/geoip\/dbip-country-lite\.mmdb:ro/);
 });
 
 test('optional authority overlay joins only the dedicated external private network', async () => {

--- a/scripts/early-birds-preview/install-geoip-country.sh
+++ b/scripts/early-birds-preview/install-geoip-country.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+target=${1:?usage: install-geoip-country.sh /absolute/path/dbip-country-lite-2026-07.mmdb}
+case "$target" in
+  /*/dbip-country-lite-2026-07.mmdb) ;;
+  *) echo 'refusing: target must be the absolute reviewed July 2026 MMDB path' >&2; exit 2 ;;
+esac
+
+url=https://download.db-ip.com/free/dbip-country-lite-2026-07.mmdb.gz
+archive_sha256=989c57a9ad1c1c93032e28acc643afdf03597ea28480520f6f1c76ea6420507f
+database_sha256=881e0b274fc0cc801fa7c33687a69810be605f80593769287cde10bdb9ee8bde
+temporary=$(mktemp -d)
+trap 'rm -rf -- "$temporary"' EXIT HUP INT TERM
+
+curl --fail --silent --show-error --location --max-time 120 "$url" \
+  --output "$temporary/country.mmdb.gz"
+printf '%s  %s\n' "$archive_sha256" "$temporary/country.mmdb.gz" | sha256sum --check --status
+gzip -dc "$temporary/country.mmdb.gz" > "$temporary/country.mmdb"
+printf '%s  %s\n' "$database_sha256" "$temporary/country.mmdb" | sha256sum --check --status
+
+mkdir -p -- "$(dirname -- "$target")"
+install -m 0444 "$temporary/country.mmdb" "$target"
+echo "Installed reviewed DB-IP Country Lite MMDB at $target"

--- a/scripts/early-birds-preview/lib.sh
+++ b/scripts/early-birds-preview/lib.sh
@@ -87,6 +87,11 @@ require_synthetic_env() {
     *) preview_fail 'stream artifact is not approved for synthetic staging' ;;
   esac
   require_exact_preview_value EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS earlybirds-staging.harmonicbeacon.com "$env_file"
+  geoip_host_path=$(preview_env_value BEACON_LISTENER_GEOIP_HOST_PATH "$env_file")
+  case "$geoip_host_path" in
+    /*/dbip-country-lite-2026-07.mmdb) ;;
+    *) preview_fail 'BEACON_LISTENER_GEOIP_HOST_PATH must be the reviewed absolute July 2026 Country MMDB path' ;;
+  esac
 
   kill_switch=$(preview_env_value EARLY_BIRDS_ENABLED "$env_file")
   case "$kill_switch" in 0|1) ;; *) preview_fail 'EARLY_BIRDS_ENABLED must be 0 or 1' ;; esac

--- a/scripts/early-birds-preview/validate.mjs
+++ b/scripts/early-birds-preview/validate.mjs
@@ -33,6 +33,7 @@ const syntheticEnv = [
   'EARLY_BIRDS_TEST_LOGIN_SECRET=synthetic-preview-login-secret-at-least-32-characters',
   'EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=0',
   'EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS=earlybirds-staging.harmonicbeacon.com',
+  'BEACON_LISTENER_GEOIP_HOST_PATH=.',
   'EARLY_BIRDS_AUTHORITY_BASE_URL=https://authority.example.invalid',
   'EARLY_BIRDS_AUTHORITY_SERVICE_KEY_ID=synthetic-v1',
   'EARLY_BIRDS_AUTHORITY_SERVICE_TOKEN=synthetic-preview-authority-token-at-least-43-characters-long',
@@ -109,10 +110,14 @@ try {
   assert.equal(listener.environment.EARLY_BIRDS_GOOGLE_CLIENT_ID, '');
   assert.equal(listener.environment.EARLY_BIRDS_APPLE_CLIENT_ID, '');
   assert.equal(listener.environment.EARLY_BIRDS_DROPIN_ES_PATH, '');
-  assert.equal(listener.volumes.length, 1);
+  assert.equal(listener.environment.BEACON_LISTENER_GEOIP_DB_PATH, '/data/geoip/dbip-country-lite.mmdb');
+  assert.equal(listener.volumes.length, 2);
   assert.equal(listener.volumes[0].type, 'bind');
   assert.equal(listener.volumes[0].target, '/media/artifacts');
   assert.equal(listener.volumes[0].read_only, true);
+  assert.equal(listener.volumes[1].type, 'bind');
+  assert.equal(listener.volumes[1].target, '/data/geoip/dbip-country-lite.mmdb');
+  assert.equal(listener.volumes[1].read_only, true);
   assert.equal(listener.depends_on.postgres.condition, 'service_healthy');
   assert.equal(listener.depends_on.migration.condition, 'service_completed_successfully');
   assert.deepEqual(Object.keys(listener.networks).sort(), ['listener_egress', 'preview_db']);

--- a/src/app/api/listener/presence/__tests__/route.test.ts
+++ b/src/app/api/listener/presence/__tests__/route.test.ts
@@ -9,6 +9,11 @@ import { GET } from '../route';
 const snapshot = {
     schema: 'listener-presence.v1' as const,
     observedAt: '2026-08-07T20:00:00.000Z',
+    attribution: {
+        label: 'IP Geolocation by DB-IP' as const,
+        href: 'https://db-ip.com' as const,
+        license: 'CC BY 4.0' as const,
+    },
     regions: [{ region: 'EUROPE' as const, level: 'cluster' as const }],
 };
 

--- a/src/lib/listener/__tests__/presence.test.ts
+++ b/src/lib/listener/__tests__/presence.test.ts
@@ -44,6 +44,11 @@ describe('anonymous Listener regional presence', () => {
         expect(snapshot).toMatchObject({
             schema: 'listener-presence.v1',
             observedAt: '2026-08-07T20:00:00.000Z',
+            attribution: {
+                label: 'IP Geolocation by DB-IP',
+                href: 'https://db-ip.com',
+                license: 'CC BY 4.0',
+            },
         });
         expect(snapshot.regions.find(({ region }) => region === 'EUROPE')?.level).toBe('radiant');
         expect(snapshot.regions.find(({ region }) => region === 'LATIN_AMERICA')?.level).toBe('cluster');

--- a/src/lib/listener/presence.ts
+++ b/src/lib/listener/presence.ts
@@ -22,6 +22,11 @@ export type ListenerPresenceLevel = 'none' | 'trace' | 'cluster' | 'field' | 'ra
 export type ListenerPresenceSnapshot = {
     schema: 'listener-presence.v1';
     observedAt: string;
+    attribution: {
+        label: 'IP Geolocation by DB-IP';
+        href: 'https://db-ip.com';
+        license: 'CC BY 4.0';
+    };
     regions: Array<{
         region: ListenerMacroRegion;
         level: ListenerPresenceLevel;
@@ -96,6 +101,11 @@ export function publicPresenceSnapshot(
     return {
         schema: 'listener-presence.v1',
         observedAt: observedAt.toISOString(),
+        attribution: {
+            label: 'IP Geolocation by DB-IP',
+            href: 'https://db-ip.com',
+            license: 'CC BY 4.0',
+        },
         regions: LISTENER_MACRO_REGIONS.map((region) => ({
             region,
             level: presenceLevel(counts.get(region) ?? 0),


### PR DESCRIPTION
## Outcome

Completes the local data plane required by #211 without any external lookup at request time.

- pins the July 2026 DB-IP Country Lite MMDB archive and decompressed SHA-256
- installs it reproducibly on the secondary data volume
- mounts it read-only into Listener
- advances preview schema provenance to the regional-presence migration
- fails preview guards closed on unreviewed paths
- includes CC BY 4.0 attribution in the public presence contract
- missing/unreadable data still degrades to UNKNOWN without blocking audio

## Evidence

- installer downloaded, verified and resolved 8.8.8.8 through the actual MMDB reader
- 26 preview contract tests green
- presence route/library tests green
- TypeScript, focused ESLint and shell syntax green

## Deploy / rollback

Install to `/mnt/beacon-data/listener/geoip/dbip-country-lite-2026-07.mmdb`, set only the host-path env, apply the additive migration and recreate the isolated Listener. Roll back the app image while retaining the additive schema/data file.

Data source: DB-IP Country Lite, CC BY 4.0. No secret, event stack or production payment change.