### PR TITLE
fix(listener): expose coarse public presence

### DIFF
--- a/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
@@ -54,6 +54,20 @@ server {
         proxy_read_timeout 5s;
     }
 
+    # Public, coarse and privacy-bounded Listener presence. The application
+    # returns only qualitative macro-region bands and caches the response.
+    location = /api/listener/presence {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+    }
+
     location = /early-birds {
         return 302 /;
     }

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -185,6 +185,7 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.match(listener, /location \^~ \/api\/early-birds\/drop-ins\//);
   assert.match(listener, /location \^~ \/api\/early-birds\/auth\//);
   assert.match(listener, /location = \/api\/early-birds\/free-window/);
+  assert.match(listener, /location = \/api\/listener\/presence/);
   assert.doesNotMatch(listener, /api\/early-birds\/(test-login|free\/|membership)/);
   assert.doesNotMatch(listener, /location \^~ \/early-birds\//);
 


### PR DESCRIPTION
## Outcome
Exposes the privacy-bounded `GET /api/listener/presence` route on the isolated public Listener vhost. The application route was healthy after #228, but the exact-path nginx allowlist still returned 404.

## Scope
- exact public route only
- forwards the trusted proxy chain used for local GeoIP
- keeps all staging/internal/event routes blocked
- adds a preview contract assertion

## Verification
- `npm --prefix ops/early-birds-preview test` — 26/26 pass
- `git diff --check`

## Rollback
Restore the previous Listener vhost; application and database remain compatible.

No audio, payments, main, live event, or Proyección del Mito changes.