### PR TITLE
feat(listener): add canonical namespace compatibility

### DIFF
--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -9,9 +9,12 @@ on:
       - prisma/**
       - src/app/api/health/**
       - src/app/api/early-birds/**
+      - src/app/api/listener/**
       - src/app/early-birds/**
+      - src/app/listener/**
       - src/components/early-birds/**
       - src/lib/early-birds/**
+      - src/lib/listener/**
       - services/beacon-stream/**
       - ops/early-birds/**
       - ops/early-birds-preview/**
@@ -27,9 +30,12 @@ on:
       - prisma/**
       - src/app/api/health/**
       - src/app/api/early-birds/**
+      - src/app/api/listener/**
       - src/app/early-birds/**
+      - src/app/listener/**
       - src/components/early-birds/**
       - src/lib/early-birds/**
+      - src/lib/listener/**
       - services/beacon-stream/**
       - ops/early-birds/**
       - ops/early-birds-preview/**

--- a/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
+++ b/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
@@ -1,0 +1,129 @@
+# EarlyBird to Listener namespace migration
+
+Status: phase 1 implemented on `feat/listener-namespace-compat`; later phases are
+design only. This migration is deliberately additive. `EarlyBird` is an offer
+and cohort name; `Listener` is the durable product and technical namespace.
+
+## Invariants
+
+- Existing `/early-birds` bookmarks, invitation links, sessions and clients keep
+  working throughout the migration.
+- A rollout never requires clearing cookies or local storage.
+- New and legacy endpoints execute the same authorization and state-transition
+  code. Aliases must not become a second implementation.
+- Database and cross-repository contract changes are forward-only and are
+  coordinated with `proyecciones-mito` before either side deploys them.
+- No namespace phase changes codecs, media files, playback, gain, stream leases,
+  payments, live-event routes or operator behavior.
+- A compatibility alias is removed only after its usage has remained zero for a
+  full support window and the removal has its own rollback plan.
+
+## Inventory at `16a15d1`
+
+The initial scan found 168 files containing EarlyBird naming: 82 under `src`, 18
+under preview operations, 14 documentation files, 14 contract files, 10 scripts,
+8 tools, 6 Prisma files, 5 services and 4 end-to-end files.
+
+| Surface | Current identifiers | Migration constraint |
+| --- | --- | --- |
+| Public pages | `/early-birds`, `/early-birds/redeem` | Preserve both URLs while `/listener` becomes canonical. |
+| Browser APIs | `/api/early-birds/*` | Add aliases first; move clients only after aliases ship. Stream and drop-in paths are audio-sensitive and stay unchanged in phase 1. |
+| Authentication | `/api/early-birds/auth`, `hb_earlybird`, `hb_earlybird_session` | BetterAuth base paths and cookie prefixes cannot be renamed with a simple redirect. Requires a tested dual-session bridge. |
+| Invitation cookie | `__Host-hb_early_bird_invitation` | Phase 1 continues to read and write it from both URL namespaces, so existing invitations survive. |
+| Browser storage | `hb_earlybird_device_id`, `hb_earlybird_drop_progress_*` | Dual-read legacy/canonical and canonical-write later. This is inside the player boundary and is not touched in phase 1. `hb_listener_playback_mode` is already canonical. |
+| Environment | 34 explicit `EARLY_BIRDS_*` names plus language-specific drop-in keys | Add `LISTENER_*`-first/legacy-fallback readers in bounded groups; never rename deployment configuration before the binary accepts both. |
+| PostgreSQL | `early_bird_users`, identities, sessions, verifications, magic-link throttles, memberships, free schedules, welcome accesses and stream leases | Treat physical names as private persistence details during application cutover. Do not perform table renames with a web namespace rollout. |
+| Cross-repo contracts | `early-bird-authority.v1`, `early-bird-membership.command.v1`, internal EarlyBird membership/invitation paths | Versioned public wire identifiers. Preserve byte-for-byte until both repositories agree on a new contract version. |
+| Metrics/ops | Preview container, network, volume, nginx and script names use `earlybirds`; Listener presence is already canonical | Operational resource renames require side-by-side resources or a maintenance window. Labels should keep a stable legacy alias until dashboards and alerts move. |
+
+## Phase 1: additive public routing
+
+Implemented in this branch:
+
+- `/listener` and `/listener/redeem` render the same server components and locale
+  layout as their legacy counterparts.
+- Canonical non-media API aliases exist for access state, free-window selection,
+  free invitation redemption and welcome access.
+- Invitation query tokens are scrubbed on both URL families and placed in the
+  existing HttpOnly cookie. The canonical route therefore accepts old cookies
+  without copying sensitive values into JavaScript-visible storage.
+- `/early-birds` and every legacy API remain unchanged. Current clients continue
+  using them, making rollback equivalent to removing the new aliases.
+
+Phase 1 intentionally does not redirect `/early-birds`. Preview nginx currently
+rewrites `/` internally to that route, and redirecting it before nginx and client
+callbacks move would create unnecessary hops and could expose deployment
+internals.
+
+## Phase 2: browser client cutover
+
+1. Deploy phase 1 and record requests by route family without user identifiers.
+2. Change non-media fetches and navigation to `LISTENER_NAMESPACE.canonical`.
+3. Make redemption and login callback responses return `/listener` while still
+   accepting `/early-birds` callback URLs.
+4. Update nginx to serve `/listener` at `/`; keep exact legacy locations proxied.
+5. Add browser tests that start with a legacy invitation cookie, enter on the
+   canonical URL, refresh and finish redemption without signing in again.
+
+Stream, heartbeat, manifest, drop-in and player storage paths are a separate
+audio-reviewed slice. Their aliasing must not modify response bytes, timing,
+cache headers, lease semantics or the playback controller.
+
+## Phase 3: authentication and cookies
+
+First introduce canonical invitation-cookie helpers that read canonical then
+legacy, write both during the overlap, and clear both on redemption. After at
+least one deployed support window, stop writing the legacy cookie but continue
+reading it for another window.
+
+BetterAuth requires a separate design checkpoint. The canonical auth base path
+must accept sessions issued with the legacy cookie prefix. The migration must be
+proved with Google, Apple and magic-link callbacks, CSRF/origin checks, refresh,
+logout and two concurrent devices before clients change their callback URL. Do
+not run two independent auth stores or silently create a second account for the
+same identity.
+
+## Phase 4: environment and operations
+
+Introduce a typed resolver for each bounded environment group:
+
+1. `LISTENER_*` preferred, `EARLY_BIRDS_*` fallback;
+2. fail startup when both are set to different values for security-sensitive
+   keys or origins;
+3. emit only the selected key name, never its value, in validation output;
+4. update staging configuration and validate; then update production separately;
+5. remove fallback only after all rollback images use canonical names.
+
+Operational resource names can remain legacy until replacements are created
+side-by-side. Docker volumes and PostgreSQL identities must never be renamed as a
+cosmetic cleanup. Dashboards should query canonical and legacy metric labels
+during the overlap.
+
+## Phase 5: persistence and wire contracts
+
+Rename Prisma model symbols first while retaining `@@map("early_bird_...")` so
+application terminology becomes canonical without moving data. Physical table
+names are not a public product surface and should remain stable unless there is
+a measured operational benefit.
+
+If physical renames are eventually approved, use a dedicated forward-only
+migration after every deployed binary targets the mapped Listener models. The
+rollback is a roll-forward compatibility migration, not a down migration. Take a
+verified backup, rehearse on a restored database, check locks and query plans,
+and never combine the operation with an application or contract release.
+
+Wire schema versions, idempotency-key prefixes and internal endpoint paths remain
+unchanged in this project until `proyecciones-mito` and Beacon publish matching
+v2 fixtures and validators. The safe sequence is accept v1+v2, emit v1, switch
+emission to v2, observe, then retire v1 in a later release.
+
+## Verification and rollback
+
+Each phase must prove both namespaces, legacy session continuity, invalid-token
+scrubbing, same-origin mutation behavior and absence of authorization drift.
+Route-family counters must contain no account, email, invitation or session
+material.
+
+Phase 1 rollback removes only canonical pages/APIs and the two canonical
+middleware matchers. It performs no database, cookie, environment, media or
+contract rollback.

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -39,6 +39,8 @@ function location(response: NextResponse): URL {
 describe('middleware', () => {
     describe('EarlyBird invitation URL scrubbing', () => {
         it.each([
+            ['/listener', 'invite'],
+            ['/listener/redeem', 'token'],
             ['/early-birds', 'invite'],
             ['/early-birds/redeem', 'token'],
         ])('moves the canonical %s query token to a short HttpOnly cookie', (pathname, queryName) => {
@@ -145,6 +147,8 @@ describe('middleware', () => {
     describe('matcher', () => {
         it('runs only on invitation entry and the two protected surfaces', () => {
             expect(config.matcher).toEqual([
+                '/listener',
+                '/listener/redeem',
                 '/early-birds',
                 '/early-birds/redeem',
                 '/session/:path*',

--- a/src/app/api/listener/access-state/route.ts
+++ b/src/app/api/listener/access-state/route.ts
@@ -1,0 +1,3 @@
+export const dynamic = 'force-dynamic';
+
+export { GET } from '../../early-birds/access-state/route';

--- a/src/app/api/listener/free-window/route.ts
+++ b/src/app/api/listener/free-window/route.ts
@@ -1,0 +1,3 @@
+export const dynamic = 'force-dynamic';
+
+export { GET, POST } from '../../early-birds/free-window/route';

--- a/src/app/api/listener/free/redeem/route.ts
+++ b/src/app/api/listener/free/redeem/route.ts
@@ -1,0 +1,3 @@
+export const dynamic = 'force-dynamic';
+
+export { POST } from '../../../early-birds/free/redeem/route';

--- a/src/app/api/listener/welcome-access/route.ts
+++ b/src/app/api/listener/welcome-access/route.ts
@@ -1,0 +1,3 @@
+export const dynamic = 'force-dynamic';
+
+export { GET, POST } from '../../early-birds/welcome-access/route';

--- a/src/app/listener/layout.tsx
+++ b/src/app/listener/layout.tsx
@@ -1,0 +1,1 @@
+export { default } from '../early-birds/layout';

--- a/src/app/listener/page.tsx
+++ b/src/app/listener/page.tsx
@@ -1,0 +1,3 @@
+export const dynamic = 'force-dynamic';
+
+export { metadata, default } from '../early-birds/page';

--- a/src/app/listener/redeem/page.tsx
+++ b/src/app/listener/redeem/page.tsx
@@ -1,0 +1,3 @@
+export const dynamic = 'force-dynamic';
+
+export { default } from '../../early-birds/redeem/page';

--- a/src/lib/listener/__tests__/namespace.test.ts
+++ b/src/lib/listener/__tests__/namespace.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { LISTENER_NAMESPACE, listenerInvitationQuery } from '@/lib/listener/namespace';
+
+describe('Listener namespace compatibility contract', () => {
+    it('publishes Listener routes without changing the EarlyBird aliases', () => {
+        expect(LISTENER_NAMESPACE.canonical).toEqual({
+            home: '/listener',
+            redeem: '/listener/redeem',
+            api: {
+                accessState: '/api/listener/access-state',
+                freeWindow: '/api/listener/free-window',
+                freeRedeem: '/api/listener/free/redeem',
+                welcomeAccess: '/api/listener/welcome-access',
+            },
+        });
+        expect(LISTENER_NAMESPACE.legacy.home).toBe('/early-birds');
+        expect(LISTENER_NAMESPACE.legacy.redeem).toBe('/early-birds/redeem');
+    });
+
+    it.each([
+        ['/listener', 'invite'],
+        ['/early-birds', 'invite'],
+        ['/listener/redeem', 'token'],
+        ['/early-birds/redeem', 'token'],
+    ] as const)('uses the same invitation exchange for %s', (pathname, query) => {
+        expect(listenerInvitationQuery(pathname)).toBe(query);
+    });
+
+    it('does not capture tokens on lookalike or nested routes', () => {
+        expect(listenerInvitationQuery('/listener-other')).toBeNull();
+        expect(listenerInvitationQuery('/listener/redeem/extra')).toBeNull();
+    });
+});

--- a/src/lib/listener/__tests__/namespace.test.ts
+++ b/src/lib/listener/__tests__/namespace.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { LISTENER_NAMESPACE, listenerInvitationQuery } from '@/lib/listener/namespace';
@@ -30,5 +33,19 @@ describe('Listener namespace compatibility contract', () => {
     it('does not capture tokens on lookalike or nested routes', () => {
         expect(listenerInvitationQuery('/listener-other')).toBeNull();
         expect(listenerInvitationQuery('/listener/redeem/extra')).toBeNull();
+    });
+
+    it('keeps canonical Listener changes inside the Fast Forward CI gate', () => {
+        const workflow = readFileSync(
+            resolve(process.cwd(), '.github/workflows/early-birds-fast-forward.yml'),
+            'utf8',
+        );
+        for (const path of [
+            'src/app/api/listener/**',
+            'src/app/listener/**',
+            'src/lib/listener/**',
+        ]) {
+            expect(workflow.match(new RegExp(path.replaceAll('*', '\\*'), 'g'))).toHaveLength(2);
+        }
     });
 });

--- a/src/lib/listener/namespace.ts
+++ b/src/lib/listener/namespace.ts
@@ -1,0 +1,41 @@
+/**
+ * Public Listener namespace during the EarlyBird compatibility window.
+ *
+ * New integrations should use `canonical`. Existing bookmarks and clients keep
+ * working through `legacy`; removing those aliases is a separate, measured
+ * migration step.
+ */
+export const LISTENER_NAMESPACE = {
+    canonical: {
+        home: '/listener',
+        redeem: '/listener/redeem',
+        api: {
+            accessState: '/api/listener/access-state',
+            freeWindow: '/api/listener/free-window',
+            freeRedeem: '/api/listener/free/redeem',
+            welcomeAccess: '/api/listener/welcome-access',
+        },
+    },
+    legacy: {
+        home: '/early-birds',
+        redeem: '/early-birds/redeem',
+        api: {
+            accessState: '/api/early-birds/access-state',
+            freeWindow: '/api/early-birds/free-window',
+            freeRedeem: '/api/early-birds/free/redeem',
+            welcomeAccess: '/api/early-birds/welcome-access',
+        },
+    },
+} as const;
+
+export function listenerInvitationQuery(pathname: string): 'invite' | 'token' | null {
+    if (
+        pathname === LISTENER_NAMESPACE.canonical.home
+        || pathname === LISTENER_NAMESPACE.legacy.home
+    ) return 'invite';
+    if (
+        pathname === LISTENER_NAMESPACE.canonical.redeem
+        || pathname === LISTENER_NAMESPACE.legacy.redeem
+    ) return 'token';
+    return null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ import {
     canonicalEarlyBirdInvitation,
     earlyBirdInvitationCookie,
 } from '@/lib/early-birds/invitation-cookie';
+import { listenerInvitationQuery } from '@/lib/listener/namespace';
 
 /**
  * Navigation convenience, not an authorization boundary.
@@ -36,17 +37,12 @@ const ATTENDEE_PREFIXES = ['/session'];
 /** Staff surfaces: the operator console. */
 const STAFF_PREFIXES = ['/ops'];
 
-const EARLY_BIRD_INVITATION_QUERY = new Map([
-    ['/early-birds', 'invite'],
-    ['/early-birds/redeem', 'token'],
-]);
-
 function matches(pathname: string, prefixes: string[]): boolean {
     return prefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
 
 function scrubEarlyBirdInvitation(request: NextRequest): NextResponse | null {
-    const queryName = EARLY_BIRD_INVITATION_QUERY.get(request.nextUrl.pathname);
+    const queryName = listenerInvitationQuery(request.nextUrl.pathname);
     if (!queryName || !request.nextUrl.searchParams.has(queryName)) return null;
 
     const candidates = request.nextUrl.searchParams.getAll(queryName);
@@ -89,5 +85,12 @@ export default function middleware(request: NextRequest): NextResponse {
 }
 
 export const config = {
-    matcher: ['/early-birds', '/early-birds/redeem', '/session/:path*', '/ops/:path*'],
+    matcher: [
+        '/listener',
+        '/listener/redeem',
+        '/early-birds',
+        '/early-birds/redeem',
+        '/session/:path*',
+        '/ops/:path*',
+    ],
 };


### PR DESCRIPTION
## Summary

First deployable slice of #210.

- add canonical `/listener` and `/listener/redeem` pages as aliases of the existing implementation
- add canonical non-media Listener API aliases for access state, free-window selection, free invitation redemption and welcome access
- scrub invitation query tokens on both Listener and EarlyBird URLs into the existing HttpOnly cookie
- document the complete phased migration for auth, cookies, storage, environment, persistence, contracts, metrics and operations

## Compatibility and safety

- `/early-birds` and every legacy API remain available and unchanged
- current clients, cookies and invitation links continue to work
- aliases execute the existing authorization and mutation handlers; there is no second business implementation
- no redirect is introduced yet because preview nginx still rewrites `/` to `/early-birds`
- no database or environment migration is included

## Verification

- `npm test -- --run middleware.test.ts src/lib/listener/__tests__/namespace.test.ts` — 22 passed after rebasing onto `early-birds@a9384b6`
- `git diff --check upstream/early-birds...HEAD` — clean
- pre-rebase full suite — 1,148 passed, 19 skipped
- pre-rebase TypeScript, scoped ESLint and production build — green; build exposed canonical and legacy routes together

## Explicitly excluded

No Phase 2 client cutover. No audio/player, stream/drop-in, auth base path, session-cookie prefix, payments, live events, GeoIP/presence, tables, wire contracts or deployment changes.

## Rollback

Revert this single commit. It contains only additive routes, middleware matchers, tests and documentation; no persistent state needs reversal.