### PR TITLE
feat(listener): clarify access and membership presentation

### DIFF
--- a/src/app/early-birds/__tests__/page.test.tsx
+++ b/src/app/early-birds/__tests__/page.test.tsx
@@ -66,7 +66,7 @@ describe('EarlyBird Listener page', () => {
         expect(result.props).toMatchObject({
             publicAccess: true,
             displayName: '',
-            membershipSource: null,
+            membership: { kind: 'none', state: 'none' },
             dropIns: { es: null, en: '/api/early-birds/drop-ins/en' },
         });
         expect(mocks.currentEarlyBirdSession).not.toHaveBeenCalled();
@@ -108,9 +108,45 @@ describe('EarlyBird Listener page', () => {
         expect(result.type).toBe(EarlyBirdHome);
         expect(result.props).toMatchObject({
             displayName: 'Nico',
-            membershipSource: null,
+            membership: { kind: 'none', state: 'none' },
             accessKind: 'free-window',
         });
+    });
+
+    it('derives a sanitized Founder presentation on the server', async () => {
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
+        mocks.cookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
+        mocks.headers.mockResolvedValue(new Headers());
+        mocks.currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1', name: 'Nico' } });
+        mocks.getEarlyBirdListeningAccess.mockResolvedValue({
+            allowed: true,
+            kind: 'membership',
+            membership: {
+                allowed: true,
+                projection: {
+                    state: 'CANCELLED_PENDING_END',
+                    source: 'MERCADO_PAGO',
+                    offerCode: 'EARLY_BIRDS_FOUNDERS_V1',
+                    synthetic: false,
+                    provider: 'internal-provider-value',
+                    reasonCode: 'PRIVATE_REASON',
+                },
+            },
+            freeWindow: inactiveFreeWindow,
+            welcome: { ...unusedWelcome, available: false },
+            allowedUntil: new Date('2026-08-31T00:00:00.000Z'),
+        });
+
+        const result = await EarlyBirdsPage({ searchParams: Promise.resolve({}) });
+
+        expect(result.type).toBe(EarlyBirdHome);
+        expect(result.props.membership).toEqual({
+            kind: 'founder',
+            provider: 'mercado-pago',
+            state: 'ending',
+        });
+        expect(JSON.stringify(result.props.membership)).not.toMatch(/PRIVATE_REASON|internal-provider-value|MERCADO_PAGO/);
     });
 
     it('shows the saved schedule rather than fabricating membership outside the window', async () => {

--- a/src/app/early-birds/page.tsx
+++ b/src/app/early-birds/page.tsx
@@ -20,6 +20,7 @@ import { freeWindowState, serializeFreeWindowState } from '@/lib/early-birds/fre
 import { serializeWelcomeAccessState, welcomeAccessState } from '@/lib/early-birds/welcome-access';
 import { earlyBirdMagicLinkAvailable } from '@/lib/early-birds/magic-link';
 import { listenerCampfirePrototypeConfig } from '@/lib/early-birds/campfire-prototype';
+import { listenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
 
 export const dynamic = 'force-dynamic';
 
@@ -43,7 +44,7 @@ export default async function EarlyBirdsPage({
                 campfirePrototype={campfire.enabled}
                 campfireFixture={campfire.fixture}
                 displayName=""
-                membershipSource={null}
+                membership={listenerMembershipPresentation(null)}
                 dropIns={{
                     es: configuredEarlyBirdDropIn('es'),
                     en: configuredEarlyBirdDropIn('en'),
@@ -70,7 +71,7 @@ export default async function EarlyBirdsPage({
                 displayName={session.user.name}
                 campfirePrototype={campfire.enabled}
                 campfireFixture={campfire.fixture}
-                membershipSource={access.membership.projection?.source ?? null}
+                membership={listenerMembershipPresentation(access.membership.projection)}
                 accessKind={access.kind === 'free-window'
                     ? 'free-window'
                     : access.kind === 'welcome' ? 'welcome' : 'membership'}
@@ -95,6 +96,7 @@ export default async function EarlyBirdsPage({
             syntheticTeamEntryAvailable={syntheticTeamEntryAllowed({ headers: incomingHeaders })}
             freeWindow={serializeFreeWindowState(access?.freeWindow ?? freeWindowState(null))}
             welcome={serializeWelcomeAccessState(access?.welcome ?? welcomeAccessState(null))}
+            membership={listenerMembershipPresentation(access?.membership.projection ?? null)}
             serverNow={serverNow}
         />
     );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1686,7 +1686,8 @@ body {
   backdrop-filter: blur(18px);
 }
 
-.listener-free-window h3 {
+.listener-free-window h3,
+.listener-welcome-access h3 {
   font-family: var(--font-cormorant), Georgia, serif;
   font-size: clamp(1.8rem, 5vw, 2.5rem);
   font-weight: 500;
@@ -1703,6 +1704,28 @@ body {
 
 .listener-welcome-access > p {
   color: var(--text-muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.listener-membership-status {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border: 1px solid rgba(255, 214, 112, 0.22);
+  border-radius: 0.9rem;
+  background: rgba(255, 214, 112, 0.06);
+}
+
+.listener-membership-status strong {
+  color: var(--paper);
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.listener-membership-status p {
+  color: var(--text-secondary);
   font-size: 0.78rem;
   line-height: 1.5;
 }

--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -4,7 +4,8 @@ import BrandLockup from '@/components/brand/BrandLockup';
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdAuthClient } from '@/lib/early-birds/auth-client';
 import type { ListenerCampfireFixture } from '@/lib/early-birds/campfire-prototype';
-import { earlyBirdHomeCopy } from '@/lib/early-birds/copy';
+import { earlyBirdCopy, earlyBirdHomeCopy, listenerMembershipPresentationCopy } from '@/lib/early-birds/copy';
+import type { ListenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
 
 import ListenerPlayer from './ListenerPlayer';
 import AccessBoundarySync from './AccessBoundarySync';
@@ -12,7 +13,7 @@ import CosmicCampfire from './CosmicCampfire';
 
 export default function EarlyBirdHome({
     displayName,
-    membershipSource,
+    membership,
     accessKind = 'membership',
     accessUntil = null,
     serverNow = new Date(0).toISOString(),
@@ -22,7 +23,7 @@ export default function EarlyBirdHome({
     campfireFixture = 'empty',
 }: {
     displayName: string;
-    membershipSource: string | null;
+    membership: ListenerMembershipPresentation;
     accessKind?: 'membership' | 'free-window' | 'welcome';
     accessUntil?: string | null;
     serverNow?: string;
@@ -33,6 +34,7 @@ export default function EarlyBirdHome({
 }) {
     const { locale } = useLocale();
     const copy = earlyBirdHomeCopy[locale];
+    const membershipCopy = listenerMembershipPresentationCopy(earlyBirdCopy[locale], membership);
 
     async function signOut() {
         await earlyBirdAuthClient.signOut();
@@ -61,8 +63,12 @@ export default function EarlyBirdHome({
                                 <p>{displayName}</p>
                                 <span>{accessKind === 'free-window'
                                     ? copy.freeActive
-                                    : accessKind === 'welcome' ? copy.welcomeActive : copy.active}</span>
-                                {membershipSource && <small>{membershipSource}</small>}
+                                    : accessKind === 'welcome'
+                                        ? copy.welcomeActive
+                                        : membershipCopy?.title ?? copy.active}</span>
+                                {accessKind === 'membership' && membership.kind === 'founder' && membershipCopy?.detail && (
+                                    <small>{membershipCopy.detail}</small>
+                                )}
                                 <button type="button" onClick={signOut}>{copy.signOut}</button>
                             </div>
                         </details>}

--- a/src/components/early-birds/EarlyBirdLanding.tsx
+++ b/src/components/early-birds/EarlyBirdLanding.tsx
@@ -5,9 +5,10 @@ import { useState } from 'react';
 import BrandLockup from '@/components/brand/BrandLockup';
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdAuthClient } from '@/lib/early-birds/auth-client';
-import { earlyBirdCopy } from '@/lib/early-birds/copy';
+import { earlyBirdCopy, listenerMembershipPresentationCopy } from '@/lib/early-birds/copy';
 import type { SerializedEarlyBirdFreeWindowState } from '@/lib/early-birds/free-window';
 import type { SerializedEarlyBirdWelcomeAccessState } from '@/lib/early-birds/welcome-access';
+import type { ListenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
 
 import AccessBoundarySync from './AccessBoundarySync';
 import BeaconField from './BeaconField';
@@ -25,6 +26,7 @@ type Props = {
     syntheticTeamEntryAvailable: boolean;
     freeWindow: SerializedEarlyBirdFreeWindowState;
     welcome: SerializedEarlyBirdWelcomeAccessState;
+    membership: ListenerMembershipPresentation;
     serverNow: string;
 };
 
@@ -35,6 +37,7 @@ export default function EarlyBirdLanding(props: Props) {
     const [error, setError] = useState(false);
     const [email, setEmail] = useState('');
     const [emailRequested, setEmailRequested] = useState(false);
+    const membership = listenerMembershipPresentationCopy(copy, props.membership);
     const callbackURL = props.invitationAvailable
         ? '/early-birds/redeem'
         : '/early-birds';
@@ -145,6 +148,12 @@ export default function EarlyBirdLanding(props: Props) {
                                     </a>
                                 ) : (
                                     <>
+                                        {membership && props.membership.state !== 'active' && (
+                                            <div className="listener-membership-status" role="status">
+                                                <strong>{membership.title}</strong>
+                                                {membership.detail && <p>{membership.detail}</p>}
+                                            </div>
+                                        )}
                                         {props.welcome.available && <WelcomeAccessAction />}
                                         <FreeWindowSetup state={props.freeWindow} />
                                     </>

--- a/src/components/early-birds/EarlyBirdUnavailable.tsx
+++ b/src/components/early-birds/EarlyBirdUnavailable.tsx
@@ -1,19 +1,18 @@
 'use client';
 
 import BrandLockup from '@/components/brand/BrandLockup';
-import LanguageControl from '@/components/brand/LanguageControl';
 import { useLocale } from '@/context/LocaleContext';
 
 const copy = {
     es: {
-        eyebrow: 'EARLYBIRDS',
+        eyebrow: 'HARMONIC BEACON · LISTENER',
         title: 'Estamos preparando el Beacon.',
-        body: 'El acceso fundador todavía no está disponible. Volvé a intentarlo más tarde.',
+        body: 'El acceso Listener no está disponible en este momento. Vuelve a intentarlo más tarde.',
     },
     en: {
-        eyebrow: 'EARLYBIRDS',
+        eyebrow: 'HARMONIC BEACON · LISTENER',
         title: 'We are preparing the Beacon.',
-        body: 'Founding access is not available yet. Please try again later.',
+        body: 'Listener access is unavailable right now. Please try again later.',
     },
 } as const;
 
@@ -26,7 +25,6 @@ export default function EarlyBirdUnavailable() {
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-8 sm:px-10 sm:py-10">
                 <header className="flex items-center justify-between gap-4">
                     <BrandLockup href="/early-birds" />
-                    <LanguageControl />
                 </header>
                 <section className="flex flex-1 items-center py-14">
                     <div className="max-w-2xl space-y-7">

--- a/src/components/early-birds/FreeInvitationRedeemer.tsx
+++ b/src/components/early-birds/FreeInvitationRedeemer.tsx
@@ -3,22 +3,21 @@
 import { useState } from 'react';
 
 import BrandLockup from '@/components/brand/BrandLockup';
-import LanguageControl from '@/components/brand/LanguageControl';
 import { useLocale } from '@/context/LocaleContext';
 
 export default function FreeInvitationRedeemer() {
     const { locale } = useLocale();
     const copy = locale === 'es' ? {
-        eyebrow: 'INVITACIÓN PERSONAL',
-        heading: 'Activa tu acceso EarlyBird.',
-        body: 'Esta invitación es individual y de un solo uso. Al activarla, tu cuenta recibirá el mismo acceso Listener que una membresía paga.',
+        eyebrow: 'HARMONIC BEACON · LISTENER',
+        heading: 'Activa tu invitación Listener.',
+        body: 'Esta invitación es individual y de un solo uso. Al activarla, tu cuenta recibirá acceso Listener por invitación; no crea una compra ni una membresía paga.',
         action: 'Activar invitación',
         activating: 'Activando…',
         error: 'Esta invitación no está disponible. Si crees que es un error, contacta a soporte.',
     } : {
-        eyebrow: 'PERSONAL INVITATION',
-        heading: 'Activate your EarlyBird access.',
-        body: 'This invitation is individual and can be used once. Activating it gives your account the same Listener access as a paid membership.',
+        eyebrow: 'HARMONIC BEACON · LISTENER',
+        heading: 'Activate your Listener invitation.',
+        body: 'This invitation is individual and can be used once. Activating it grants invitation access; it does not create a purchase or paid membership.',
         action: 'Activate invitation',
         activating: 'Activating…',
         error: 'This invitation is unavailable. Contact support if you believe this is a mistake.',
@@ -48,7 +47,6 @@ export default function FreeInvitationRedeemer() {
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-lg flex-col justify-center gap-8 px-6 py-12">
                 <header className="flex items-center justify-between gap-4">
                     <BrandLockup href="/early-birds" />
-                    <LanguageControl />
                 </header>
                 <section className="space-y-6 rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-7 shadow-[var(--shadow-deep)]">
                     <p className="font-mono text-xs tracking-[0.22em] text-[var(--gold)]">{copy.eyebrow}</p>

--- a/src/components/early-birds/FreeWindowSetup.tsx
+++ b/src/components/early-birds/FreeWindowSetup.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { useLocale } from '@/context/LocaleContext';
 import type { SerializedEarlyBirdFreeWindowState } from '@/lib/early-birds/free-window';
@@ -21,12 +22,13 @@ function localStartMinute(value: string): number | null {
 }
 
 export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdFreeWindowState }) {
+    const router = useRouter();
     const { locale } = useLocale();
     const copy = earlyBirdCopy[locale];
     const [timeZone, setTimeZone] = useState<string | null>(null);
     const [time, setTime] = useState(currentLocalTime);
     const [choosing, setChoosing] = useState(false);
-    const [busy, setBusy] = useState(false);
+    const [busy, setBusy] = useState<'now' | 'custom' | null>(null);
     const [error, setError] = useState(false);
     const selectionRequestId = useRef<string | null>(null);
 
@@ -43,12 +45,22 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
         }).format(new Date(value));
     };
 
+    const formatLocalStart = (minute: number | null) => {
+        if (minute === null) return null;
+        const instant = new Date(Date.UTC(2026, 0, 1, Math.floor(minute / 60), minute % 60));
+        return new Intl.DateTimeFormat(locale === 'es' ? 'es' : 'en', {
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZone: 'UTC',
+        }).format(instant);
+    };
+
     async function select(mode: 'now' | 'custom') {
-        if (!timeZone || busy) return;
+        if (!timeZone || busy !== null) return;
         const minute = localStartMinute(time);
         if (mode === 'custom' && minute === null) return;
         selectionRequestId.current ??= crypto.randomUUID();
-        setBusy(true);
+        setBusy(mode);
         setError(false);
         try {
             const response = await fetch('/api/early-birds/free-window', {
@@ -63,23 +75,32 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
             });
             if (response.ok) {
                 selectionRequestId.current = null;
-                window.location.reload();
+                setBusy(null);
+                setChoosing(false);
+                router.refresh();
                 return;
             }
         } catch {}
-        setBusy(false);
+        setBusy(null);
         setError(true);
     }
 
     const nextWindow = formatInstant(state.nextStart);
     const changeAllowed = formatInstant(state.changeAllowedAt);
+    const savedStart = formatLocalStart(state.localStartMinute);
     const mayChoose = !state.configured || state.canChange;
 
     return (
-        <div className="listener-free-window">
+        <div className="listener-free-window" aria-busy={busy !== null}>
             <h3>{copy.freeTitle}</h3>
             <p>{copy.freeDescription}</p>
 
+            {state.configured && savedStart && state.timeZone && (
+                <p className="listener-free-window__fact">
+                    <span>{copy.savedFreeTime}</span>
+                    <strong>{savedStart} · {state.timeZone}</strong>
+                </p>
+            )}
             {state.configured && nextWindow && (
                 <p className="listener-free-window__fact">
                     <span>{copy.nextFreeWindow}</span>
@@ -98,15 +119,15 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
                     <button
                         type="button"
                         className="event-button event-button--primary w-full"
-                        disabled={!timeZone || busy}
+                        disabled={!timeZone || busy !== null}
                         onClick={() => select('now')}
                     >
-                        {copy.listenFreeNow}
+                        {busy === 'now' ? copy.startingFreeTime : copy.listenFreeNow}
                     </button>
                     <button
                         type="button"
                         className="event-button event-button--secondary w-full"
-                        disabled={!timeZone || busy}
+                        disabled={!timeZone || busy !== null}
                         onClick={() => setChoosing(true)}
                     >
                         {copy.chooseFreeTime}
@@ -124,10 +145,18 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
                     <button
                         type="button"
                         className="event-button event-button--primary w-full"
-                        disabled={!timeZone || busy || localStartMinute(time) === null}
+                        disabled={!timeZone || busy !== null || localStartMinute(time) === null}
                         onClick={() => select('custom')}
                     >
-                        {copy.saveFreeTime}
+                        {busy === 'custom' ? copy.savingFreeTime : copy.saveFreeTime}
+                    </button>
+                    <button
+                        type="button"
+                        className="event-button event-button--secondary w-full"
+                        disabled={busy !== null}
+                        onClick={() => setChoosing(false)}
+                    >
+                        {copy.cancelFreeTime}
                     </button>
                 </div>
             )}

--- a/src/components/early-birds/WelcomeAccessAction.tsx
+++ b/src/components/early-birds/WelcomeAccessAction.tsx
@@ -33,7 +33,9 @@ export default function WelcomeAccessAction() {
     }
 
     return (
-        <div className="listener-welcome-access">
+        <div className="listener-welcome-access" aria-busy={busy}>
+            <h3>{copy.welcomeTitle}</h3>
+            <p>{copy.welcomeDescription}</p>
             <button
                 type="button"
                 className="event-button event-button--primary w-full"
@@ -42,7 +44,6 @@ export default function WelcomeAccessAction() {
             >
                 {busy ? copy.welcomeStarting : copy.welcomeListen}
             </button>
-            <p>{copy.welcomeDescription}</p>
             {error && <p role="alert" className="event-alert event-alert--error">{copy.welcomeError}</p>}
         </div>
     );

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -22,7 +22,7 @@ describe('EarlyBird Listener home access chrome', () => {
             <LocaleProvider initialLocale="en">
                 <EarlyBirdHome
                     displayName="Nico"
-                    membershipSource="FREE"
+                    membership={{ kind: 'invitation', state: 'active' }}
                     dropIns={{ es: null, en: null }}
                 />
             </LocaleProvider>,
@@ -30,6 +30,8 @@ describe('EarlyBird Listener home access chrome', () => {
 
         expect(screen.getByLabelText('Account')).toBeInTheDocument();
         expect(screen.getByText('Sign out')).toBeInTheDocument();
+        expect(screen.getByText('Invitation access')).toBeInTheDocument();
+        expect(screen.queryByText('FREE')).not.toBeInTheDocument();
     });
 
     it('does not imply an account or expose sign-out in public mode', () => {
@@ -38,7 +40,7 @@ describe('EarlyBird Listener home access chrome', () => {
                 <EarlyBirdHome
                     publicAccess
                     displayName=""
-                    membershipSource={null}
+                    membership={{ kind: 'none', state: 'none' }}
                     dropIns={{ es: null, en: null }}
                 />
             </LocaleProvider>,
@@ -55,7 +57,7 @@ describe('EarlyBird Listener home access chrome', () => {
             <LocaleProvider initialLocale="en">
                 <EarlyBirdHome
                     displayName="Nico"
-                    membershipSource="FREE"
+                    membership={{ kind: 'invitation', state: 'active' }}
                     dropIns={{ es: null, en: null }}
                 />
             </LocaleProvider>,
@@ -68,7 +70,7 @@ describe('EarlyBird Listener home access chrome', () => {
                     campfirePrototype
                     campfireFixture="far"
                     displayName="Nico"
-                    membershipSource="FREE"
+                    membership={{ kind: 'invitation', state: 'active' }}
                     dropIns={{ es: null, en: null }}
                 />
             </LocaleProvider>,
@@ -76,5 +78,21 @@ describe('EarlyBird Listener home access chrome', () => {
 
         expect(screen.getByTestId('listener-campfire')).toHaveAttribute('data-fixture', 'far');
         expect(screen.getByTestId('listener-campfire')).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('presents a normalized Founder status and provider without raw membership source', () => {
+        render(
+            <LocaleProvider initialLocale="en">
+                <EarlyBirdHome
+                    displayName="Nico"
+                    membership={{ kind: 'founder', provider: 'mercado-pago', state: 'ending' }}
+                    dropIns={{ es: null, en: null }}
+                />
+            </LocaleProvider>,
+        );
+
+        expect(screen.getByText('Founder · active until the end of the period')).toBeInTheDocument();
+        expect(screen.getByText('Mercado Pago')).toBeInTheDocument();
+        expect(screen.queryByText('MERCADO_PAGO')).not.toBeInTheDocument();
     });
 });

--- a/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
@@ -9,10 +9,11 @@ import { earlyBirdCopy } from '@/lib/early-birds/copy';
 const signInSocial = vi.hoisted(() => vi.fn());
 const signInMagicLink = vi.hoisted(() => vi.fn());
 const signOut = vi.hoisted(() => vi.fn());
+const refresh = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh }) }));
 vi.mock('@/lib/early-birds/auth-client', () => ({
     earlyBirdAuthClient: { signIn: { social: signInSocial, magicLink: signInMagicLink }, signOut },
 }));
-vi.mock('@/components/brand/LanguageControl', () => ({ default: () => <div data-testid="language" /> }));
 vi.mock('@/components/brand/BrandLockup', () => ({ default: () => <a href="/early-birds">Harmonic Beacon</a> }));
 
 import EarlyBirdLanding from '../EarlyBirdLanding';
@@ -48,6 +49,7 @@ function renderLanding(overrides: Partial<React.ComponentProps<typeof EarlyBirdL
                     startedAt: null,
                     endsAt: null,
                 }}
+                membership={{ kind: 'none', state: 'none' }}
                 serverNow="2026-08-07T15:00:00.000Z"
                 {...overrides}
             />
@@ -63,6 +65,7 @@ describe('EarlyBird public landing', () => {
         signInMagicLink.mockResolvedValue({ data: { status: true }, error: null });
         signOut.mockReset();
         signOut.mockResolvedValue({ error: null });
+        refresh.mockReset();
         window.localStorage.clear();
     });
     afterEach(() => cleanup());
@@ -83,13 +86,17 @@ describe('EarlyBird public landing', () => {
 
     it('uses audience-neutral account and privacy language in both locales', () => {
         expect(earlyBirdCopy.es.privacy).toBe(
-            'Tu cuenta y membresía administran el acceso privado. No creamos historiales personales de escucha.',
+            'Tu cuenta y membresía administran el acceso. Durante la escucha sólo compartimos una presencia regional amplia y efímera; nunca tu ubicación exacta ni un historial personal de escucha.',
         );
         expect(earlyBirdCopy.en.privacy).toBe(
-            'Your account and membership manage private access. We do not create personal listening histories.',
+            'Your account and membership manage access. While you listen, we share only broad, ephemeral regional presence—never your exact location or a personal listening history.',
         );
         expect(`${earlyBirdCopy.es.privacy} ${earlyBirdCopy.en.privacy}`)
             .not.toMatch(/adult|child|minor|menor|adulta/i);
+        expect(`${earlyBirdCopy.es.privacy} ${earlyBirdCopy.en.privacy}`)
+            .toMatch(/regional.*efímera|ephemeral regional/i);
+        expect(`${earlyBirdCopy.es.privacy} ${earlyBirdCopy.en.privacy}`)
+            .toMatch(/ubicación exacta|exact location/i);
     });
 
     it('hides an unconfigured provider from the public identity surface', () => {
@@ -165,12 +172,41 @@ describe('EarlyBird public landing', () => {
             },
         });
 
-        await userEvent.click(screen.getByRole('button', { name: 'Listen for 30 minutes now' }));
+        expect(screen.getByRole('heading', { name: 'Your first listen · 30 minutes' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Your daily time · 2 hours' })).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', { name: 'Listen now' }));
 
         expect(fetchMock).toHaveBeenCalledWith('/api/early-birds/welcome-access', expect.objectContaining({
             method: 'POST',
         }));
         expect(fetchMock.mock.calls[0]?.[1]?.body).toContain('activationRequestId');
         fetchMock.mockRestore();
+    });
+
+    it('explains terminal Founder access and returns the account to truthful Free choices', () => {
+        renderLanding({
+            signedIn: true,
+            membership: { kind: 'founder', provider: 'mercado-pago', state: 'refunded' },
+        });
+
+        expect(screen.getByRole('status')).toHaveTextContent(
+            'The payment was refunded and Founder access has ended.',
+        );
+        expect(screen.getByRole('status')).toHaveTextContent(
+            'You can continue with the Free listening available to your account.',
+        );
+        expect(screen.getByRole('heading', { name: 'Your daily time · 2 hours' })).toBeInTheDocument();
+        expect(screen.queryByText('MERCADO_PAGO')).not.toBeInTheDocument();
+    });
+
+    it('uses neutral Listener positioning in both languages', () => {
+        expect(earlyBirdCopy.es.eyebrow).toBe('HARMONIC BEACON · LISTENER');
+        expect(earlyBirdCopy.en.eyebrow).toBe('HARMONIC BEACON · LISTENER');
+        expect(`${earlyBirdCopy.es.live} ${earlyBirdCopy.en.live}`)
+            .not.toMatch(/disponible siempre|available whenever/i);
+        expect(`${earlyBirdCopy.es.membership} ${earlyBirdCopy.en.membership}`)
+            .not.toMatch(/Founding Listener/i);
+        expect(Object.values(earlyBirdCopy.es).join(' '))
+            .not.toMatch(/\b(elegí|tocá|habilitá|querés)\b/i);
     });
 });

--- a/src/components/early-birds/__tests__/FreeInvitationRedeemer.test.tsx
+++ b/src/components/early-birds/__tests__/FreeInvitationRedeemer.test.tsx
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event';
 
 import { LocaleProvider } from '@/context/LocaleContext';
 
-vi.mock('@/components/brand/LanguageControl', () => ({ default: () => <div data-testid="language" /> }));
 vi.mock('@/components/brand/BrandLockup', () => ({ default: () => <a href="/early-birds">Harmonic Beacon</a> }));
 
 import FreeInvitationRedeemer from '../FreeInvitationRedeemer';
@@ -16,6 +15,18 @@ afterEach(() => {
 });
 
 describe('EarlyBird free invitation redeemer', () => {
+    it('presents invitation access without claiming a paid membership', () => {
+        render(
+            <LocaleProvider initialLocale="en">
+                <FreeInvitationRedeemer />
+            </LocaleProvider>,
+        );
+
+        expect(screen.getByRole('heading', { name: 'Activate your Listener invitation.' })).toBeInTheDocument();
+        expect(screen.getByText(/does not create a purchase or paid membership/)).toBeInTheDocument();
+        expect(screen.queryByText(/same Listener access as a paid membership/)).not.toBeInTheDocument();
+    });
+
     it('reports a network failure and re-enables redemption', async () => {
         const request = vi.fn().mockRejectedValue(new Error('network unavailable'));
         vi.stubGlobal('fetch', request);

--- a/src/components/early-birds/__tests__/FreeWindowSetup.test.tsx
+++ b/src/components/early-birds/__tests__/FreeWindowSetup.test.tsx
@@ -8,6 +8,9 @@ import type { SerializedEarlyBirdFreeWindowState } from '@/lib/early-birds/free-
 
 import FreeWindowSetup from '../FreeWindowSetup';
 
+const refresh = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh }) }));
+
 const emptyState: SerializedEarlyBirdFreeWindowState = {
     configured: false,
     active: false,
@@ -32,6 +35,7 @@ function renderSetup(state = emptyState) {
 
 describe('Free listening schedule UI', () => {
     beforeEach(() => {
+        refresh.mockReset();
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 400 })));
     });
     afterEach(() => {
@@ -42,7 +46,7 @@ describe('Free listening schedule UI', () => {
 
     it('offers immediate or chosen daily Free hours after registration', async () => {
         renderSetup();
-        expect(screen.getByRole('heading', { name: 'Two hours of Beacon every day' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Your daily time · 2 hours' })).toBeInTheDocument();
         await waitFor(() => expect(screen.getByRole('button', { name: 'Listen free now' })).toBeEnabled());
         expect(screen.getByRole('button', { name: 'Choose another time' })).toBeEnabled();
     });
@@ -51,6 +55,7 @@ describe('Free listening schedule UI', () => {
         renderSetup();
         await waitFor(() => expect(screen.getByRole('button', { name: 'Choose another time' })).toBeEnabled());
         await userEvent.click(screen.getByRole('button', { name: 'Choose another time' }));
+        expect(screen.getByRole('button', { name: 'Back' })).toBeEnabled();
         await userEvent.clear(screen.getByLabelText('Start time'));
         await userEvent.type(screen.getByLabelText('Start time'), '09:45');
         await userEvent.click(screen.getByRole('button', { name: 'Save my listening time' }));
@@ -63,6 +68,28 @@ describe('Free listening schedule UI', () => {
         });
         expect(JSON.parse(init.body as string).timeZone).toBeTruthy();
         expect(JSON.parse(init.body as string).selectionRequestId).toMatch(/^[0-9a-f-]{36}$/i);
+    });
+
+    it('can leave the custom chooser without changing the saved schedule', async () => {
+        renderSetup();
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Choose another time' })).toBeEnabled());
+        await userEvent.click(screen.getByRole('button', { name: 'Choose another time' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+        expect(screen.getByRole('button', { name: 'Listen free now' })).toBeEnabled();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('refreshes authoritative state without leaving the chooser busy after save', async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(new Response('{}', { status: 200 }));
+        renderSetup();
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Choose another time' })).toBeEnabled());
+        await userEvent.click(screen.getByRole('button', { name: 'Choose another time' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Save my listening time' }));
+
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(screen.getByRole('button', { name: 'Listen free now' })).toBeEnabled();
+        expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
     });
 
     it('shows the next window and cooldown without offering a forbidden change', () => {
@@ -79,6 +106,8 @@ describe('Free listening schedule UI', () => {
         });
 
         expect(screen.getByText('Your next listening window begins')).toBeInTheDocument();
+        expect(screen.getByText('Your daily time')).toBeInTheDocument();
+        expect(screen.getByText(/10:00.*UTC/)).toBeInTheDocument();
         expect(screen.getByText('You can change this schedule')).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Listen free now' })).not.toBeInTheDocument();
     });

--- a/src/lib/early-birds/__tests__/membership-presentation.test.ts
+++ b/src/lib/early-birds/__tests__/membership-presentation.test.ts
@@ -1,0 +1,80 @@
+import type { EarlyBirdMembershipProjection } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+
+import { listenerMembershipPresentation } from '../membership-presentation';
+
+const NOW = new Date('2026-08-07T12:00:00.000Z');
+
+function projection(overrides: Partial<EarlyBirdMembershipProjection> = {}): EarlyBirdMembershipProjection {
+    return {
+        id: '00000000-0000-4000-8000-000000000001',
+        accountId: 'listener-1',
+        revision: 9,
+        commandHash: 'a'.repeat(64),
+        state: 'ACTIVE',
+        source: 'PAYPAL',
+        offerCode: 'EARLY_BIRDS_FOUNDERS_V1',
+        offerRevision: 1,
+        effectiveAt: NOW,
+        paidThrough: null,
+        graceUntil: null,
+        provider: 'paypal',
+        amountMinor: 200,
+        currency: 'USD',
+        reasonCode: 'PAYMENT_CONFIRMED',
+        synthetic: false,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+describe('public Listener membership presentation', () => {
+    it('exposes only a normalized Founder provider and lifecycle state', () => {
+        const result = listenerMembershipPresentation(projection({
+            state: 'CANCELLED_PENDING_END',
+            provider: 'provider-internal-value',
+            reasonCode: 'PRIVATE_REASON',
+        }));
+
+        expect(result).toEqual({ kind: 'founder', provider: 'paypal', state: 'ending' });
+        expect(JSON.stringify(result)).not.toMatch(/PRIVATE_REASON|provider-internal-value|PAYPAL/);
+    });
+
+    it.each([
+        ['ACTIVE', 'active'],
+        ['GRACE', 'grace'],
+        ['CANCELLED_PENDING_END', 'ending'],
+        ['EXPIRED', 'expired'],
+        ['REFUNDED', 'refunded'],
+        ['REVOKED', 'revoked'],
+        ['PENDING', 'pending'],
+    ] as const)('normalizes the %s lifecycle without exposing the raw enum', (state, expected) => {
+        expect(listenerMembershipPresentation(projection({ state }))).toEqual({
+            kind: 'founder',
+            provider: 'paypal',
+            state: expected,
+        });
+    });
+
+    it('distinguishes invitation and preview access without exposing FREE or synthetic internals', () => {
+        expect(listenerMembershipPresentation(projection({ source: 'FREE' })))
+            .toEqual({ kind: 'invitation', state: 'active' });
+        expect(listenerMembershipPresentation(projection({ source: null, synthetic: true })))
+            .toEqual({ kind: 'preview', state: 'active' });
+    });
+
+    it('does not infer Founder status from offer or price fields', () => {
+        expect(listenerMembershipPresentation(projection({ source: null, synthetic: false })))
+            .toEqual({ kind: 'none', state: 'none' });
+        expect(listenerMembershipPresentation(projection({
+            source: 'PAYPAL',
+            offerCode: 'FUTURE_PRODUCT',
+        }))).toEqual({ kind: 'none', state: 'none' });
+        expect(listenerMembershipPresentation(projection({
+            source: 'MERCADO_PAGO',
+            offerCode: null,
+        }))).toEqual({ kind: 'none', state: 'none' });
+        expect(listenerMembershipPresentation(null)).toEqual({ kind: 'none', state: 'none' });
+    });
+});

--- a/src/lib/early-birds/copy.ts
+++ b/src/lib/early-birds/copy.ts
@@ -1,13 +1,14 @@
 import type { UiLocale } from '@/lib/i18n';
+import type { ListenerMembershipPresentation } from './membership-presentation';
 
 export const earlyBirdCopy = {
     es: {
-        eyebrow: 'HARMONIC BEACON · FOUNDING LISTENER',
+        eyebrow: 'HARMONIC BEACON · LISTENER',
         title: 'Recuerda tu centro armónico.',
         intro: 'Un campo armónico continuo, compartido alrededor del mundo.',
-        live: 'Escucha privada, disponible siempre',
+        live: 'Escucha durante el acceso disponible para tu cuenta',
         privateDropIns: 'Una introducción opcional antes de entrar al Beacon',
-        membership: 'Acceso Founding Listener',
+        membership: 'Primera escucha y horario Free diario',
         signInGoogle: 'Continuar con Google',
         signInApple: 'Continuar con Apple',
         signingIn: 'Abriendo acceso…',
@@ -23,30 +24,47 @@ export const earlyBirdCopy = {
         enter: 'Entrar al Beacon',
         redeem: 'Activar mi invitación',
         accessNeeded: 'Tu cuenta todavía no tiene una membresía activa.',
-        freeTitle: 'Dos horas de Beacon cada día',
-        freeDescription: 'Elegí una hora local. Será la misma todos los días y podrás cambiarla después de siete días.',
+        freeTitle: 'Tu horario diario · 2 horas',
+        freeDescription: 'Elige una hora local. Será la misma todos los días y podrás cambiarla después de siete días.',
         listenFreeNow: 'Escuchar gratis ahora',
         chooseFreeTime: 'Elegir otro horario',
         freeStartTime: 'Hora de inicio',
         saveFreeTime: 'Guardar mi horario',
+        savingFreeTime: 'Guardando horario…',
+        startingFreeTime: 'Abriendo horario Free…',
+        cancelFreeTime: 'Volver',
         freeTimeZone: 'Zona horaria',
+        savedFreeTime: 'Tu horario diario',
         nextFreeWindow: 'Tu próxima escucha comienza',
         freeScheduleLocked: 'Podrás cambiar este horario',
         freeScheduleError: 'No pudimos guardar el horario. Inténtalo nuevamente.',
-        welcomeListen: 'Escuchar 30 minutos ahora',
+        welcomeTitle: 'Tu primera escucha · 30 minutos',
+        welcomeListen: 'Escuchar ahora',
         welcomeStarting: 'Abriendo el Beacon…',
         welcomeDescription: 'Tu primera escucha no fija todavía el horario diario.',
         welcomeError: 'No pudimos abrir esta primera escucha. Inténtalo nuevamente.',
         authError: 'No pudimos completar el acceso. Usa el mismo proveedor con el que creaste tu cuenta o contacta a soporte.',
-        privacy: 'Tu cuenta y membresía administran el acceso privado. No creamos historiales personales de escucha.',
+        privacy: 'Tu cuenta y membresía administran el acceso. Durante la escucha sólo compartimos una presencia regional amplia y efímera; nunca tu ubicación exacta ni un historial personal de escucha.',
+        membershipInvitation: 'Acceso por invitación',
+        membershipPreview: 'Acceso de prueba',
+        membershipFounderActive: 'Founder activo',
+        membershipFounderGrace: 'Founder · acceso temporal',
+        membershipFounderEnding: 'Founder · activo hasta el final del período',
+        membershipFounderPending: 'La membresía Founder todavía no está confirmada.',
+        membershipFounderExpired: 'La membresía Founder finalizó.',
+        membershipFounderRefunded: 'El pago fue reembolsado y el acceso Founder finalizó.',
+        membershipFounderRevoked: 'El acceso Founder fue cerrado.',
+        membershipFreeFallback: 'Puedes continuar con la escucha Free disponible para tu cuenta.',
+        membershipInvitationEnded: 'La invitación ya no habilita el acceso.',
+        membershipPreviewEnded: 'El acceso de prueba finalizó.',
     },
     en: {
-        eyebrow: 'HARMONIC BEACON · FOUNDING LISTENER',
+        eyebrow: 'HARMONIC BEACON · LISTENER',
         title: 'Remember your harmonic center.',
         intro: 'A continuous harmonic field, shared across the world.',
-        live: 'Private listening, available whenever you return',
+        live: 'Listen during the access available to your account',
         privateDropIns: 'An optional introduction before entering the Beacon',
-        membership: 'Founding Listener access',
+        membership: 'A first listen and a daily Free schedule',
         signInGoogle: 'Continue with Google',
         signInApple: 'Continue with Apple',
         signingIn: 'Opening access…',
@@ -62,22 +80,39 @@ export const earlyBirdCopy = {
         enter: 'Enter the Beacon',
         redeem: 'Activate my invitation',
         accessNeeded: 'Your account does not have an active membership yet.',
-        freeTitle: 'Two hours of Beacon every day',
+        freeTitle: 'Your daily time · 2 hours',
         freeDescription: 'Choose a local start time. It repeats daily and can be changed after seven days.',
         listenFreeNow: 'Listen free now',
         chooseFreeTime: 'Choose another time',
         freeStartTime: 'Start time',
         saveFreeTime: 'Save my listening time',
+        savingFreeTime: 'Saving your time…',
+        startingFreeTime: 'Opening your Free time…',
+        cancelFreeTime: 'Back',
         freeTimeZone: 'Time zone',
+        savedFreeTime: 'Your daily time',
         nextFreeWindow: 'Your next listening window begins',
         freeScheduleLocked: 'You can change this schedule',
         freeScheduleError: 'We could not save the schedule. Please try again.',
-        welcomeListen: 'Listen for 30 minutes now',
+        welcomeTitle: 'Your first listen · 30 minutes',
+        welcomeListen: 'Listen now',
         welcomeStarting: 'Opening the Beacon…',
         welcomeDescription: 'Your first listen does not set your daily time yet.',
         welcomeError: 'We could not open this first listen. Please try again.',
         authError: 'We could not complete sign-in. Use the provider that created your account, or contact support.',
-        privacy: 'Your account and membership manage private access. We do not create personal listening histories.',
+        privacy: 'Your account and membership manage access. While you listen, we share only broad, ephemeral regional presence—never your exact location or a personal listening history.',
+        membershipInvitation: 'Invitation access',
+        membershipPreview: 'Preview access',
+        membershipFounderActive: 'Founder active',
+        membershipFounderGrace: 'Founder · temporary access',
+        membershipFounderEnding: 'Founder · active until the end of the period',
+        membershipFounderPending: 'Founder membership is not confirmed yet.',
+        membershipFounderExpired: 'Founder membership has ended.',
+        membershipFounderRefunded: 'The payment was refunded and Founder access has ended.',
+        membershipFounderRevoked: 'Founder access was closed.',
+        membershipFreeFallback: 'You can continue with the Free listening available to your account.',
+        membershipInvitationEnded: 'The invitation no longer provides access.',
+        membershipPreviewEnded: 'Preview access has ended.',
     },
 } satisfies Record<UiLocale, Record<string, string>>;
 
@@ -109,15 +144,15 @@ export const earlyBirdHomeCopy = {
         eyebrow: 'HARMONIC BEACON · LISTENER',
         heading: 'Beacon',
         listen: 'Escuchar',
-        mode: 'Cómo querés entrar',
+        mode: 'Cómo quieres entrar',
         withIntro: 'Con introducción',
         beaconOnly: 'Solo Beacon',
         skipToBeacon: 'Saltar al Beacon',
         seek: 'Posición',
         prepareDevice: 'Habilitar este dispositivo',
-        deviceReady: 'Dispositivo listo. Tocá otra vez para escuchar o elegí un drop-in.',
+        deviceReady: 'Dispositivo listo. Toca otra vez para escuchar o elige una introducción.',
         deviceLimitClaim: 'Ya hay dos dispositivos activos. Habilitar éste detendrá la escucha en el menos reciente.',
-        prepareHelp: 'No pudimos preparar el stream automáticamente. Habilitá este dispositivo antes de escuchar.',
+        prepareHelp: 'No pudimos preparar el stream automáticamente. Habilita este dispositivo antes de escuchar.',
         pause: 'Pausar',
         resume: 'Continuar',
         paused: 'Pausado',
@@ -125,8 +160,8 @@ export const earlyBirdHomeCopy = {
         reconnecting: 'Restableciendo conexión…',
         unavailable: 'El Beacon no está disponible en este momento.',
         displaced: 'Este dispositivo fue desplazado porque la cuenta ya está escuchando en otros dos dispositivos.',
-        spanish: 'Caldeamiento · Español',
-        english: 'Warm-up · English',
+        spanish: 'Introducción · Español',
+        english: 'Introducción · Inglés',
         dropUnavailable: 'El render aprobado todavía no fue publicado.',
         introSelection: 'Intro antes del Beacon',
         stop: 'Detener',
@@ -135,7 +170,7 @@ export const earlyBirdHomeCopy = {
         stopped: 'Detenido',
         master: 'Volumen',
         signOut: 'Cerrar sesión',
-        active: 'Founding Listener activo',
+        active: 'Listener activo',
         freeActive: 'Horario Free activo',
         welcomeActive: 'Primera escucha activa',
         account: 'Cuenta',
@@ -170,9 +205,42 @@ export const earlyBirdHomeCopy = {
         stopped: 'Stopped',
         master: 'Volume',
         signOut: 'Sign out',
-        active: 'Founding Listener active',
+        active: 'Listener active',
         freeActive: 'Free window active',
         welcomeActive: 'First listen active',
         account: 'Account',
     },
 } satisfies Record<UiLocale, Record<string, string>>;
+
+type MembershipCopy = { [Key in keyof typeof earlyBirdCopy.en]: string };
+
+export function listenerMembershipPresentationCopy(
+    copy: MembershipCopy,
+    presentation: ListenerMembershipPresentation,
+): { title: string; detail: string | null } | null {
+    if (presentation.kind === 'none') return null;
+
+    if (presentation.kind === 'invitation') {
+        return {
+            title: copy.membershipInvitation,
+            detail: presentation.state === 'active' ? null : copy.membershipInvitationEnded,
+        };
+    }
+    if (presentation.kind === 'preview') {
+        return {
+            title: copy.membershipPreview,
+            detail: presentation.state === 'active' ? null : copy.membershipPreviewEnded,
+        };
+    }
+
+    const provider = presentation.provider === 'paypal' ? 'PayPal' : 'Mercado Pago';
+    switch (presentation.state) {
+        case 'active': return { title: copy.membershipFounderActive, detail: provider };
+        case 'grace': return { title: copy.membershipFounderGrace, detail: provider };
+        case 'ending': return { title: copy.membershipFounderEnding, detail: provider };
+        case 'pending': return { title: copy.membershipFounderPending, detail: copy.membershipFreeFallback };
+        case 'expired': return { title: copy.membershipFounderExpired, detail: copy.membershipFreeFallback };
+        case 'refunded': return { title: copy.membershipFounderRefunded, detail: copy.membershipFreeFallback };
+        case 'revoked': return { title: copy.membershipFounderRevoked, detail: copy.membershipFreeFallback };
+    }
+}

--- a/src/lib/early-birds/membership-presentation.ts
+++ b/src/lib/early-birds/membership-presentation.ts
@@ -1,0 +1,68 @@
+import type { EarlyBirdMembershipProjection } from '@prisma/client';
+
+import { EARLY_BIRDS_FOUNDERS_OFFER } from './membership';
+
+export type ListenerMembershipPresentationState =
+    | 'pending'
+    | 'active'
+    | 'grace'
+    | 'ending'
+    | 'expired'
+    | 'refunded'
+    | 'revoked';
+
+export type ListenerMembershipPresentation =
+    | { kind: 'none'; state: 'none' }
+    | { kind: 'invitation'; state: ListenerMembershipPresentationState }
+    | { kind: 'preview'; state: ListenerMembershipPresentationState }
+    | {
+        kind: 'founder';
+        provider: 'paypal' | 'mercado-pago';
+        state: ListenerMembershipPresentationState;
+    };
+
+function presentationState(
+    state: EarlyBirdMembershipProjection['state'],
+): ListenerMembershipPresentationState {
+    switch (state) {
+        case 'PENDING': return 'pending';
+        case 'ACTIVE': return 'active';
+        case 'GRACE': return 'grace';
+        case 'CANCELLED_PENDING_END': return 'ending';
+        case 'EXPIRED': return 'expired';
+        case 'REFUNDED': return 'refunded';
+        case 'REVOKED': return 'revoked';
+    }
+}
+
+/**
+ * Reduce the canonical read model to the only membership facts the public UI
+ * may present. Internal source names, revisions, reason codes and payment
+ * identifiers never cross the Server Component boundary.
+ */
+export function listenerMembershipPresentation(
+    projection: EarlyBirdMembershipProjection | null,
+): ListenerMembershipPresentation {
+    if (!projection) return { kind: 'none', state: 'none' };
+
+    const state = presentationState(projection.state);
+    if (projection.synthetic) return { kind: 'preview', state };
+    if (projection.source === 'FREE') return { kind: 'invitation', state };
+    if (
+        projection.offerCode === EARLY_BIRDS_FOUNDERS_OFFER
+        && projection.source === 'PAYPAL'
+    ) {
+        return { kind: 'founder', provider: 'paypal', state };
+    }
+    if (
+        projection.offerCode === EARLY_BIRDS_FOUNDERS_OFFER
+        && projection.source === 'MERCADO_PAGO'
+    ) {
+        return { kind: 'founder', provider: 'mercado-pago', state };
+    }
+
+    // Unknown and incomplete projections fail closed in presentation just as
+    // they do in authorization. Never infer Founder status from an offer,
+    // price, redirect or reason code.
+    return { kind: 'none', state: 'none' };
+}


### PR DESCRIPTION
## Diagnosis

The Listener entry surface mixed the one-time 30-minute welcome with the recurring two-hour Free schedule, exposed raw membership source values in the account menu, and described invitation or inactive access as if it were a generic Founder membership. The custom schedule chooser also had no way back and did not present the saved wall-clock time and IANA time zone clearly.

## Scope

- Present a clear hierarchy between the one-time 30-minute welcome and the recurring daily two-hour Free schedule.
- Add chooser back/cancel, busy states, `aria-busy`, authoritative refresh, and explicit saved local time plus IANA zone.
- Derive a sanitized membership presentation on the server: invitation, preview, or Founder lifecycle.
- Recognize Founder only for PayPal or Mercado Pago projections carrying the canonical `EARLY_BIRDS_FOUNDERS_V1` offer; unknown or future products fail closed.
- Explain terminal Founder states truthfully and return the account to its available Free path.
- Remove generic permanent-access and paid-equivalence claims; use international Spanish and neutral Listener labeling.
- State in the privacy footer that listening shares only broad, ephemeral regional presence, never exact location or personal listening history.
- Keep UI language automatic; no LanguageControl remains on Listener surfaces. The player intro selector remains the only visible language override and does not change UI locale.

## Evidence

- 38/38 focused tests passed.
- `npx tsc --noEmit` passed.
- Focused ESLint passed.
- `git diff --check` passed.
- `rg LanguageControl src/components/early-birds src/app/early-birds` returns no matches.
- Rebased on `early-birds@fc6f7df` with the Listener namespace compatibility slice and no conflicts.

## Boundaries and risk

- No audio player, controller, assets, codec, gain, fades, buffering, stream routing, or event audio changed.
- No payment adapter, checkout, webhook, backend commerce contract, GeoIP resolver, namespace route, nginx, or production event surface changed.
- No raw membership source, reason code, provider-internal value, payment identifier, or PII crosses the public presentation boundary.

## Rollback

Revert commit `db93229d800436039e5f5bf3d474305052c4b846`. The change has no migration or external-state side effect; reverting restores the previous copy and presentation props.