### PR TITLE
test(listener): align intro labels with bilingual copy

### DIFF
--- a/src/components/early-birds/__tests__/ListenerTransport.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerTransport.test.tsx
@@ -89,8 +89,8 @@ describe('Listener one-action playlist transport', () => {
     it('uses the browser-derived page language to play only the matching introduction', async () => {
         const { play } = prepareMedia();
         renderPlayer({ es: '/api/drop-ins/es', en: '/api/drop-ins/en' }, 'es');
-        const spanish = screen.getByLabelText('Caldeamiento · Español') as HTMLAudioElement;
-        const english = screen.getByLabelText('Warm-up · English') as HTMLAudioElement;
+        const spanish = screen.getByLabelText('Introducción · Español') as HTMLAudioElement;
+        const english = screen.getByLabelText('Introducción · Inglés') as HTMLAudioElement;
         await waitForListen();
 
         await waitFor(() => expect(screen.getByRole('combobox', { name: 'Intro antes del Beacon' }))
@@ -105,8 +105,8 @@ describe('Listener one-action playlist transport', () => {
     it('lets the intro dropdown override the browser-language default', async () => {
         const { play } = prepareMedia();
         renderPlayer({ es: '/api/drop-ins/es', en: '/api/drop-ins/en' }, 'es');
-        const spanish = screen.getByLabelText('Caldeamiento · Español') as HTMLAudioElement;
-        const english = screen.getByLabelText('Warm-up · English') as HTMLAudioElement;
+        const spanish = screen.getByLabelText('Introducción · Español') as HTMLAudioElement;
+        const english = screen.getByLabelText('Introducción · Inglés') as HTMLAudioElement;
         await waitForListen();
 
         fireEvent.change(screen.getByRole('combobox', { name: 'Intro antes del Beacon' }), {


### PR DESCRIPTION
## Summary

- align two Spanish-locale transport tests with the copy merged in #231
- restore the aggregate EarlyBirds CI gate without changing runtime or audio

## Evidence

- `npm test -- --run src/components/early-birds/__tests__/ListenerTransport.test.tsx` — 11/11 passed
- `git diff --check`

## Risk / rollback

Test-only change. Revert commit `14ad9c0` to roll back.

Closes the CI regression observed on aggregate PR #203.