### PR TITLE
feat(listener): add host-safe public discovery

### DIFF
--- a/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
@@ -68,6 +68,27 @@ server {
         proxy_read_timeout 5s;
     }
 
+    # Public search discovery is exposed only at the canonical filenames. The
+    # application endpoints remain internal and also verify the Host header so
+    # this branch cannot publish Listener discovery on an event vhost.
+    location = /robots.txt {
+        rewrite ^ /api/listener/public-discovery/robots.txt break;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+    }
+
+    location = /sitemap.xml {
+        rewrite ^ /api/listener/public-discovery/sitemap.xml break;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+    }
+
     location = /early-birds {
         return 302 /;
     }

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -186,6 +186,11 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.match(listener, /location \^~ \/api\/early-birds\/auth\//);
   assert.match(listener, /location = \/api\/early-birds\/free-window/);
   assert.match(listener, /location = \/api\/listener\/presence/);
+  assert.match(listener, /location = \/robots\.txt \{[^}]*rewrite \^ \/api\/listener\/public-discovery\/robots\.txt break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;[^}]*proxy_set_header Host \$host;/s);
+  assert.match(listener, /location = \/sitemap\.xml \{[^}]*rewrite \^ \/api\/listener\/public-discovery\/sitemap\.xml break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;[^}]*proxy_set_header Host \$host;/s);
+  assert.equal((listener.match(/location = \/robots\.txt/g) ?? []).length, 1);
+  assert.equal((listener.match(/location = \/sitemap\.xml/g) ?? []).length, 1);
+  assert.doesNotMatch(listener, /location \^~ \/api\/listener\/public-discovery\//);
   assert.doesNotMatch(listener, /api\/early-birds\/(test-login|free\/|membership)/);
   assert.doesNotMatch(listener, /location \^~ \/early-birds\//);
 

--- a/src/app/api/listener/public-discovery/__tests__/route.test.ts
+++ b/src/app/api/listener/public-discovery/__tests__/route.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { GET as getRobots } from '../robots.txt/route';
+import { GET as getSitemap } from '../sitemap.xml/route';
+
+function request(path: string, host: string): Request {
+    return new Request(`https://${host}${path}`, { headers: { host } });
+}
+
+describe('Listener discovery routes', () => {
+    it('serves robots and sitemap on the canonical public host', async () => {
+        const robots = getRobots(request('/robots.txt', 'listen.harmonicbeacon.com'));
+        const sitemap = getSitemap(request('/sitemap.xml', 'listen.harmonicbeacon.com'));
+
+        expect(robots.status).toBe(200);
+        expect(robots.headers.get('content-type')).toBe('text/plain; charset=utf-8');
+        expect(await robots.text()).toContain('https://listen.harmonicbeacon.com/sitemap.xml');
+        expect(sitemap.status).toBe(200);
+        expect(sitemap.headers.get('content-type')).toBe('application/xml; charset=utf-8');
+        expect(await sitemap.text()).toContain('<loc>https://listen.harmonicbeacon.com/</loc>');
+    });
+
+    it.each(['live.harmonicbeacon.com', 'earlybirds-staging.harmonicbeacon.com']) (
+        'fails closed on %s',
+        async (host) => {
+            const robots = getRobots(request('/robots.txt', host));
+            const sitemap = getSitemap(request('/sitemap.xml', host));
+
+            expect(robots.status).toBe(404);
+            expect(sitemap.status).toBe(404);
+            expect(await robots.text()).toBe('');
+            expect(await sitemap.text()).toBe('');
+        },
+    );
+});

--- a/src/app/api/listener/public-discovery/robots.txt/route.ts
+++ b/src/app/api/listener/public-discovery/robots.txt/route.ts
@@ -1,0 +1,19 @@
+import {
+    isCanonicalListenerHost,
+    listenerRobotsText,
+} from '@/lib/listener/public-discovery';
+
+const PUBLIC_CACHE = 'public, max-age=300, stale-while-revalidate=3600';
+
+export function GET(request: Request): Response {
+    if (!isCanonicalListenerHost(request.headers)) {
+        return new Response(null, { status: 404 });
+    }
+
+    return new Response(listenerRobotsText(), {
+        headers: {
+            'Cache-Control': PUBLIC_CACHE,
+            'Content-Type': 'text/plain; charset=utf-8',
+        },
+    });
+}

--- a/src/app/api/listener/public-discovery/sitemap.xml/route.ts
+++ b/src/app/api/listener/public-discovery/sitemap.xml/route.ts
@@ -1,0 +1,19 @@
+import {
+    isCanonicalListenerHost,
+    listenerSitemapXml,
+} from '@/lib/listener/public-discovery';
+
+const PUBLIC_CACHE = 'public, max-age=300, stale-while-revalidate=3600';
+
+export function GET(request: Request): Response {
+    if (!isCanonicalListenerHost(request.headers)) {
+        return new Response(null, { status: 404 });
+    }
+
+    return new Response(listenerSitemapXml(), {
+        headers: {
+            'Cache-Control': PUBLIC_CACHE,
+            'Content-Type': 'application/xml; charset=utf-8',
+        },
+    });
+}

--- a/src/app/early-birds/page.tsx
+++ b/src/app/early-birds/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import { cookies, headers as requestHeaders } from 'next/headers';
 
 import EarlyBirdLanding from '@/components/early-birds/EarlyBirdLanding';
@@ -21,13 +20,23 @@ import { serializeWelcomeAccessState, welcomeAccessState } from '@/lib/early-bir
 import { earlyBirdMagicLinkAvailable } from '@/lib/early-birds/magic-link';
 import { listenerCampfirePrototypeConfig } from '@/lib/early-birds/campfire-prototype';
 import { listenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
+import { localeForBrowserLanguage } from '@/lib/i18n';
+import {
+    isCanonicalListenerHost,
+    listenerPreviewMetadata,
+    listenerPublicMetadata,
+} from '@/lib/listener/public-discovery';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
-    title: 'Listen · Harmonic Beacon',
-    description: 'A continuous harmonic field, shared across the world.',
-};
+export async function generateMetadata() {
+    const incomingHeaders = await requestHeaders();
+    if (!isCanonicalListenerHost(incomingHeaders)) return listenerPreviewMetadata();
+
+    return listenerPublicMetadata(
+        localeForBrowserLanguage(incomingHeaders.get('accept-language')),
+    );
+}
 
 export default async function EarlyBirdsPage({
     searchParams,

--- a/src/app/listener/page.tsx
+++ b/src/app/listener/page.tsx
@@ -1,3 +1,3 @@
 export const dynamic = 'force-dynamic';
 
-export { metadata, default } from '../early-birds/page';
+export { generateMetadata, default } from '../early-birds/page';

--- a/src/lib/listener/__tests__/public-discovery.test.ts
+++ b/src/lib/listener/__tests__/public-discovery.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    isCanonicalListenerHost,
+    LISTENER_CANONICAL_URL,
+    listenerPreviewMetadata,
+    listenerPublicMetadata,
+    listenerRobotsText,
+    listenerSitemapXml,
+} from '../public-discovery';
+
+function requestHeaders(host: string | null): Headers {
+    const headers = new Headers();
+    if (host) headers.set('host', host);
+    return headers;
+}
+
+describe('Listener public discovery', () => {
+    it('accepts only the canonical Listener host, including its explicit port', () => {
+        expect(isCanonicalListenerHost(requestHeaders('listen.harmonicbeacon.com'))).toBe(true);
+        expect(isCanonicalListenerHost(requestHeaders('listen.harmonicbeacon.com:443'))).toBe(true);
+        expect(isCanonicalListenerHost(requestHeaders('earlybirds-staging.harmonicbeacon.com'))).toBe(false);
+        expect(isCanonicalListenerHost(requestHeaders('live.harmonicbeacon.com'))).toBe(false);
+        expect(isCanonicalListenerHost(requestHeaders('live.harmonicbeacon.com, listen.harmonicbeacon.com'))).toBe(false);
+        expect(isCanonicalListenerHost(requestHeaders('live.harmonicbeacon.com@listen.harmonicbeacon.com'))).toBe(false);
+        expect(isCanonicalListenerHost(requestHeaders('listen.harmonicbeacon.com:99999'))).toBe(false);
+        expect(isCanonicalListenerHost(requestHeaders(null))).toBe(false);
+    });
+
+    it.each([
+        ['es', 'Harmonic Beacon · Recuerda tu centro armónico.', 'Un campo armónico continuo, compartido alrededor del mundo.'],
+        ['en', 'Harmonic Beacon · Remember your harmonic center.', 'A continuous harmonic field, shared across the world.'],
+    ] as const)('builds complete %s metadata for the one canonical URL', (locale, title, description) => {
+        const metadata = listenerPublicMetadata(locale);
+
+        expect(metadata.metadataBase?.toString()).toBe('https://listen.harmonicbeacon.com/');
+        expect(metadata.title).toBe(title);
+        expect(metadata.description).toBe(description);
+        expect(metadata.alternates).toEqual({ canonical: '/' });
+        expect(metadata.openGraph).toMatchObject({
+            type: 'website',
+            url: '/',
+            siteName: 'Harmonic Beacon',
+            title,
+            description,
+        });
+        expect(metadata.twitter).toEqual({ card: 'summary', title, description });
+        expect(metadata.robots).toEqual({ index: true, follow: true });
+        expect(JSON.stringify(metadata)).not.toMatch(/early.?bird|projection|psychodrama|therap/i);
+    });
+
+    it('keeps non-public hosts out of search indexes without assigning a canonical URL', () => {
+        const metadata = listenerPreviewMetadata();
+
+        expect(metadata.metadataBase).toBeUndefined();
+        expect(metadata.alternates).toBeUndefined();
+        expect(metadata.robots).toEqual({ index: false, follow: false, nocache: true });
+    });
+
+    it('enumerates only the canonical Listener surface in robots and sitemap', () => {
+        const robots = listenerRobotsText();
+        const sitemap = listenerSitemapXml();
+
+        expect(robots).toBe(
+            'User-agent: *\nAllow: /\nSitemap: https://listen.harmonicbeacon.com/sitemap.xml\n',
+        );
+        expect(sitemap).toContain(`<loc>${LISTENER_CANONICAL_URL}</loc>`);
+        expect(sitemap.match(/<url>/g)).toHaveLength(1);
+        expect(`${robots}\n${sitemap}`).not.toMatch(/early.?bird|staging|live\.harmonic|event|evento|hreflang/i);
+    });
+});

--- a/src/lib/listener/public-discovery.ts
+++ b/src/lib/listener/public-discovery.ts
@@ -1,0 +1,102 @@
+import type { Metadata } from 'next';
+
+import type { UiLocale } from '@/lib/i18n';
+
+export const LISTENER_PUBLIC_HOST = 'listen.harmonicbeacon.com';
+export const LISTENER_PUBLIC_ORIGIN = `https://${LISTENER_PUBLIC_HOST}`;
+export const LISTENER_CANONICAL_URL = `${LISTENER_PUBLIC_ORIGIN}/`;
+
+const localizedMetadata: Record<UiLocale, { title: string; description: string }> = {
+    es: {
+        title: 'Harmonic Beacon · Recuerda tu centro armónico.',
+        description: 'Un campo armónico continuo, compartido alrededor del mundo.',
+    },
+    en: {
+        title: 'Harmonic Beacon · Remember your harmonic center.',
+        description: 'A continuous harmonic field, shared across the world.',
+    },
+};
+
+function normalizedHost(value: string | null): string | null {
+    const candidate = value?.trim().toLowerCase();
+    if (!candidate) return null;
+    const authority = /^([a-z0-9.-]+)(?::(\d{1,5}))?$/.exec(candidate);
+    if (!authority) return null;
+    if (authority[2] && Number(authority[2]) > 65_535) return null;
+    return authority[1];
+}
+
+/**
+ * Public discovery is deliberately bound to the Listener hostname. This keeps
+ * the routes inert if the Listener branch is later merged into the event app.
+ * The Listener nginx template always forwards the original Host header.
+ */
+export function isCanonicalListenerHost(headers: Pick<Headers, 'get'>): boolean {
+    return normalizedHost(headers.get('host')) === LISTENER_PUBLIC_HOST;
+}
+
+export function listenerPublicMetadata(locale: UiLocale): Metadata {
+    const copy = localizedMetadata[locale];
+
+    return {
+        metadataBase: new URL(LISTENER_PUBLIC_ORIGIN),
+        applicationName: 'Harmonic Beacon',
+        title: copy.title,
+        description: copy.description,
+        keywords: ['Harmonic Beacon'],
+        authors: [{ name: 'Harmonic Beacon' }],
+        creator: 'Harmonic Beacon',
+        publisher: 'Harmonic Beacon',
+        alternates: {
+            canonical: '/',
+        },
+        openGraph: {
+            type: 'website',
+            url: '/',
+            siteName: 'Harmonic Beacon',
+            title: copy.title,
+            description: copy.description,
+            locale: locale === 'es' ? 'es_ES' : 'en_US',
+        },
+        twitter: {
+            card: 'summary',
+            title: copy.title,
+            description: copy.description,
+        },
+        robots: {
+            index: true,
+            follow: true,
+        },
+    };
+}
+
+export function listenerPreviewMetadata(): Metadata {
+    return {
+        title: 'Listen · Harmonic Beacon',
+        description: 'A continuous harmonic field, shared across the world.',
+        robots: {
+            index: false,
+            follow: false,
+            nocache: true,
+        },
+    };
+}
+
+export function listenerRobotsText(): string {
+    return [
+        'User-agent: *',
+        'Allow: /',
+        `Sitemap: ${LISTENER_PUBLIC_ORIGIN}/sitemap.xml`,
+        '',
+    ].join('\n');
+}
+
+export function listenerSitemapXml(): string {
+    return [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        `  <url><loc>${LISTENER_CANONICAL_URL}</loc></url>`,
+        '</urlset>',
+        '',
+    ].join('\n');
+}


### PR DESCRIPTION
## Outcome

Adds the bounded public-discovery slice of #213 for `listen.harmonicbeacon.com` without changing the Listener UI, player, audio, payments, events or `live.harmonicbeacon.com`.

- host-aware ES/EN metadata with Harmonic Beacon naming, `metadataBase`, canonical root, Open Graph and Twitter summary metadata;
- non-Listener hosts remain `noindex`, without a Listener canonical URL;
- internal, host-guarded robots and sitemap endpoints;
- exact Listener nginx allowlist/rewrites for `/robots.txt` and `/sitemap.xml`;
- sitemap enumerates only `https://listen.harmonicbeacon.com/`;
- no hreflang because ES and EN intentionally share one URL;
- no EarlyBird, event, staging or medical/therapeutic language in public discovery.

This contributes the metadata/discovery acceptance item to #213; it does **not** close the broader journey issue.

## Evidence

- `npm test -- --run src/app/early-birds/__tests__/page.test.tsx src/lib/listener/__tests__/public-discovery.test.ts src/app/api/listener/public-discovery/__tests__/route.test.ts` — 14 passed
- `npm --prefix ops/early-birds-preview test` — 26 passed
- `npx tsc --noEmit` — passed
- focused ESLint on all touched TypeScript/TSX files — passed
- `npm run build` — passed
- `git diff --check` — passed

## Security / isolation

The application discovery routes reject every Host except `listen.harmonicbeacon.com`. The public vhost exposes only the two exact conventional filenames; the internal API prefix is not allowlisted. This keeps Listener discovery inert if the branch is later merged into the event app.

## Risk

Low and isolated. The only runtime edge change is two exact nginx locations. A malformed or unexpected Host fails closed with 404. Metadata on preview/non-Listener hosts is explicitly non-indexable.

## Rollback

Revert commit `c04c500` and restore the previous Listener nginx template. No schema, data, session, payment or audio rollback is required.

## Deployment verification (not executed in this PR)

After installing the Listener vhost template and deploying the app SHA:

1. verify ES and EN page metadata with corresponding `Accept-Language` headers;
2. verify `/robots.txt` and `/sitemap.xml` return 200 only on the Listener hostname;
3. verify the sitemap contains exactly one `<url>` for the canonical root;
4. verify staging/live Host requests to the internal discovery endpoints return 404;
5. smoke health/readiness and existing Google sign-in unchanged.
