### PR TITLE
fix(deps): update nanoid for GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8108,9 +8108,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update transitive `nanoid` from 3.3.16 to 3.3.17 in the lockfile
- clear the new high-severity production dependency gate without broad dependency churn

Advisory: GHSA-2v37-7h3g-55p8.

## Evidence

- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- lockfile diff is exactly one package version/resolved/integrity tuple
- `git diff --check`

## Risk / rollback

No source or audio changes. Revert this commit to roll back the lockfile update.