### PR TITLE
test(listener): verify zero-request 4k and 5k plans

### DIFF
--- a/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+++ b/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
@@ -202,6 +202,16 @@ evidence, not authorization to promote it to `main` or production.
   `f7d3254d510530172ed1fcc708fb6f7c70487e5d75f5416da3c9ebb591a28d1e`
   and attest zero network requests. This proves distribution readiness, not
   throughput or customer capacity.
+- The 4,000 expansion and 5,000 critical profiles were subsequently dry-run
+  across the same two external generators as six and eight shards. The verified
+  plans cover every index, sum to exactly 4,000 and 5,000 clients, use two
+  distinct generator fingerprints, preserve mode `0600` and attest zero network
+  requests. Their plan hashes are respectively
+  `67b68f412789c1ae3ad8e950c49480704d5c06f33b445788272a0a73fb73a3dd`
+  and `845206f4b8c1e605953a1efd8066b73b9bba87e2487627f3022bd337ec6d44ec`.
+  The exact redacted evidence record is
+  `docs/ops/evidence/2026-08-07-listener-4k5k-dryruns.md`. No load was executed;
+  measured origin, application and customer capacity remain open.
 
 Protected runtime configuration remains under `/etc/harmonic-beacon/`; this
 record never includes its values. The supervised human Free invitation is

--- a/docs/ops/evidence/2026-08-07-listener-4k5k-dryruns.md
+++ b/docs/ops/evidence/2026-08-07-listener-4k5k-dryruns.md
@@ -1,0 +1,57 @@
+# Listener 4,000 / 5,000 zero-request capacity plans
+
+Date: 2026-08-07
+
+These are distributed **planning** artifacts, not load, throughput or customer
+capacity evidence. The HLS harness ran only with `--dry-run`; all fourteen shard
+files attest `networkRequestsMade=false` and contain zero runtime measurements.
+No manifest URL, signing key, cookie, session or network request was used.
+
+## Inputs and generators
+
+- branch base: `5ae1e030c43c118b5efa749831ba3f8b75fe9a05`;
+- profile document SHA-256:
+  `06ad500c07d212f7caeccff70a13fad11f3a69730e338cc8f5197408535b7c4e`;
+- protected non-production target-policy SHA-256:
+  `60cc2a02be737d522e60a14b8c8cbb6d174689dba050f5eb8002c89bc97e740f`;
+- external generators: `legion` and `daimonmatrix`, both reporting
+  `NTPSynchronized=yes` at planning time;
+- raw and collected evidence files: exact mode `0600`;
+- durable archives:
+  `~/.local/state/harmonic-beacon/listener-load-evidence/20260807-4k5k-zero-request`
+  on both generators. The consolidated verifier summaries are retained on
+  `legion` at the same path.
+
+The target policy contains no credential or signed URL. It is still kept out of
+Git because a high-limit policy is an operator input, not authorization to run.
+
+## Verified plans
+
+| Profile | Clients | Shards | Generators | Plan hash | Summary SHA-256 |
+| --- | ---: | ---: | ---: | --- | --- |
+| `origin-media-4000-expansion` | 4,000 | 6 | 2 | `67b68f412789c1ae3ad8e950c49480704d5c06f33b445788272a0a73fb73a3dd` | `9ffee73162898f99d1ebe13925e460acd44628f9d6d198aa0f5c3206a0d98452` |
+| `origin-media-5000-critical` | 5,000 | 8 | 2 | `845206f4b8c1e605953a1efd8066b73b9bba87e2487627f3022bd337ec6d44ec` | `022068aa97e6be03f90d205f1907dd856db9e0d9ab1feaf2ecc86fade22b1d3f` |
+
+The 4,000 plan covers indices `0..5`, with local client counts
+`667,667,667,667,666,666` and an exact total of 4,000. The 5,000 plan covers
+indices `0..7`, with 625 clients per shard and an exact total of 5,000. Every
+plan has two distinct generator fingerprints and unique client-ordinal hashes.
+
+Verification command:
+
+```bash
+node tools/early-birds-hls-load/verify-planned.mjs \
+  --min-generators 2 /secure/collected/<profile>-shard-*.json
+```
+
+The committed verifier independently checks the plan hash, input hashes,
+complete unique indices, client sum, generator count, ordinal hashes, redaction,
+exact source mode and absence of network/runtime activity.
+
+## Gate that remains closed
+
+This record does not authorize the next step. A network run still requires an
+explicit monitored window, fresh short-lived signed manifest files, external
+decoded canary, target operators and stepwise go/no-go starting at the smallest
+approved client count. It must never jump directly to 4,000 or 5,000 and must
+never run from `mona`.

--- a/tools/early-birds-hls-load/README.md
+++ b/tools/early-birds-hls-load/README.md
@@ -65,6 +65,9 @@ runtime code.
   limits no larger than the reviewed run.
 - `run.mjs`: one dry-run or network shard.
 - `aggregate.mjs`: verifies and combines one evidence file from every shard.
+- `verify-planned.mjs`: verifies a complete multi-generator dry-run set, including
+  shared plan hash, complete shard indices, exact client sum, distinct generator
+  fingerprints, redaction, zero network requests and mode `0600` sources.
 
 ## Tiny dry-run
 
@@ -84,6 +87,18 @@ node tools/early-birds-hls-load/run.mjs \
 Dry-run validates the complete plan, writes `PLANNED` evidence and prints the
 exact confirmation required by a network run. It does not read a signed URL or
 contact the target.
+
+Validate a complete distributed plan before requesting a network run:
+
+```bash
+node tools/early-birds-hls-load/verify-planned.mjs \
+  --min-generators 2 \
+  /secure/load-plan/shard-*.json
+```
+
+The verifier emits a redacted JSON summary. It refuses partial/duplicate shard
+sets, a mismatched plan or input hash, non-`0600` sources and any evidence that
+contains runtime measurements or claims a network request.
 
 See [`docs/ops/EARLY_BIRDS_HLS_LOAD_SOAK.md`](../../docs/ops/EARLY_BIRDS_HLS_LOAD_SOAK.md)
 for the distributed procedure, stop conditions and evidence interpretation.

--- a/tools/early-birds-hls-load/package.json
+++ b/tools/early-birds-hls-load/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "External, bounded, format-neutral HLS load and soak evidence harness",
   "scripts": {
-    "check": "node --check run.mjs && node --check aggregate.mjs && node --check src/contracts.mjs && node --check src/runner.mjs",
+    "check": "node --check run.mjs && node --check aggregate.mjs && node --check verify-planned.mjs && node --check src/contracts.mjs && node --check src/runner.mjs",
     "test": "node --test test/*.test.mjs"
   },
   "engines": {

--- a/tools/early-birds-hls-load/test/verify-planned.test.mjs
+++ b/tools/early-birds-hls-load/test/verify-planned.test.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { chmod, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import test from 'node:test';
+
+import { buildPlan, selectTarget } from '../src/contracts.mjs';
+import { plannedEvidence } from '../src/runner.mjs';
+
+const profile = {
+  clients: 2,
+  rampPerSecond: 2,
+  soakSeconds: 1,
+  manifestIntervalMs: 100,
+  requestTimeoutMs: 100,
+  startupSegments: 1,
+  maxSegmentsPerPoll: 2,
+  maxInflightPerShard: 4,
+  minShards: 1,
+  maxErrorRate: 0,
+  maxFetchMissRate: 0,
+  maxManifestP95Ms: 100,
+  maxSegmentP95Ms: 100,
+  syntheticOnly: true,
+};
+
+const target = selectTarget({
+  schemaVersion: 1,
+  targets: [{
+    id: 'tiny-origin',
+    environment: 'synthetic',
+    production: false,
+    origins: ['http://127.0.0.1:9'],
+    limits: {
+      maxClients: 2,
+      maxRampPerSecond: 2,
+      maxSoakSeconds: 2,
+      maxShardCount: 2,
+      minManifestIntervalMs: 25,
+      maxInflightPerShard: 4,
+      maxSegmentsPerPoll: 2,
+      maxRequestsPerSecond: 100,
+      maxManifestBytes: 65536,
+      maxSegmentBytes: 1048576,
+      maxClockOffsetMs: 100,
+    },
+  }],
+}, 'tiny-origin');
+
+async function invoke(paths, minimumGenerators = 2) {
+  const script = path.resolve(import.meta.dirname, '..', 'verify-planned.mjs');
+  const child = spawn(process.execPath, [
+    script,
+    '--min-generators', String(minimumGenerators),
+    ...paths,
+  ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  const [code] = await once(child, 'close');
+  return { code, stdout, stderr };
+}
+
+async function fixture() {
+  const directory = await mkdtemp(path.join(tmpdir(), 'listener-planned-evidence-'));
+  const paths = [];
+  for (let index = 0; index < 2; index += 1) {
+    const plan = buildPlan({
+      runId: 'dry-run-proof',
+      profileName: 'tiny-synthetic',
+      profile,
+      target,
+      shardIndex: index,
+      shardCount: 2,
+      startAt: '2030-01-01T00:00:00.000Z',
+      networkRun: false,
+    });
+    const evidence = plannedEvidence({
+      plan,
+      target,
+      policySha256: 'a'.repeat(64),
+      profileSha256: 'b'.repeat(64),
+      hostname: `generator-${index}`,
+    });
+    const evidencePath = path.join(directory, `shard-${index}.json`);
+    await writeFile(evidencePath, `${JSON.stringify(evidence)}\n`, { mode: 0o600 });
+    await chmod(evidencePath, 0o600);
+    paths.push(evidencePath);
+  }
+  return paths;
+}
+
+test('verifies a complete zero-request multi-generator plan', async () => {
+  const paths = await fixture();
+  const result = await invoke(paths);
+  assert.equal(result.code, 0, result.stderr);
+  const summary = JSON.parse(result.stdout);
+  assert.equal(summary.status, 'PLANNED');
+  assert.equal(summary.clients, 2);
+  assert.equal(summary.shardCount, 2);
+  assert.equal(summary.distinctGenerators, 2);
+  assert.equal(summary.networkRequestsMade, false);
+  assert.deepEqual(summary.sourceShards.map((entry) => entry.index), [0, 1]);
+});
+
+test('refuses evidence that claims network activity', async () => {
+  const paths = await fixture();
+  const evidence = JSON.parse(await readFile(paths[1], 'utf8'));
+  evidence.generator.networkRequestsMade = true;
+  await writeFile(paths[1], `${JSON.stringify(evidence)}\n`);
+  const result = await invoke(paths);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /zero network requests/);
+});
+
+test('refuses evidence that is not mode 0600', async () => {
+  const paths = await fixture();
+  await chmod(paths[1], 0o640);
+  const result = await invoke(paths);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /mode must be exactly 0600/);
+});

--- a/tools/early-birds-hls-load/verify-planned.mjs
+++ b/tools/early-birds-hls-load/verify-planned.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFile, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import {
+  EVIDENCE_KIND,
+  EVIDENCE_SCHEMA_VERSION,
+  assertRedactedEvidence,
+  sha256,
+  validateProfile,
+} from './src/contracts.mjs';
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => (
+      `${JSON.stringify(key)}:${canonicalJson(value[key])}`
+    )).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sameValue(left, right) {
+  return sha256(canonicalJson(left)) === sha256(canonicalJson(right));
+}
+
+function emptyMeasurements(measurements) {
+  return measurements?.clients?.started === 0
+    && measurements.clients.completed === 0
+    && measurements.clients.generatorScheduleMisses === 0
+    && measurements.requests?.total === 0
+    && measurements.requests.successful === 0
+    && measurements.requests.failed === 0
+    && measurements.bytes?.total === 0
+    && measurements.fetchContinuity?.opportunities === 0
+    && measurements.fetchContinuity.successfulMediaFetches === 0
+    && measurements.fetchContinuity.misses === 0
+    && measurements.manifest?.samples === 0;
+}
+
+function validatePlannedEvidence(evidence) {
+  assert(evidence?.schemaVersion === EVIDENCE_SCHEMA_VERSION, 'unexpected evidence schema');
+  assert(evidence.kind === EVIDENCE_KIND, 'unexpected evidence kind');
+  assert(evidence.status === 'PLANNED', 'planned verification accepts only PLANNED evidence');
+  assertRedactedEvidence(evidence);
+  assert(evidence.generator?.role === 'dry-run', 'planned evidence generator role must be dry-run');
+  assert(evidence.generator.networkRequestsMade === false,
+    'planned evidence must attest zero network requests');
+  assert(/^[a-f0-9]{64}$/.test(evidence.generator.hostFingerprintSha256 ?? ''),
+    'generator fingerprint is invalid');
+  assert(evidence.target?.origin === null && evidence.target?.manifestPathSha256 === null,
+    'planned evidence cannot identify a manifest target');
+
+  const { planHash, deterministicSchedule, ...publicGlobalPlan } = evidence.plan ?? {};
+  assert(deterministicSchedule === 'utc-start-plus-global-client-ramp-ordinal',
+    'deterministic schedule identifier differs');
+  assert(/^[a-f0-9]{64}$/.test(planHash ?? ''), 'planHash is invalid');
+  assert(sha256(canonicalJson({ runId: evidence.runId, ...publicGlobalPlan })) === planHash,
+    'planHash does not match the public deterministic plan');
+  const normalizedProfile = validateProfile(evidence.plan.profile, 'evidence plan profile');
+  assert(sameValue(evidence.plan.profile, normalizedProfile),
+    'evidence plan profile is not normalized');
+
+  assert(Number.isSafeInteger(evidence.shard?.index) && evidence.shard.index >= 0,
+    'shard index is invalid');
+  assert(evidence.shard.count === evidence.plan.shardCount,
+    'shard count differs from the global plan');
+  assert(Number.isSafeInteger(evidence.shard.localClients) && evidence.shard.localClients > 0,
+    'local client count is invalid');
+  assert(/^[a-f0-9]{64}$/.test(evidence.shard.clientOrdinalsSha256 ?? ''),
+    'client ordinal hash is invalid');
+  assert(evidence.measurements?.clients?.planned === evidence.shard.localClients,
+    'planned clients differ from the shard');
+  assert(emptyMeasurements(evidence.measurements),
+    'PLANNED evidence contains runtime measurements or network activity');
+  assert(evidence.redactionChecked === true, 'redaction check is not attested');
+  return evidence;
+}
+
+async function readEvidence(path) {
+  const resolved = resolve(path);
+  const details = await stat(resolved);
+  assert(details.isFile(), 'evidence source must be a regular file');
+  assert((details.mode & 0o777) === 0o600, 'evidence source mode must be exactly 0600');
+  const bytes = await readFile(resolved);
+  let evidence;
+  try {
+    evidence = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    throw new Error('evidence source is not valid JSON');
+  }
+  return {
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+    evidence: validatePlannedEvidence(evidence),
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(
+      'Usage: node verify-planned.mjs [--min-generators N] SHARD_EVIDENCE...\n',
+    );
+    return;
+  }
+  const minimumIndex = args.indexOf('--min-generators');
+  let minimumGenerators = 1;
+  if (minimumIndex >= 0) {
+    minimumGenerators = Number(args[minimumIndex + 1]);
+    assert(Number.isSafeInteger(minimumGenerators) && minimumGenerators > 0,
+      '--min-generators must be a positive integer');
+  }
+  const sources = args.filter((_, index) => (
+    index !== minimumIndex && index !== minimumIndex + 1
+  ));
+  assert(sources.length > 0 && sources.every((source) => !source.startsWith('--')),
+    'one exact PLANNED evidence path per shard is required');
+
+  const entries = await Promise.all(sources.map(readEvidence));
+  const first = entries[0].evidence;
+  const shardCount = first.plan.shardCount;
+  assert(entries.length === shardCount, 'evidence count must equal shardCount');
+  const indices = new Set();
+  const ordinalHashes = new Set();
+  const generatorFingerprints = new Set();
+  let plannedClients = 0;
+  for (const { evidence } of entries) {
+    assert(evidence.runId === first.runId && evidence.plan.planHash === first.plan.planHash,
+      'shard evidence does not share one deterministic plan');
+    assert(sameValue(evidence.plan, first.plan), 'public plan differs between shards');
+    assert(sameValue(evidence.target, first.target), 'planned target differs between shards');
+    assert(sameValue(evidence.thresholds, first.thresholds), 'thresholds differ between shards');
+    assert(sameValue(evidence.inputs, first.inputs), 'input hashes differ between shards');
+    assert(!indices.has(evidence.shard.index), 'shard indices must be unique');
+    assert(!ordinalHashes.has(evidence.shard.clientOrdinalsSha256),
+      'client ordinal hashes must be unique');
+    indices.add(evidence.shard.index);
+    ordinalHashes.add(evidence.shard.clientOrdinalsSha256);
+    generatorFingerprints.add(evidence.generator.hostFingerprintSha256);
+    plannedClients += evidence.shard.localClients;
+  }
+  assert([...indices].sort((a, b) => a - b).every((index, offset) => index === offset),
+    'shard indices must be complete from zero');
+  assert(plannedClients === first.plan.profile.clients,
+    'shard clients do not sum to the global client count');
+  assert(generatorFingerprints.size >= minimumGenerators,
+    `planned evidence requires at least ${minimumGenerators} distinct generators`);
+
+  const summary = assertRedactedEvidence({
+    schemaVersion: 1,
+    kind: `${EVIDENCE_KIND}-planned-verification`,
+    status: 'PLANNED',
+    runId: first.runId,
+    profileName: first.plan.profileName,
+    planHash: first.plan.planHash,
+    clients: plannedClients,
+    shardCount,
+    distinctGenerators: generatorFingerprints.size,
+    networkRequestsMade: false,
+    modeChecked: '0600',
+    redactionChecked: true,
+    sourceShards: entries
+      .map(({ sha256: digest, evidence }) => ({
+        index: evidence.shard.index,
+        localClients: evidence.shard.localClients,
+        sha256: digest,
+      }))
+      .sort((left, right) => left.index - right.index),
+  });
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `Planned evidence verification refused: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Outcome

Archives deterministic 4,000- and 5,000-client origin-media **dry-run plans** across `legion` and `daimonmatrix`. No load or HTTP request was executed.

## Evidence

- 4k: six complete shards, two generator fingerprints, exact 4,000-client sum, plan `67b68f412789c1ae3ad8e950c49480704d5c06f33b445788272a0a73fb73a3dd`.
- 5k: eight complete shards, two generator fingerprints, exact 5,000-client sum, plan `845206f4b8c1e605953a1efd8066b73b9bba87e2487627f3022bd337ec6d44ec`.
- all fourteen raw artifacts and collected copies are mode `0600` and attest `networkRequestsMade=false`.
- no manifest URL, session, cookie, signing key or other secret was used or stored.
- raw evidence stays in protected host-local archives; the committed record contains hashes and redacted summaries only.

## Implementation

Adds `verify-planned.mjs`, which independently refuses incomplete/duplicate shards, plan/input mismatch, incorrect client totals, insufficient generators, non-`0600` files, non-redacted evidence or any claimed runtime/network activity.

## Verification

- `npm --prefix tools/early-birds-hls-load run check`
- `npm --prefix tools/early-birds-hls-load test` — 18/18
- verifier passed both distributed protected evidence sets

## Safety / rollback

This PR does not authorize or execute load and changes no runtime, nginx, audio, production data or secrets. Rollback is a source revert; protected planning evidence may remain as an audit artifact.

Closes no capacity claim. Actual stepwise external load, end-to-end Listener capacity and CDN rehearsal remain open in #195/#201.
