### PR TITLE
ops(listener): add atomic public disable command

### DIFF
--- a/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+++ b/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
@@ -374,6 +374,36 @@ relaxation of production validation.
 
 ## Open, stop, and rollback
 
+The emergency public-entry switch is one reviewed command. Always preview the
+exact operation first; dry-run takes the same lock and validates the complete
+protected environment but writes no backup, changes no value and invokes no
+container or HTTP command:
+
+```bash
+sudo scripts/early-birds-preview/disable-public.sh --dry-run \
+  /etc/harmonic-beacon/earlybirds-preview.env
+sudo scripts/early-birds-preview/disable-public.sh --apply \
+  /etc/harmonic-beacon/earlybirds-preview.env
+```
+
+Apply requires root and a mode-`0600` environment. It takes an exclusive lock,
+refuses duplicate switch assignments, creates a timestamped mode-`0600` backup,
+atomically sets `EARLY_BIRDS_ENABLED`, `EARLY_BIRDS_FREE_FOR_ALL` and
+`EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED` to `0`, and recreates only Listener.
+It then requires liveness, readiness and an anonymous lease denial with HTTP
+503. PostgreSQL, origin, LiveKit, playlist-bot and the event project are not
+targeted. If recreation or smoke fails after the atomic replacement, the script
+keeps the flags disabled and stops only Listener rather than risking an older
+enabled process.
+
+The command prints the exact backup path. Keep public entry disabled while the
+incident is investigated. To roll back a mistaken operator invocation, under
+the same maintenance lock copy that exact backup to a new mode-`0600` candidate
+beside the env file, run `require_synthetic_env` against the candidate, replace
+the env atomically, recreate only Listener with `--no-deps --no-build`, and run
+the full preview health smoke plus the intended access-mode smoke. Never restore
+an arbitrary or older backup and never roll back the additive database.
+
 After migration, both liveness/readiness probes, nginx syntax, TLS, and
 synthetic negative-access checks pass, change only:
 

--- a/ops/early-birds-preview/package.json
+++ b/ops/early-birds-preview/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "node --check ../../scripts/early-birds-preview/validate.mjs && sh -n ../../scripts/early-birds-preview/lib.sh ../../scripts/early-birds-preview/start.sh ../../scripts/early-birds-preview/stop.sh ../../scripts/early-birds-preview/rollback.sh ../../scripts/early-birds-preview/rehearse-migration.sh ../../scripts/early-birds-preview/health-smoke.sh ../../scripts/early-birds-preview/canonical-free-smoke.sh ../../scripts/early-birds-preview/registered-free-smoke.sh",
+    "check": "node --check ../../scripts/early-birds-preview/validate.mjs && sh -n ../../scripts/early-birds-preview/lib.sh ../../scripts/early-birds-preview/start.sh ../../scripts/early-birds-preview/stop.sh ../../scripts/early-birds-preview/rollback.sh ../../scripts/early-birds-preview/disable-public.sh ../../scripts/early-birds-preview/rehearse-migration.sh ../../scripts/early-birds-preview/health-smoke.sh ../../scripts/early-birds-preview/canonical-free-smoke.sh ../../scripts/early-birds-preview/registered-free-smoke.sh",
     "validate": "node ../../scripts/early-birds-preview/validate.mjs",
     "validate:build": "node ../../scripts/early-birds-preview/validate.mjs --build",
     "test": "node --test test/*.test.mjs"

--- a/ops/early-birds-preview/test/disable-public.test.mjs
+++ b/ops/early-birds-preview/test/disable-public.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const previewRoot = path.resolve(import.meta.dirname, '..');
+const repositoryRoot = path.resolve(previewRoot, '../..');
+const script = path.join(repositoryRoot, 'scripts/early-birds-preview/disable-public.sh');
+const example = path.join(previewRoot, 'preview.env.synthetic.example');
+
+async function executable(pathname, content) {
+  await fs.writeFile(pathname, content, { mode: 0o700 });
+  await fs.chmod(pathname, 0o700);
+}
+
+async function fixture(t, { denialStatus = '503' } = {}) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'listener-disable-public-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const envFile = path.join(directory, 'preview.env');
+  const source = (await fs.readFile(example, 'utf8'))
+    .replace('EARLY_BIRDS_ENABLED=0', 'EARLY_BIRDS_ENABLED=1')
+    .replace('EARLY_BIRDS_FREE_FOR_ALL=0', 'EARLY_BIRDS_FREE_FOR_ALL=1')
+    .replace(
+      'EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=0',
+      'EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=1',
+    );
+  await fs.writeFile(envFile, source, { mode: 0o600 });
+  await fs.chmod(envFile, 0o600);
+
+  const bin = path.join(directory, 'bin');
+  await fs.mkdir(bin);
+  const commandLog = path.join(directory, 'commands.log');
+  await executable(path.join(bin, 'id'), '#!/bin/sh\necho 0\n');
+  await executable(path.join(bin, 'docker'), [
+    '#!/bin/sh',
+    'printf "%s\\n" "$*" >> "$TEST_COMMAND_LOG"',
+    'case "$*" in',
+    '  "ps -q --filter label=com.docker.compose.project=earlybirds-preview --filter label=com.docker.compose.service=listener") printf "isolated-listener-id\\n" ;;',
+    'esac',
+    'exit 0',
+    '',
+  ].join('\n'));
+  await executable(path.join(bin, 'curl'), [
+    '#!/bin/sh',
+    'printf "%s\\n" "$*" >> "$TEST_COMMAND_LOG"',
+    'case "$*" in',
+    `  *api/early-birds/stream/lease*) printf '${denialStatus}' ;;`,
+    'esac',
+    '',
+  ].join('\n'));
+  return { directory, envFile, bin, commandLog, source };
+}
+
+function run(mode, current) {
+  return spawnSync('sh', [script, mode, current.envFile], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${current.bin}:${process.env.PATH}`,
+      TEST_COMMAND_LOG: current.commandLog,
+    },
+  });
+}
+
+test('explicit dry-run is non-mutating and invokes no runtime command', async (t) => {
+  const current = await fixture(t);
+  const before = await fs.readFile(current.envFile, 'utf8');
+  const result = run('--dry-run', current);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /DRY RUN/);
+  assert.equal(await fs.readFile(current.envFile, 'utf8'), before);
+  await assert.rejects(fs.access(current.commandLog));
+  const files = await fs.readdir(current.directory);
+  assert.equal(files.some((name) => name.includes('pre-disable-public')), false);
+});
+
+test('dry-run refuses a concurrent public-mode operation', async (t) => {
+  const current = await fixture(t);
+  const lockFile = `${current.envFile}.listener-public.lock`;
+  const holder = spawn('flock', [
+    lockFile,
+    'sh', '-c', 'echo locked; read line',
+  ], { stdio: ['pipe', 'pipe', 'pipe'] });
+  await once(holder.stdout, 'data');
+  try {
+    const result = run('--dry-run', current);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /holds the lock/);
+  } finally {
+    holder.stdin.end();
+    await once(holder, 'close');
+  }
+});
+
+test('dry-run refuses duplicate public switch assignments', async (t) => {
+  const current = await fixture(t);
+  await fs.appendFile(current.envFile, '\nEARLY_BIRDS_ENABLED=0\n');
+  const result = run('--dry-run', current);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /EARLY_BIRDS_ENABLED must appear exactly once/);
+});
+
+test('apply backs up mode 0600, disables every public flag and recreates only Listener', async (t) => {
+  const current = await fixture(t);
+  const result = run('--apply', current);
+  assert.equal(result.status, 0, result.stderr);
+  const updated = await fs.readFile(current.envFile, 'utf8');
+  assert.match(updated, /^EARLY_BIRDS_ENABLED=0$/m);
+  assert.match(updated, /^EARLY_BIRDS_FREE_FOR_ALL=0$/m);
+  assert.match(updated, /^EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=0$/m);
+  assert.equal((await fs.stat(current.envFile)).mode & 0o777, 0o600);
+
+  const backupName = (await fs.readdir(current.directory))
+    .find((name) => name.includes('pre-disable-public'));
+  assert.ok(backupName);
+  const backup = path.join(current.directory, backupName);
+  assert.equal((await fs.stat(backup)).mode & 0o777, 0o600);
+  assert.equal(await fs.readFile(backup, 'utf8'), current.source);
+
+  const commands = await fs.readFile(current.commandLog, 'utf8');
+  const dockerCommands = commands.split('\n').filter((line) => line.startsWith('compose '));
+  assert.equal(dockerCommands.length, 1);
+  assert.match(dockerCommands[0], / up -d --no-deps --force-recreate --no-build listener$/);
+  assert.match(commands, /api\/health\b/);
+  assert.match(commands, /api\/health\/ready/);
+  assert.match(commands, /api\/early-birds\/stream\/lease/);
+  assert.match(result.stdout, /denied with 503/);
+});
+
+test('failed denial smoke leaves flags disabled and stops only Listener', async (t) => {
+  const current = await fixture(t, { denialStatus: '401' });
+  const result = run('--apply', current);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /stopping only Listener/);
+  const updated = await fs.readFile(current.envFile, 'utf8');
+  assert.match(updated, /^EARLY_BIRDS_ENABLED=0$/m);
+  const commands = await fs.readFile(current.commandLog, 'utf8');
+  assert.match(commands, /ps -q --filter label=com\.docker\.compose\.project=earlybirds-preview --filter label=com\.docker\.compose\.service=listener/);
+  assert.match(commands, /stop isolated-listener-id/);
+  assert.doesNotMatch(commands, /stop (?:.* )?(postgres|beacon-stream|livekit|playlist-bot)/);
+});

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -249,6 +249,20 @@ test('smoke and rollback contracts cover both probes without deleting state', as
   const stop = await readRepository('scripts/early-birds-preview/stop.sh');
   assert.match(stop, /stop listener beacon-stream postgres/);
   assert.doesNotMatch(stop, /\bdown\b|-v\b|volume rm/);
+
+  const disablePublic = await readRepository('scripts/early-birds-preview/disable-public.sh');
+  assert.match(disablePublic, /--dry-run\|--apply/);
+  assert.match(disablePublic, /flock -n 9/);
+  assert.match(disablePublic, /pre-disable-public/);
+  assert.match(disablePublic, /chmod 0600 "\$backup"/);
+  assert.match(disablePublic, /mv -f "\$candidate" "\$env_file"/);
+  assert.match(disablePublic, /sync -f "\$env_file"/);
+  assert.match(disablePublic, /up -d --no-deps --force-recreate --no-build listener/);
+  assert.match(disablePublic, /api\/health\/ready/);
+  assert.match(disablePublic, /api\/early-birds\/stream\/lease/);
+  assert.match(disablePublic, /test "\$denial_status" = 503/);
+  assert.match(disablePublic, /stop listener/);
+  assert.doesNotMatch(disablePublic, /\bdown\b|volume rm|stop (?:.* )?(postgres|beacon-stream)/);
 });
 
 test('canonical Free smoke keeps credentials out of argv and verifies the entitled home', async () => {

--- a/scripts/early-birds-preview/disable-public.sh
+++ b/scripts/early-birds-preview/disable-public.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env sh
+set -eu
+
+. "$(dirname -- "$0")/lib.sh"
+
+usage() {
+  echo 'usage: disable-public.sh {--dry-run|--apply} /secure/preview.env' >&2
+  exit 2
+}
+
+mode=${1:-}
+env_file=${2:-}
+test "$#" -eq 2 || usage
+case "$mode" in --dry-run|--apply) ;; *) usage ;; esac
+test -n "$env_file" || usage
+test -f "$env_file" && test ! -L "$env_file" \
+  || preview_fail 'preview env path must be a regular non-symlink file'
+
+umask 077
+lock_file="${env_file}.listener-public.lock"
+exec 9>"$lock_file"
+chmod 0600 "$lock_file"
+flock -n 9 || preview_fail 'another Listener public-mode operation holds the lock'
+
+protected_env_file=$env_file
+require_synthetic_env "$env_file"
+env_file=$protected_env_file
+test "$(stat -c '%a' "$env_file")" = 600 \
+  || preview_fail 'preview env file mode must be exactly 0600'
+
+for key in \
+  EARLY_BIRDS_ENABLED \
+  EARLY_BIRDS_FREE_FOR_ALL \
+  EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED
+do
+  count=$(grep -c "^${key}=" "$env_file" || true)
+  test "$count" -eq 1 || preview_fail "$key must appear exactly once"
+done
+
+if test "$mode" = --dry-run; then
+  echo 'DRY RUN: no environment value, container or public route was changed.'
+  echo "Would set EARLY_BIRDS_ENABLED=0 (currently $(preview_env_value EARLY_BIRDS_ENABLED "$env_file"))."
+  echo "Would set EARLY_BIRDS_FREE_FOR_ALL=0 (currently $(preview_env_value EARLY_BIRDS_FREE_FOR_ALL "$env_file"))."
+  echo "Would set EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=0 (currently $(preview_env_value EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED "$env_file"))."
+  echo 'Would create one mode-0600 backup, atomically replace the env file, recreate only Listener, then verify health/readiness and lease denial.'
+  exit 0
+fi
+
+test "$(id -u)" -eq 0 || preview_fail '--apply must run as root'
+
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+backup="${env_file}.pre-disable-public-${timestamp}-$$"
+candidate=$(mktemp "${env_file}.disable-public.XXXXXX")
+cleanup() { test -z "$candidate" || rm -f "$candidate"; }
+trap cleanup EXIT HUP INT TERM
+
+test ! -e "$backup" || preview_fail 'refusing to overwrite an existing disable backup'
+cp -p "$env_file" "$backup"
+chmod 0600 "$backup"
+
+awk '
+  /^EARLY_BIRDS_ENABLED=/ { print "EARLY_BIRDS_ENABLED=0"; next }
+  /^EARLY_BIRDS_FREE_FOR_ALL=/ { print "EARLY_BIRDS_FREE_FOR_ALL=0"; next }
+  /^EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=/ {
+    print "EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=0"; next
+  }
+  { print }
+' "$env_file" > "$candidate"
+chmod 0600 "$candidate"
+require_synthetic_env "$candidate"
+env_file=$protected_env_file
+for key in \
+  EARLY_BIRDS_ENABLED \
+  EARLY_BIRDS_FREE_FOR_ALL \
+  EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED
+do
+  test "$(preview_env_value "$key" "$candidate")" = 0 \
+    || preview_fail "$key candidate value is not disabled"
+done
+
+mv -f "$candidate" "$env_file"
+candidate=''
+sync -f "$env_file"
+
+fail_closed() {
+  echo "Listener disable failed after the env was secured; stopping only Listener. Backup: $backup" >&2
+  listener_ids=$(docker ps -q \
+    --filter label=com.docker.compose.project=earlybirds-preview \
+    --filter label=com.docker.compose.service=listener 2>/dev/null || true)
+  if test -n "$listener_ids"; then
+    for listener_id in $listener_ids; do docker stop "$listener_id" >/dev/null 2>&1 || true; done
+  else
+    (preview_compose_command "$env_file" stop listener) >/dev/null 2>&1 || true
+  fi
+  exit 1
+}
+
+(preview_compose_command "$env_file" \
+  up -d --no-deps --force-recreate --no-build listener) || fail_closed
+
+app_port=$(preview_env_value EARLYBIRDS_PREVIEW_APP_PORT "$env_file")
+curl --fail --silent --show-error --max-time 10 \
+  "http://127.0.0.1:${app_port}/api/health" >/dev/null || fail_closed
+curl --fail --silent --show-error --max-time 10 \
+  "http://127.0.0.1:${app_port}/api/health/ready" >/dev/null || fail_closed
+denial_status=$(curl --silent --show-error --max-time 10 \
+  --output /dev/null --write-out '%{http_code}' \
+  --request POST --header 'content-type: application/json' \
+  --data '{"deviceId":"00000000-0000-4000-8000-000000000000","intent":"play"}' \
+  "http://127.0.0.1:${app_port}/api/early-birds/stream/lease") || fail_closed
+test "$denial_status" = 503 || fail_closed
+
+echo 'Listener public entry, Free for All and staging team entry are disabled.'
+echo 'Only Listener was recreated; PostgreSQL and stream origin were retained.'
+echo "Health/readiness passed and the lease endpoint denied with 503. Backup: $backup"


### PR DESCRIPTION
## Outcome

Adds a single fail-closed operator command for disabling every public Listener entry mode without targeting the event stack:

```bash
sudo scripts/early-birds-preview/disable-public.sh --dry-run /etc/harmonic-beacon/earlybirds-preview.env
sudo scripts/early-birds-preview/disable-public.sh --apply /etc/harmonic-beacon/earlybirds-preview.env
```

## Safety contract

- only accepts the guarded synthetic Listener environment, as a regular non-symlink mode-`0600` file;
- takes an exclusive lock before validation or mutation;
- refuses duplicate switch assignments;
- requires explicit `--dry-run` or `--apply`; dry-run creates no backup and invokes no runtime/HTTP command;
- apply requires root, creates a timestamped mode-`0600` backup and atomically replaces the env on the same filesystem;
- sets `EARLY_BIRDS_ENABLED`, `EARLY_BIRDS_FREE_FOR_ALL` and `EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED` to `0`;
- recreates only Compose service `listener` with `--no-deps --no-build`;
- requires health, readiness and HTTP 503 from anonymous lease issuance;
- on failed recreation/smoke, leaves the flags disabled and stops containers selected only by exact Compose project/service labels.

PostgreSQL, origin, LiveKit, playlist-bot, nginx, audio, event production and databases are untouched.

## Verification

- shell syntax/check gate passes;
- preview contract and behavioral suite: 31/31;
- behavior covers non-mutating dry-run, concurrent lock refusal, duplicate assignment refusal, mode-0600 backup, exact flag mutation, Listener-only recreation, health/denial probes and fail-closed Listener stop.

## Rollback

The runbook requires the exact printed backup, the same maintenance lock, guarded candidate validation, atomic replacement, Listener-only recreation and the full intended access-mode smoke. It explicitly forbids database rollback or arbitrary historical backups.

No deploy is included or authorized by this PR. The command must not be applied before/during the event without a separate incident decision.
