### PR TITLE
feat(listener): cut over non-media runtime namespace

### DIFF
--- a/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
+++ b/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
@@ -69,9 +69,12 @@ internals.
 The phase 2A candidate changes only account-local access-state, Free-window,
 welcome-access and staging invitation redemption. Better Auth continues to use
 its legacy base path and cookies. The public edge continues to exclude
-invitation redemption and synthetic entry; the staging edge exposes only the
-four exact canonical non-media APIs. Stream, heartbeat, manifest, drop-in and
-player storage paths remain on their accepted legacy URLs.
+invitation redemption and synthetic entry: invitation queries are accepted only
+on the exact staging hostname, while the public edge suppresses access logs,
+scrubs the bearer with no-store/no-referrer and never mints its cookie. The
+staging edge exposes only the four exact canonical non-media APIs. Stream,
+heartbeat, manifest, drop-in and player storage paths remain on their accepted
+legacy URLs.
 
 Roll out the edge and application as a compatibility handoff, never as one
 blind replacement:

--- a/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
+++ b/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
@@ -1,8 +1,9 @@
 # EarlyBird to Listener namespace migration
 
-Status: phase 1 implemented on `feat/listener-namespace-compat`; later phases are
-design only. This migration is deliberately additive. `EarlyBird` is an offer
-and cohort name; `Listener` is the durable product and technical namespace.
+Status: phase 1 is integrated; phase 2A is an undeployed candidate on
+`feat/listener-namespace-runtime`. This migration is deliberately additive.
+`EarlyBird` is an offer and cohort name; `Listener` is the durable product and
+technical namespace.
 
 ## Invariants
 
@@ -55,7 +56,7 @@ rewrites `/` internally to that route, and redirecting it before nginx and clien
 callbacks move would create unnecessary hops and could expose deployment
 internals.
 
-## Phase 2: browser client cutover
+## Phase 2A: non-media browser and edge cutover
 
 1. Deploy phase 1 and record requests by route family without user identifiers.
 2. Change non-media fetches and navigation to `LISTENER_NAMESPACE.canonical`.
@@ -64,6 +65,28 @@ internals.
 4. Update nginx to serve `/listener` at `/`; keep exact legacy locations proxied.
 5. Add browser tests that start with a legacy invitation cookie, enter on the
    canonical URL, refresh and finish redemption without signing in again.
+
+The phase 2A candidate changes only account-local access-state, Free-window,
+welcome-access and staging invitation redemption. Better Auth continues to use
+its legacy base path and cookies. The public edge continues to exclude
+invitation redemption and synthetic entry; the staging edge exposes only the
+four exact canonical non-media APIs. Stream, heartbeat, manifest, drop-in and
+player storage paths remain on their accepted legacy URLs.
+
+Roll out the edge and application as a compatibility handoff, never as one
+blind replacement:
+
+1. install the additive exact nginx locations while `/` still rewrites to
+   `/early-birds`, run `nginx -t`, reload and confirm legacy smoke;
+2. deploy the application image containing both route families;
+3. smoke `/listener` and every canonical non-media API directly;
+4. change the internal `/` rewrite to `/listener`, run `nginx -t`, reload and
+   verify that the browser-visible URL remains `/`;
+5. retain legacy routes for the full measured support window.
+
+Rollback reverses that order: restore the `/early-birds` root rewrite first,
+then restore the previous image. The additive exact locations may remain dark;
+no database, cookie, environment or media rollback is required.
 
 Stream, heartbeat, manifest, drop-in and player storage paths are a separate
 audio-reviewed slice. Their aliasing must not modify response bytes, timing,

--- a/e2e/tests/early-birds-boundary.spec.ts
+++ b/e2e/tests/early-birds-boundary.spec.ts
@@ -69,7 +69,7 @@ test.describe('Listener scheduled Free browser boundary', () => {
             let leavingStateRequests = 0;
             let enteringLeaseRequests = 0;
             let failEnteringOnce = true;
-            await enteringPage.route('**/api/early-birds/access-state', async (route) => {
+            await enteringPage.route('**/api/listener/access-state', async (route) => {
                 enteringStateRequests += 1;
                 if (failEnteringOnce) {
                     failEnteringOnce = false;
@@ -82,14 +82,14 @@ test.describe('Listener scheduled Free browser boundary', () => {
                 enteringLeaseRequests += 1;
                 await route.continue();
             });
-            await leavingPage.route('**/api/early-birds/access-state', async (route) => {
+            await leavingPage.route('**/api/listener/access-state', async (route) => {
                 leavingStateRequests += 1;
                 await route.continue();
             });
 
             await Promise.all([
-                enteringPage.goto('/early-birds'),
-                leavingPage.goto('/early-birds'),
+                enteringPage.goto('/listener'),
+                leavingPage.goto('/listener'),
             ]);
             await expect(enteringPage.locator('.listener-shell--public')).toBeVisible();
             await expect(enteringPage.locator('.listener-experience')).toHaveCount(0);
@@ -97,8 +97,8 @@ test.describe('Listener scheduled Free browser boundary', () => {
 
             const enteringEpoch = await documentEpoch(enteringPage);
             const leavingEpoch = await documentEpoch(leavingPage);
-            const enteringState = await enteringPage.request.get('/api/early-birds/access-state');
-            const leavingState = await leavingPage.request.get('/api/early-birds/access-state');
+            const enteringState = await enteringPage.request.get('/api/listener/access-state');
+            const leavingState = await leavingPage.request.get('/api/listener/access-state');
             const enteringPayload = await enteringState.json() as { serverNow: string; freeWindow: { nextStart: string } };
             const leavingPayload = await leavingState.json() as { serverNow: string; access: { allowedUntil: string } };
 

--- a/e2e/tests/listener-namespace-compat.spec.ts
+++ b/e2e/tests/listener-namespace-compat.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+
+import { EARLY_BIRD_INVITATION_COOKIE } from '../../src/lib/early-birds/invitation-cookie';
+import {
+    deleteSyntheticListenerEmails,
+    signInSyntheticListener,
+} from '../fixtures/listener-boundary';
+import { requireDirectDb } from '../fixtures/db';
+
+const INVITATION = `ebi_v1.${'a'.repeat(32)}.${'b'.repeat(32)}.${'c'.repeat(32)}`;
+
+// The fixture bearer and cookies must never enter a retained browser trace.
+test.use({ trace: 'off' });
+
+test.describe('Listener namespace compatibility', () => {
+    test('keeps a legacy invitation cookie and Listener session through canonical refresh and redemption', async ({ browser }, testInfo) => {
+        test.skip(testInfo.project.name !== 'chromium', 'one browser proves the namespace/session contract');
+        requireDirectDb(testInfo);
+        const baseURL = new URL(String(testInfo.project.use.baseURL));
+        if (!['localhost', '127.0.0.1', '[::1]'].includes(baseURL.hostname)) {
+            throw new Error('refusing to run Listener namespace E2E against a non-local application');
+        }
+
+        const email = `namespace-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@e2e.invalid`;
+        const context = await browser.newContext();
+        try {
+            await signInSyntheticListener(context.request, email);
+            const sessionCookie = (await context.cookies()).find((cookie) => (
+                cookie.name !== EARLY_BIRD_INVITATION_COOKIE
+                && cookie.name.includes('session')
+            ));
+            expect(sessionCookie).toBeDefined();
+
+            await context.addCookies([{
+                name: EARLY_BIRD_INVITATION_COOKIE,
+                value: INVITATION,
+                domain: baseURL.hostname,
+                path: '/',
+                httpOnly: true,
+                secure: true,
+                sameSite: 'Lax',
+            }]);
+
+            const page = await context.newPage();
+            await page.goto('/listener');
+            await page.getByRole('link', { name: /Activar mi invitación|Activate my invitation/ }).click();
+            await expect(page).toHaveURL(/\/listener\/redeem$/);
+            await page.reload();
+            await expect(page.getByRole('button', { name: /Activar invitación|Activate invitation/ })).toBeVisible();
+
+            let canonicalRedemption = 0;
+            await page.route('**/api/listener/free/redeem', async (route) => {
+                canonicalRedemption += 1;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    headers: {
+                        'set-cookie': `${EARLY_BIRD_INVITATION_COOKIE}=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; HttpOnly; Secure; SameSite=Lax`,
+                    },
+                    body: JSON.stringify({ ok: true, landing: '/listener', replayed: false }),
+                });
+            });
+            await page.getByRole('button', { name: /Activar invitación|Activate invitation/ }).click();
+
+            await expect(page).toHaveURL(/\/listener$/);
+            await expect(page.getByRole('button', { name: /Cerrar sesión|Sign out/ })).toBeVisible();
+            expect(canonicalRedemption).toBe(1);
+            const cookies = await context.cookies();
+            expect(cookies.find((cookie) => cookie.name === EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+            expect(cookies.find((cookie) => cookie.name === sessionCookie!.name)?.value)
+                .toBe(sessionCookie!.value);
+        } finally {
+            await context.close();
+            await deleteSyntheticListenerEmails(testInfo, [email]);
+        }
+    });
+});

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -24,12 +24,18 @@ const INVITATION = `ebi_v1.${'a'.repeat(32)}.${'b'.repeat(32)}.${'c'.repeat(32)}
  * one that should make that obvious.
  */
 
-function request(pathname: string, cookie?: string): NextRequest {
+function request(
+    pathname: string,
+    cookie?: string,
+    hostname = 'live.harmonicbeacon.com',
+    extraHeaders: Record<string, string> = {},
+): NextRequest {
     const headers = new Headers();
     if (cookie) {
         headers.set('cookie', cookie);
     }
-    return new NextRequest(new URL(pathname, 'https://live.harmonicbeacon.com'), { headers });
+    for (const [name, value] of Object.entries(extraHeaders)) headers.set(name, value);
+    return new NextRequest(new URL(pathname, `https://${hostname}`), { headers });
 }
 
 function location(response: NextResponse): URL {
@@ -44,7 +50,11 @@ describe('middleware', () => {
             ['/early-birds', 'invite'],
             ['/early-birds/redeem', 'token'],
         ])('moves the canonical %s query token to a short HttpOnly cookie', (pathname, queryName) => {
-            const response = middleware(request(`${pathname}?${queryName}=${INVITATION}&locale=en`));
+            const response = middleware(request(
+                `${pathname}?${queryName}=${INVITATION}&locale=en`,
+                undefined,
+                'earlybirds-staging.harmonicbeacon.com',
+            ));
 
             expect(response.status).toBe(307);
             const target = location(response);
@@ -61,6 +71,38 @@ describe('middleware', () => {
                 path: '/',
                 maxAge: EARLY_BIRD_INVITATION_MAX_AGE_SECONDS,
             });
+        });
+
+        it.each([
+            ['listen.harmonicbeacon.com', '/listener', 'invite'],
+            ['listen.harmonicbeacon.com', '/listener/redeem', 'token'],
+            ['listen.harmonicbeacon.com', '/early-birds', 'invite'],
+            ['listen.harmonicbeacon.com', '/early-birds/redeem', 'token'],
+            ['live.harmonicbeacon.com', '/early-birds', 'invite'],
+        ])('scrubs but never persists %s%s invitation queries', (hostname, pathname, queryName) => {
+            const response = middleware(request(
+                `${pathname}?${queryName}=${INVITATION}&locale=en`,
+                undefined,
+                hostname,
+            ));
+
+            expect(response.status).toBe(307);
+            expect(location(response).searchParams.has(queryName)).toBe(false);
+            expect(location(response).searchParams.get('locale')).toBe('en');
+            expect(response.headers.get('cache-control')).toBe('private, no-store');
+            expect(response.headers.get('referrer-policy')).toBe('no-referrer');
+            expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+        });
+
+        it('does not trust a forwarded staging host on the public Listener URL', () => {
+            const response = middleware(request(
+                `/listener?invite=${INVITATION}`,
+                undefined,
+                'listen.harmonicbeacon.com',
+                { 'x-forwarded-host': 'earlybirds-staging.harmonicbeacon.com' },
+            ));
+
+            expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
         });
 
         it('scrubs malformed or ambiguous query values without persisting them', () => {

--- a/ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template
@@ -9,6 +9,13 @@ server {
         root /var/www/html;
     }
 
+    location = / {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://earlybirds-staging.harmonicbeacon.com$request_uri;
+    }
+
     # Legacy invitation links carry a bearer in the query string. Suppress the
     # very first edge log and avoid caching the one redirect that still has it.
     location = /early-birds {

--- a/ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template
@@ -25,6 +25,20 @@ server {
         return 302 https://earlybirds-staging.harmonicbeacon.com$request_uri;
     }
 
+    location = /listener {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://earlybirds-staging.harmonicbeacon.com$request_uri;
+    }
+
+    location = /listener/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://earlybirds-staging.harmonicbeacon.com$request_uri;
+    }
+
     location / {
         return 301 https://earlybirds-staging.harmonicbeacon.com$request_uri;
     }
@@ -86,12 +100,19 @@ server {
         return 302 /$is_args$args;
     }
 
+    location = /listener {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 /$is_args$args;
+    }
+
     # The preview hostname exists only for this product, so keep its public
-    # address canonical at `/`. The application still receives its stable
-    # internal route, preserving production compatibility and auth callbacks.
+    # address canonical at `/`. The application receives the canonical
+    # Listener route while legacy aliases and auth callbacks remain available.
     location = / {
         access_log off;
-        rewrite ^ /early-birds break;
+        rewrite ^ /listener break;
         proxy_pass http://127.0.0.1:13000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -120,6 +141,72 @@ server {
         proxy_connect_timeout 10s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
+    }
+
+    location = /listener/redeem {
+        access_log off;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location = /api/listener/access-state {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    location = /api/listener/free-window {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    location = /api/listener/free/redeem {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    location = /api/listener/welcome-access {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
     }
 
     location ^~ /early-birds/ {

--- a/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
@@ -10,6 +10,44 @@ server {
         root /var/www/html;
     }
 
+    # A shared invitation may arrive over HTTP first. Preserve it only long
+    # enough for the HTTPS middleware to scrub it, without edge logging,
+    # referrer propagation or a cacheable permanent redirect.
+    location = / {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://listen.harmonicbeacon.com$request_uri;
+    }
+
+    location = /early-birds {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://listen.harmonicbeacon.com$request_uri;
+    }
+
+    location = /listener {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://listen.harmonicbeacon.com$request_uri;
+    }
+
+    location = /early-birds/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://listen.harmonicbeacon.com$request_uri;
+    }
+
+    location = /listener/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://listen.harmonicbeacon.com$request_uri;
+    }
+
     location / {
         return 301 https://listen.harmonicbeacon.com$request_uri;
     }
@@ -90,14 +128,39 @@ server {
     }
 
     location = /early-birds {
-        return 302 /;
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 /$is_args$args;
     }
 
     location = /listener {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 /$is_args$args;
+    }
+
+    # Invitation redemption is staging-only. Clean either redeem alias without
+    # proxying or retaining its bearer query on the public Listener host.
+    location = /early-birds/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 /;
+    }
+
+    location = /listener/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
         return 302 /;
     }
 
     location = / {
+        # The root may receive a legacy invitation bearer before the internal
+        # Listener rewrite can scrub it. Never persist that first request.
+        access_log off;
         rewrite ^ /listener break;
         proxy_pass http://127.0.0.1:13000;
         proxy_http_version 1.1;

--- a/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
@@ -93,8 +93,12 @@ server {
         return 302 /;
     }
 
+    location = /listener {
+        return 302 /;
+    }
+
     location = / {
-        rewrite ^ /early-birds break;
+        rewrite ^ /listener break;
         proxy_pass http://127.0.0.1:13000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -133,9 +137,75 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Authenticated ordinary-Free scheduling. This is account-local access
-    # state, not a commerce membership or a staging synthetic seam.
+    # Canonical account-local Listener state. Keep the exact legacy aliases
+    # during the measured namespace support window; neither family exposes a
+    # commerce membership or staging synthetic seam.
+    location = /api/listener/access-state {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    location = /api/early-birds/access-state {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    location = /api/listener/free-window {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
     location = /api/early-birds/free-window {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    location = /api/listener/welcome-access {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    location = /api/early-birds/welcome-access {
         proxy_pass http://127.0.0.1:13000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -184,8 +184,19 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.match(listener, /location \^~ \/api\/early-birds\/stream\//);
   assert.match(listener, /location \^~ \/api\/early-birds\/drop-ins\//);
   assert.match(listener, /location \^~ \/api\/early-birds\/auth\//);
-  assert.match(listener, /location = \/listener \{\s*return 302 \/;/);
-  assert.match(listener, /location = \/ \{[^}]*rewrite \^ \/listener break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;/s);
+  for (const path of ['early-birds', 'listener']) {
+    assert.match(listener, new RegExp(
+      `location = /${path} \\{[^}]*access_log off;[^}]*Cache-Control "private, no-store"[^}]*Referrer-Policy "no-referrer"[^}]*return 302 /\\$is_args\\$args;`,
+      's',
+    ));
+  }
+  for (const path of ['early-birds/redeem', 'listener/redeem']) {
+    assert.match(listener, new RegExp(
+      `location = /${path} \\{[^}]*access_log off;[^}]*Cache-Control "private, no-store"[^}]*Referrer-Policy "no-referrer"[^}]*return 302 /;`,
+      's',
+    ));
+  }
+  assert.match(listener, /location = \/ \{[^}]*access_log off;[^}]*rewrite \^ \/listener break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;/s);
   assert.match(listener, /location = \/api\/listener\/access-state/);
   assert.match(listener, /location = \/api\/early-birds\/access-state/);
   assert.match(listener, /location = \/api\/listener\/free-window/);
@@ -203,13 +214,27 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.doesNotMatch(listener, /api\/listener\/(test-login|free\/|membership)/);
   assert.doesNotMatch(listener, /location \^~ \/early-birds\//);
 
+  const publicSensitiveEntries = [...listener.matchAll(
+    /location = \/(?:listener(?:\/redeem)?|early-birds(?:\/redeem)?)? \{([^}]*)\}/g,
+  )];
+  assert.equal(publicSensitiveEntries.length, 10, 'HTTP and HTTPS must protect root and every invitation alias');
+  assert.ok(publicSensitiveEntries.every((match) => /access_log off;/.test(match[1])));
+  const edgeHeaderProtected = publicSensitiveEntries.filter((match) => (
+    /Cache-Control "private, no-store"/.test(match[1])
+    && /Referrer-Policy "no-referrer"/.test(match[1])
+  ));
+  assert.equal(edgeHeaderProtected.length, 9, 'the proxied HTTPS root delegates no-store/no-referrer to middleware');
+
   const invitationEntryLocations = [...app.matchAll(
     /location = \/(?:listener|early-birds)(?:\/redeem)? \{([^}]*)\}/g,
   )];
   assert.equal(invitationEntryLocations.length, 8, 'HTTP and HTTPS must protect canonical and legacy invitation entries');
   assert.ok(invitationEntryLocations.every((match) => /access_log off;/.test(match[1])));
-  assert.equal((app.match(/add_header Referrer-Policy "no-referrer" always;/g) ?? []).length, 6);
-  assert.equal((app.match(/add_header Cache-Control "private, no-store" always;/g) ?? []).length, 6);
+  assert.equal((app.match(/add_header Referrer-Policy "no-referrer" always;/g) ?? []).length, 7);
+  assert.equal((app.match(/add_header Cache-Control "private, no-store" always;/g) ?? []).length, 7);
+  const stagingRoots = [...app.matchAll(/location = \/ \{([^}]*)\}/g)];
+  assert.equal(stagingRoots.length, 2, 'HTTP and HTTPS staging roots must both be explicit');
+  assert.ok(stagingRoots.every((match) => /access_log off;/.test(match[1])));
   for (const path of ['access-state', 'free-window', 'free/redeem', 'welcome-access']) {
     assert.match(app, new RegExp(`location = /api/listener/${path.replace('/', '\\/')}`));
   }

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -176,7 +176,7 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.match(app, /location \^~ \/api\/early-birds\//);
   assert.equal((combined.match(/X-Harmonic-Beacon-Environment "early-birds-staging"/g) ?? []).length, 2);
   assert.equal((listener.match(/X-Harmonic-Beacon-Environment "listener-public-free"/g) ?? []).length, 1);
-  assert.match(app, /location = \/ \{[^}]*access_log off;[^}]*rewrite \^ \/early-birds break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;/s);
+  assert.match(app, /location = \/ \{[^}]*access_log off;[^}]*rewrite \^ \/listener break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;/s);
   assert.match(app, /location = \/early-birds\/home \{\s*return 302 \/;/);
   assert.match(app, /location \/ \{\s*return 404;/);
   assert.doesNotMatch(app, /location \^~ \/api\/(auth|ops)|location \^~ \/(login|ops|session)/);
@@ -184,23 +184,36 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.match(listener, /location \^~ \/api\/early-birds\/stream\//);
   assert.match(listener, /location \^~ \/api\/early-birds\/drop-ins\//);
   assert.match(listener, /location \^~ \/api\/early-birds\/auth\//);
+  assert.match(listener, /location = \/listener \{\s*return 302 \/;/);
+  assert.match(listener, /location = \/ \{[^}]*rewrite \^ \/listener break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;/s);
+  assert.match(listener, /location = \/api\/listener\/access-state/);
+  assert.match(listener, /location = \/api\/early-birds\/access-state/);
+  assert.match(listener, /location = \/api\/listener\/free-window/);
   assert.match(listener, /location = \/api\/early-birds\/free-window/);
+  assert.match(listener, /location = \/api\/listener\/welcome-access/);
+  assert.match(listener, /location = \/api\/early-birds\/welcome-access/);
   assert.match(listener, /location = \/api\/listener\/presence/);
   assert.match(listener, /location = \/robots\.txt \{[^}]*rewrite \^ \/api\/listener\/public-discovery\/robots\.txt break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;[^}]*proxy_set_header Host \$host;/s);
   assert.match(listener, /location = \/sitemap\.xml \{[^}]*rewrite \^ \/api\/listener\/public-discovery\/sitemap\.xml break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;[^}]*proxy_set_header Host \$host;/s);
   assert.equal((listener.match(/location = \/robots\.txt/g) ?? []).length, 1);
   assert.equal((listener.match(/location = \/sitemap\.xml/g) ?? []).length, 1);
   assert.doesNotMatch(listener, /location \^~ \/api\/listener\/public-discovery\//);
+  assert.doesNotMatch(listener, /location \^~ \/api\/listener\//);
   assert.doesNotMatch(listener, /api\/early-birds\/(test-login|free\/|membership)/);
+  assert.doesNotMatch(listener, /api\/listener\/(test-login|free\/|membership)/);
   assert.doesNotMatch(listener, /location \^~ \/early-birds\//);
 
   const invitationEntryLocations = [...app.matchAll(
-    /location = \/early-birds(?:\/redeem)? \{([^}]*)\}/g,
+    /location = \/(?:listener|early-birds)(?:\/redeem)? \{([^}]*)\}/g,
   )];
-  assert.equal(invitationEntryLocations.length, 4, 'HTTP and HTTPS must both protect both legacy invitation entries');
+  assert.equal(invitationEntryLocations.length, 8, 'HTTP and HTTPS must protect canonical and legacy invitation entries');
   assert.ok(invitationEntryLocations.every((match) => /access_log off;/.test(match[1])));
-  assert.equal((app.match(/add_header Referrer-Policy "no-referrer" always;/g) ?? []).length, 3);
-  assert.equal((app.match(/add_header Cache-Control "private, no-store" always;/g) ?? []).length, 3);
+  assert.equal((app.match(/add_header Referrer-Policy "no-referrer" always;/g) ?? []).length, 6);
+  assert.equal((app.match(/add_header Cache-Control "private, no-store" always;/g) ?? []).length, 6);
+  for (const path of ['access-state', 'free-window', 'free/redeem', 'welcome-access']) {
+    assert.match(app, new RegExp(`location = /api/listener/${path.replace('/', '\\/')}`));
+  }
+  assert.doesNotMatch(app, /location \^~ \/api\/listener\//);
 });
 
 test('ACME bootstrap serves only challenges and never proxies preview traffic', async () => {

--- a/src/app/api/early-birds/auth/[...all]/__tests__/route.test.ts
+++ b/src/app/api/early-birds/auth/[...all]/__tests__/route.test.ts
@@ -66,7 +66,12 @@ describe('EarlyBird public auth route', () => {
         expect(handler).toHaveBeenCalledOnce();
     });
 
-    it('accepts only fixed Listener callbacks and constrained locale metadata for magic links', async () => {
+    it.each([
+        ['/listener', '/listener?authError=1'],
+        ['/listener/redeem', '/listener?authError=1'],
+        ['/early-birds', '/early-birds?authError=1'],
+        ['/early-birds/redeem', '/early-birds?authError=1'],
+    ])('accepts exact Listener callback %s with constrained locale metadata', async (callbackURL, errorCallbackURL) => {
         const request = new NextRequest(
             'https://listen.example.test/api/early-birds/auth/sign-in/magic-link',
             {
@@ -77,8 +82,8 @@ describe('EarlyBird public auth route', () => {
                 },
                 body: JSON.stringify({
                     email: 'listener@example.test',
-                    callbackURL: '/early-birds',
-                    errorCallbackURL: '/early-birds?authError=1',
+                    callbackURL,
+                    errorCallbackURL,
                     metadata: { locale: 'es' },
                 }),
             },
@@ -92,6 +97,9 @@ describe('EarlyBird public auth route', () => {
         {},
         { callbackURL: 'https://attacker.invalid/collect' },
         { callbackURL: '/ops' },
+        { callbackURL: '/listener-other' },
+        { callbackURL: '/listener/redeem/extra' },
+        { callbackURL: '/listener', errorCallbackURL: '/listener?authError=2' },
         { callbackURL: '/early-birds', metadata: { locale: 'en', token: 'leak' } },
     ])('rejects unsafe magic-link request fields: %j', async (body) => {
         const request = new NextRequest(

--- a/src/app/api/early-birds/auth/[...all]/route.ts
+++ b/src/app/api/early-birds/auth/[...all]/route.ts
@@ -10,6 +10,7 @@ import {
     earlyBirdsEnabled,
     earlyBirdsUnavailableResponse,
 } from '@/lib/early-birds/enabled';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 export const dynamic = 'force-dynamic';
 
@@ -47,13 +48,22 @@ function magicLinkVerification(request: NextRequest): boolean {
     return request.nextUrl.pathname.endsWith(EARLY_BIRD_MAGIC_LINK_VERIFY_PATH);
 }
 
-const LISTENER_CALLBACKS = new Set(['/early-birds', '/early-birds/redeem']);
+const LISTENER_CALLBACKS: ReadonlySet<string> = new Set([
+    LISTENER_NAMESPACE.canonical.home,
+    LISTENER_NAMESPACE.canonical.redeem,
+    LISTENER_NAMESPACE.legacy.home,
+    LISTENER_NAMESPACE.legacy.redeem,
+]);
+const LISTENER_ERROR_CALLBACKS: ReadonlySet<string> = new Set([
+    LISTENER_NAMESPACE.canonical.authError,
+    LISTENER_NAMESPACE.legacy.authError,
+]);
 
 function safeListenerCallback(value: unknown, kind: 'success' | 'error'): boolean {
     if (value === undefined) return true;
     if (typeof value !== 'string') return false;
     if (kind === 'success') return LISTENER_CALLBACKS.has(value);
-    return value === '/early-birds?authError=1';
+    return LISTENER_ERROR_CALLBACKS.has(value);
 }
 
 async function safeMagicLinkRequest(request: NextRequest): Promise<boolean> {

--- a/src/app/api/early-birds/free/redeem/__tests__/route.test.ts
+++ b/src/app/api/early-birds/free/redeem/__tests__/route.test.ts
@@ -18,10 +18,13 @@ import { POST } from '../route';
 
 const TOKEN = `ebi_v1.${'a'.repeat(32)}.${'b'.repeat(32)}.${'c'.repeat(32)}`;
 
-function request(token: string | null = TOKEN) {
+function request(token: string | null = TOKEN, namespace: 'legacy' | 'canonical' = 'legacy') {
     const headers = new Headers();
     if (token) headers.set('cookie', `${EARLY_BIRD_INVITATION_COOKIE}=${token}`);
-    return new NextRequest('https://live.example.test/api/early-birds/free/redeem', {
+    const pathname = namespace === 'canonical'
+        ? '/api/listener/free/redeem'
+        : '/api/early-birds/free/redeem';
+    return new NextRequest(`https://live.example.test${pathname}`, {
         method: 'POST',
         headers,
     });
@@ -74,6 +77,21 @@ describe('EarlyBird Free redemption boundary', () => {
             sameSite: 'lax',
             path: '/',
         });
+    });
+
+    it('returns the canonical landing only to the canonical alias', async () => {
+        currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
+        redeemFreeThroughCanonicalGateway.mockResolvedValue({
+            ok: true,
+            replayed: true,
+            alreadyEntitled: true,
+        });
+
+        const canonical = await POST(request(TOKEN, 'canonical'));
+        await expect(canonical.json()).resolves.toMatchObject({ landing: '/listener' });
+
+        const legacy = await POST(request(TOKEN, 'legacy'));
+        await expect(legacy.json()).resolves.toMatchObject({ landing: '/early-birds' });
     });
 
     it('does not accept an invitation token from a request body', async () => {

--- a/src/app/api/early-birds/free/redeem/route.ts
+++ b/src/app/api/early-birds/free/redeem/route.ts
@@ -11,6 +11,7 @@ import {
     EarlyBirdMembershipGatewayUnavailableError,
     redeemFreeThroughCanonicalGateway,
 } from '@/lib/early-birds/membership-gateway';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 export const dynamic = 'force-dynamic';
 
@@ -39,9 +40,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     if (!result.ok) {
         return NextResponse.json({ error: 'Invitation unavailable.' }, { status: 409 });
     }
+    const landing = request.nextUrl.pathname === LISTENER_NAMESPACE.canonical.api.freeRedeem
+        ? LISTENER_NAMESPACE.canonical.home
+        : LISTENER_NAMESPACE.legacy.home;
     const response = NextResponse.json({
         ok: true,
-        landing: '/early-birds',
+        landing,
         replayed: result.replayed,
         alreadyEntitled: result.alreadyEntitled,
     });

--- a/src/app/early-birds/home/page.tsx
+++ b/src/app/early-birds/home/page.tsx
@@ -1,7 +1,9 @@
 import { redirect } from 'next/navigation';
 
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
+
 export const dynamic = 'force-dynamic';
 
 export default async function EarlyBirdHomePage() {
-    redirect('/early-birds');
+    redirect(LISTENER_NAMESPACE.canonical.home);
 }

--- a/src/app/early-birds/redeem/page.tsx
+++ b/src/app/early-birds/redeem/page.tsx
@@ -8,20 +8,21 @@ import {
     canonicalEarlyBirdInvitation,
     EARLY_BIRD_INVITATION_COOKIE,
 } from '@/lib/early-birds/invitation-cookie';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 export const dynamic = 'force-dynamic';
 
 export default async function EarlyBirdRedeemPage() {
-    if (!earlyBirdsEnabled()) redirect('/early-birds');
+    if (!earlyBirdsEnabled()) redirect(LISTENER_NAMESPACE.canonical.home);
 
     const cookieStore = await cookies();
     const token = canonicalEarlyBirdInvitation(
         cookieStore.get(EARLY_BIRD_INVITATION_COOKIE)?.value,
     );
-    if (!token) redirect('/early-birds');
+    if (!token) redirect(LISTENER_NAMESPACE.canonical.home);
 
     const session = await currentEarlyBirdSession().catch(() => null);
-    if (!session) redirect('/early-birds');
+    if (!session) redirect(LISTENER_NAMESPACE.canonical.home);
 
     return <FreeInvitationRedeemer />;
 }

--- a/src/components/early-birds/AccessBoundarySync.tsx
+++ b/src/components/early-birds/AccessBoundarySync.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
+
 type AccessKind = 'membership' | 'free-window' | 'welcome' | 'denied';
 
 /**
@@ -36,7 +38,7 @@ export default function AccessBoundarySync({
             inFlight = true;
             if (timer !== null) window.clearTimeout(timer);
             try {
-                const response = await fetch('/api/early-birds/access-state', {
+                const response = await fetch(LISTENER_NAMESPACE.canonical.api.accessState, {
                     cache: 'no-store',
                     headers: { Accept: 'application/json' },
                 });

--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -6,6 +6,7 @@ import { earlyBirdAuthClient } from '@/lib/early-birds/auth-client';
 import type { ListenerCampfireFixture } from '@/lib/early-birds/campfire-prototype';
 import { earlyBirdCopy, earlyBirdHomeCopy, listenerMembershipPresentationCopy } from '@/lib/early-birds/copy';
 import type { ListenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 import ListenerPlayer from './ListenerPlayer';
 import AccessBoundarySync from './AccessBoundarySync';
@@ -38,7 +39,7 @@ export default function EarlyBirdHome({
 
     async function signOut() {
         await earlyBirdAuthClient.signOut();
-        window.location.assign('/early-birds');
+        window.location.assign(LISTENER_NAMESPACE.canonical.home);
     }
 
     return (
@@ -53,7 +54,7 @@ export default function EarlyBirdHome({
             )}
             <div className="listener-shell__frame">
                 <header className="listener-rail">
-                    <BrandLockup href="/early-birds" />
+                    <BrandLockup href={LISTENER_NAMESPACE.canonical.home} />
                     <div className="listener-rail__actions">
                         {!publicAccess && <details className="listener-account">
                             <summary aria-label={copy.account} title={copy.account}>

--- a/src/components/early-birds/EarlyBirdLanding.tsx
+++ b/src/components/early-birds/EarlyBirdLanding.tsx
@@ -9,6 +9,7 @@ import { earlyBirdCopy, listenerMembershipPresentationCopy } from '@/lib/early-b
 import type { SerializedEarlyBirdFreeWindowState } from '@/lib/early-birds/free-window';
 import type { SerializedEarlyBirdWelcomeAccessState } from '@/lib/early-birds/welcome-access';
 import type { ListenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 import AccessBoundarySync from './AccessBoundarySync';
 import BeaconField from './BeaconField';
@@ -39,8 +40,8 @@ export default function EarlyBirdLanding(props: Props) {
     const [emailRequested, setEmailRequested] = useState(false);
     const membership = listenerMembershipPresentationCopy(copy, props.membership);
     const callbackURL = props.invitationAvailable
-        ? '/early-birds/redeem'
-        : '/early-birds';
+        ? LISTENER_NAMESPACE.canonical.redeem
+        : LISTENER_NAMESPACE.canonical.home;
 
     async function signIn(provider: 'google' | 'apple') {
         if (busy || !props.providers[provider]) return;
@@ -50,7 +51,7 @@ export default function EarlyBirdLanding(props: Props) {
             const result = await earlyBirdAuthClient.signIn.social({
                 provider,
                 callbackURL,
-                errorCallbackURL: '/early-birds?authError=1',
+                errorCallbackURL: LISTENER_NAMESPACE.canonical.authError,
                 requestSignUp: true,
             });
             if (!result.error) return;
@@ -61,7 +62,7 @@ export default function EarlyBirdLanding(props: Props) {
 
     async function signOut() {
         await earlyBirdAuthClient.signOut();
-        window.location.assign('/early-birds');
+        window.location.assign(LISTENER_NAMESPACE.canonical.home);
     }
 
     async function requestMagicLink(event: React.FormEvent<HTMLFormElement>) {
@@ -73,7 +74,7 @@ export default function EarlyBirdLanding(props: Props) {
             await earlyBirdAuthClient.signIn.magicLink({
                 email,
                 callbackURL,
-                errorCallbackURL: '/early-birds?authError=1',
+                errorCallbackURL: LISTENER_NAMESPACE.canonical.authError,
                 metadata: { locale },
             });
             // The same response is intentionally shown for unknown accounts,
@@ -99,7 +100,7 @@ export default function EarlyBirdLanding(props: Props) {
             )}
             <div className="listener-shell__frame">
                 <header className="listener-rail">
-                    <BrandLockup href="/early-birds" />
+                    <BrandLockup href={LISTENER_NAMESPACE.canonical.home} />
                 </header>
 
                 <section className="listener-public-hero">
@@ -139,7 +140,7 @@ export default function EarlyBirdLanding(props: Props) {
                             <div className="space-y-5">
                                 <p className="text-sm text-[var(--text-secondary)]">{copy.signedIn}</p>
                                 {props.entitled ? (
-                                    <a href="/early-birds" className="event-button event-button--primary inline-flex w-full">
+                                    <a href={LISTENER_NAMESPACE.canonical.home} className="event-button event-button--primary inline-flex w-full">
                                         {copy.enter}
                                     </a>
                                 ) : props.invitationAvailable ? (

--- a/src/components/early-birds/EarlyBirdUnavailable.tsx
+++ b/src/components/early-birds/EarlyBirdUnavailable.tsx
@@ -2,6 +2,7 @@
 
 import BrandLockup from '@/components/brand/BrandLockup';
 import { useLocale } from '@/context/LocaleContext';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 const copy = {
     es: {
@@ -24,7 +25,7 @@ export default function EarlyBirdUnavailable() {
         <main className="event-shell">
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-8 sm:px-10 sm:py-10">
                 <header className="flex items-center justify-between gap-4">
-                    <BrandLockup href="/early-birds" />
+                    <BrandLockup href={LISTENER_NAMESPACE.canonical.home} />
                 </header>
                 <section className="flex flex-1 items-center py-14">
                     <div className="max-w-2xl space-y-7">

--- a/src/components/early-birds/FreeInvitationRedeemer.tsx
+++ b/src/components/early-birds/FreeInvitationRedeemer.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import BrandLockup from '@/components/brand/BrandLockup';
 import { useLocale } from '@/context/LocaleContext';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 export default function FreeInvitationRedeemer() {
     const { locale } = useLocale();
@@ -30,11 +31,11 @@ export default function FreeInvitationRedeemer() {
         setBusy(true);
         setError(false);
         try {
-            const response = await fetch('/api/early-birds/free/redeem', {
+            const response = await fetch(LISTENER_NAMESPACE.canonical.api.freeRedeem, {
                 method: 'POST',
             });
             if (response.ok) {
-                window.location.assign('/early-birds');
+                window.location.assign(LISTENER_NAMESPACE.canonical.home);
                 return;
             }
         } catch {}
@@ -46,7 +47,7 @@ export default function FreeInvitationRedeemer() {
         <main className="event-shell">
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-lg flex-col justify-center gap-8 px-6 py-12">
                 <header className="flex items-center justify-between gap-4">
-                    <BrandLockup href="/early-birds" />
+                    <BrandLockup href={LISTENER_NAMESPACE.canonical.home} />
                 </header>
                 <section className="space-y-6 rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-7 shadow-[var(--shadow-deep)]">
                     <p className="font-mono text-xs tracking-[0.22em] text-[var(--gold)]">{copy.eyebrow}</p>

--- a/src/components/early-birds/FreeWindowSetup.tsx
+++ b/src/components/early-birds/FreeWindowSetup.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useLocale } from '@/context/LocaleContext';
 import type { SerializedEarlyBirdFreeWindowState } from '@/lib/early-birds/free-window';
 import { earlyBirdCopy } from '@/lib/early-birds/copy';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 function currentLocalTime(): string {
     const now = new Date();
@@ -63,7 +64,7 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
         setBusy(mode);
         setError(false);
         try {
-            const response = await fetch('/api/early-birds/free-window', {
+            const response = await fetch(LISTENER_NAMESPACE.canonical.api.freeWindow, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/src/components/early-birds/SyntheticTeamEntryForm.tsx
+++ b/src/components/early-birds/SyntheticTeamEntryForm.tsx
@@ -4,10 +4,11 @@ import { useState, type FormEvent } from 'react';
 
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdSyntheticEntryCopy } from '@/lib/early-birds/copy';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 export default function SyntheticTeamEntryForm({
     authOnly = false,
-    postLoginPath = '/early-birds',
+    postLoginPath = LISTENER_NAMESPACE.canonical.home,
 }: {
     authOnly?: boolean;
     postLoginPath?: string;

--- a/src/components/early-birds/WelcomeAccessAction.tsx
+++ b/src/components/early-birds/WelcomeAccessAction.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdCopy } from '@/lib/early-birds/copy';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 export default function WelcomeAccessAction() {
     const { locale } = useLocale();
@@ -18,7 +19,7 @@ export default function WelcomeAccessAction() {
         setBusy(true);
         setError(false);
         try {
-            const response = await fetch('/api/early-birds/welcome-access', {
+            const response = await fetch(LISTENER_NAMESPACE.canonical.api.welcomeAccess, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ activationRequestId: activationRequestId.current }),

--- a/src/components/early-birds/__tests__/AccessBoundarySync.test.tsx
+++ b/src/components/early-birds/__tests__/AccessBoundarySync.test.tsx
@@ -35,6 +35,10 @@ describe('Listener access boundary synchronization', () => {
         await act(async () => { await vi.advanceTimersByTimeAsync(60_750); });
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('/api/listener/access-state', {
+            cache: 'no-store',
+            headers: { Accept: 'application/json' },
+        });
         expect(changed).toHaveBeenCalledTimes(1);
     });
 

--- a/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
@@ -14,7 +14,7 @@ vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh }) }));
 vi.mock('@/lib/early-birds/auth-client', () => ({
     earlyBirdAuthClient: { signIn: { social: signInSocial, magicLink: signInMagicLink }, signOut },
 }));
-vi.mock('@/components/brand/BrandLockup', () => ({ default: () => <a href="/early-birds">Harmonic Beacon</a> }));
+vi.mock('@/components/brand/BrandLockup', () => ({ default: ({ href }: { href: string }) => <a href={href}>Harmonic Beacon</a> }));
 
 import EarlyBirdLanding from '../EarlyBirdLanding';
 
@@ -78,8 +78,8 @@ describe('EarlyBird public landing', () => {
         await userEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
         expect(signInSocial).toHaveBeenCalledWith({
             provider: 'google',
-            callbackURL: '/early-birds/redeem',
-            errorCallbackURL: '/early-birds?authError=1',
+            callbackURL: '/listener/redeem',
+            errorCallbackURL: '/listener?authError=1',
             requestSignUp: true,
         });
     });
@@ -124,8 +124,8 @@ describe('EarlyBird public landing', () => {
 
         expect(signInMagicLink).toHaveBeenCalledWith({
             email: 'listener@example.test',
-            callbackURL: '/early-birds',
-            errorCallbackURL: '/early-birds?authError=1',
+            callbackURL: '/listener',
+            errorCallbackURL: '/listener?authError=1',
             metadata: { locale: 'en' },
         });
         expect(screen.getByRole('status')).toHaveTextContent('If this email can be used for access');
@@ -152,7 +152,7 @@ describe('EarlyBird public landing', () => {
         renderLanding({ signedIn: true, entitled: true });
         expect(screen.getAllByRole('link', { name: 'Enter the Beacon' }))
             .toEqual(expect.arrayContaining([
-                expect.objectContaining({ href: expect.stringMatching(/\/early-birds$/) }),
+                expect.objectContaining({ href: expect.stringMatching(/\/listener$/) }),
             ]));
         expect(screen.queryByRole('button', { name: 'Continue with Google' })).toBeNull();
         expect(screen.getByRole('button', { name: 'Sign out' })).toBeEnabled();
@@ -176,7 +176,7 @@ describe('EarlyBird public landing', () => {
         expect(screen.getByRole('heading', { name: 'Your daily time · 2 hours' })).toBeInTheDocument();
         await userEvent.click(screen.getByRole('button', { name: 'Listen now' }));
 
-        expect(fetchMock).toHaveBeenCalledWith('/api/early-birds/welcome-access', expect.objectContaining({
+        expect(fetchMock).toHaveBeenCalledWith('/api/listener/welcome-access', expect.objectContaining({
             method: 'POST',
         }));
         expect(fetchMock.mock.calls[0]?.[1]?.body).toContain('activationRequestId');

--- a/src/components/early-birds/__tests__/FreeInvitationRedeemer.test.tsx
+++ b/src/components/early-birds/__tests__/FreeInvitationRedeemer.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import { LocaleProvider } from '@/context/LocaleContext';
 
-vi.mock('@/components/brand/BrandLockup', () => ({ default: () => <a href="/early-birds">Harmonic Beacon</a> }));
+vi.mock('@/components/brand/BrandLockup', () => ({ default: ({ href }: { href: string }) => <a href={href}>Harmonic Beacon</a> }));
 
 import FreeInvitationRedeemer from '../FreeInvitationRedeemer';
 
@@ -40,7 +40,8 @@ describe('EarlyBird free invitation redeemer', () => {
 
         expect(await screen.findByRole('alert')).toHaveTextContent('This invitation is unavailable.');
         expect(screen.getByRole('button', { name: 'Activate invitation' })).toBeEnabled();
-        expect(request).toHaveBeenCalledWith('/api/early-birds/free/redeem', { method: 'POST' });
+        expect(request).toHaveBeenCalledWith('/api/listener/free/redeem', { method: 'POST' });
+        expect(screen.getByRole('link', { name: 'Harmonic Beacon' })).toHaveAttribute('href', '/listener');
         expect(JSON.stringify(request.mock.calls)).not.toContain('invitation-token');
     });
 });

--- a/src/components/early-birds/__tests__/FreeWindowSetup.test.tsx
+++ b/src/components/early-birds/__tests__/FreeWindowSetup.test.tsx
@@ -61,6 +61,7 @@ describe('Free listening schedule UI', () => {
         await userEvent.click(screen.getByRole('button', { name: 'Save my listening time' }));
 
         expect(fetch).toHaveBeenCalledOnce();
+        expect(vi.mocked(fetch).mock.calls[0][0]).toBe('/api/listener/free-window');
         const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
         expect(JSON.parse(init.body as string)).toMatchObject({
             mode: 'custom',

--- a/src/components/early-birds/__tests__/SyntheticTeamEntryForm.test.tsx
+++ b/src/components/early-birds/__tests__/SyntheticTeamEntryForm.test.tsx
@@ -62,7 +62,7 @@ describe('EarlyBird staging team entry form', () => {
             <LocaleProvider initialLocale="en">
                 <SyntheticTeamEntryForm
                     authOnly
-                    postLoginPath="/early-birds/redeem"
+                    postLoginPath="/listener/redeem"
                 />
             </LocaleProvider>,
         );

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const MEDIA_FILE_SHA256 = {
+    'src/components/early-birds/ListenerPlayer.tsx': '7b0f6f4e75e6b1c84ad65bb3ccbb08c32759dd591bcc51048a0cfe3b71dd8b78',
+    'src/lib/early-birds/stream.ts': 'e386413874e5ad799e17607e2b030851cc7baadea48161191c7daecb45183bea',
+    'src/lib/early-birds/drop-ins.ts': '3b0d18c2c8548aa3ee917ece726cbca4b6d253ea3b4941a8424f8bcbfb8922e2',
+    'src/app/api/early-birds/stream/lease/route.ts': 'd858affc655c6df6607e76470508a59c3ebd442744bc12e5da334729fcb5d660',
+    'src/app/api/early-birds/stream/manifest/route.ts': 'f149e9ed081579d75c0d588f7e6a75663b449c4baf28658418014a8e0c87a0de',
+    'src/app/api/early-birds/stream/heartbeat/route.ts': '316a2690db50472b67bd0251d995e6d3375c710030ccf30e460e92d9ade1a407',
+    'src/app/api/early-birds/drop-ins/[language]/route.ts': 'c905ba0ce68aa22448a2f41c9ed9563473dc097f0284e245421dae787cd30d94',
+} as const;
+
+function sha256(value: string | Buffer): string {
+    return createHash('sha256').update(value).digest('hex');
+}
+
+function nginxLocation(source: string, location: string): string {
+    const escaped = location.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replaceAll('/', '\\/');
+    const match = source.match(new RegExp(`    location \\^~ ${escaped} \\{[\\s\\S]*?\\n    \\}`));
+    if (!match) throw new Error(`Missing nginx media location ${location}`);
+    return match[0];
+}
+
+describe('Listener namespace media boundary', () => {
+    it('keeps every player and media handler byte-identical to the accepted Phase 1 baseline', () => {
+        for (const [path, expected] of Object.entries(MEDIA_FILE_SHA256)) {
+            expect(sha256(readFileSync(resolve(process.cwd(), path))), path).toBe(expected);
+        }
+    });
+
+    it('keeps public stream and drop-in proxy blocks byte-identical', () => {
+        const source = readFileSync(resolve(
+            process.cwd(),
+            'ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template',
+        ), 'utf8');
+
+        expect(sha256(nginxLocation(source, '/api/early-birds/stream/')))
+            .toBe('877f937d145631a55f41b71fddb2142ad6f9b2833be1c57731eb772ed040fdb9');
+        expect(sha256(nginxLocation(source, '/api/early-birds/drop-ins/')))
+            .toBe('6738ce8a66d53fab790452e1b62bd74a3ff9439d7addc5c2a739cef00f8c17d4');
+    });
+
+    it('keeps the staging legacy API proxy block byte-identical', () => {
+        const source = readFileSync(resolve(
+            process.cwd(),
+            'ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template',
+        ), 'utf8');
+
+        expect(sha256(nginxLocation(source, '/api/early-birds/')))
+            .toBe('31f610cfd1d4d5778d6d3a2c10879790a5c2dcb8e39563738b2b39aa9cdc14c8');
+    });
+});

--- a/src/lib/listener/__tests__/namespace.test.ts
+++ b/src/lib/listener/__tests__/namespace.test.ts
@@ -10,6 +10,7 @@ describe('Listener namespace compatibility contract', () => {
         expect(LISTENER_NAMESPACE.canonical).toEqual({
             home: '/listener',
             redeem: '/listener/redeem',
+            authError: '/listener?authError=1',
             api: {
                 accessState: '/api/listener/access-state',
                 freeWindow: '/api/listener/free-window',
@@ -19,6 +20,7 @@ describe('Listener namespace compatibility contract', () => {
         });
         expect(LISTENER_NAMESPACE.legacy.home).toBe('/early-birds');
         expect(LISTENER_NAMESPACE.legacy.redeem).toBe('/early-birds/redeem');
+        expect(LISTENER_NAMESPACE.legacy.authError).toBe('/early-birds?authError=1');
     });
 
     it.each([

--- a/src/lib/listener/namespace.ts
+++ b/src/lib/listener/namespace.ts
@@ -9,6 +9,7 @@ export const LISTENER_NAMESPACE = {
     canonical: {
         home: '/listener',
         redeem: '/listener/redeem',
+        authError: '/listener?authError=1',
         api: {
             accessState: '/api/listener/access-state',
             freeWindow: '/api/listener/free-window',
@@ -19,6 +20,7 @@ export const LISTENER_NAMESPACE = {
     legacy: {
         home: '/early-birds',
         redeem: '/early-birds/redeem',
+        authError: '/early-birds?authError=1',
         api: {
             accessState: '/api/early-birds/access-state',
             freeWindow: '/api/early-birds/free-window',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,11 +16,12 @@ import { listenerInvitationQuery } from '@/lib/listener/namespace';
  * as authorization would mean a revoked ticket kept its access simply because
  * the browser still held the cookie.
  *
- * It performs two edge-local navigation chores: it exchanges a canonical
- * EarlyBird invitation query for a short browser-inaccessible cookie before any
- * page renders, and it sends visitors with no session cookie to the relevant
- * login surface. Every protected page and API route still resolves the principal
- * itself through `@/lib/auth`, and none of them may assume this file ran.
+ * It performs two edge-local navigation chores: on the exact invitation
+ * staging host it exchanges a canonical Listener invitation query for a short
+ * browser-inaccessible cookie, while every other host only scrubs the bearer;
+ * it also sends visitors with no session cookie to the relevant login surface.
+ * Every protected page and API route still resolves the principal itself
+ * through `@/lib/auth`, and none of them may assume this file ran.
  */
 
 /**
@@ -36,6 +37,7 @@ const ATTENDEE_PREFIXES = ['/session'];
 
 /** Staff surfaces: the operator console. */
 const STAFF_PREFIXES = ['/ops'];
+const LISTENER_INVITATION_HOST = 'earlybirds-staging.harmonicbeacon.com';
 
 function matches(pathname: string, prefixes: string[]): boolean {
     return prefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
@@ -54,7 +56,12 @@ function scrubEarlyBirdInvitation(request: NextRequest): NextResponse | null {
     const response = NextResponse.redirect(target);
     response.headers.set('Cache-Control', 'private, no-store');
     response.headers.set('Referrer-Policy', 'no-referrer');
-    if (token) response.cookies.set(earlyBirdInvitationCookie(token));
+    // Invitation redemption remains a staging-only surface. The canonical
+    // public Listener edge must still remove a bearer query without turning it
+    // into a durable browser credential or a dead-end redemption state.
+    if (token && request.nextUrl.hostname === LISTENER_INVITATION_HOST) {
+        response.cookies.set(earlyBirdInvitationCookie(token));
+    }
     return response;
 }
 


### PR DESCRIPTION
## Outcome

Phase 2A moves new browser navigation and account-local non-media requests to the canonical Listener namespace while every legacy route remains compatible.

Closes no umbrella automatically; advances #210.

## Scope

- canonical `/listener` and `/api/listener/{access-state,free-window,welcome-access}` runtime usage;
- canonical staging invitation redemption with legacy response compatibility;
- canonical and legacy post-auth callback allowlists;
- exact additive nginx locations for both route families;
- root internal rewrite candidate from `/early-birds` to `/listener`;
- explicit byte-level guard proving player, stream, drop-in and legacy media edge blocks are unchanged.

Not changed: Better Auth base path or cookies, stream, drop-ins, manifest, heartbeat, player/audio, Prisma, environment keys, physical tables, wire contracts, event/live routes or production.

## Verification

- 59 focused Vitest tests passed;
- 31 preview/edge contract tests passed;
- TypeScript passed;
- changed-file ESLint passed;
- preview shell/config checks and Compose validation passed;
- production build completed and emitted all canonical routes;
- media boundary SHA tests passed against the accepted `fd105aa` baseline.

## Rollout

1. Install only the additive exact nginx locations while `/` still rewrites to `/early-birds`; run `nginx -t`, reload and smoke legacy routes.
2. Deploy the application image containing both route families.
3. Smoke `/listener` and all canonical non-media APIs directly.
4. Change the internal root rewrite to `/listener`; run `nginx -t`, reload and verify the visible URL remains `/`.
5. Keep legacy aliases for the measured support window.

No deployment is part of this PR.

## Rollback

Restore the root rewrite to `/early-birds` first, then restore the previous application image. Additive exact aliases can remain dark. No database, cookie, environment or media rollback is required.

## Risks

- Deploying the client before nginx canonical locations would produce 404s; the order above is mandatory.
- Auth base-path/cookie migration and cross-repo contract/table renames remain later coordinated phases.
- Public invitation redemption remains deliberately closed at the Listener public edge until bearer-query logging is reviewed.