### PR TITLE
feat(listener): enable secure public invitation deep links

### DIFF
--- a/docs/architecture/EARLY_BIRDS_LISTENER.md
+++ b/docs/architecture/EARLY_BIRDS_LISTENER.md
@@ -23,8 +23,8 @@ The staging callbacks with the same suffixes may be registered for isolated QA,
 but the shared preview runtime uses `listen.harmonicbeacon.com` as its canonical
 OAuth base URL. Provider credentials may remain unset during local testing; the
 corresponding provider is absent from the public UI and auth runtime. Public nginx exposes this dedicated
-auth namespace while continuing to block synthetic login, invitations and
-internal membership routes.
+auth namespace plus only the exact invitation entry/redeem routes. It continues
+to block synthetic login and internal membership routes.
 
 Browser-initiated auth mutations require an exact configured Listener
 `Origin`. OAuth provider callbacks are the sole exception because Apple uses a
@@ -77,6 +77,35 @@ Byte-exact copies live in `contracts/early-bird-authority/v1` and
   `STALE`, and equal revisions with different payloads conflict.
 - `ACTIVE`, time-valid `GRACE`, and time-valid `CANCELLED_PENDING_END` allow access. Every missing,
   expired, revoked, refunded or unavailable state fails closed.
+
+### Public invitation handoff
+
+An invitation link is accepted only on `listen.harmonicbeacon.com` or the
+isolated staging host. Staging carries the bearer in one unlogged,
+no-store/no-referrer redirect to the canonical
+`https://listen.harmonicbeacon.com/listener/redeem` page; it never mints an
+invitation cookie. Middleware on `listen` immediately removes the signed bearer
+query, places it in a 30-minute `__Host-`, Secure, HttpOnly, SameSite=Lax cookie
+and redirects to the clean URL. Neither the event host nor a forwarded-host
+header can mint this cookie.
+
+Google and configured magic-link callbacks return to the exact
+`/listener/redeem` allowlist. The cookie therefore survives an identity round
+trip in the same browser without entering JavaScript, OAuth state or email.
+Opening a magic link in another browser or device intentionally does not carry
+the invitation; a future cross-device flow needs an authority-mediated claim
+contract and must not place the invitation bearer in mail.
+
+The browser redeem POST is exposed only at the canonical and compatibility
+aliases on `listen`. It requires the exact Listener Host and same Origin, and
+nginx bounds each address to 30 requests per minute with a 20-request burst so
+a shared household/NAT cannot lock out independent one-use redemptions. Both
+POST aliases fail closed with an unlogged 404 on staging. A terminal authority
+rejection clears the cookie; a transient 503 preserves it for a safe retry. All
+responses and exact edge locations are no-store and no-referrer. The exact
+magic-link verification URL is excluded from HTTP and HTTPS access logs and
+staging redirects it once to the canonical host, because its query carries the
+one-use authentication token.
 
 ## Ordinary Free listening window
 

--- a/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
+++ b/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
@@ -45,9 +45,10 @@ Implemented in this branch:
   layout as their legacy counterparts.
 - Canonical non-media API aliases exist for access state, free-window selection,
   free invitation redemption and welcome access.
-- Invitation query tokens are scrubbed on both URL families and placed in the
-  existing HttpOnly cookie. The canonical route therefore accepts old cookies
-  without copying sensitive values into JavaScript-visible storage.
+- Invitation query tokens are scrubbed on both URL families. Only the canonical
+  `listen.harmonicbeacon.com` host places one in the existing HttpOnly cookie;
+  staging first redirects the bearer once to that host and cannot mint a
+  staging-scoped cookie that would be lost during OAuth.
 - `/early-birds` and every legacy API remain unchanged. Current clients continue
   using them, making rollback equivalent to removing the new aliases.
 
@@ -67,14 +68,14 @@ internals.
    canonical URL, refresh and finish redemption without signing in again.
 
 The phase 2A candidate changes only account-local access-state, Free-window,
-welcome-access and staging invitation redemption. Better Auth continues to use
-its legacy base path and cookies. The public edge continues to exclude
-invitation redemption and synthetic entry: invitation queries are accepted only
-on the exact staging hostname, while the public edge suppresses access logs,
-scrubs the bearer with no-store/no-referrer and never mints its cookie. The
-staging edge exposes only the four exact canonical non-media APIs. Stream,
-heartbeat, manifest, drop-in and player storage paths remain on their accepted
-legacy URLs.
+welcome-access and invitation redemption. Better Auth continues to use its
+legacy base path and cookies. The public `listen` edge exposes only the exact
+canonical and compatibility invitation pages and POSTs; synthetic entry remains
+staging only. Staging invitation pages and magic verification redirect through
+exact unlogged locations to `listen`, while both staging redeem POST aliases
+fail closed. Every non-Listener application host scrubs an invitation query but
+never mints its cookie. Stream, heartbeat, manifest, drop-in and player storage
+paths remain on their accepted legacy URLs.
 
 Roll out the edge and application as a compatibility handoff, never as one
 blind replacement:

--- a/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+++ b/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
@@ -356,10 +356,16 @@ and returns 404 for the image's weekend, staff, event and checkout surfaces.
 The `listen.harmonicbeacon.com` vhost is narrower: it exposes only `/`, Next
 static assets, health, the dedicated Listener OAuth/session namespace, the
 exact ordinary-Free schedule endpoint, stream leases/manifests and configured
-drop-ins. Synthetic login, invitation,
-membership projection and all other app routes remain unreachable from that
-host. The application additionally returns a hidden 404 for Better Auth's
-email/password endpoints, so the public namespace offers only configured
+drop-ins. Synthetic login, membership projection and all other app routes
+remain unreachable from that host. Public invitations use only the exact
+Listener and legacy entry/redeem pages plus their two exact POST aliases on
+`listen`; the edge applies no-store/no-referrer, suppresses bearer-path logs and
+rate-limits redemption at 30 requests/minute with a 20-request burst. Staging
+entry and magic-link bearer paths redirect once through exact unlogged
+no-store/no-referrer locations to the canonical host. Both staging redeem POST
+aliases return an unlogged, no-store 404 so neither can fall through the broad
+legacy prefix. The application additionally returns a hidden 404 for Better
+Auth's email/password endpoints, so the public namespace offers only configured
 Google and Apple social providers.
 
 A host operator must review certificate/DNS ownership, provision each named

--- a/e2e/tests/listener-namespace-compat.spec.ts
+++ b/e2e/tests/listener-namespace-compat.spec.ts
@@ -13,6 +13,55 @@ const INVITATION = `ebi_v1.${'a'.repeat(32)}.${'b'.repeat(32)}.${'c'.repeat(32)}
 test.use({ trace: 'off' });
 
 test.describe('Listener namespace compatibility', () => {
+    test('keeps a public invitation through a same-browser identity round trip', async ({ browser, request }, testInfo) => {
+        test.skip(testInfo.project.name !== 'chromium', 'one browser proves the provider-independent cookie contract');
+        requireDirectDb(testInfo);
+        const baseURL = new URL(String(testInfo.project.use.baseURL));
+        if (!['localhost', '127.0.0.1', '[::1]'].includes(baseURL.hostname)) {
+            throw new Error('refusing to run Listener namespace E2E against a non-local application');
+        }
+
+        const email = `invitation-roundtrip-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@e2e.invalid`;
+        const context = await browser.newContext();
+        try {
+            // Middleware owns the public query-to-cookie exchange. The browser
+            // exercise starts immediately after that edge boundary and proves
+            // the host-only bearer survives identity session creation without
+            // ever becoming script-readable. Google and magic link use this
+            // same callback cookie contract; their exact callback is locked by
+            // the landing/auth route unit suites.
+            await context.addCookies([{
+                name: EARLY_BIRD_INVITATION_COOKIE,
+                value: INVITATION,
+                domain: baseURL.hostname,
+                path: '/',
+                httpOnly: true,
+                secure: true,
+                sameSite: 'Lax',
+            }]);
+            // A provider callback adds its session cookie to the returning
+            // browser; it does not forward the pre-existing invitation to the
+            // provider. Mint the synthetic session out of band, then apply its
+            // Set-Cookie result to model that exact boundary.
+            await signInSyntheticListener(request, email);
+            const identityState = await request.storageState();
+            await context.addCookies(identityState.cookies.filter((cookie) => cookie.name.includes('session')));
+
+            const cookiesAfterIdentity = await context.cookies();
+            expect(cookiesAfterIdentity.find((cookie) => cookie.name === EARLY_BIRD_INVITATION_COOKIE))
+                .toMatchObject({ value: INVITATION, httpOnly: true, secure: true, sameSite: 'Lax' });
+            expect(cookiesAfterIdentity.some((cookie) => cookie.name.includes('session'))).toBe(true);
+
+            const page = await context.newPage();
+            await page.goto('/listener/redeem');
+            await expect(page.getByRole('button', { name: /Activar invitación|Activate invitation/ }))
+                .toBeVisible();
+        } finally {
+            await context.close();
+            await deleteSyntheticListenerEmails(testInfo, [email]);
+        }
+    });
+
     test('keeps a legacy invitation cookie and Listener session through canonical refresh and redemption', async ({ browser }, testInfo) => {
         test.skip(testInfo.project.name !== 'chromium', 'one browser proves the namespace/session contract');
         requireDirectDb(testInfo);

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -49,7 +49,7 @@ describe('middleware', () => {
             ['/listener/redeem', 'token'],
             ['/early-birds', 'invite'],
             ['/early-birds/redeem', 'token'],
-        ])('moves the canonical %s query token to a short HttpOnly cookie', (pathname, queryName) => {
+        ])('forwards staging %s bearer once to the canonical redeem host', (pathname, queryName) => {
             const response = middleware(request(
                 `${pathname}?${queryName}=${INVITATION}&locale=en`,
                 undefined,
@@ -58,12 +58,56 @@ describe('middleware', () => {
 
             expect(response.status).toBe(307);
             const target = location(response);
-            expect(target.pathname).toBe(pathname);
-            expect(target.searchParams.has(queryName)).toBe(false);
-            expect(target.searchParams.get('locale')).toBe('en');
+            expect(target.origin).toBe('https://listen.harmonicbeacon.com');
+            expect(target.pathname).toBe('/listener/redeem');
+            expect(target.searchParams.get('token')).toBe(INVITATION);
+            expect(target.searchParams.has('invite')).toBe(false);
+            expect(target.searchParams.has('locale')).toBe(false);
             expect(response.headers.get('cache-control')).toBe('private, no-store');
             expect(response.headers.get('referrer-policy')).toBe('no-referrer');
+            expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+        });
+
+        it.each([
+            ['listen.harmonicbeacon.com', '/listener', 'invite'],
+            ['listen.harmonicbeacon.com', '/listener/redeem', 'token'],
+            ['listen.harmonicbeacon.com', '/early-birds', 'invite'],
+            ['listen.harmonicbeacon.com', '/early-birds/redeem', 'token'],
+        ])('moves a canonical %s%s query into the host-only handoff cookie', (hostname, pathname, queryName) => {
+            const response = middleware(request(
+                `${pathname}?${queryName}=${INVITATION}&locale=en`,
+                undefined,
+                hostname,
+            ));
+
+            expect(response.status).toBe(307);
+            expect(location(response).searchParams.has(queryName)).toBe(false);
             expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toMatchObject({
+                value: INVITATION,
+                httpOnly: true,
+                secure: true,
+                sameSite: 'lax',
+            });
+        });
+
+        it('completes the real staging-to-canonical scrub topology without a staging cookie', () => {
+            const staging = middleware(request(
+                `/listener?invite=${INVITATION}`,
+                undefined,
+                'earlybirds-staging.harmonicbeacon.com',
+            ));
+            expect(staging.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+
+            const canonicalURL = location(staging);
+            const canonical = middleware(request(
+                `${canonicalURL.pathname}${canonicalURL.search}`,
+                undefined,
+                canonicalURL.hostname,
+            ));
+            expect(location(canonical).toString()).toBe(
+                'https://listen.harmonicbeacon.com/listener/redeem',
+            );
+            expect(canonical.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toMatchObject({
                 value: INVITATION,
                 httpOnly: true,
                 secure: true,
@@ -74,11 +118,8 @@ describe('middleware', () => {
         });
 
         it.each([
-            ['listen.harmonicbeacon.com', '/listener', 'invite'],
-            ['listen.harmonicbeacon.com', '/listener/redeem', 'token'],
-            ['listen.harmonicbeacon.com', '/early-birds', 'invite'],
-            ['listen.harmonicbeacon.com', '/early-birds/redeem', 'token'],
             ['live.harmonicbeacon.com', '/early-birds', 'invite'],
+            ['listen.harmonicbeacon.com.attacker.invalid', '/listener', 'invite'],
         ])('scrubs but never persists %s%s invitation queries', (hostname, pathname, queryName) => {
             const response = middleware(request(
                 `${pathname}?${queryName}=${INVITATION}&locale=en`,
@@ -94,12 +135,12 @@ describe('middleware', () => {
             expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
         });
 
-        it('does not trust a forwarded staging host on the public Listener URL', () => {
+        it('does not trust a forwarded Listener host on an off-surface URL', () => {
             const response = middleware(request(
-                `/listener?invite=${INVITATION}`,
+                `/early-birds?invite=${INVITATION}`,
                 undefined,
-                'listen.harmonicbeacon.com',
-                { 'x-forwarded-host': 'earlybirds-staging.harmonicbeacon.com' },
+                'live.harmonicbeacon.com',
+                { 'x-forwarded-host': 'listen.harmonicbeacon.com' },
             ));
 
             expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
@@ -115,6 +156,16 @@ describe('middleware', () => {
                 expect(location(response).searchParams.has('invite')).toBe(false);
                 expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
             }
+        });
+
+        it('sends malformed staging input to the canonical clean entry without carrying it', () => {
+            const response = middleware(request(
+                '/listener?invite=not-canonical',
+                undefined,
+                'earlybirds-staging.harmonicbeacon.com',
+            ));
+            expect(location(response).toString()).toBe('https://listen.harmonicbeacon.com/listener');
+            expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
         });
     });
 

--- a/ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template
@@ -29,7 +29,7 @@ server {
         access_log off;
         add_header Cache-Control "private, no-store" always;
         add_header Referrer-Policy "no-referrer" always;
-        return 302 https://earlybirds-staging.harmonicbeacon.com$request_uri;
+        return 302 https://listen.harmonicbeacon.com/listener/redeem$is_args$args;
     }
 
     location = /listener {
@@ -43,7 +43,31 @@ server {
         access_log off;
         add_header Cache-Control "private, no-store" always;
         add_header Referrer-Policy "no-referrer" always;
-        return 302 https://earlybirds-staging.harmonicbeacon.com$request_uri;
+        return 302 https://listen.harmonicbeacon.com/listener/redeem$is_args$args;
+    }
+
+    location = /api/early-birds/auth/magic-link/verify {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://listen.harmonicbeacon.com$request_uri;
+    }
+
+    # Redemption authority lives only on the canonical Listener origin. Keep
+    # both compatibility POST aliases dark on staging instead of forwarding a
+    # mutation (or allowing the legacy alias to fall through a broad prefix).
+    location = /api/listener/free/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 404;
+    }
+
+    location = /api/early-birds/free/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 404;
     }
 
     location / {
@@ -138,30 +162,62 @@ server {
 
     location = /early-birds/redeem {
         access_log off;
-        proxy_pass http://127.0.0.1:13000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_connect_timeout 10s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "early-birds-staging" always;
+        return 302 https://listen.harmonicbeacon.com/listener/redeem$is_args$args;
     }
 
     location = /listener/redeem {
         access_log off;
-        proxy_pass http://127.0.0.1:13000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_connect_timeout 10s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "early-birds-staging" always;
+        return 302 https://listen.harmonicbeacon.com/listener/redeem$is_args$args;
+    }
+
+    # The shared preview's auth/session origin is the canonical Listener host.
+    # Never let the one-use magic token fall through the logged broad API
+    # prefix; carry it once to the exact unlogged canonical verifier.
+    location = /api/early-birds/auth/magic-link/verify {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "early-birds-staging" always;
+        return 302 https://listen.harmonicbeacon.com$request_uri;
+    }
+
+    # The canonical Listener host owns the session and invitation cookie. A
+    # POST cannot be safely redirected, so fail both staging aliases closed.
+    location = /api/listener/free/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "early-birds-staging" always;
+        return 404;
+    }
+
+    location = /api/early-birds/free/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "early-birds-staging" always;
+        return 404;
     }
 
     location = /api/listener/access-state {
@@ -178,19 +234,6 @@ server {
     }
 
     location = /api/listener/free-window {
-        proxy_pass http://127.0.0.1:13000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_connect_timeout 10s;
-        proxy_send_timeout 30s;
-        proxy_read_timeout 30s;
-    }
-
-    location = /api/listener/free/redeem {
         proxy_pass http://127.0.0.1:13000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
@@ -1,6 +1,9 @@
 # Public Listener edge. It shares the isolated Listener runtime and exposes the
-# Listener's dedicated OAuth/session boundary, but never staging synthetic
-# entry, invitations, membership projection, staff or event routes.
+# Listener's dedicated OAuth/session and exact invitation-redeem boundaries,
+# but never staging synthetic entry, membership projection, staff or event
+# routes.
+limit_req_zone $binary_remote_addr zone=listener_invitation_redeem:1m rate=30r/m;
+
 server {
     listen 80;
     listen [::]:80;
@@ -42,6 +45,15 @@ server {
     }
 
     location = /listener/redeem {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 302 https://listen.harmonicbeacon.com$request_uri;
+    }
+
+    # A magic-link bearer is valid only over HTTPS. Suppress accidental HTTP
+    # request logging before preserving the URI for the TLS endpoint.
+    location = /api/early-birds/auth/magic-link/verify {
         access_log off;
         add_header Cache-Control "private, no-store" always;
         add_header Referrer-Policy "no-referrer" always;
@@ -141,20 +153,47 @@ server {
         return 302 /$is_args$args;
     }
 
-    # Invitation redemption is staging-only. Clean either redeem alias without
-    # proxying or retaining its bearer query on the public Listener host.
+    # The exact invitation pages are safe to expose: middleware first moves a
+    # valid bearer query into a short HttpOnly host cookie and redirects to the
+    # clean URL. No prefix or internal membership route is opened here.
     location = /early-birds/redeem {
         access_log off;
         add_header Cache-Control "private, no-store" always;
         add_header Referrer-Policy "no-referrer" always;
-        return 302 /;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "listener-public-free" always;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
     }
 
     location = /listener/redeem {
         access_log off;
         add_header Cache-Control "private, no-store" always;
         add_header Referrer-Policy "no-referrer" always;
-        return 302 /;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "listener-public-free" always;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
     }
 
     location = / {
@@ -281,6 +320,76 @@ server {
         proxy_read_timeout 30s;
     }
 
+    # Invitation mutation stays exact, same-origin and rate bounded. The app
+    # independently verifies Host, Origin, Listener session and the one-use
+    # canonical authority token before changing access.
+    location = /api/listener/free/redeem {
+        access_log off;
+        limit_req zone=listener_invitation_redeem burst=20 nodelay;
+        limit_req_status 429;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "listener-public-free" always;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    location = /api/early-birds/free/redeem {
+        access_log off;
+        limit_req zone=listener_invitation_redeem burst=20 nodelay;
+        limit_req_status 429;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "listener-public-free" always;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    # Better Auth puts the one-use magic token in this exact query URL. Keep it
+    # out of edge logs even while the delivery backend and public control stay
+    # disabled. Exact matching still leaves every unrelated route fail closed.
+    location = /api/early-birds/auth/magic-link/verify {
+        access_log off;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Harmonic-Beacon-Environment "listener-public-free" always;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
     # Better Auth owns only this dedicated Listener namespace. The app itself
     # hides synthetic email sign-up/sign-in; nginx keeps every staging-only
     # entry and internal membership route outside the public edge.
@@ -297,7 +406,7 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Synthetic entry, invitations, projection, staff and event routes are
+    # Synthetic entry, membership projection, staff and event routes are
     # deliberately absent from the public Listener host.
     location / {
         return 404;

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -174,8 +174,16 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.match(listener, /letsencrypt\/live\/listen\.harmonicbeacon\.com/);
   assert.match(app, /location \^~ \/api\/internal\//);
   assert.match(app, /location \^~ \/api\/early-birds\//);
-  assert.equal((combined.match(/X-Harmonic-Beacon-Environment "early-birds-staging"/g) ?? []).length, 2);
-  assert.equal((listener.match(/X-Harmonic-Beacon-Environment "listener-public-free"/g) ?? []).length, 1);
+  assert.equal(
+    (app.match(/X-Harmonic-Beacon-Environment "early-birds-staging"/g) ?? []).length,
+    6,
+    'server plus five sensitive HTTPS staging locations retain the environment attestation when add_header inheritance stops',
+  );
+  assert.equal(
+    (listener.match(/X-Harmonic-Beacon-Environment "listener-public-free"/g) ?? []).length,
+    6,
+    'server plus five sensitive HTTPS locations retain the environment attestation when add_header inheritance stops',
+  );
   assert.match(app, /location = \/ \{[^}]*access_log off;[^}]*rewrite \^ \/listener break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13000;/s);
   assert.match(app, /location = \/early-birds\/home \{\s*return 302 \/;/);
   assert.match(app, /location \/ \{\s*return 404;/);
@@ -192,7 +200,7 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   }
   for (const path of ['early-birds/redeem', 'listener/redeem']) {
     assert.match(listener, new RegExp(
-      `location = /${path} \\{[^}]*access_log off;[^}]*Cache-Control "private, no-store"[^}]*Referrer-Policy "no-referrer"[^}]*return 302 /;`,
+      `location = /${path} \\{[^}]*access_log off;[^}]*Cache-Control "private, no-store"[^}]*Referrer-Policy "no-referrer"[^}]*proxy_pass http://127\\.0\\.0\\.1:13000;`,
       's',
     ));
   }
@@ -210,9 +218,26 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.equal((listener.match(/location = \/sitemap\.xml/g) ?? []).length, 1);
   assert.doesNotMatch(listener, /location \^~ \/api\/listener\/public-discovery\//);
   assert.doesNotMatch(listener, /location \^~ \/api\/listener\//);
-  assert.doesNotMatch(listener, /api\/early-birds\/(test-login|free\/|membership)/);
-  assert.doesNotMatch(listener, /api\/listener\/(test-login|free\/|membership)/);
+  assert.doesNotMatch(listener, /api\/early-birds\/(test-login|membership)/);
+  assert.doesNotMatch(listener, /api\/listener\/(test-login|membership)/);
   assert.doesNotMatch(listener, /location \^~ \/early-birds\//);
+
+  assert.match(listener, /limit_req_zone \$binary_remote_addr zone=listener_invitation_redeem:1m rate=30r\/m;/);
+  for (const path of ['api/listener/free/redeem', 'api/early-birds/free/redeem']) {
+    assert.match(listener, new RegExp(
+      `location = /${path} \\{[^}]*access_log off;[^}]*limit_req zone=listener_invitation_redeem burst=20 nodelay;[^}]*Cache-Control "private, no-store"[^}]*Referrer-Policy "no-referrer"[^}]*proxy_pass http://127\\.0\\.0\\.1:13000;`,
+      's',
+    ));
+  }
+  const magicVerificationLocations = [...listener.matchAll(
+    /location = \/api\/early-birds\/auth\/magic-link\/verify \{([^}]*)\}/g,
+  )];
+  assert.equal(magicVerificationLocations.length, 2, 'HTTP and HTTPS magic bearer entries must be exact');
+  assert.ok(magicVerificationLocations.every((match) => (
+    /access_log off;/.test(match[1])
+    && /Cache-Control "private, no-store"/.test(match[1])
+    && /Referrer-Policy "no-referrer"/.test(match[1])
+  )));
 
   const publicSensitiveEntries = [...listener.matchAll(
     /location = \/(?:listener(?:\/redeem)?|early-birds(?:\/redeem)?)? \{([^}]*)\}/g,
@@ -229,13 +254,54 @@ test('nginx templates isolate staging, stream and the constrained public Listene
     /location = \/(?:listener|early-birds)(?:\/redeem)? \{([^}]*)\}/g,
   )];
   assert.equal(invitationEntryLocations.length, 8, 'HTTP and HTTPS must protect canonical and legacy invitation entries');
-  assert.ok(invitationEntryLocations.every((match) => /access_log off;/.test(match[1])));
-  assert.equal((app.match(/add_header Referrer-Policy "no-referrer" always;/g) ?? []).length, 7);
-  assert.equal((app.match(/add_header Cache-Control "private, no-store" always;/g) ?? []).length, 7);
+  assert.ok(invitationEntryLocations.every((match) => (
+    /access_log off;/.test(match[1])
+    && /Cache-Control "private, no-store"/.test(match[1])
+    && /Referrer-Policy "no-referrer"/.test(match[1])
+  )));
+  for (const path of ['early-birds/redeem', 'listener/redeem']) {
+    const stagingRedeemPages = [...app.matchAll(new RegExp(
+      `location = /${path} \\{([^}]*)\\}`,
+      'g',
+    ))];
+    assert.equal(stagingRedeemPages.length, 2, `HTTP and HTTPS /${path} must be exact`);
+    assert.ok(stagingRedeemPages.every((match) => (
+      /access_log off;/.test(match[1])
+      && /Cache-Control "private, no-store"/.test(match[1])
+      && /Referrer-Policy "no-referrer"/.test(match[1])
+      && /return 302 https:\/\/listen\.harmonicbeacon\.com\/listener\/redeem\$is_args\$args;/.test(match[1])
+    )));
+  }
+
+  const stagingMagicVerificationLocations = [...app.matchAll(
+    /location = \/api\/early-birds\/auth\/magic-link\/verify \{([^}]*)\}/g,
+  )];
+  assert.equal(stagingMagicVerificationLocations.length, 2, 'staging HTTP and HTTPS magic bearer entries must be exact');
+  assert.ok(stagingMagicVerificationLocations.every((match) => (
+    /access_log off;/.test(match[1])
+    && /Cache-Control "private, no-store"/.test(match[1])
+    && /Referrer-Policy "no-referrer"/.test(match[1])
+    && /return 302 https:\/\/listen\.harmonicbeacon\.com\$request_uri;/.test(match[1])
+  )));
+
+  for (const path of ['api/listener/free/redeem', 'api/early-birds/free/redeem']) {
+    const closedStagingPosts = [...app.matchAll(new RegExp(
+      `location = /${path} \\{([^}]*)\\}`,
+      'g',
+    ))];
+    assert.equal(closedStagingPosts.length, 2, `HTTP and HTTPS /${path} must be exact`);
+    assert.ok(closedStagingPosts.every((match) => (
+      /access_log off;/.test(match[1])
+      && /Cache-Control "private, no-store"/.test(match[1])
+      && /Referrer-Policy "no-referrer"/.test(match[1])
+      && /return 404;/.test(match[1])
+      && !/proxy_pass/.test(match[1])
+    )), `staging /${path} must fail closed without reaching the application`);
+  }
   const stagingRoots = [...app.matchAll(/location = \/ \{([^}]*)\}/g)];
   assert.equal(stagingRoots.length, 2, 'HTTP and HTTPS staging roots must both be explicit');
   assert.ok(stagingRoots.every((match) => /access_log off;/.test(match[1])));
-  for (const path of ['access-state', 'free-window', 'free/redeem', 'welcome-access']) {
+  for (const path of ['access-state', 'free-window', 'welcome-access']) {
     assert.match(app, new RegExp(`location = /api/listener/${path.replace('/', '\\/')}`));
   }
   assert.doesNotMatch(app, /location \^~ \/api\/listener\//);

--- a/src/app/api/early-birds/free/redeem/__tests__/route.test.ts
+++ b/src/app/api/early-birds/free/redeem/__tests__/route.test.ts
@@ -18,13 +18,21 @@ import { POST } from '../route';
 
 const TOKEN = `ebi_v1.${'a'.repeat(32)}.${'b'.repeat(32)}.${'c'.repeat(32)}`;
 
-function request(token: string | null = TOKEN, namespace: 'legacy' | 'canonical' = 'legacy') {
+function request(
+    token: string | null = TOKEN,
+    namespace: 'legacy' | 'canonical' = 'legacy',
+    origin = 'https://listen.harmonicbeacon.com',
+    hostname = 'listen.harmonicbeacon.com',
+) {
     const headers = new Headers();
     if (token) headers.set('cookie', `${EARLY_BIRD_INVITATION_COOKIE}=${token}`);
+    if (origin) headers.set('origin', origin);
+    headers.set('host', hostname);
+    headers.set('x-forwarded-proto', 'https');
     const pathname = namespace === 'canonical'
         ? '/api/listener/free/redeem'
         : '/api/early-birds/free/redeem';
-    return new NextRequest(`https://live.example.test${pathname}`, {
+    return new NextRequest(`https://${hostname}${pathname}`, {
         method: 'POST',
         headers,
     });
@@ -52,6 +60,52 @@ describe('EarlyBird Free redemption boundary', () => {
         const response = await POST(request());
         expect(response.status).toBe(401);
         expect(redeemFreeThroughCanonicalGateway).not.toHaveBeenCalled();
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(response.headers.get('referrer-policy')).toBe('no-referrer');
+    });
+
+    it.each([
+        [null, 'listen.harmonicbeacon.com'],
+        ['https://attacker.invalid', 'listen.harmonicbeacon.com'],
+        ['https://listen.harmonicbeacon.com', 'live.harmonicbeacon.com'],
+    ])('rejects a missing/cross-origin or off-host mutation before auth: %s %s', async (origin, hostname) => {
+        const response = await POST(request(TOKEN, 'canonical', origin ?? '', hostname));
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(response.headers.get('referrer-policy')).toBe('no-referrer');
+        expect(currentEarlyBirdSession).not.toHaveBeenCalled();
+        expect(redeemFreeThroughCanonicalGateway).not.toHaveBeenCalled();
+    });
+
+    it('rejects a direct plaintext request even when Host and Origin match', async () => {
+        const response = await POST(new NextRequest(
+            'http://listen.harmonicbeacon.com/api/listener/free/redeem',
+            {
+                method: 'POST',
+                headers: {
+                    origin: 'http://listen.harmonicbeacon.com',
+                    host: 'listen.harmonicbeacon.com',
+                    cookie: `${EARLY_BIRD_INVITATION_COOKIE}=${TOKEN}`,
+                },
+            },
+        ));
+
+        expect(response.status).toBe(403);
+        expect(currentEarlyBirdSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects the exact staging host because redemption belongs to the canonical session origin', async () => {
+        const response = await POST(request(
+            TOKEN,
+            'canonical',
+            'https://earlybirds-staging.harmonicbeacon.com',
+            'earlybirds-staging.harmonicbeacon.com',
+        ));
+
+        expect(response.status).toBe(403);
+        expect(currentEarlyBirdSession).not.toHaveBeenCalled();
+        expect(redeemFreeThroughCanonicalGateway).not.toHaveBeenCalled();
     });
 
     it('passes the opaque token and account id to the canonical gateway after auth', async () => {
@@ -77,6 +131,8 @@ describe('EarlyBird Free redemption boundary', () => {
             sameSite: 'lax',
             path: '/',
         });
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(response.headers.get('referrer-policy')).toBe('no-referrer');
     });
 
     it('returns the canonical landing only to the canonical alias', async () => {
@@ -97,10 +153,15 @@ describe('EarlyBird Free redemption boundary', () => {
     it('does not accept an invitation token from a request body', async () => {
         currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
         const response = await POST(new NextRequest(
-            'https://live.example.test/api/early-birds/free/redeem',
+            'https://listen.harmonicbeacon.com/api/early-birds/free/redeem',
             {
                 method: 'POST',
-                headers: { 'content-type': 'application/json' },
+                headers: {
+                    origin: 'https://listen.harmonicbeacon.com',
+                    host: 'listen.harmonicbeacon.com',
+                    'x-forwarded-proto': 'https',
+                    'content-type': 'application/json',
+                },
                 body: JSON.stringify({ token: TOKEN }),
             },
         ));
@@ -109,11 +170,27 @@ describe('EarlyBird Free redemption boundary', () => {
         expect(redeemFreeThroughCanonicalGateway).not.toHaveBeenCalled();
     });
 
-    it('fails closed without leaking whether a token exists', async () => {
+    it('clears a terminally rejected token without leaking cross-account use or revocation', async () => {
         currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
         redeemFreeThroughCanonicalGateway.mockResolvedValue({ ok: false, reason: 'unavailable' });
         const response = await POST(request());
         expect(response.status).toBe(409);
         await expect(response.json()).resolves.toEqual({ error: 'Invitation unavailable.' });
+        expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toMatchObject({
+            value: '',
+            maxAge: 0,
+        });
+    });
+
+    it('retains the short invitation cookie when the canonical authority is unavailable', async () => {
+        currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
+        redeemFreeThroughCanonicalGateway.mockRejectedValue(new Error('timeout'));
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(503);
+        expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(response.headers.get('referrer-policy')).toBe('no-referrer');
     });
 });

--- a/src/app/api/early-birds/free/redeem/route.ts
+++ b/src/app/api/early-birds/free/redeem/route.ts
@@ -5,6 +5,7 @@ import { earlyBirdsEnabled, earlyBirdsUnavailableResponse } from '@/lib/early-bi
 import {
     canonicalEarlyBirdInvitation,
     clearedEarlyBirdInvitationCookie,
+    earlyBirdInvitationCookieHost,
     EARLY_BIRD_INVITATION_COOKIE,
 } from '@/lib/early-birds/invitation-cookie';
 import {
@@ -15,17 +16,52 @@ import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 export const dynamic = 'force-dynamic';
 
+function sensitive(response: NextResponse): NextResponse {
+    response.headers.set('Cache-Control', 'private, no-store');
+    response.headers.set('Referrer-Policy', 'no-referrer');
+    return response;
+}
+
+function json(body: Record<string, unknown>, status: number): NextResponse {
+    return sensitive(NextResponse.json(body, { status }));
+}
+
+function terminalInvitationUnavailable(): NextResponse {
+    const response = json({ error: 'Invitation unavailable.' }, 409);
+    response.cookies.set(clearedEarlyBirdInvitationCookie());
+    return response;
+}
+
+function sameOriginInvitationRequest(request: NextRequest): boolean {
+    const host = request.headers.get('host')?.trim().toLowerCase() ?? '';
+    const protocol = request.headers.get('x-forwarded-proto')?.trim().toLowerCase()
+        ?? request.nextUrl.protocol.replace(/:$/, '').toLowerCase();
+    if (protocol !== 'https' || !earlyBirdInvitationCookieHost(host)) return false;
+    const origin = request.headers.get('origin');
+    if (!origin) return false;
+    try {
+        const parsed = new URL(origin);
+        return parsed.protocol === 'https:' && parsed.origin === `https://${host}`;
+    } catch {
+        return false;
+    }
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
-    if (!earlyBirdsEnabled()) return earlyBirdsUnavailableResponse();
+    if (!earlyBirdsEnabled()) return sensitive(earlyBirdsUnavailableResponse());
+
+    if (!sameOriginInvitationRequest(request)) {
+        return json({ error: 'Invalid request.' }, 403);
+    }
 
     const session = await currentEarlyBirdSession(request.headers).catch(() => null);
-    if (!session) return NextResponse.json({ error: 'Sign in required.' }, { status: 401 });
+    if (!session) return json({ error: 'Sign in required.' }, 401);
 
     const token = canonicalEarlyBirdInvitation(
         request.cookies.get(EARLY_BIRD_INVITATION_COOKIE)?.value,
     );
     if (!token) {
-        return NextResponse.json({ error: 'Invitation unavailable.' }, { status: 409 });
+        return terminalInvitationUnavailable();
     }
 
     let result;
@@ -33,22 +69,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         result = await redeemFreeThroughCanonicalGateway(session.user.id, token);
     } catch (error) {
         if (error instanceof EarlyBirdMembershipGatewayUnavailableError) {
-            return NextResponse.json({ error: 'Membership service unavailable.' }, { status: 503 });
+            return json({ error: 'Membership service unavailable.' }, 503);
         }
-        return NextResponse.json({ error: 'Membership service unavailable.' }, { status: 503 });
+        return json({ error: 'Membership service unavailable.' }, 503);
     }
     if (!result.ok) {
-        return NextResponse.json({ error: 'Invitation unavailable.' }, { status: 409 });
+        return terminalInvitationUnavailable();
     }
     const landing = request.nextUrl.pathname === LISTENER_NAMESPACE.canonical.api.freeRedeem
         ? LISTENER_NAMESPACE.canonical.home
         : LISTENER_NAMESPACE.legacy.home;
-    const response = NextResponse.json({
+    const response = sensitive(NextResponse.json({
         ok: true,
         landing,
         replayed: result.replayed,
         alreadyEntitled: result.alreadyEntitled,
-    });
+    }));
     response.cookies.set(clearedEarlyBirdInvitationCookie());
     return response;
 }

--- a/src/lib/early-birds/__tests__/invitation-cookie.test.ts
+++ b/src/lib/early-birds/__tests__/invitation-cookie.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import {
     canonicalEarlyBirdInvitation,
     clearedEarlyBirdInvitationCookie,
+    earlyBirdInvitationCookieHost,
+    earlyBirdInvitationHost,
     earlyBirdInvitationCookie,
+    earlyBirdInvitationStagingHost,
     EARLY_BIRD_INVITATION_COOKIE,
 } from '@/lib/early-birds/invitation-cookie';
 
@@ -32,5 +35,17 @@ describe('EarlyBird invitation handoff cookie', () => {
             maxAge: 0,
             path: '/',
         });
+    });
+
+    it('accepts invitation entry only on the exact Listener product and staging hosts', () => {
+        expect(earlyBirdInvitationHost('listen.harmonicbeacon.com')).toBe(true);
+        expect(earlyBirdInvitationHost('earlybirds-staging.harmonicbeacon.com')).toBe(true);
+        expect(earlyBirdInvitationHost('LISTEN.HARMONICBEACON.COM')).toBe(true);
+        expect(earlyBirdInvitationHost('live.harmonicbeacon.com')).toBe(false);
+        expect(earlyBirdInvitationHost('listen.harmonicbeacon.com.attacker.invalid')).toBe(false);
+        expect(earlyBirdInvitationCookieHost('listen.harmonicbeacon.com')).toBe(true);
+        expect(earlyBirdInvitationCookieHost('earlybirds-staging.harmonicbeacon.com')).toBe(false);
+        expect(earlyBirdInvitationStagingHost('earlybirds-staging.harmonicbeacon.com')).toBe(true);
+        expect(earlyBirdInvitationStagingHost('listen.harmonicbeacon.com')).toBe(false);
     });
 });

--- a/src/lib/early-birds/invitation-cookie.ts
+++ b/src/lib/early-birds/invitation-cookie.ts
@@ -1,7 +1,29 @@
 const CANONICAL_INVITATION_TOKEN = /^ebi_v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
+const LISTENER_INVITATION_HOSTS = new Set([
+    'listen.harmonicbeacon.com',
+    'earlybirds-staging.harmonicbeacon.com',
+]);
+const LISTENER_INVITATION_COOKIE_HOST = 'listen.harmonicbeacon.com';
+const LISTENER_INVITATION_STAGING_HOST = 'earlybirds-staging.harmonicbeacon.com';
+
+export const LISTENER_INVITATION_CANONICAL_ORIGIN = 'https://listen.harmonicbeacon.com';
+
 export const EARLY_BIRD_INVITATION_COOKIE = '__Host-hb_early_bird_invitation';
 export const EARLY_BIRD_INVITATION_MAX_AGE_SECONDS = 30 * 60;
+
+/** Public product and isolated preview are the only invitation entry hosts. */
+export function earlyBirdInvitationHost(hostname: string): boolean {
+    return LISTENER_INVITATION_HOSTS.has(hostname.toLowerCase());
+}
+
+export function earlyBirdInvitationCookieHost(hostname: string): boolean {
+    return hostname.toLowerCase() === LISTENER_INVITATION_COOKIE_HOST;
+}
+
+export function earlyBirdInvitationStagingHost(hostname: string): boolean {
+    return hostname.toLowerCase() === LISTENER_INVITATION_STAGING_HOST;
+}
 
 export function canonicalEarlyBirdInvitation(value: unknown): string | null {
     if (typeof value !== 'string' || value.length < 32 || value.length > 512) return null;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,10 @@ import type { NextRequest } from 'next/server';
 
 import {
     canonicalEarlyBirdInvitation,
+    earlyBirdInvitationCookieHost,
     earlyBirdInvitationCookie,
+    earlyBirdInvitationStagingHost,
+    LISTENER_INVITATION_CANONICAL_ORIGIN,
 } from '@/lib/early-birds/invitation-cookie';
 import { listenerInvitationQuery } from '@/lib/listener/namespace';
 
@@ -16,8 +19,8 @@ import { listenerInvitationQuery } from '@/lib/listener/namespace';
  * as authorization would mean a revoked ticket kept its access simply because
  * the browser still held the cookie.
  *
- * It performs two edge-local navigation chores: on the exact invitation
- * staging host it exchanges a canonical Listener invitation query for a short
+ * It performs two edge-local navigation chores: staging forwards a canonical
+ * invitation once to the Listener product host, which exchanges it for a short
  * browser-inaccessible cookie, while every other host only scrubs the bearer;
  * it also sends visitors with no session cookie to the relevant login surface.
  * Every protected page and API route still resolves the principal itself
@@ -37,8 +40,6 @@ const ATTENDEE_PREFIXES = ['/session'];
 
 /** Staff surfaces: the operator console. */
 const STAFF_PREFIXES = ['/ops'];
-const LISTENER_INVITATION_HOST = 'earlybirds-staging.harmonicbeacon.com';
-
 function matches(pathname: string, prefixes: string[]): boolean {
     return prefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
@@ -51,15 +52,29 @@ function scrubEarlyBirdInvitation(request: NextRequest): NextResponse | null {
     const token = candidates.length === 1
         ? canonicalEarlyBirdInvitation(candidates[0])
         : null;
+    const hostname = request.nextUrl.hostname;
+    if (earlyBirdInvitationStagingHost(hostname)) {
+        // OAuth/session authority lives on the canonical Listener host. Carry
+        // the bearer through exactly one unlogged/no-store redirect so the
+        // canonical edge can scrub it into its own host-only __Host- cookie.
+        const canonical = new URL(
+            token ? '/listener/redeem' : '/listener',
+            LISTENER_INVITATION_CANONICAL_ORIGIN,
+        );
+        if (token) canonical.searchParams.set('token', token);
+        const response = NextResponse.redirect(canonical);
+        response.headers.set('Cache-Control', 'private, no-store');
+        response.headers.set('Referrer-Policy', 'no-referrer');
+        return response;
+    }
     const target = request.nextUrl.clone();
     target.searchParams.delete(queryName);
     const response = NextResponse.redirect(target);
     response.headers.set('Cache-Control', 'private, no-store');
     response.headers.set('Referrer-Policy', 'no-referrer');
-    // Invitation redemption remains a staging-only surface. The canonical
-    // public Listener edge must still remove a bearer query without turning it
-    // into a durable browser credential or a dead-end redemption state.
-    if (token && request.nextUrl.hostname === LISTENER_INVITATION_HOST) {
+    // Host is taken from the request URL populated by the exact nginx vhost;
+    // forwarded host headers are deliberately not trusted.
+    if (token && earlyBirdInvitationCookieHost(hostname)) {
         response.cookies.set(earlyBirdInvitationCookie(token));
     }
     return response;


### PR DESCRIPTION
## Outcome

Enables signed one-use Listener invitation links on the exact public Listener host without opening broad application or authority prefixes.

Closes the implementation slice of #213 and contributes to #197. No deployment is included.

## Boundary

- accepts invitation query handoff only on `listen.harmonicbeacon.com` and `earlybirds-staging.harmonicbeacon.com`;
- staging carries the bearer through one exact unlogged, no-store/no-referrer redirect to `https://listen.harmonicbeacon.com/listener/redeem` and never mints a staging cookie;
- only `listen` scrubs the bearer into the existing 30-minute `__Host-`, Secure, HttpOnly, SameSite=Lax cookie;
- both exact staging redeem POST aliases return 404, so neither can mutate locally or fall through the broad legacy prefix;
- ignores forwarded-host spoofing and exposes only the exact canonical/compatibility redeem pages and POST routes;
- requires HTTPS, exact canonical Host and exact same Origin before resolving the Listener session;
- rate-limits public redemption to 30 requests/minute per edge address with burst 20, avoiding unnecessary lockout behind household or institutional NAT;
- clears the cookie after success or a terminal generic 409, but retains it across a transient authority 503;
- gives every response and sensitive edge entry `private, no-store` + `no-referrer` while retaining HSTS/nosniff/frame/environment headers;
- suppresses HTTP and HTTPS access logs on the exact Better Auth magic-link verification URL; staging forwards it only through an exact canonical redirect;
- leaves synthetic login, internal projections, staff, events, payments and broad public route prefixes closed.

The canonical authority remains the only component that verifies signature, enforces one-use/revoke/idempotency, and projects access. This PR changes no schema, invitation expiry/capacity, payment contract, ListenerPlayer or audio.

## Evidence

- commit hook: **147 files passed / 4 skipped; 1,208 tests passed / 19 skipped**;
- expanded focal Listener invitation/auth/membership/lease/heartbeat suites: **166/166**;
- nginx/preview contract: **26/26**;
- Playwright Chromium on disposable PostgreSQL 16: **2/2** (same-browser identity round trip and canonical redemption lifecycle);
- staging→canonical middleware topology and exact nginx redirect/closed-POST contract tests: green;
- TypeScript: green;
- full ESLint: green;
- production build: green;
- `git diff --check`: green.

The disposable local PostgreSQL container and its data were removed after the browser run.

## Rollout

1. deploy the application image to isolated Listener staging;
2. install both reviewed nginx templates, run `nginx -t`, then reload only nginx;
3. use one synthetic signed invitation through staging and prove the bearer reaches `listen`, is scrubbed there, survives Google callback, redeems explicitly and enters Listener;
4. prove both staging redeem POST aliases return an unlogged 404;
5. prove same-account retry, cross-account rejection, consumed/revoked rejection, projection reconciliation and current lease denial;
6. repeat on `listen.harmonicbeacon.com` with a fresh synthetic invitation and inspect edge logs for absence of bearer material;
7. do not enable magic link until `SairaAsua/proyecciones-mito#44` is deployed and configured.

## Rollback

Restore the previous Listener/staging nginx files and previous Listener image, run `nginx -t`, reload nginx, and recreate only the isolated Listener container. Do not roll back the database or authority: this PR has no migration and does not change issued/consumed invitation state.

## Residual risks / human gates

- Google invitation callback still needs one real-browser synthetic acceptance after deployment.
- Magic-link end-to-end remains blocked by `proyecciones-mito#44`.
- Invitation continuity is intentionally same-browser. Opening a magic link on another device does not carry the host-only invitation cookie; a future cross-device flow requires an authority-mediated claim contract and must not put the invitation bearer in email.
- Current authority invitations are capacity-one and non-expiring by accepted backend design; this PR does not change that product contract.
