### PR TITLE
feat(listener): add runtime env compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,14 @@ BEACON_COMMERCE_SERVICE_KEY_CURRENT=replace-with-at-least-43-random-characters
 SESSION_COOKIE_TTL_SECONDS=604800
 
 # ===================
-# EarlyBird Listener identity, membership and private stream
+# Listener identity, membership and private stream
 # ===================
+# Identity/access settings below keep their EARLY_BIRDS_ deployment names for
+# rollback compatibility. The application also accepts the stable
+# BEACON_LISTENER_ alias for ENABLED, FREE_FOR_ALL, AUTH_BASE_URL,
+# TRUSTED_ORIGINS, AUTH_SECRET, Google/Apple credentials, the magic-link trio,
+# test access and staging team entry. Never mix generations within a credential
+# bundle; if both aliases are present they must have the same trimmed value.
 # Public entry defaults OFF. Set to exactly 1 only after the isolated stack is
 # healthy; switching it back to 0 presents a truthful unavailable page while
 # private membership projection and reconciliation continue.

--- a/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
+++ b/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
@@ -32,7 +32,7 @@ under preview operations, 14 documentation files, 14 contract files, 10 scripts,
 | Authentication | `/api/early-birds/auth`, `hb_earlybird`, `hb_earlybird_session` | BetterAuth base paths and cookie prefixes cannot be renamed with a simple redirect. Requires a tested dual-session bridge. |
 | Invitation cookie | `__Host-hb_early_bird_invitation` | Phase 1 continues to read and write it from both URL namespaces, so existing invitations survive. |
 | Browser storage | `hb_earlybird_device_id`, `hb_earlybird_drop_progress_*` | Dual-read legacy/canonical and canonical-write later. This is inside the player boundary and is not touched in phase 1. `hb_listener_playback_mode` is already canonical. |
-| Environment | 34 explicit `EARLY_BIRDS_*` names plus language-specific drop-in keys | Add `LISTENER_*`-first/legacy-fallback readers in bounded groups; never rename deployment configuration before the binary accepts both. |
+| Environment | 34 explicit `EARLY_BIRDS_*` names plus language-specific drop-in keys | Add `BEACON_LISTENER_*`-first/legacy-fallback readers in bounded groups; never rename deployment configuration before the binary accepts both. |
 | PostgreSQL | `early_bird_users`, identities, sessions, verifications, magic-link throttles, memberships, free schedules, welcome accesses and stream leases | Treat physical names as private persistence details during application cutover. Do not perform table renames with a web namespace rollout. |
 | Cross-repo contracts | `early-bird-authority.v1`, `early-bird-membership.command.v1`, internal EarlyBird membership/invitation paths | Versioned public wire identifiers. Preserve byte-for-byte until both repositories agree on a new contract version. |
 | Metrics/ops | Preview container, network, volume, nginx and script names use `earlybirds`; Listener presence is already canonical | Operational resource renames require side-by-side resources or a maintenance window. Labels should keep a stable legacy alias until dashboards and alerts move. |
@@ -114,12 +114,28 @@ same identity.
 
 Introduce a typed resolver for each bounded environment group:
 
-1. `LISTENER_*` preferred, `EARLY_BIRDS_*` fallback;
-2. fail startup when both are set to different values for security-sensitive
+1. `BEACON_LISTENER_*` preferred, `EARLY_BIRDS_*` fallback;
+2. fail readiness when both are set to different values for security-sensitive
    keys or origins;
 3. emit only the selected key name, never its value, in validation output;
 4. update staging configuration and validate; then update production separately;
 5. remove fallback only after all rollback images use canonical names.
+
+The first bounded slice covers identity and non-media access controls only:
+public enablement, Free For All, auth base/trusted origins/secret, Google and
+Apple credential pairs, the magic-link delivery trio, and synthetic staging
+entry. Credential bundles must be complete within one generation and a dual
+configuration must agree after normalization. Conflicts fail closed and error
+messages contain variable names only. The deployed preview compose continues
+to emit the legacy keys for the first support window, so its existing rollback
+image remains valid. Authority, service credentials, stream, drop-ins and
+device identifiers are explicitly deferred to separate reviewed slices.
+The auth singleton reads configuration once; every env transition therefore
+requires a Listener process restart and cannot be treated as a hot switch. The
+readiness endpoint validates this bounded configuration before reporting green;
+it reports only a generic public failure while the server diagnostic contains
+variable names and never their values. Processes without Listener configuration
+remain unaffected.
 
 Operational resource names can remain legacy until replacements are created
 side-by-side. Docker volumes and PostgreSQL identities must never be renamed as a

--- a/src/app/api/early-birds/auth/[...all]/__tests__/route.test.ts
+++ b/src/app/api/early-birds/auth/[...all]/__tests__/route.test.ts
@@ -57,6 +57,23 @@ describe('EarlyBird public auth route', () => {
         expect(handler).toHaveBeenCalledOnce();
     });
 
+    it('accepts canonical Listener origin config and rejects conflicting aliases', async () => {
+        vi.stubEnv('EARLY_BIRDS_AUTH_BASE_URL', '');
+        vi.stubEnv('EARLY_BIRDS_TRUSTED_ORIGINS', '');
+        vi.stubEnv('BEACON_LISTENER_AUTH_BASE_URL', 'https://listen.example.test');
+        vi.stubEnv('BEACON_LISTENER_TRUSTED_ORIGINS', 'https://listen.example.test');
+        const request = () => new NextRequest(
+            'https://listen.example.test/api/early-birds/auth/sign-in/social',
+            { method: 'POST', headers: { origin: 'https://listen.example.test' }, body: '{}' },
+        );
+        expect((await POST(request())).status).toBe(204);
+
+        handler.mockClear();
+        vi.stubEnv('EARLY_BIRDS_AUTH_BASE_URL', 'https://other.example.test');
+        expect((await POST(request())).status).toBe(403);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
     it('lets the provider callback reach its one-time state verifier', async () => {
         const request = new NextRequest(
             'https://listen.example.test/api/early-birds/auth/callback/apple',

--- a/src/app/api/early-birds/auth/[...all]/route.ts
+++ b/src/app/api/early-birds/auth/[...all]/route.ts
@@ -11,6 +11,7 @@ import {
     earlyBirdsUnavailableResponse,
 } from '@/lib/early-birds/enabled';
 import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
+import { listenerRuntimeTrustedOrigins } from '@/lib/listener/runtime-env';
 
 export const dynamic = 'force-dynamic';
 
@@ -26,14 +27,13 @@ function hiddenSyntheticEmailEndpoint(request: NextRequest): Response | null {
 function trustedMutationOrigin(request: NextRequest): boolean {
     const origin = request.headers.get('origin');
     if (!origin) return false;
-    const configured = [
-        process.env.EARLY_BIRDS_AUTH_BASE_URL,
-        ...(process.env.EARLY_BIRDS_TRUSTED_ORIGINS ?? '').split(','),
-    ]
-        .map((value) => value?.trim())
-        .filter((value): value is string => Boolean(value));
-    const allowed = configured.length > 0 ? configured : [request.nextUrl.origin];
-    return allowed.includes(origin);
+    try {
+        const configured = listenerRuntimeTrustedOrigins();
+        const allowed = configured.length > 0 ? configured : [request.nextUrl.origin];
+        return allowed.includes(origin);
+    } catch {
+        return false;
+    }
 }
 
 function oauthCallback(request: NextRequest): boolean {

--- a/src/app/api/early-birds/free-window/route.ts
+++ b/src/app/api/early-birds/free-window/route.ts
@@ -9,6 +9,7 @@ import {
     selectEarlyBirdFreeWindow,
     serializeFreeWindowState,
 } from '@/lib/early-birds/free-window';
+import { listenerRuntimeTrustedOrigins } from '@/lib/listener/runtime-env';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,14 +18,13 @@ const PRIVATE_HEADERS = { 'Cache-Control': 'private, no-store, max-age=0' };
 function sameOriginMutation(request: NextRequest): boolean {
     const origin = request.headers.get('origin');
     if (!origin) return false;
-    const configured = [
-        process.env.EARLY_BIRDS_AUTH_BASE_URL,
-        ...(process.env.EARLY_BIRDS_TRUSTED_ORIGINS ?? '').split(','),
-    ]
-        .map((value) => value?.trim())
-        .filter((value): value is string => Boolean(value));
-    const allowed = configured.length > 0 ? configured : [request.nextUrl.origin];
-    return allowed.includes(origin);
+    try {
+        const configured = listenerRuntimeTrustedOrigins();
+        const allowed = configured.length > 0 ? configured : [request.nextUrl.origin];
+        return allowed.includes(origin);
+    } catch {
+        return false;
+    }
 }
 
 async function authenticatedAccount(request: NextRequest) {

--- a/src/app/api/early-birds/test-login/route.ts
+++ b/src/app/api/early-birds/test-login/route.ts
@@ -6,6 +6,7 @@ import {
     EARLY_BIRD_AUTH_BASE_PATH,
     earlyBirdAuth,
     earlyBirdTestAuthEnabled,
+    earlyBirdTestLoginSecret,
 } from '@/lib/early-birds/auth';
 import { issueSyntheticMembership } from '@/lib/early-birds/membership';
 import { earlyBirdsEnabled } from '@/lib/early-birds/enabled';
@@ -22,17 +23,19 @@ function digest(value: string): Buffer {
 }
 
 function authorizedSyntheticLogin(request: NextRequest): boolean {
-    if (!earlyBirdTestAuthEnabled()) return false;
+    const expected = earlyBirdTestLoginSecret();
+    if (!expected || !earlyBirdTestAuthEnabled()) return false;
     const authorization = request.headers.get('authorization');
     const presented = authorization?.startsWith('Bearer ')
         ? authorization.slice('Bearer '.length)
         : '';
-    const expected = process.env.EARLY_BIRDS_TEST_LOGIN_SECRET ?? '';
     return timingSafeEqual(digest(presented), digest(expected));
 }
 
 function testPassword(email: string): string {
-    return createHmac('sha256', process.env.EARLY_BIRDS_TEST_LOGIN_SECRET!)
+    const secret = earlyBirdTestLoginSecret();
+    if (!secret) throw new Error('Listener synthetic login is not configured');
+    return createHmac('sha256', secret)
         .update(`early-birds-test-login:v1:${email}`)
         .digest('base64url');
 }

--- a/src/app/api/early-birds/welcome-access/route.ts
+++ b/src/app/api/early-birds/welcome-access/route.ts
@@ -13,6 +13,7 @@ import {
     serializeWelcomeAccessState,
     startEarlyBirdWelcomeAccess,
 } from '@/lib/early-birds/welcome-access';
+import { listenerRuntimeTrustedOrigins } from '@/lib/listener/runtime-env';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,14 +22,13 @@ const PRIVATE_HEADERS = { 'Cache-Control': 'private, no-store, max-age=0' };
 function sameOriginMutation(request: NextRequest): boolean {
     const origin = request.headers.get('origin');
     if (!origin) return false;
-    const configured = [
-        process.env.EARLY_BIRDS_AUTH_BASE_URL,
-        ...(process.env.EARLY_BIRDS_TRUSTED_ORIGINS ?? '').split(','),
-    ]
-        .map((value) => value?.trim())
-        .filter((value): value is string => Boolean(value));
-    const allowed = configured.length > 0 ? configured : [request.nextUrl.origin];
-    return allowed.includes(origin);
+    try {
+        const configured = listenerRuntimeTrustedOrigins();
+        const allowed = configured.length > 0 ? configured : [request.nextUrl.origin];
+        return allowed.includes(origin);
+    } catch {
+        return false;
+    }
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {

--- a/src/app/api/health/__tests__/ready-route.test.ts
+++ b/src/app/api/health/__tests__/ready-route.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { parseResponse } from '@/__tests__/helpers';
 
 describe('GET /api/health/ready', () => {
     beforeEach(() => {
         vi.resetModules();
     });
+    afterEach(() => vi.unstubAllEnvs());
 
     it('returns 200 when the database query succeeds', async () => {
         const mockPrisma = { $queryRaw: vi.fn().mockResolvedValue([{ '?column?': 1 }]) };
@@ -17,6 +18,37 @@ describe('GET /api/health/ready', () => {
         expect(status).toBe(200);
         expect(body).toEqual({ status: 'ok', checks: { database: 'ok' } });
         expect(response.headers.get('cache-control')).toBe('no-store');
+    });
+
+    it('fails readiness without leaking values when Listener aliases conflict', async () => {
+        const canonicalSecret = 'canonical-secret-that-must-not-leak';
+        const legacySecret = 'legacy-secret-that-must-not-leak';
+        vi.stubEnv('BEACON_LISTENER_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('BEACON_LISTENER_AUTH_BASE_URL', 'https://listen.example.test');
+        vi.stubEnv('EARLY_BIRDS_AUTH_BASE_URL', 'https://listen.example.test');
+        vi.stubEnv('BEACON_LISTENER_AUTH_SECRET', canonicalSecret);
+        vi.stubEnv('EARLY_BIRDS_AUTH_SECRET', legacySecret);
+        const mockPrisma = { $queryRaw: vi.fn() };
+        vi.doMock('@/lib/db', () => ({ prisma: mockPrisma, default: mockPrisma }));
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            const { GET } = await import('../ready/route');
+            const response = await GET();
+            const { status, body } = await parseResponse(response);
+            expect(status).toBe(503);
+            expect(body).toEqual({
+                status: 'error',
+                checks: { database: 'unknown', listenerRuntime: 'invalid' },
+            });
+            expect(mockPrisma.$queryRaw).not.toHaveBeenCalled();
+            const logged = errorSpy.mock.calls.flat().map(String).join(' ');
+            expect(logged).toContain('BEACON_LISTENER_AUTH_SECRET');
+            expect(logged).not.toContain(canonicalSecret);
+            expect(logged).not.toContain(legacySecret);
+        } finally {
+            errorSpy.mockRestore();
+        }
     });
 
     it('returns 503 when the database query rejects', async () => {

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { redactError } from '@/lib/redact';
+import {
+    ListenerRuntimeEnvironmentError,
+    validateListenerRuntimeEnvironment,
+} from '@/lib/listener/runtime-env';
 import { OperationTimeoutError, withTimeout } from '@/lib/with-timeout';
 
 export const dynamic = 'force-dynamic';
@@ -17,10 +21,32 @@ const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' };
  * body distinguishes only 'timeout' from 'unreachable', nothing more.
  */
 export async function GET() {
+    let listenerRuntimeConfigured = false;
+    try {
+        listenerRuntimeConfigured = validateListenerRuntimeEnvironment();
+    } catch (error) {
+        const diagnostic = error instanceof ListenerRuntimeEnvironmentError
+            ? error.message
+            : 'unexpected validation failure';
+        console.error('Listener runtime configuration invalid:', diagnostic);
+        return NextResponse.json(
+            {
+                status: 'error',
+                checks: { database: 'unknown', listenerRuntime: 'invalid' },
+            },
+            { status: 503, headers: NO_STORE_HEADERS },
+        );
+    }
     try {
         await withTimeout(prisma.$queryRaw`SELECT 1`, DB_CHECK_TIMEOUT_MS, 'Database check');
         return NextResponse.json(
-            { status: 'ok', checks: { database: 'ok' } },
+            {
+                status: 'ok',
+                checks: {
+                    database: 'ok',
+                    ...(listenerRuntimeConfigured ? { listenerRuntime: 'ok' } : {}),
+                },
+            },
             { headers: NO_STORE_HEADERS },
         );
     } catch (error) {

--- a/src/lib/early-birds/__tests__/auth.test.ts
+++ b/src/lib/early-birds/__tests__/auth.test.ts
@@ -5,6 +5,8 @@ import {
     earlyBirdAuth,
     earlyBirdOAuthAvailability,
     earlyBirdSocialProviders,
+    earlyBirdTestLoginSecret,
+    earlyBirdTrustedOrigins,
 } from '../auth';
 
 describe('EarlyBird Better Auth isolation', () => {
@@ -42,6 +44,40 @@ describe('EarlyBird Better Auth isolation', () => {
 
         expect(earlyBirdOAuthAvailability(environment)).toEqual({ google: true, apple: false });
         expect(Object.keys(earlyBirdSocialProviders(environment))).toEqual(['google']);
+    });
+
+    it('accepts canonical auth config without mixing credential generations', () => {
+        const canonical = {
+            BEACON_LISTENER_GOOGLE_CLIENT_ID: 'canonical-google-id',
+            BEACON_LISTENER_GOOGLE_CLIENT_SECRET: 'canonical-google-secret',
+            BEACON_LISTENER_AUTH_BASE_URL: 'https://listen.example.test',
+            BEACON_LISTENER_TRUSTED_ORIGINS: 'https://staging.example.test',
+        } as unknown as NodeJS.ProcessEnv;
+        expect(earlyBirdOAuthAvailability(canonical)).toEqual({ google: true, apple: false });
+        expect(earlyBirdSocialProviders(canonical)).toMatchObject({
+            google: { clientId: 'canonical-google-id', clientSecret: 'canonical-google-secret' },
+        });
+        expect(earlyBirdTrustedOrigins(canonical)).toEqual([
+            'https://listen.example.test',
+            'https://staging.example.test',
+        ]);
+
+        expect(earlyBirdOAuthAvailability({
+            BEACON_LISTENER_GOOGLE_CLIENT_ID: 'new-id',
+            EARLY_BIRDS_GOOGLE_CLIENT_SECRET: 'old-secret',
+        } as unknown as NodeJS.ProcessEnv).google).toBe(false);
+    });
+
+    it('keeps the synthetic-login gate and secret in one generation', () => {
+        const secret = 's'.repeat(32);
+        expect(earlyBirdTestLoginSecret({
+            BEACON_LISTENER_TEST_ACCESS_ENABLED: '1',
+            BEACON_LISTENER_TEST_LOGIN_SECRET: secret,
+        } as unknown as NodeJS.ProcessEnv)).toBe(secret);
+        expect(earlyBirdTestLoginSecret({
+            BEACON_LISTENER_TEST_ACCESS_ENABLED: '1',
+            EARLY_BIRDS_TEST_LOGIN_SECRET: secret,
+        } as unknown as NodeJS.ProcessEnv)).toBeNull();
     });
 
     it('scrubs provider token material before create and update reach Prisma', async () => {

--- a/src/lib/early-birds/__tests__/enabled.test.ts
+++ b/src/lib/early-birds/__tests__/enabled.test.ts
@@ -24,6 +24,16 @@ describe('EarlyBird public kill switch', () => {
         expect(earlyBirdsEnabled()).toBe(true);
     });
 
+    it('prefers the canonical gate and fails closed when aliases disagree', () => {
+        expect(earlyBirdsEnabled({
+            BEACON_LISTENER_ENABLED: '1',
+        } as unknown as NodeJS.ProcessEnv)).toBe(true);
+        expect(earlyBirdsEnabled({
+            BEACON_LISTENER_ENABLED: '1',
+            EARLY_BIRDS_ENABLED: '0',
+        } as unknown as NodeJS.ProcessEnv)).toBe(false);
+    });
+
     it('enables the Free for All override only for the explicit value 1', () => {
         for (const value of ['', 'true', 'yes', '0', ' 1 ']) {
             vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', value);

--- a/src/lib/early-birds/__tests__/magic-link.test.ts
+++ b/src/lib/early-birds/__tests__/magic-link.test.ts
@@ -104,6 +104,21 @@ describe('EarlyBird email magic link', () => {
         })).toBe(false);
     });
 
+    it('accepts a complete canonical delivery bundle and rejects mixed generations', () => {
+        expect(earlyBirdMagicLinkAvailable({
+            BEACON_LISTENER_MAGIC_LINK_DELIVERY_URL:
+                `https://mail.example.test${EARLY_BIRD_MAGIC_LINK_DELIVERY_PATH}`,
+            BEACON_LISTENER_MAGIC_LINK_DELIVERY_TOKEN: 'canonical-token-with-at-least-32-characters',
+            BEACON_LISTENER_MAGIC_LINK_RATE_SECRET: 'canonical-rate-secret-with-at-least-32-characters',
+        })).toBe(true);
+        expect(earlyBirdMagicLinkAvailable({
+            BEACON_LISTENER_MAGIC_LINK_DELIVERY_URL:
+                `https://mail.example.test${EARLY_BIRD_MAGIC_LINK_DELIVERY_PATH}`,
+            EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN: 'legacy-token-with-at-least-32-characters',
+            EARLY_BIRDS_MAGIC_LINK_RATE_SECRET: 'legacy-rate-secret-with-at-least-32-characters',
+        })).toBe(false);
+    });
+
     it('stores a one-way verifier rather than the raw token', () => {
         const token = 'raw-token-that-must-not-be-persisted';
         const verifier = hashEarlyBirdMagicLinkToken(token);

--- a/src/lib/early-birds/__tests__/synthetic-team-entry.test.ts
+++ b/src/lib/early-birds/__tests__/synthetic-team-entry.test.ts
@@ -47,4 +47,21 @@ describe('EarlyBird synthetic team entry staging gate', () => {
             EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS: 'earlybirds-staging.example.test,bad/value',
         })).toBe(false);
     });
+
+    it('accepts a complete canonical staging gate', () => {
+        const canonical = {
+            NODE_ENV: 'production',
+            BEACON_LISTENER_ENABLED: '1',
+            BEACON_LISTENER_TEST_ACCESS_ENABLED: '1',
+            BEACON_LISTENER_TEST_LOGIN_SECRET: 's'.repeat(32),
+            BEACON_LISTENER_STAGING_TEAM_ENTRY_ENABLED: '1',
+            BEACON_LISTENER_STAGING_TEAM_ENTRY_HOSTS: 'earlybirds-staging.example.test',
+        } as NodeJS.ProcessEnv;
+        expect(syntheticTeamEntryAllowed({
+            headers: new Headers({
+                host: 'earlybirds-staging.example.test',
+                'x-forwarded-proto': 'https',
+            }),
+        }, canonical)).toBe(true);
+    });
 });

--- a/src/lib/early-birds/auth.ts
+++ b/src/lib/early-birds/auth.ts
@@ -5,6 +5,12 @@ import { magicLink } from 'better-auth/plugins';
 
 import { prisma } from '@/lib/db';
 import {
+    listenerRuntimeBundle,
+    listenerRuntimeFlag,
+    listenerRuntimeTrustedOrigins,
+    listenerRuntimeValue,
+} from '@/lib/listener/runtime-env';
+import {
     deliverEarlyBirdMagicLink,
     EARLY_BIRD_MAGIC_LINK_TTL_SECONDS,
     earlyBirdMagicLinkAvailable,
@@ -16,66 +22,96 @@ export const EARLY_BIRD_AUTH_BASE_PATH = '/api/early-birds/auth';
 export const EARLY_BIRD_COOKIE_PREFIX = 'hb_earlybird';
 export const EARLY_BIRD_SESSION_COOKIE = 'hb_earlybird_session';
 
-function nonEmpty(value: string | undefined): string | undefined {
-    const normalized = value?.trim();
-    return normalized ? normalized : undefined;
+export function earlyBirdTestAuthEnabled(environment: NodeJS.ProcessEnv = process.env): boolean {
+    return earlyBirdTestLoginSecret(environment) !== null;
 }
 
-export function earlyBirdTestAuthEnabled(environment: NodeJS.ProcessEnv = process.env): boolean {
-    const secret = nonEmpty(environment.EARLY_BIRDS_TEST_LOGIN_SECRET);
-    return (
-        environment.EARLY_BIRDS_TEST_ACCESS_ENABLED === '1' &&
-        Boolean(secret && secret.length >= 32)
-    );
+export function earlyBirdTestLoginSecret(
+    environment: NodeJS.ProcessEnv = process.env,
+): string | null {
+    try {
+        const configuration = listenerRuntimeBundle(
+            ['TEST_ACCESS_ENABLED', 'TEST_LOGIN_SECRET'],
+            environment,
+        );
+        return configuration && listenerRuntimeFlag('TEST_ACCESS_ENABLED', environment) &&
+            configuration.TEST_LOGIN_SECRET.length >= 32
+            ? configuration.TEST_LOGIN_SECRET
+            : null;
+    } catch {
+        return null;
+    }
 }
 
 export function earlyBirdOAuthAvailability(environment: NodeJS.ProcessEnv = process.env) {
+    let google = null;
+    let apple = null;
+    try {
+        google = listenerRuntimeBundle(
+            ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'],
+            environment,
+        );
+    } catch { /* An invalid pair is unavailable. */ }
+    try {
+        apple = listenerRuntimeBundle(
+            ['APPLE_CLIENT_ID', 'APPLE_CLIENT_SECRET'],
+            environment,
+        );
+    } catch { /* An invalid pair is unavailable. */ }
     return {
-        google: Boolean(
-            nonEmpty(environment.EARLY_BIRDS_GOOGLE_CLIENT_ID) &&
-            nonEmpty(environment.EARLY_BIRDS_GOOGLE_CLIENT_SECRET),
-        ),
-        apple: Boolean(
-            nonEmpty(environment.EARLY_BIRDS_APPLE_CLIENT_ID) &&
-            nonEmpty(environment.EARLY_BIRDS_APPLE_CLIENT_SECRET),
-        ),
+        google: google !== null,
+        apple: apple !== null,
     } as const;
 }
 
 export function earlyBirdSocialProviders(environment: NodeJS.ProcessEnv = process.env) {
-    const googleId = nonEmpty(environment.EARLY_BIRDS_GOOGLE_CLIENT_ID);
-    const googleSecret = nonEmpty(environment.EARLY_BIRDS_GOOGLE_CLIENT_SECRET);
-    const appleId = nonEmpty(environment.EARLY_BIRDS_APPLE_CLIENT_ID);
-    const appleSecret = nonEmpty(environment.EARLY_BIRDS_APPLE_CLIENT_SECRET);
+    let google = null;
+    let apple = null;
+    try {
+        google = listenerRuntimeBundle(
+            ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'],
+            environment,
+        );
+    } catch { /* Do not expose a provider with mixed credentials. */ }
+    try {
+        apple = listenerRuntimeBundle(
+            ['APPLE_CLIENT_ID', 'APPLE_CLIENT_SECRET'],
+            environment,
+        );
+    } catch { /* Do not expose a provider with mixed credentials. */ }
     return {
-        ...(googleId && googleSecret ? {
-            google: { clientId: googleId, clientSecret: googleSecret, accessType: 'online' as const },
+        ...(google ? {
+            google: {
+                clientId: google.GOOGLE_CLIENT_ID,
+                clientSecret: google.GOOGLE_CLIENT_SECRET,
+                accessType: 'online' as const,
+            },
         } : {}),
-        ...(appleId && appleSecret ? {
-            apple: { clientId: appleId, clientSecret: appleSecret },
+        ...(apple ? {
+            apple: {
+                clientId: apple.APPLE_CLIENT_ID,
+                clientSecret: apple.APPLE_CLIENT_SECRET,
+            },
         } : {}),
     };
 }
 
 function authSecret(): string {
-    const configured = nonEmpty(process.env.EARLY_BIRDS_AUTH_SECRET);
+    const configured = listenerRuntimeValue('AUTH_SECRET');
     if (configured) return configured;
 
     if (process.env.NODE_ENV === 'production') {
-        throw new Error('EARLY_BIRDS_AUTH_SECRET is required at runtime');
+        throw new Error('BEACON_LISTENER_AUTH_SECRET or its legacy alias is required at runtime');
     }
 
     // Local/test fallback only. Production never reaches this value.
     return 'early-birds-local-only-secret-change-before-deploy';
 }
 
-function trustedOrigins(): string[] {
-    const configured = (process.env.EARLY_BIRDS_TRUSTED_ORIGINS ?? '')
-        .split(',')
-        .map((origin) => origin.trim())
-        .filter(Boolean);
-    const baseURL = nonEmpty(process.env.EARLY_BIRDS_AUTH_BASE_URL);
-    return baseURL ? [...new Set([baseURL, ...configured])] : configured;
+export function earlyBirdTrustedOrigins(
+    environment: NodeJS.ProcessEnv = process.env,
+): string[] {
+    return listenerRuntimeTrustedOrigins(environment);
 }
 
 function scrubOAuthTokens<T extends Record<string, unknown>>(account: T): T {
@@ -100,7 +136,7 @@ function scrubSessionMetadata<T extends Record<string, unknown>>(session: T): T 
 
 function buildEarlyBirdAuth() {
     const testAuth = earlyBirdTestAuthEnabled();
-    const baseURL = nonEmpty(process.env.EARLY_BIRDS_AUTH_BASE_URL);
+    const baseURL = listenerRuntimeValue('AUTH_BASE_URL');
     const magicLinkEnabled = earlyBirdMagicLinkAvailable();
 
     return betterAuth({
@@ -108,7 +144,7 @@ function buildEarlyBirdAuth() {
         ...(baseURL ? { baseURL } : {}),
         basePath: EARLY_BIRD_AUTH_BASE_PATH,
         secret: authSecret(),
-        trustedOrigins: trustedOrigins(),
+        trustedOrigins: earlyBirdTrustedOrigins(),
         database: prismaAdapter(prisma, { provider: 'postgresql' }),
         socialProviders: earlyBirdSocialProviders(),
         plugins: magicLinkEnabled ? [magicLink({

--- a/src/lib/early-birds/enabled.ts
+++ b/src/lib/early-birds/enabled.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from 'next/server';
 
+import { listenerRuntimeFlag } from '@/lib/listener/runtime-env';
+
 /**
  * Public EarlyBird entry is fail-closed. Internal membership projection routes
  * deliberately do not use this switch so reconciliation can continue while
  * the customer-facing experience is paused.
  */
 export function earlyBirdsEnabled(environment: NodeJS.ProcessEnv = process.env): boolean {
-    return environment.EARLY_BIRDS_ENABLED === '1';
+    try {
+        return listenerRuntimeFlag('ENABLED', environment);
+    } catch {
+        return false;
+    }
 }
 
 /**
@@ -15,7 +21,11 @@ export function earlyBirdsEnabled(environment: NodeJS.ProcessEnv = process.env):
  * drop-in authorization stops on the next request/manifest refresh.
  */
 export function earlyBirdsFreeForAll(environment: NodeJS.ProcessEnv = process.env): boolean {
-    return environment.EARLY_BIRDS_FREE_FOR_ALL === '1';
+    try {
+        return listenerRuntimeFlag('FREE_FOR_ALL', environment);
+    } catch {
+        return false;
+    }
 }
 
 export function earlyBirdsUnavailableResponse(): NextResponse {

--- a/src/lib/early-birds/magic-link.ts
+++ b/src/lib/early-birds/magic-link.ts
@@ -3,6 +3,7 @@ import { createHash, createHmac } from 'node:crypto';
 import { Prisma } from '@prisma/client';
 
 import { prisma } from '@/lib/db';
+import { listenerRuntimeBundle } from '@/lib/listener/runtime-env';
 
 export const EARLY_BIRD_MAGIC_LINK_PATH = '/sign-in/magic-link';
 export const EARLY_BIRD_MAGIC_LINK_VERIFY_PATH = '/magic-link/verify';
@@ -30,18 +31,24 @@ type DeliveryConfiguration = {
 
 type ThrottleClient = Pick<typeof prisma, '$transaction'>;
 
-function nonEmpty(value: string | undefined): string | undefined {
-    const normalized = value?.trim();
-    return normalized ? normalized : undefined;
-}
-
 export function earlyBirdMagicLinkConfiguration(
     environment: MagicLinkEnvironment = process.env,
 ): DeliveryConfiguration | null {
-    const rawURL = nonEmpty(environment.EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL);
-    const token = nonEmpty(environment.EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN);
-    const rateSecret = nonEmpty(environment.EARLY_BIRDS_MAGIC_LINK_RATE_SECRET);
-    if (!rawURL || !token || token.length < 32 || !rateSecret || rateSecret.length < 32) return null;
+    let configuration;
+    try {
+        configuration = listenerRuntimeBundle([
+            'MAGIC_LINK_DELIVERY_URL',
+            'MAGIC_LINK_DELIVERY_TOKEN',
+            'MAGIC_LINK_RATE_SECRET',
+        ], environment);
+    } catch {
+        return null;
+    }
+    if (!configuration) return null;
+    const rawURL = configuration.MAGIC_LINK_DELIVERY_URL;
+    const token = configuration.MAGIC_LINK_DELIVERY_TOKEN;
+    const rateSecret = configuration.MAGIC_LINK_RATE_SECRET;
+    if (token.length < 32 || rateSecret.length < 32) return null;
 
     try {
         const url = new URL(rawURL);

--- a/src/lib/early-birds/synthetic-team-entry.ts
+++ b/src/lib/early-birds/synthetic-team-entry.ts
@@ -1,3 +1,5 @@
+import { listenerRuntimeBundle, listenerRuntimeFlag } from '@/lib/listener/runtime-env';
+
 import { earlyBirdTestAuthEnabled } from './auth';
 import { earlyBirdsEnabled } from './enabled';
 
@@ -15,7 +17,17 @@ function canonicalHost(value: string): string | null {
 }
 
 function allowedHosts(environment: NodeJS.ProcessEnv): string[] | null {
-    const raw = environment.EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS ?? '';
+    let configuration;
+    try {
+        configuration = listenerRuntimeBundle([
+            'STAGING_TEAM_ENTRY_ENABLED',
+            'STAGING_TEAM_ENTRY_HOSTS',
+        ], environment);
+    } catch {
+        return null;
+    }
+    if (!configuration || !listenerRuntimeFlag('STAGING_TEAM_ENTRY_ENABLED', environment)) return null;
+    const raw = configuration.STAGING_TEAM_ENTRY_HOSTS;
     const entries = raw.split(',').map((entry) => canonicalHost(entry)).filter(Boolean);
     if (entries.length === 0 || entries.length !== raw.split(',').length) return null;
     return [...new Set(entries)] as string[];
@@ -31,8 +43,6 @@ export function syntheticTeamEntryAllowed(
 ): boolean {
     if (environment.NODE_ENV !== 'production') return false;
     if (!earlyBirdsEnabled(environment) || !earlyBirdTestAuthEnabled(environment)) return false;
-    if (environment.EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED !== '1') return false;
-
     const host = canonicalHost(input.headers.get('host') ?? '');
     const hosts = allowedHosts(environment);
     if (!host || !hosts?.includes(host)) return false;

--- a/src/lib/listener/__tests__/runtime-env.test.ts
+++ b/src/lib/listener/__tests__/runtime-env.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    ListenerRuntimeEnvironmentError,
+    listenerRuntimeBundle,
+    listenerRuntimeFlag,
+    listenerRuntimeValue,
+    validateListenerRuntimeEnvironment,
+} from '../runtime-env';
+
+describe('Listener runtime environment compatibility', () => {
+    it('reads canonical-only, legacy-only and matching dual values', () => {
+        expect(listenerRuntimeValue('ENABLED', { BEACON_LISTENER_ENABLED: ' 1 ' })).toBe('1');
+        expect(listenerRuntimeValue('ENABLED', { EARLY_BIRDS_ENABLED: '1' })).toBe('1');
+        expect(listenerRuntimeValue('ENABLED', {
+            BEACON_LISTENER_ENABLED: '1',
+            EARLY_BIRDS_ENABLED: ' 1 ',
+        })).toBe('1');
+        expect(listenerRuntimeValue('ENABLED', {
+            BEACON_LISTENER_ENABLED: '   ',
+            EARLY_BIRDS_ENABLED: '',
+        })).toBeUndefined();
+    });
+
+    it('keeps feature gates exact even though ordinary values are trimmed', () => {
+        expect(listenerRuntimeFlag('ENABLED', { BEACON_LISTENER_ENABLED: '1' })).toBe(true);
+        expect(listenerRuntimeFlag('ENABLED', { BEACON_LISTENER_ENABLED: ' 1 ' })).toBe(false);
+        expect(listenerRuntimeFlag('ENABLED', { EARLY_BIRDS_ENABLED: '1' })).toBe(true);
+        expect(listenerRuntimeFlag('ENABLED', { EARLY_BIRDS_ENABLED: 'true' })).toBe(false);
+    });
+
+    it('fails closed on conflicting generations without including values', () => {
+        const canonicalSecret = 'canonical-secret-value';
+        const legacySecret = 'legacy-secret-value';
+        expect(() => listenerRuntimeValue('AUTH_SECRET', {
+            BEACON_LISTENER_AUTH_SECRET: canonicalSecret,
+            EARLY_BIRDS_AUTH_SECRET: legacySecret,
+        })).toThrow(ListenerRuntimeEnvironmentError);
+        try {
+            listenerRuntimeValue('AUTH_SECRET', {
+                BEACON_LISTENER_AUTH_SECRET: canonicalSecret,
+                EARLY_BIRDS_AUTH_SECRET: legacySecret,
+            });
+        } catch (error) {
+            expect(String(error)).toContain('BEACON_LISTENER_AUTH_SECRET');
+            expect(String(error)).toContain('EARLY_BIRDS_AUTH_SECRET');
+            expect(String(error)).not.toContain(canonicalSecret);
+            expect(String(error)).not.toContain(legacySecret);
+        }
+    });
+
+    it('keeps OAuth pairs within one complete generation', () => {
+        expect(listenerRuntimeBundle(['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'], {
+            BEACON_LISTENER_GOOGLE_CLIENT_ID: 'id',
+            BEACON_LISTENER_GOOGLE_CLIENT_SECRET: 'secret',
+        })).toEqual({ GOOGLE_CLIENT_ID: 'id', GOOGLE_CLIENT_SECRET: 'secret' });
+        expect(listenerRuntimeBundle(['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'], {
+            EARLY_BIRDS_GOOGLE_CLIENT_ID: 'old-id',
+            EARLY_BIRDS_GOOGLE_CLIENT_SECRET: 'old-secret',
+        })).toEqual({ GOOGLE_CLIENT_ID: 'old-id', GOOGLE_CLIENT_SECRET: 'old-secret' });
+        expect(() => listenerRuntimeBundle(['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'], {
+            BEACON_LISTENER_GOOGLE_CLIENT_ID: 'new-id',
+            EARLY_BIRDS_GOOGLE_CLIENT_SECRET: 'old-secret',
+        })).toThrow(/Incomplete Listener runtime bundle/);
+    });
+
+    it('accepts matching dual bundles and rejects a mismatched member', () => {
+        const matching = {
+            BEACON_LISTENER_MAGIC_LINK_DELIVERY_URL: 'https://mail.example.test/deliver',
+            BEACON_LISTENER_MAGIC_LINK_DELIVERY_TOKEN: 'token',
+            BEACON_LISTENER_MAGIC_LINK_RATE_SECRET: 'rate',
+            EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL: 'https://mail.example.test/deliver',
+            EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN: 'token',
+            EARLY_BIRDS_MAGIC_LINK_RATE_SECRET: 'rate',
+        };
+        expect(listenerRuntimeBundle([
+            'MAGIC_LINK_DELIVERY_URL',
+            'MAGIC_LINK_DELIVERY_TOKEN',
+            'MAGIC_LINK_RATE_SECRET',
+        ], matching)).toEqual({
+            MAGIC_LINK_DELIVERY_URL: 'https://mail.example.test/deliver',
+            MAGIC_LINK_DELIVERY_TOKEN: 'token',
+            MAGIC_LINK_RATE_SECRET: 'rate',
+        });
+        expect(() => listenerRuntimeBundle([
+            'MAGIC_LINK_DELIVERY_URL',
+            'MAGIC_LINK_DELIVERY_TOKEN',
+            'MAGIC_LINK_RATE_SECRET',
+        ], {
+            ...matching,
+            EARLY_BIRDS_MAGIC_LINK_RATE_SECRET: 'different-rate',
+        })).toThrow(/BEACON_LISTENER_MAGIC_LINK_RATE_SECRET, EARLY_BIRDS_MAGIC_LINK_RATE_SECRET/);
+    });
+
+    it('validates the deployed legacy shape and catches a dead dual-env rollout', () => {
+        const legacy = {
+            EARLY_BIRDS_ENABLED: '1',
+            EARLY_BIRDS_FREE_FOR_ALL: '0',
+            EARLY_BIRDS_AUTH_BASE_URL: 'https://listen.example.test',
+            EARLY_BIRDS_TRUSTED_ORIGINS: 'https://listen.example.test',
+            EARLY_BIRDS_AUTH_SECRET: 'a'.repeat(32),
+            EARLY_BIRDS_GOOGLE_CLIENT_ID: 'google-id',
+            EARLY_BIRDS_GOOGLE_CLIENT_SECRET: 'google-secret',
+            EARLY_BIRDS_TEST_ACCESS_ENABLED: '0',
+            EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED: '0',
+        };
+        expect(validateListenerRuntimeEnvironment(legacy)).toBe(true);
+        expect(validateListenerRuntimeEnvironment({})).toBe(false);
+        expect(() => validateListenerRuntimeEnvironment({
+            ...legacy,
+            BEACON_LISTENER_AUTH_BASE_URL: 'https://different.example.test',
+        })).toThrow(/BEACON_LISTENER_AUTH_BASE_URL, EARLY_BIRDS_AUTH_BASE_URL/);
+    });
+
+    it('rejects ambiguous flags and incomplete enabled credential bundles', () => {
+        expect(() => validateListenerRuntimeEnvironment({
+            BEACON_LISTENER_ENABLED: ' 1 ',
+            BEACON_LISTENER_AUTH_BASE_URL: 'https://listen.example.test',
+            BEACON_LISTENER_AUTH_SECRET: 'a'.repeat(32),
+        })).toThrow(/Invalid Listener runtime flag/);
+        expect(() => validateListenerRuntimeEnvironment({
+            BEACON_LISTENER_ENABLED: '1',
+            BEACON_LISTENER_AUTH_BASE_URL: 'https://listen.example.test',
+        })).toThrow(/Enabled Listener requires/);
+        expect(() => validateListenerRuntimeEnvironment({
+            BEACON_LISTENER_ENABLED: '0',
+            BEACON_LISTENER_GOOGLE_CLIENT_ID: 'id-only',
+        })).toThrow(/Incomplete Listener runtime bundle/);
+    });
+});

--- a/src/lib/listener/runtime-env.ts
+++ b/src/lib/listener/runtime-env.ts
@@ -1,0 +1,209 @@
+const CANONICAL_PREFIX = 'BEACON_LISTENER_';
+const LEGACY_PREFIX = 'EARLY_BIRDS_';
+
+type Environment = Record<string, string | undefined>;
+
+const BOUNDED_SUFFIXES = [
+    'ENABLED',
+    'FREE_FOR_ALL',
+    'AUTH_BASE_URL',
+    'TRUSTED_ORIGINS',
+    'AUTH_SECRET',
+    'GOOGLE_CLIENT_ID',
+    'GOOGLE_CLIENT_SECRET',
+    'APPLE_CLIENT_ID',
+    'APPLE_CLIENT_SECRET',
+    'MAGIC_LINK_DELIVERY_URL',
+    'MAGIC_LINK_DELIVERY_TOKEN',
+    'MAGIC_LINK_RATE_SECRET',
+    'TEST_ACCESS_ENABLED',
+    'TEST_LOGIN_SECRET',
+    'STAGING_TEAM_ENTRY_ENABLED',
+    'STAGING_TEAM_ENTRY_HOSTS',
+] as const;
+
+function normalized(value: string | undefined): string | undefined {
+    const result = value?.trim();
+    return result ? result : undefined;
+}
+
+function names(suffix: string): { canonical: string; legacy: string } {
+    return {
+        canonical: `${CANONICAL_PREFIX}${suffix}`,
+        legacy: `${LEGACY_PREFIX}${suffix}`,
+    };
+}
+
+/**
+ * Configuration errors intentionally include variable names only. Runtime
+ * values may be credentials and must never be copied into logs or responses.
+ */
+export class ListenerRuntimeEnvironmentError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ListenerRuntimeEnvironmentError';
+    }
+}
+
+/**
+ * Prefer the stable Listener namespace while accepting the previous name for
+ * rollback compatibility. Two populated generations must agree exactly after
+ * trimming; disagreement fails closed instead of choosing an arbitrary value.
+ */
+export function listenerRuntimeValue(
+    suffix: string,
+    environment: Environment = process.env,
+): string | undefined {
+    const variable = names(suffix);
+    const canonical = normalized(environment[variable.canonical]);
+    const legacy = normalized(environment[variable.legacy]);
+    if (canonical && legacy && canonical !== legacy) {
+        throw new ListenerRuntimeEnvironmentError(
+            `Conflicting Listener runtime variables: ${variable.canonical}, ${variable.legacy}`,
+        );
+    }
+    return canonical ?? legacy;
+}
+
+/** Feature gates remain deliberately stricter than ordinary string config. */
+export function listenerRuntimeFlag(
+    suffix: string,
+    environment: Environment = process.env,
+): boolean {
+    // Resolve first so conflicting generations still fail closed.
+    listenerRuntimeValue(suffix, environment);
+    const variable = names(suffix);
+    const canonical = environment[variable.canonical];
+    const legacy = environment[variable.legacy];
+    const selected = normalized(canonical) ? canonical : legacy;
+    return selected === '1';
+}
+
+/**
+ * Resolve credentials that must come from one complete configuration
+ * generation. This prevents, for example, pairing a new OAuth client id with
+ * an old secret during a gradual cutover.
+ */
+export function listenerRuntimeBundle<const Suffix extends string>(
+    suffixes: readonly Suffix[],
+    environment: Environment = process.env,
+): Record<Suffix, string> | null {
+    const canonical = suffixes.map((suffix) => {
+        const variable = names(suffix);
+        return { suffix, name: variable.canonical, value: normalized(environment[variable.canonical]) };
+    });
+    const legacy = suffixes.map((suffix) => {
+        const variable = names(suffix);
+        return { suffix, name: variable.legacy, value: normalized(environment[variable.legacy]) };
+    });
+    const canonicalPresent = canonical.filter((entry) => entry.value !== undefined);
+    const legacyPresent = legacy.filter((entry) => entry.value !== undefined);
+
+    if (canonicalPresent.length > 0 && canonicalPresent.length !== canonical.length) {
+        throw new ListenerRuntimeEnvironmentError(
+            `Incomplete Listener runtime bundle: ${canonical.map((entry) => entry.name).join(', ')}`,
+        );
+    }
+    if (canonicalPresent.length === 0 && legacyPresent.length > 0 && legacyPresent.length !== legacy.length) {
+        throw new ListenerRuntimeEnvironmentError(
+            `Incomplete Listener runtime bundle: ${legacy.map((entry) => entry.name).join(', ')}`,
+        );
+    }
+    if (canonicalPresent.length === 0 && legacyPresent.length === 0) return null;
+
+    if (canonicalPresent.length === canonical.length) {
+        canonical.forEach((entry, index) => {
+            const previous = legacy[index];
+            if (previous.value && previous.value !== entry.value) {
+                throw new ListenerRuntimeEnvironmentError(
+                    `Conflicting Listener runtime variables: ${entry.name}, ${previous.name}`,
+                );
+            }
+        });
+        return Object.fromEntries(canonical.map((entry) => [entry.suffix, entry.value])) as Record<Suffix, string>;
+    }
+
+    return Object.fromEntries(legacy.map((entry) => [entry.suffix, entry.value])) as Record<Suffix, string>;
+}
+
+export function listenerRuntimeTrustedOrigins(
+    environment: Environment = process.env,
+): string[] {
+    const configured = (listenerRuntimeValue('TRUSTED_ORIGINS', environment) ?? '')
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean);
+    const baseURL = listenerRuntimeValue('AUTH_BASE_URL', environment);
+    return baseURL ? [...new Set([baseURL, ...configured])] : configured;
+}
+
+function selectedRawValue(suffix: string, environment: Environment): string | undefined {
+    const variable = names(suffix);
+    return normalized(environment[variable.canonical])
+        ? environment[variable.canonical]
+        : environment[variable.legacy];
+}
+
+function validateFlag(suffix: string, environment: Environment): boolean {
+    const value = listenerRuntimeValue(suffix, environment);
+    if (value === undefined) return false;
+    const selected = selectedRawValue(suffix, environment);
+    if (selected !== '0' && selected !== '1') {
+        const variable = names(suffix);
+        throw new ListenerRuntimeEnvironmentError(
+            `Invalid Listener runtime flag: ${variable.canonical}, ${variable.legacy}`,
+        );
+    }
+    return selected === '1';
+}
+
+function anyBoundedValue(environment: Environment): boolean {
+    return BOUNDED_SUFFIXES.some((suffix) => {
+        const variable = names(suffix);
+        return normalized(environment[variable.canonical]) !== undefined ||
+            normalized(environment[variable.legacy]) !== undefined;
+    });
+}
+
+/**
+ * Readiness-time validation for the bounded compatibility slice. It is inert
+ * in event/runtime processes that do not carry Listener configuration.
+ */
+export function validateListenerRuntimeEnvironment(
+    environment: Environment = process.env,
+): boolean {
+    if (!anyBoundedValue(environment)) return false;
+
+    const enabled = validateFlag('ENABLED', environment);
+    validateFlag('FREE_FOR_ALL', environment);
+    const baseURL = listenerRuntimeValue('AUTH_BASE_URL', environment);
+    listenerRuntimeTrustedOrigins(environment);
+    const authSecret = listenerRuntimeValue('AUTH_SECRET', environment);
+
+    listenerRuntimeBundle(['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'], environment);
+    listenerRuntimeBundle(['APPLE_CLIENT_ID', 'APPLE_CLIENT_SECRET'], environment);
+    listenerRuntimeBundle([
+        'MAGIC_LINK_DELIVERY_URL',
+        'MAGIC_LINK_DELIVERY_TOKEN',
+        'MAGIC_LINK_RATE_SECRET',
+    ], environment);
+
+    const testAccess = validateFlag('TEST_ACCESS_ENABLED', environment);
+    if (testAccess) {
+        listenerRuntimeBundle(['TEST_ACCESS_ENABLED', 'TEST_LOGIN_SECRET'], environment);
+    }
+    const stagingEntry = validateFlag('STAGING_TEAM_ENTRY_ENABLED', environment);
+    if (stagingEntry) {
+        listenerRuntimeBundle([
+            'STAGING_TEAM_ENTRY_ENABLED',
+            'STAGING_TEAM_ENTRY_HOSTS',
+        ], environment);
+    }
+
+    if (enabled && (!baseURL || !authSecret)) {
+        throw new ListenerRuntimeEnvironmentError(
+            'Enabled Listener requires BEACON_LISTENER_AUTH_BASE_URL and BEACON_LISTENER_AUTH_SECRET or matching legacy aliases',
+        );
+    }
+    return true;
+}


### PR DESCRIPTION
Implements the next bounded phase of #210 without changing databases, cookies, media, payments, or backend contracts.

- Adds BEACON_LISTENER_ preferred / EARLY_BIRDS_ fallback resolution for identity and non-media access settings.
- Credential pairs and the magic-link trio cannot be assembled from mixed generations.
- Dual values must match after normalization; conflicts, incomplete bundles and ambiguous flags fail readiness without exposing values.
- Existing preview deployment remains on legacy keys for rollback compatibility.
- Covers public switches, origins, OAuth, magic link, synthetic login and staging entry.

Consolidated evidence after rebasing on merged PR #241: 1,222 unit/integration tests pass (19 skipped); full lint, TypeScript, production build and diff-check pass. Independent adversarial review found no remaining blocker.