### PR TITLE
fix(listener): retry kill-switch readiness smoke

### DIFF
--- a/ops/early-birds-preview/test/disable-public.test.mjs
+++ b/ops/early-birds-preview/test/disable-public.test.mjs
@@ -16,7 +16,7 @@ async function executable(pathname, content) {
   await fs.chmod(pathname, 0o700);
 }
 
-async function fixture(t, { denialStatus = '503' } = {}) {
+async function fixture(t, { denialStatus = '503', healthFailures = 0 } = {}) {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'listener-disable-public-'));
   t.after(() => fs.rm(directory, { recursive: true, force: true }));
   const envFile = path.join(directory, 'preview.env');
@@ -48,10 +48,15 @@ async function fixture(t, { denialStatus = '503' } = {}) {
     'printf "%s\\n" "$*" >> "$TEST_COMMAND_LOG"',
     'case "$*" in',
     `  *api/early-birds/stream/lease*) printf '${denialStatus}' ;;`,
+    '  *api/health*)',
+    '    attempts=$(grep -c "api/health" "$TEST_COMMAND_LOG" || true)',
+    '    test "$attempts" -le "$TEST_HEALTH_FAILURES" && exit 56',
+    '    ;;',
     'esac',
+    'exit 0',
     '',
   ].join('\n'));
-  return { directory, envFile, bin, commandLog, source };
+  return { directory, envFile, bin, commandLog, source, healthFailures };
 }
 
 function run(mode, current) {
@@ -61,6 +66,7 @@ function run(mode, current) {
       ...process.env,
       PATH: `${current.bin}:${process.env.PATH}`,
       TEST_COMMAND_LOG: current.commandLog,
+      TEST_HEALTH_FAILURES: String(current.healthFailures),
     },
   });
 }
@@ -141,4 +147,14 @@ test('failed denial smoke leaves flags disabled and stops only Listener', async 
   assert.match(commands, /ps -q --filter label=com\.docker\.compose\.project=earlybirds-preview --filter label=com\.docker\.compose\.service=listener/);
   assert.match(commands, /stop isolated-listener-id/);
   assert.doesNotMatch(commands, /stop (?:.* )?(postgres|beacon-stream|livekit|playlist-bot)/);
+});
+
+test('apply tolerates a healthy Listener that needs several startup probes', async (t) => {
+  const current = await fixture(t, { healthFailures: 2 });
+  const result = run('--apply', current);
+  assert.equal(result.status, 0, result.stderr);
+  const commands = await fs.readFile(current.commandLog, 'utf8');
+  const healthAttempts = commands.split('\n').filter((line) => /api\/health$/.test(line));
+  assert.equal(healthAttempts.length, 3);
+  assert.match(result.stdout, /denied with 503/);
 });

--- a/scripts/early-birds-preview/disable-public.sh
+++ b/scripts/early-birds-preview/disable-public.sh
@@ -95,14 +95,26 @@ fail_closed() {
   exit 1
 }
 
+wait_for_http_success() {
+  wait_url=${1:?usage: wait_for_http_success URL}
+  wait_attempt=1
+  while test "$wait_attempt" -le 10; do
+    if curl --fail --silent --show-error --max-time 2 "$wait_url" >/dev/null; then
+      return 0
+    fi
+    test "$wait_attempt" -lt 10 || return 1
+    sleep 1
+    wait_attempt=$((wait_attempt + 1))
+  done
+  return 1
+}
+
 (preview_compose_command "$env_file" \
   up -d --no-deps --force-recreate --no-build listener) || fail_closed
 
 app_port=$(preview_env_value EARLYBIRDS_PREVIEW_APP_PORT "$env_file")
-curl --fail --silent --show-error --max-time 10 \
-  "http://127.0.0.1:${app_port}/api/health" >/dev/null || fail_closed
-curl --fail --silent --show-error --max-time 10 \
-  "http://127.0.0.1:${app_port}/api/health/ready" >/dev/null || fail_closed
+wait_for_http_success "http://127.0.0.1:${app_port}/api/health" || fail_closed
+wait_for_http_success "http://127.0.0.1:${app_port}/api/health/ready" || fail_closed
 denial_status=$(curl --silent --show-error --max-time 10 \
   --output /dev/null --write-out '%{http_code}' \
   --request POST --header 'content-type: application/json' \


### PR DESCRIPTION
Fixes the false fail-closed observed during the 2344b10 Listener deployment: disable-public recreated a healthy Listener but issued its only health probe before Next.js was accepting connections, then stopped the container.

The kill switch now retries liveness and readiness for up to 30 seconds while preserving the same fail-closed behavior. A deterministic regression test makes the first two health probes fail and proves the third succeeds; terminal denial failure still stops only Listener.

Evidence: 6/6 disable-public tests, shell syntax and diff-check pass. No app, audio, event, payment, schema or nginx behavior changes.