### PR TITLE
feat(listener): migrate invitation cookie safely

### DIFF
--- a/docs/architecture/EARLY_BIRDS_LISTENER.md
+++ b/docs/architecture/EARLY_BIRDS_LISTENER.md
@@ -85,9 +85,14 @@ isolated staging host. Staging carries the bearer in one unlogged,
 no-store/no-referrer redirect to the canonical
 `https://listen.harmonicbeacon.com/listener/redeem` page; it never mints an
 invitation cookie. Middleware on `listen` immediately removes the signed bearer
-query, places it in a 30-minute `__Host-`, Secure, HttpOnly, SameSite=Lax cookie
-and redirects to the clean URL. Neither the event host nor a forwarded-host
-header can mint this cookie.
+query, dual-writes the canonical `__Host-hb_listener_invitation` and legacy
+`__Host-hb_early_bird_invitation` cookies with the same 30-minute value, and
+redirects to the clean URL. Both are host-only, Secure, HttpOnly, SameSite=Lax
+and Path=/; neither the event host nor a forwarded-host header can mint them.
+Readers require unambiguous same-name cookies, prefer the canonical generation
+and accept legacy-only state only when canonical state is absent. Conflicting or
+malformed overlap fails closed. Success and terminal rejection clear both;
+transient 503 and pre-redemption authentication retain both for a safe retry.
 
 Google and configured magic-link callbacks return to the exact
 `/listener/redeem` allowlist. The cookie therefore survives an identity round
@@ -100,8 +105,7 @@ The browser redeem POST is exposed only at the canonical and compatibility
 aliases on `listen`. It requires the exact Listener Host and same Origin, and
 nginx bounds each address to 30 requests per minute with a 20-request burst so
 a shared household/NAT cannot lock out independent one-use redemptions. Both
-POST aliases fail closed with an unlogged 404 on staging. A terminal authority
-rejection clears the cookie; a transient 503 preserves it for a safe retry. All
+POST aliases fail closed with an unlogged 404 on staging. All
 responses and exact edge locations are no-store and no-referrer. The exact
 magic-link verification URL is excluded from HTTP and HTTPS access logs and
 staging redirects it once to the canonical host, because its query carries the

--- a/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
+++ b/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
@@ -30,7 +30,7 @@ under preview operations, 14 documentation files, 14 contract files, 10 scripts,
 | Public pages | `/early-birds`, `/early-birds/redeem` | Preserve both URLs while `/listener` becomes canonical. |
 | Browser APIs | `/api/early-birds/*` | Add aliases first; move clients only after aliases ship. Stream and drop-in paths are audio-sensitive and stay unchanged in phase 1. |
 | Authentication | `/api/early-birds/auth`, `hb_earlybird`, `hb_earlybird_session` | BetterAuth base paths and cookie prefixes cannot be renamed with a simple redirect. Requires a tested dual-session bridge. |
-| Invitation cookie | `__Host-hb_early_bird_invitation` | Phase 1 continues to read and write it from both URL namespaces, so existing invitations survive. |
+| Invitation cookie | `__Host-hb_early_bird_invitation` | Phase 2 emits canonical `__Host-hb_listener_invitation` first, reads canonical then legacy, and dual-writes/dual-clears during the rollback window so existing invitations and rollback images survive. |
 | Browser storage | `hb_earlybird_device_id`, `hb_earlybird_drop_progress_*` | Dual-read legacy/canonical and canonical-write later. This is inside the player boundary and is not touched in phase 1. `hb_listener_playback_mode` is already canonical. |
 | Environment | 34 explicit `EARLY_BIRDS_*` names plus language-specific drop-in keys | Add `BEACON_LISTENER_*`-first/legacy-fallback readers in bounded groups; never rename deployment configuration before the binary accepts both. |
 | PostgreSQL | `early_bird_users`, identities, sessions, verifications, magic-link throttles, memberships, free schedules, welcome accesses and stream leases | Treat physical names as private persistence details during application cutover. Do not perform table renames with a web namespace rollout. |
@@ -102,6 +102,17 @@ First introduce canonical invitation-cookie helpers that read canonical then
 legacy, write both during the overlap, and clear both on redemption. After at
 least one deployed support window, stop writing the legacy cookie but continue
 reading it for another window.
+
+The overlap is not retired by date alone. Keep dual-write for at least seven
+consecutive days after every Listener instance runs the compatibility image,
+one real Google invitation completes, rollback passes and no eligible rollback
+image depends on legacy-only state. Then keep canonical-write/dual-read for a
+second seven-day observation window with zero legacy-only/conflict observations
+(record presence only, never cookie values). A legacy-only or conflict
+observation resets that window. Remove the legacy read only afterward, and keep
+dual-clear for one additional release. The invitation TTL remains 30 minutes;
+the longer windows protect rollback and in-flight identity rather than extend
+the bearer lifetime.
 
 BetterAuth requires a separate design checkpoint. The canonical auth base path
 must accept sessions issued with the legacy cookie prefix. The migration must be

--- a/e2e/tests/listener-namespace-compat.spec.ts
+++ b/e2e/tests/listener-namespace-compat.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from '@playwright/test';
 
-import { EARLY_BIRD_INVITATION_COOKIE } from '../../src/lib/early-birds/invitation-cookie';
+import {
+    EARLY_BIRD_INVITATION_COOKIE,
+    LISTENER_INVITATION_COOKIE,
+} from '../../src/lib/early-birds/invitation-cookie';
 import {
     deleteSyntheticListenerEmails,
     signInSyntheticListener,
@@ -31,7 +34,7 @@ test.describe('Listener namespace compatibility', () => {
             // same callback cookie contract; their exact callback is locked by
             // the landing/auth route unit suites.
             await context.addCookies([{
-                name: EARLY_BIRD_INVITATION_COOKIE,
+                name: LISTENER_INVITATION_COOKIE,
                 value: INVITATION,
                 domain: baseURL.hostname,
                 path: '/',
@@ -48,7 +51,7 @@ test.describe('Listener namespace compatibility', () => {
             await context.addCookies(identityState.cookies.filter((cookie) => cookie.name.includes('session')));
 
             const cookiesAfterIdentity = await context.cookies();
-            expect(cookiesAfterIdentity.find((cookie) => cookie.name === EARLY_BIRD_INVITATION_COOKIE))
+            expect(cookiesAfterIdentity.find((cookie) => cookie.name === LISTENER_INVITATION_COOKIE))
                 .toMatchObject({ value: INVITATION, httpOnly: true, secure: true, sameSite: 'Lax' });
             expect(cookiesAfterIdentity.some((cookie) => cookie.name.includes('session'))).toBe(true);
 

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -5,6 +5,7 @@ import { SESSION_COOKIE_NAME } from './src/lib/session-auth';
 import {
     EARLY_BIRD_INVITATION_COOKIE,
     EARLY_BIRD_INVITATION_MAX_AGE_SECONDS,
+    LISTENER_INVITATION_COOKIE,
 } from './src/lib/early-birds/invitation-cookie';
 // `src/middleware.ts`, not the repository root: Next only loads the middleware
 // convention from inside `src` when the app lives there, and a root-level file is
@@ -66,6 +67,7 @@ describe('middleware', () => {
             expect(response.headers.get('cache-control')).toBe('private, no-store');
             expect(response.headers.get('referrer-policy')).toBe('no-referrer');
             expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+            expect(response.cookies.get(LISTENER_INVITATION_COOKIE)).toBeUndefined();
         });
 
         it.each([
@@ -88,6 +90,12 @@ describe('middleware', () => {
                 secure: true,
                 sameSite: 'lax',
             });
+            expect(response.cookies.get(LISTENER_INVITATION_COOKIE)).toMatchObject({
+                value: INVITATION,
+                httpOnly: true,
+                secure: true,
+                sameSite: 'lax',
+            });
         });
 
         it('completes the real staging-to-canonical scrub topology without a staging cookie', () => {
@@ -97,6 +105,7 @@ describe('middleware', () => {
                 'earlybirds-staging.harmonicbeacon.com',
             ));
             expect(staging.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+            expect(staging.cookies.get(LISTENER_INVITATION_COOKIE)).toBeUndefined();
 
             const canonicalURL = location(staging);
             const canonical = middleware(request(
@@ -112,6 +121,11 @@ describe('middleware', () => {
                 httpOnly: true,
                 secure: true,
                 sameSite: 'lax',
+                path: '/',
+                maxAge: EARLY_BIRD_INVITATION_MAX_AGE_SECONDS,
+            });
+            expect(canonical.cookies.get(LISTENER_INVITATION_COOKIE)).toMatchObject({
+                value: INVITATION,
                 path: '/',
                 maxAge: EARLY_BIRD_INVITATION_MAX_AGE_SECONDS,
             });
@@ -133,6 +147,7 @@ describe('middleware', () => {
             expect(response.headers.get('cache-control')).toBe('private, no-store');
             expect(response.headers.get('referrer-policy')).toBe('no-referrer');
             expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+            expect(response.cookies.get(LISTENER_INVITATION_COOKIE)).toBeUndefined();
         });
 
         it('does not trust a forwarded Listener host on an off-surface URL', () => {
@@ -144,6 +159,7 @@ describe('middleware', () => {
             ));
 
             expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+            expect(response.cookies.get(LISTENER_INVITATION_COOKIE)).toBeUndefined();
         });
 
         it('scrubs malformed or ambiguous query values without persisting them', () => {

--- a/src/app/api/early-birds/free/redeem/__tests__/route.test.ts
+++ b/src/app/api/early-birds/free/redeem/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 
 import {
     EARLY_BIRD_INVITATION_COOKIE,
+    LISTENER_INVITATION_COOKIE,
 } from '@/lib/early-birds/invitation-cookie';
 
 const currentEarlyBirdSession = vi.hoisted(() => vi.fn());
@@ -23,9 +24,11 @@ function request(
     namespace: 'legacy' | 'canonical' = 'legacy',
     origin = 'https://listen.harmonicbeacon.com',
     hostname = 'listen.harmonicbeacon.com',
+    cookieHeader?: string,
 ) {
     const headers = new Headers();
-    if (token) headers.set('cookie', `${EARLY_BIRD_INVITATION_COOKIE}=${token}`);
+    if (cookieHeader) headers.set('cookie', cookieHeader);
+    else if (token) headers.set('cookie', `${EARLY_BIRD_INVITATION_COOKIE}=${token}`);
     if (origin) headers.set('origin', origin);
     headers.set('host', hostname);
     headers.set('x-forwarded-proto', 'https');
@@ -131,8 +134,49 @@ describe('EarlyBird Free redemption boundary', () => {
             sameSite: 'lax',
             path: '/',
         });
+        expect(response.cookies.get(LISTENER_INVITATION_COOKIE)).toMatchObject({
+            value: '',
+            maxAge: 0,
+            path: '/',
+        });
         expect(response.headers.get('cache-control')).toBe('private, no-store');
         expect(response.headers.get('referrer-policy')).toBe('no-referrer');
+    });
+
+    it('redeems a canonical-only cookie during the compatibility window', async () => {
+        currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
+        redeemFreeThroughCanonicalGateway.mockResolvedValue({
+            ok: true,
+            replayed: false,
+            alreadyEntitled: false,
+        });
+        const response = await POST(request(
+            TOKEN,
+            'canonical',
+            undefined,
+            undefined,
+            `${LISTENER_INVITATION_COOKIE}=${TOKEN}`,
+        ));
+
+        expect(response.status).toBe(200);
+        expect(redeemFreeThroughCanonicalGateway).toHaveBeenCalledWith('listener-1', TOKEN);
+    });
+
+    it('fails closed and clears both generations when dual cookies conflict', async () => {
+        currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
+        const other = `ebi_v1.${'d'.repeat(32)}.${'e'.repeat(32)}.${'f'.repeat(32)}`;
+        const response = await POST(request(
+            TOKEN,
+            'canonical',
+            undefined,
+            undefined,
+            `${LISTENER_INVITATION_COOKIE}=${other}; ${EARLY_BIRD_INVITATION_COOKIE}=${TOKEN}`,
+        ));
+
+        expect(response.status).toBe(409);
+        expect(redeemFreeThroughCanonicalGateway).not.toHaveBeenCalled();
+        expect(response.cookies.get(LISTENER_INVITATION_COOKIE)?.maxAge).toBe(0);
+        expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)?.maxAge).toBe(0);
     });
 
     it('returns the canonical landing only to the canonical alias', async () => {
@@ -180,6 +224,10 @@ describe('EarlyBird Free redemption boundary', () => {
             value: '',
             maxAge: 0,
         });
+        expect(response.cookies.get(LISTENER_INVITATION_COOKIE)).toMatchObject({
+            value: '',
+            maxAge: 0,
+        });
     });
 
     it('retains the short invitation cookie when the canonical authority is unavailable', async () => {
@@ -190,6 +238,7 @@ describe('EarlyBird Free redemption boundary', () => {
 
         expect(response.status).toBe(503);
         expect(response.cookies.get(EARLY_BIRD_INVITATION_COOKIE)).toBeUndefined();
+        expect(response.cookies.get(LISTENER_INVITATION_COOKIE)).toBeUndefined();
         expect(response.headers.get('cache-control')).toBe('private, no-store');
         expect(response.headers.get('referrer-policy')).toBe('no-referrer');
     });

--- a/src/app/api/early-birds/free/redeem/route.ts
+++ b/src/app/api/early-birds/free/redeem/route.ts
@@ -3,10 +3,9 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { currentEarlyBirdSession } from '@/lib/early-birds/auth';
 import { earlyBirdsEnabled, earlyBirdsUnavailableResponse } from '@/lib/early-birds/enabled';
 import {
-    canonicalEarlyBirdInvitation,
-    clearedEarlyBirdInvitationCookie,
+    clearedListenerInvitationCookies,
     earlyBirdInvitationCookieHost,
-    EARLY_BIRD_INVITATION_COOKIE,
+    listenerInvitationFromCookieHeader,
 } from '@/lib/early-birds/invitation-cookie';
 import {
     EarlyBirdMembershipGatewayUnavailableError,
@@ -28,7 +27,7 @@ function json(body: Record<string, unknown>, status: number): NextResponse {
 
 function terminalInvitationUnavailable(): NextResponse {
     const response = json({ error: 'Invitation unavailable.' }, 409);
-    response.cookies.set(clearedEarlyBirdInvitationCookie());
+    for (const cookie of clearedListenerInvitationCookies()) response.cookies.set(cookie);
     return response;
 }
 
@@ -57,9 +56,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const session = await currentEarlyBirdSession(request.headers).catch(() => null);
     if (!session) return json({ error: 'Sign in required.' }, 401);
 
-    const token = canonicalEarlyBirdInvitation(
-        request.cookies.get(EARLY_BIRD_INVITATION_COOKIE)?.value,
-    );
+    const token = listenerInvitationFromCookieHeader(request.headers.get('cookie'));
     if (!token) {
         return terminalInvitationUnavailable();
     }
@@ -85,6 +82,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         replayed: result.replayed,
         alreadyEntitled: result.alreadyEntitled,
     }));
-    response.cookies.set(clearedEarlyBirdInvitationCookie());
+    for (const cookie of clearedListenerInvitationCookies()) response.cookies.set(cookie);
     return response;
 }

--- a/src/app/early-birds/__tests__/page.test.tsx
+++ b/src/app/early-birds/__tests__/page.test.tsx
@@ -5,12 +5,10 @@ const mocks = vi.hoisted(() => ({
     earlyBirdOAuthAvailability: vi.fn(),
     earlyBirdMagicLinkAvailable: vi.fn(),
     getEarlyBirdListeningAccess: vi.fn(),
-    cookies: vi.fn(),
     headers: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({
-    cookies: mocks.cookies,
     headers: mocks.headers,
 }));
 vi.mock('@/lib/early-birds/auth', () => ({
@@ -25,7 +23,13 @@ vi.mock('@/lib/early-birds/access', () => ({
 }));
 
 import EarlyBirdHome from '@/components/early-birds/EarlyBirdHome';
+import {
+    EARLY_BIRD_INVITATION_COOKIE,
+    LISTENER_INVITATION_COOKIE,
+} from '@/lib/early-birds/invitation-cookie';
 import EarlyBirdsPage from '../page';
+
+const INVITATION = `ebi_v1.${'a'.repeat(32)}.${'b'.repeat(32)}.${'c'.repeat(32)}`;
 
 afterEach(() => {
     vi.clearAllMocks();
@@ -91,7 +95,6 @@ describe('EarlyBird Listener page', () => {
     it('renders an authenticated Listener during an active Free window', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
-        mocks.cookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
         mocks.headers.mockResolvedValue(new Headers());
         mocks.currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1', name: 'Nico' } });
         mocks.getEarlyBirdListeningAccess.mockResolvedValue({
@@ -116,7 +119,6 @@ describe('EarlyBird Listener page', () => {
     it('derives a sanitized Founder presentation on the server', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
-        mocks.cookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
         mocks.headers.mockResolvedValue(new Headers());
         mocks.currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1', name: 'Nico' } });
         mocks.getEarlyBirdListeningAccess.mockResolvedValue({
@@ -152,7 +154,6 @@ describe('EarlyBird Listener page', () => {
     it('shows the saved schedule rather than fabricating membership outside the window', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
-        mocks.cookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
         mocks.headers.mockResolvedValue(new Headers());
         mocks.currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1', name: 'Nico' } });
         mocks.earlyBirdOAuthAvailability.mockReturnValue({ google: true, apple: false });
@@ -184,7 +185,6 @@ describe('EarlyBird Listener page', () => {
     it('renders the Listener during the one-time welcome session', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
-        mocks.cookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
         mocks.headers.mockResolvedValue(new Headers());
         mocks.currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1', name: 'Nico' } });
         mocks.getEarlyBirdListeningAccess.mockResolvedValue({
@@ -214,7 +214,6 @@ describe('EarlyBird Listener page', () => {
     it('does not fabricate Free or welcome state when identity resolution fails', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
-        mocks.cookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
         mocks.headers.mockResolvedValue(new Headers());
         mocks.currentEarlyBirdSession.mockRejectedValue(new Error('identity unavailable'));
         mocks.earlyBirdOAuthAvailability.mockReturnValue({ google: true, apple: false });
@@ -234,7 +233,6 @@ describe('EarlyBird Listener page', () => {
     it('does not fabricate Free or welcome state when access resolution fails', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
-        mocks.cookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
         mocks.headers.mockResolvedValue(new Headers());
         mocks.currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1', name: 'Nico' } });
         mocks.getEarlyBirdListeningAccess.mockRejectedValue(new Error('database unavailable'));
@@ -254,7 +252,6 @@ describe('EarlyBird Listener page', () => {
     it('shows identity unavailable when no public sign-in method is configured', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
-        mocks.cookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
         mocks.headers.mockResolvedValue(new Headers());
         mocks.currentEarlyBirdSession.mockResolvedValue(null);
         mocks.earlyBirdOAuthAvailability.mockReturnValue({ google: false, apple: false });
@@ -263,5 +260,38 @@ describe('EarlyBird Listener page', () => {
         const result = await EarlyBirdsPage({ searchParams: Promise.resolve({}) });
 
         expect(result.props.serviceUnavailable).toBe('identity');
+    });
+
+    it.each([
+        [LISTENER_INVITATION_COOKIE],
+        [EARLY_BIRD_INVITATION_COOKIE],
+    ])('recognizes a valid %s invitation cookie without exposing its value', async (name) => {
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
+        mocks.headers.mockResolvedValue(new Headers({ cookie: `${name}=${INVITATION}` }));
+        mocks.currentEarlyBirdSession.mockResolvedValue(null);
+        mocks.earlyBirdOAuthAvailability.mockReturnValue({ google: true, apple: false });
+        mocks.earlyBirdMagicLinkAvailable.mockReturnValue(false);
+
+        const result = await EarlyBirdsPage({ searchParams: Promise.resolve({}) });
+
+        expect(result.props.invitationAvailable).toBe(true);
+        expect(JSON.stringify(result.props)).not.toContain(INVITATION);
+    });
+
+    it('fails closed when canonical and legacy invitation cookies conflict', async () => {
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
+        const other = `ebi_v1.${'d'.repeat(32)}.${'e'.repeat(32)}.${'f'.repeat(32)}`;
+        mocks.headers.mockResolvedValue(new Headers({
+            cookie: `${LISTENER_INVITATION_COOKIE}=${other}; ${EARLY_BIRD_INVITATION_COOKIE}=${INVITATION}`,
+        }));
+        mocks.currentEarlyBirdSession.mockResolvedValue(null);
+        mocks.earlyBirdOAuthAvailability.mockReturnValue({ google: true, apple: false });
+        mocks.earlyBirdMagicLinkAvailable.mockReturnValue(false);
+
+        const result = await EarlyBirdsPage({ searchParams: Promise.resolve({}) });
+
+        expect(result.props.invitationAvailable).toBe(false);
     });
 });

--- a/src/app/early-birds/page.tsx
+++ b/src/app/early-birds/page.tsx
@@ -1,4 +1,4 @@
-import { cookies, headers as requestHeaders } from 'next/headers';
+import { headers as requestHeaders } from 'next/headers';
 
 import EarlyBirdLanding from '@/components/early-birds/EarlyBirdLanding';
 import EarlyBirdHome from '@/components/early-birds/EarlyBirdHome';
@@ -10,8 +10,7 @@ import {
 import { getEarlyBirdListeningAccess } from '@/lib/early-birds/access';
 import { earlyBirdsEnabled, earlyBirdsFreeForAll } from '@/lib/early-birds/enabled';
 import {
-    canonicalEarlyBirdInvitation,
-    EARLY_BIRD_INVITATION_COOKIE,
+    listenerInvitationFromCookieHeader,
 } from '@/lib/early-birds/invitation-cookie';
 import { syntheticTeamEntryAllowed } from '@/lib/early-birds/synthetic-team-entry';
 import { configuredEarlyBirdDropIn } from '@/lib/early-birds/drop-ins';
@@ -65,7 +64,6 @@ export default async function EarlyBirdsPage({
     const params = await searchParams;
     const serverNow = new Date().toISOString();
     const incomingHeaders = new Headers(await requestHeaders());
-    const cookieStore = await cookies();
     const sessionResolution = await currentEarlyBirdSession()
         .then((session) => ({ session, unavailable: false as const }))
         .catch(() => ({ session: null, unavailable: true as const }));
@@ -76,8 +74,8 @@ export default async function EarlyBirdsPage({
             .catch(() => ({ access: null, unavailable: true as const }))
         : { access: null, unavailable: false as const };
     const access = accessResolution.access;
-    const invitationAvailable = canonicalEarlyBirdInvitation(
-        cookieStore.get(EARLY_BIRD_INVITATION_COOKIE)?.value,
+    const invitationAvailable = listenerInvitationFromCookieHeader(
+        incomingHeaders.get('cookie'),
     ) !== null;
 
     if (session && access?.allowed === true) {

--- a/src/app/early-birds/redeem/__tests__/page.test.tsx
+++ b/src/app/early-birds/redeem/__tests__/page.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    headers: vi.fn(),
+    currentEarlyBirdSession: vi.fn(),
+    redirect: vi.fn((target: string) => {
+        throw new Error(`REDIRECT:${target}`);
+    }),
+}));
+
+vi.mock('next/headers', () => ({ headers: mocks.headers }));
+vi.mock('next/navigation', () => ({ redirect: mocks.redirect }));
+vi.mock('@/lib/early-birds/auth', () => ({
+    currentEarlyBirdSession: mocks.currentEarlyBirdSession,
+}));
+
+import FreeInvitationRedeemer from '@/components/early-birds/FreeInvitationRedeemer';
+import {
+    EARLY_BIRD_INVITATION_COOKIE,
+    LISTENER_INVITATION_COOKIE,
+} from '@/lib/early-birds/invitation-cookie';
+import EarlyBirdRedeemPage from '../page';
+
+const TOKEN = `ebi_v1.${'a'.repeat(32)}.${'b'.repeat(32)}.${'c'.repeat(32)}`;
+
+function cookieHeaders(entries: Array<[string, string]>) {
+    return new Headers({
+        cookie: entries.map(([name, value]) => `${name}=${value}`).join('; '),
+    });
+}
+
+beforeEach(() => {
+    vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+    mocks.currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+});
+
+describe('Listener invitation redeem page compatibility', () => {
+    it.each([
+        [LISTENER_INVITATION_COOKIE],
+        [EARLY_BIRD_INVITATION_COOKIE],
+    ])('accepts an authenticated %s-only handoff', async (name) => {
+        mocks.headers.mockResolvedValue(cookieHeaders([[name, TOKEN]]));
+
+        const result = await EarlyBirdRedeemPage();
+
+        expect(result.type).toBe(FreeInvitationRedeemer);
+        expect(mocks.redirect).not.toHaveBeenCalled();
+    });
+
+    it('accepts equal dual cookies', async () => {
+        mocks.headers.mockResolvedValue(cookieHeaders([
+            [LISTENER_INVITATION_COOKIE, TOKEN],
+            [EARLY_BIRD_INVITATION_COOKIE, TOKEN],
+        ]));
+
+        const result = await EarlyBirdRedeemPage();
+
+        expect(result.type).toBe(FreeInvitationRedeemer);
+    });
+
+    it('fails closed before auth when generations conflict or a name is duplicated', async () => {
+        const other = `ebi_v1.${'d'.repeat(32)}.${'e'.repeat(32)}.${'f'.repeat(32)}`;
+        for (const entries of [
+            [
+                [LISTENER_INVITATION_COOKIE, other],
+                [EARLY_BIRD_INVITATION_COOKIE, TOKEN],
+            ],
+            [
+                [LISTENER_INVITATION_COOKIE, TOKEN],
+                [LISTENER_INVITATION_COOKIE, TOKEN],
+            ],
+        ] as Array<Array<[string, string]>>) {
+            mocks.headers.mockResolvedValueOnce(cookieHeaders(entries));
+            await expect(EarlyBirdRedeemPage()).rejects.toThrow('REDIRECT:/listener');
+        }
+        expect(mocks.currentEarlyBirdSession).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/early-birds/redeem/page.tsx
+++ b/src/app/early-birds/redeem/page.tsx
@@ -1,12 +1,11 @@
 import { redirect } from 'next/navigation';
-import { cookies } from 'next/headers';
+import { headers } from 'next/headers';
 
 import FreeInvitationRedeemer from '@/components/early-birds/FreeInvitationRedeemer';
 import { currentEarlyBirdSession } from '@/lib/early-birds/auth';
 import { earlyBirdsEnabled } from '@/lib/early-birds/enabled';
 import {
-    canonicalEarlyBirdInvitation,
-    EARLY_BIRD_INVITATION_COOKIE,
+    listenerInvitationFromCookieHeader,
 } from '@/lib/early-birds/invitation-cookie';
 import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
@@ -15,10 +14,8 @@ export const dynamic = 'force-dynamic';
 export default async function EarlyBirdRedeemPage() {
     if (!earlyBirdsEnabled()) redirect(LISTENER_NAMESPACE.canonical.home);
 
-    const cookieStore = await cookies();
-    const token = canonicalEarlyBirdInvitation(
-        cookieStore.get(EARLY_BIRD_INVITATION_COOKIE)?.value,
-    );
+    const incomingHeaders = await headers();
+    const token = listenerInvitationFromCookieHeader(incomingHeaders.get('cookie'));
     if (!token) redirect(LISTENER_NAMESPACE.canonical.home);
 
     const session = await currentEarlyBirdSession().catch(() => null);

--- a/src/lib/early-birds/__tests__/invitation-cookie.test.ts
+++ b/src/lib/early-birds/__tests__/invitation-cookie.test.ts
@@ -8,6 +8,11 @@ import {
     earlyBirdInvitationCookie,
     earlyBirdInvitationStagingHost,
     EARLY_BIRD_INVITATION_COOKIE,
+    EARLY_BIRD_INVITATION_MAX_AGE_SECONDS,
+    LISTENER_INVITATION_COOKIE,
+    listenerInvitationCookies,
+    listenerInvitationFromCookieHeader,
+    clearedListenerInvitationCookies,
 } from '@/lib/early-birds/invitation-cookie';
 
 const TOKEN = `ebi_v1.${'a'.repeat(32)}.${'b'.repeat(32)}.${'c'.repeat(32)}`;
@@ -35,6 +40,45 @@ describe('EarlyBird invitation handoff cookie', () => {
             maxAge: 0,
             path: '/',
         });
+        const dualCookies = listenerInvitationCookies(TOKEN);
+        expect(dualCookies.map(({ name }) => name)).toEqual([
+            LISTENER_INVITATION_COOKIE,
+            EARLY_BIRD_INVITATION_COOKIE,
+        ]);
+        for (const cookie of dualCookies) {
+            expect(cookie).toMatchObject({
+                value: TOKEN,
+                httpOnly: true,
+                secure: true,
+                sameSite: 'lax',
+                path: '/',
+                maxAge: EARLY_BIRD_INVITATION_MAX_AGE_SECONDS,
+            });
+            expect(cookie).not.toHaveProperty('domain');
+        }
+        expect(clearedListenerInvitationCookies()).toHaveLength(2);
+    });
+
+    it('reads equal dual cookies and accepts a valid legacy-only fallback', () => {
+        const other = `ebi_v1.${'d'.repeat(32)}.${'e'.repeat(32)}.${'f'.repeat(32)}`;
+        expect(listenerInvitationFromCookieHeader(
+            `${EARLY_BIRD_INVITATION_COOKIE}=${TOKEN}`,
+        )).toBe(TOKEN);
+        expect(listenerInvitationFromCookieHeader(
+            `${LISTENER_INVITATION_COOKIE}=${TOKEN}; ${EARLY_BIRD_INVITATION_COOKIE}=${TOKEN}`,
+        )).toBe(TOKEN);
+        expect(listenerInvitationFromCookieHeader(
+            `${LISTENER_INVITATION_COOKIE}=${other}; ${EARLY_BIRD_INVITATION_COOKIE}=${TOKEN}`,
+        )).toBeNull();
+        expect(listenerInvitationFromCookieHeader(
+            `${LISTENER_INVITATION_COOKIE}=invalid; ${EARLY_BIRD_INVITATION_COOKIE}=${TOKEN}`,
+        )).toBeNull();
+    });
+
+    it('fails closed on duplicate same-name cookies before considering either generation', () => {
+        expect(listenerInvitationFromCookieHeader(
+            `${LISTENER_INVITATION_COOKIE}=${TOKEN}; ${LISTENER_INVITATION_COOKIE}=${TOKEN}; ${EARLY_BIRD_INVITATION_COOKIE}=${TOKEN}`,
+        )).toBeNull();
     });
 
     it('accepts invitation entry only on the exact Listener product and staging hosts', () => {

--- a/src/lib/early-birds/invitation-cookie.ts
+++ b/src/lib/early-birds/invitation-cookie.ts
@@ -9,8 +9,14 @@ const LISTENER_INVITATION_STAGING_HOST = 'earlybirds-staging.harmonicbeacon.com'
 
 export const LISTENER_INVITATION_CANONICAL_ORIGIN = 'https://listen.harmonicbeacon.com';
 
+export const LISTENER_INVITATION_COOKIE = '__Host-hb_listener_invitation';
 export const EARLY_BIRD_INVITATION_COOKIE = '__Host-hb_early_bird_invitation';
 export const EARLY_BIRD_INVITATION_MAX_AGE_SECONDS = 30 * 60;
+
+const LISTENER_INVITATION_COOKIE_NAMES = [
+    LISTENER_INVITATION_COOKIE,
+    EARLY_BIRD_INVITATION_COOKIE,
+] as const;
 
 /** Public product and isolated preview are the only invitation entry hosts. */
 export function earlyBirdInvitationHost(hostname: string): boolean {
@@ -30,9 +36,9 @@ export function canonicalEarlyBirdInvitation(value: unknown): string | null {
     return CANONICAL_INVITATION_TOKEN.test(value) ? value : null;
 }
 
-export function earlyBirdInvitationCookie(value: string) {
+function invitationCookie(name: string, value: string) {
     return {
-        name: EARLY_BIRD_INVITATION_COOKIE,
+        name,
         value,
         httpOnly: true,
         secure: true,
@@ -42,10 +48,56 @@ export function earlyBirdInvitationCookie(value: string) {
     };
 }
 
+/** Legacy single-cookie constructor retained for rollback-compatible callers. */
+export function earlyBirdInvitationCookie(value: string) {
+    return invitationCookie(EARLY_BIRD_INVITATION_COOKIE, value);
+}
+
+function cookieHeaderValues(header: string | null, name: string): string[] {
+    if (!header) return [];
+    return header.split(';').flatMap((part) => {
+        const separator = part.indexOf('=');
+        if (separator < 1 || part.slice(0, separator).trim() !== name) return [];
+        return [part.slice(separator + 1).trim()];
+    });
+}
+
+/** Canonical-first raw-header read that rejects duplicate or conflicting cookies. */
+export function listenerInvitationFromCookieHeader(header: string | null): string | null {
+    const values = LISTENER_INVITATION_COOKIE_NAMES.map((name) => (
+        cookieHeaderValues(header, name)
+    ));
+    const [canonicalValues, legacyValues] = values;
+    if (canonicalValues.length > 1 || legacyValues.length > 1) return null;
+
+    const canonicalValue = canonicalValues[0];
+    const legacyValue = legacyValues[0];
+    if (canonicalValue !== undefined) {
+        const canonical = canonicalEarlyBirdInvitation(canonicalValue);
+        if (!canonical) return null;
+        if (legacyValue !== undefined && legacyValue !== canonical) return null;
+        return canonical;
+    }
+    return canonicalEarlyBirdInvitation(legacyValue);
+}
+
+/** Dual-write keeps in-flight legacy pages and rollback images compatible. */
+export function listenerInvitationCookies(value: string) {
+    return LISTENER_INVITATION_COOKIE_NAMES.map((name) => invitationCookie(name, value));
+}
+
 export function clearedEarlyBirdInvitationCookie() {
     return {
         ...earlyBirdInvitationCookie(''),
         maxAge: 0,
         expires: new Date(0),
     };
+}
+
+export function clearedListenerInvitationCookies() {
+    return LISTENER_INVITATION_COOKIE_NAMES.map((name) => ({
+        ...invitationCookie(name, ''),
+        maxAge: 0,
+        expires: new Date(0),
+    }));
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,8 +4,8 @@ import type { NextRequest } from 'next/server';
 import {
     canonicalEarlyBirdInvitation,
     earlyBirdInvitationCookieHost,
-    earlyBirdInvitationCookie,
     earlyBirdInvitationStagingHost,
+    listenerInvitationCookies,
     LISTENER_INVITATION_CANONICAL_ORIGIN,
 } from '@/lib/early-birds/invitation-cookie';
 import { listenerInvitationQuery } from '@/lib/listener/namespace';
@@ -75,7 +75,7 @@ function scrubEarlyBirdInvitation(request: NextRequest): NextResponse | null {
     // Host is taken from the request URL populated by the exact nginx vhost;
     // forwarded host headers are deliberately not trusted.
     if (token && earlyBirdInvitationCookieHost(hostname)) {
-        response.cookies.set(earlyBirdInvitationCookie(token));
+        for (const cookie of listenerInvitationCookies(token)) response.cookies.set(cookie);
     }
     return response;
 }


### PR DESCRIPTION
## Outcome

Adds the canonical host-only Listener invitation cookie while preserving active invitations and rollback compatibility.

- canonical `__Host-hb_listener_invitation`
- legacy `__Host-hb_early_bird_invitation` during a measured overlap
- canonical-first, raw-header parsing that rejects duplicate, conflicting or malformed cookies
- exact canonical Host/Origin/HTTPS boundary unchanged
- staging/off-host mint neither cookie
- success and terminal rejection clear both; 401/503 retain both
- no DB, backend, event, media or audio change

## Verification

- 60 focused tests
- TypeScript
- ESLint
- diff check
- independent adversarial review: no blockers

## Rollback

Revert this commit or select the prior Listener image. Legacy cookie emission remains present specifically so rollback images continue working. The additive canonical cookie expires after 30 minutes and carries the same opaque value.