### PR TITLE
feat(listener): bridge canonical session cookie safely

### DIFF
--- a/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
+++ b/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
@@ -121,6 +121,71 @@ logout and two concurrent devices before clients change their callback URL. Do
 not run two independent auth stores or silently create a second account for the
 same identity.
 
+### Listener session-cookie bridge
+
+The first step of that checkpoint ships as a strict wrapper around the single
+Better Auth instance (`src/lib/listener/session-cookie-bridge.ts`). Better Auth
+stays the sole session authority on the legacy base path; its signed cookie
+value is opaque and its HMAC does not cover the cookie name, so the value is
+portable verbatim under a second name. The bridge never parses, decodes,
+re-signs or logs the value, and it never touches OAuth state, PKCE or any other
+non-session cookie.
+
+Outbound, every legacy session `Set-Cookie` Better Auth emits (mint, rotation,
+clear) is mirrored onto the canonical name byte-identically, so sign-in,
+refresh and sign-out always move both cookies together with one scope.
+Ambiguous output (repeated same-name mutations, mismatched pairs, canonical
+mutations without a legacy counterpart) is an internal failure: the response
+is replaced by a generic 500 carrying no `Set-Cookie` at all.
+
+Inbound, exactly three states may reach Better Auth:
+
+1. no session cookie;
+2. exactly one legacy-only session cookie (the rollback window);
+3. exactly one canonical plus one legacy cookie with byte-identical values.
+
+Everything else terminates with a generic 400/401 BEFORE Better Auth can mint,
+rotate or clear anything: canonical-only (401), duplicate same-name cookies,
+conflicting pairs, malformed percent encoding or control characters, oversized
+values, and oversized Cookie headers (all 400). The generic body carries no
+token or cookie detail and rejected values are never echoed.
+
+Every rejection also expires BOTH exact session cookie names with `Max-Age=0`
+and the scope Better Auth actually resolved (`Path=/`, `HttpOnly`,
+`SameSite=Lax`, `Secure` when the resolved names carry the `__Secure-` prefix;
+the scope is derived from `getCookies(auth.options)` and no `Domain` is ever
+invented). This dual-clear is what keeps a deploy → rollback to `20406` →
+redeploy sequence recoverable: the rollback image's sign-out clears only the
+legacy name, so a stale canonical cookie would otherwise 401 forever, and an
+old re-login can leave a stale canonical A plus a fresh legacy B that conflicts
+with 400 — while every auth mutation that could repair the jar stops before
+Better Auth. Expiring both names logs the client out but lets the next clean
+sign-in mint a fresh dual pair. Direct `getSession` paths apply the same
+inbound policy, fail closed to `null`, and cannot set response cookies.
+
+Canonical-only acceptance is deliberately deferred until every rollback image
+in the support window emits and accepts the canonical name; accepting it now
+would let a rollback image silently strand the session it cannot read. The
+401-plus-dual-clear state flips to accepted only after the dual-write bridge
+has been the oldest supported rollback image for a full support window.
+
+Browser-state matrix for the bridge image:
+
+| Browser jar on request | Bridge response | Client outcome |
+| --- | --- | --- |
+| No session cookie | Forwarded | Sign-in/OAuth mints the exact dual pair. |
+| Legacy only | Forwarded | Session valid; rotation and sign-out stay dual. Rollback-safe. |
+| Canonical + legacy, identical | Forwarded | Session valid; both cookies move together. |
+| Canonical only | 401 + dual expiry | Logged out; next clean sign-in recovers with a fresh dual pair. |
+| Canonical A + legacy B (conflict) | 400 + dual expiry | Logged out; next clean sign-in recovers. |
+| Duplicate of either name | 400 + dual expiry | Logged out; never silently selected first-wins. |
+| Malformed, oversized value or header | 400 + dual expiry | Logged out; no downgrade to an adjacent valid cookie. |
+
+Rollback of the bridge itself removes only the wrapper: the legacy-only path
+is byte-identical to `20406`, no database, environment or cookie migration is
+required, and canonical cookies left behind are expired by the dual-clear on
+the next rejected request or sit harmlessly unread.
+
 ## Phase 4: environment and operations
 
 Introduce a typed resolver for each bounded environment group:

--- a/src/app/api/early-birds/auth/[...all]/__tests__/route.test.ts
+++ b/src/app/api/early-birds/auth/[...all]/__tests__/route.test.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handler = vi.hoisted(() => vi.fn());
-vi.mock('@/lib/early-birds/auth', () => ({ earlyBirdAuth: () => ({ handler }) }));
+vi.mock('@/lib/early-birds/auth', () => ({ earlyBirdAuthHandler: handler }));
 
 import { GET, POST } from '../route';
 

--- a/src/app/api/early-birds/auth/[...all]/route.ts
+++ b/src/app/api/early-birds/auth/[...all]/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { earlyBirdAuth } from '@/lib/early-birds/auth';
+import { earlyBirdAuthHandler } from '@/lib/early-birds/auth';
 import {
     EARLY_BIRD_MAGIC_LINK_PATH,
     EARLY_BIRD_MAGIC_LINK_VERIFY_PATH,
@@ -111,7 +111,7 @@ export function GET(request: NextRequest): Promise<Response> | Response {
         if (!earlyBirdMagicLinkAvailable()) return hiddenMagicLinkResponse();
         if (!safeMagicLinkVerification(request)) return invalidMagicLinkResponse();
     }
-    return earlyBirdAuth().handler(request);
+    return earlyBirdAuthHandler(request);
 }
 
 export async function POST(request: NextRequest): Promise<Response> {
@@ -131,5 +131,5 @@ export async function POST(request: NextRequest): Promise<Response> {
             headers: { 'Cache-Control': 'private, no-store' },
         });
     }
-    return earlyBirdAuth().handler(request);
+    return earlyBirdAuthHandler(request);
 }

--- a/src/app/api/early-birds/test-login/__tests__/route.test.ts
+++ b/src/app/api/early-birds/test-login/__tests__/route.test.ts
@@ -2,10 +2,19 @@ import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({ handler: vi.fn(), issueMembership: vi.fn() }));
-vi.mock('@/lib/early-birds/auth', async (importOriginal) => ({
-    ...await importOriginal<typeof import('@/lib/early-birds/auth')>(),
-    earlyBirdAuth: () => ({ handler: mocks.handler }),
-}));
+vi.mock('@/lib/early-birds/auth', async (importOriginal) => {
+    const bridge = await import('@/lib/listener/session-cookie-bridge');
+    // The route crosses the real bridge; only Better Auth itself is stubbed,
+    // so rejection/mirroring behavior under test is the production wrapper.
+    const names = bridge.listenerSessionCookieNames('__Secure-hb_earlybird_session');
+    return {
+        ...await importOriginal<typeof import('@/lib/early-birds/auth')>(),
+        earlyBirdAuth: () => ({ handler: mocks.handler }),
+        earlyBirdSessionCookieNames: () => names,
+        earlyBirdAuthHandler: (request: Request) =>
+            bridge.listenerSessionAuthHandler(mocks.handler, names)(request),
+    };
+});
 vi.mock('@/lib/early-birds/membership', () => ({
     issueSyntheticMembership: mocks.issueMembership,
 }));
@@ -13,8 +22,13 @@ vi.mock('@/lib/early-birds/membership', () => ({
 import { POST } from '../route';
 
 const URL = 'https://app.example.test/api/early-birds/test-login';
+const LEGACY_SESSION = '__Secure-hb_earlybird_session';
+const CANONICAL_SESSION = '__Secure-hb_listener_session';
+const SYNTHETIC_MINT = `${LEGACY_SESSION}=synthetic; Max-Age=2592000; Path=/; HttpOnly; SameSite=Lax; Secure`;
+const LEGACY_CLEAR = `${LEGACY_SESSION}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure`;
+const CANONICAL_CLEAR = `${CANONICAL_SESSION}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure`;
 
-function request(authorization?: string, authOnly = false): NextRequest {
+function request(authorization?: string, authOnly = false, cookie?: string): NextRequest {
     return new NextRequest(URL, {
         method: 'POST',
         headers: {
@@ -22,6 +36,7 @@ function request(authorization?: string, authOnly = false): NextRequest {
             'x-forwarded-proto': 'https',
             'content-type': 'application/json',
             ...(authorization ? { authorization } : {}),
+            ...(cookie ? { cookie } : {}),
         },
         body: JSON.stringify({
             email: 'listener@e2e.invalid',
@@ -44,7 +59,7 @@ describe('EarlyBird synthetic login seam', () => {
             user: { id: 'listener-synthetic-1' },
         }), {
             status: 200,
-            headers: { 'set-cookie': 'hb_earlybird_session=synthetic; HttpOnly; Secure' },
+            headers: { 'set-cookie': SYNTHETIC_MINT },
         }));
         mocks.issueMembership.mockResolvedValue({});
     });
@@ -106,7 +121,7 @@ describe('EarlyBird synthetic login seam', () => {
                 user: { id: 'listener-synthetic-new' },
             }), {
                 status: 200,
-                headers: { 'set-cookie': 'hb_earlybird_session=synthetic; HttpOnly; Secure' },
+                headers: { 'set-cookie': SYNTHETIC_MINT },
             }));
 
         const response = await POST(request(`Bearer ${'s'.repeat(32)}`));
@@ -125,6 +140,59 @@ describe('EarlyBird synthetic login seam', () => {
         const response = await POST(request(`Bearer ${secret}`, true));
         expect(response.status).toBe(200);
         expect(mocks.handler).toHaveBeenCalledOnce();
+        expect(mocks.issueMembership).not.toHaveBeenCalled();
+    });
+
+    it('preserves the actual dual session Set-Cookie pair on a successful login', async () => {
+        const response = await POST(request(`Bearer ${'s'.repeat(32)}`));
+
+        expect(response.status).toBe(200);
+        // Not a mocked bridge: the real wrapper mirrored the legacy mint onto
+        // the canonical name byte-identically apart from the name itself.
+        expect(response.headers.getSetCookie()).toEqual([
+            SYNTHETIC_MINT,
+            `${CANONICAL_SESSION}${SYNTHETIC_MINT.slice(LEGACY_SESSION.length)}`,
+        ]);
+    });
+
+    it('rejects invalid inbound session cookies before Better Auth and mints nothing', async () => {
+        const conflict = `${CANONICAL_SESSION}=stale.token%3D; ${LEGACY_SESSION}=fresh.token%3D`;
+        const response = await POST(request(`Bearer ${'s'.repeat(32)}`, false, conflict));
+
+        // Both internal sign-in and sign-up terminate at the bridge; the
+        // wrapped Better Auth handler is never invoked and no session exists.
+        expect(mocks.handler).not.toHaveBeenCalled();
+        expect(mocks.issueMembership).not.toHaveBeenCalled();
+        expect(response.status).toBe(503);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(response.headers.getSetCookie()).toEqual([LEGACY_CLEAR, CANONICAL_CLEAR]);
+
+        // Once the browser honours the two expiries, a clean retry reaches
+        // Better Auth and mints a fresh byte-identical dual pair.
+        const retry = await POST(request(`Bearer ${'s'.repeat(32)}`));
+        expect(retry.status).toBe(200);
+        expect(mocks.handler).toHaveBeenCalledOnce();
+        expect(retry.headers.getSetCookie()).toEqual([
+            SYNTHETIC_MINT,
+            `${CANONICAL_SESSION}${SYNTHETIC_MINT.slice(LEGACY_SESSION.length)}`,
+        ]);
+    });
+
+    it('never forwards malformed, incomplete or unrelated internal cookies on failure', async () => {
+        mocks.handler.mockResolvedValue(new Response(JSON.stringify({ error: 'nope' }), {
+            status: 401,
+            headers: [
+                ['set-cookie', 'unrelated=secret; Path=/; HttpOnly'],
+                ['set-cookie', LEGACY_CLEAR],
+            ],
+        }));
+
+        const response = await POST(request(`Bearer ${'s'.repeat(32)}`));
+
+        expect(response.status).toBe(503);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(response.headers.getSetCookie()).toEqual([]);
+        expect(mocks.handler).toHaveBeenCalledTimes(2);
         expect(mocks.issueMembership).not.toHaveBeenCalled();
     });
 });

--- a/src/app/api/early-birds/test-login/route.ts
+++ b/src/app/api/early-birds/test-login/route.ts
@@ -4,13 +4,15 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 import {
     EARLY_BIRD_AUTH_BASE_PATH,
-    earlyBirdAuth,
+    earlyBirdAuthHandler,
+    earlyBirdSessionCookieNames,
     earlyBirdTestAuthEnabled,
     earlyBirdTestLoginSecret,
 } from '@/lib/early-birds/auth';
 import { issueSyntheticMembership } from '@/lib/early-birds/membership';
 import { earlyBirdsEnabled } from '@/lib/early-birds/enabled';
 import { syntheticTeamEntryAllowed } from '@/lib/early-birds/synthetic-team-entry';
+import { listenerSessionClearCookies } from '@/lib/listener/session-cookie-bridge';
 
 export const dynamic = 'force-dynamic';
 
@@ -40,6 +42,25 @@ function testPassword(email: string): string {
         .digest('base64url');
 }
 
+/**
+ * Preserve only the bridge's exact, empty dual-cookie recovery response.
+ * Better Auth bodies, token values, unrelated cookies and other internal
+ * headers never cross the synthetic-login boundary.
+ */
+function recoveryHeaders(authResponse: Response): Headers {
+    const headers = new Headers({ 'cache-control': 'private, no-store' });
+    const expected = listenerSessionClearCookies(earlyBirdSessionCookieNames());
+    const actual = authResponse.headers.getSetCookie();
+    if (
+        actual.length !== expected.length ||
+        new Set(actual).size !== actual.length ||
+        !expected.every((entry) => actual.includes(entry))
+    ) return headers;
+
+    for (const entry of expected) headers.append('set-cookie', entry);
+    return headers;
+}
+
 async function authRequest(
     request: NextRequest,
     operation: 'sign-up' | 'sign-in',
@@ -51,7 +72,7 @@ async function authRequest(
     // of Better Auth's request and never enters a cookie or client response.
     headers.delete('authorization');
     headers.set('content-type', 'application/json');
-    return earlyBirdAuth().handler(new Request(url, {
+    return earlyBirdAuthHandler(new Request(url, {
         method: 'POST',
         headers,
         body: JSON.stringify(body),
@@ -99,7 +120,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         });
     }
     if (!authResponse.ok) {
-        return NextResponse.json({ error: 'Synthetic login failed.' }, { status: 503 });
+        return NextResponse.json(
+            { error: 'Synthetic login failed.' },
+            { status: 503, headers: recoveryHeaders(authResponse) },
+        );
     }
 
     const payload = await authResponse.clone().json() as { user?: { id?: unknown } };

--- a/src/lib/early-birds/auth.ts
+++ b/src/lib/early-birds/auth.ts
@@ -1,9 +1,17 @@
 import { headers as requestHeaders } from 'next/headers';
 import { betterAuth } from 'better-auth/minimal';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
+import { getCookies } from 'better-auth/cookies';
 import { magicLink } from 'better-auth/plugins';
 
 import { prisma } from '@/lib/db';
+import {
+    LISTENER_SESSION_COOKIE,
+    listenerSessionAuthHandler,
+    listenerSessionCookieNames,
+    resolveListenerSessionCookie,
+    type ListenerSessionCookieNames,
+} from '@/lib/listener/session-cookie-bridge';
 import {
     listenerRuntimeBundle,
     listenerRuntimeFlag,
@@ -21,6 +29,7 @@ import {
 export const EARLY_BIRD_AUTH_BASE_PATH = '/api/early-birds/auth';
 export const EARLY_BIRD_COOKIE_PREFIX = 'hb_earlybird';
 export const EARLY_BIRD_SESSION_COOKIE = 'hb_earlybird_session';
+export { LISTENER_SESSION_COOKIE };
 
 export function earlyBirdTestAuthEnabled(environment: NodeJS.ProcessEnv = process.env): boolean {
     return earlyBirdTestLoginSecret(environment) !== null;
@@ -235,6 +244,39 @@ export function earlyBirdAuth() {
     return singleton;
 }
 
+/**
+ * The session cookie pair as Better Auth actually resolved it, including its
+ * `__Secure-` convention, plus the canonical Listener mirror name and the
+ * resolved cookie scope. Passing the resolved attributes through keeps every
+ * bridge-side expiry on exactly the scope Better Auth minted into; Better
+ * Auth never resolves a Domain here, and the bridge never invents one.
+ */
+export function earlyBirdSessionCookieNames(): ListenerSessionCookieNames {
+    const sessionToken = getCookies(earlyBirdAuth().options).sessionToken;
+    return listenerSessionCookieNames(sessionToken.name, {
+        path: sessionToken.attributes.path,
+        httpOnly: sessionToken.attributes.httpOnly,
+        // Better Auth resolves lowercase; emit the canonical wire casing.
+        sameSite: sessionToken.attributes.sameSite.charAt(0).toUpperCase() +
+            sessionToken.attributes.sameSite.slice(1),
+        secure: sessionToken.attributes.secure,
+    });
+}
+
+/**
+ * Shared Better Auth route handler with the Listener session-cookie bridge:
+ * invalid inbound session-cookie states are rejected generically before
+ * Better Auth runs, and every emitted session cookie (sign-in, rotation,
+ * sign-out) is mirrored on the way out. Better Auth's own base path, cookie
+ * and verification are unchanged.
+ */
+export function earlyBirdAuthHandler(request: Request): Promise<Response> {
+    return listenerSessionAuthHandler(
+        (bridged) => earlyBirdAuth().handler(bridged),
+        earlyBirdSessionCookieNames(),
+    )(request);
+}
+
 export type EarlyBirdSession = {
     user: {
         id: string;
@@ -253,6 +295,13 @@ export async function currentEarlyBirdSession(
     suppliedHeaders?: Headers,
 ): Promise<EarlyBirdSession | null> {
     const resolvedHeaders = suppliedHeaders ?? new Headers(await requestHeaders());
+    // The same strict inbound policy as the route handler: ambiguous
+    // session-cookie states never reach Better Auth, they fail closed here.
+    const resolution = resolveListenerSessionCookie(
+        resolvedHeaders.get('cookie'),
+        earlyBirdSessionCookieNames(),
+    );
+    if (resolution.kind === 'reject') return null;
     const result = await earlyBirdAuth().api.getSession({ headers: resolvedHeaders });
     if (!result) return null;
 

--- a/src/lib/listener/__tests__/session-cookie-bridge.integration.test.ts
+++ b/src/lib/listener/__tests__/session-cookie-bridge.integration.test.ts
@@ -1,0 +1,453 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { memoryAdapter } from 'better-auth/adapters/memory';
+import { betterAuth } from 'better-auth/minimal';
+import { getCookies } from 'better-auth/cookies';
+
+import {
+    listenerSessionAuthHandler,
+    listenerSessionClearCookies,
+    listenerSessionCookieNames,
+    type ListenerSessionCookieNames,
+} from '@/lib/listener/session-cookie-bridge';
+
+type MemoryRow = Record<string, unknown>;
+type BridgedHandler = (request: Request) => Promise<Response>;
+
+const BASE_URL = 'https://listen.example.test';
+
+function bridge(updateAge = 60 * 60 * 24) {
+    const database: Record<string, MemoryRow[]> = {
+        user: [],
+        session: [],
+        account: [],
+        verification: [],
+    };
+    const auth = betterAuth({
+        baseURL: BASE_URL,
+        basePath: '/api/early-birds/auth',
+        secret: 'test-auth-secret-with-at-least-32-characters',
+        trustedOrigins: [BASE_URL],
+        database: memoryAdapter(database),
+        rateLimit: { enabled: false },
+        emailAndPassword: { enabled: true },
+        session: {
+            expiresIn: 60 * 60 * 24 * 30,
+            updateAge,
+            cookieCache: { enabled: false },
+        },
+        advanced: {
+            cookiePrefix: 'hb_earlybird',
+            cookies: { session_token: { name: 'hb_earlybird_session' } },
+            useSecureCookies: true,
+        },
+    });
+    const names = listenerSessionCookieNames(getCookies(auth.options).sessionToken.name);
+    expect(names).toEqual({
+        legacy: '__Secure-hb_earlybird_session',
+        canonical: '__Secure-hb_listener_session',
+        scope: { path: '/', httpOnly: true, sameSite: 'Lax', secure: true },
+    });
+    return {
+        auth,
+        database,
+        names,
+        handler: listenerSessionAuthHandler((request) => auth.handler(request), names),
+    };
+}
+
+function signUp(handler: BridgedHandler, email: string, cookie?: string): Promise<Response> {
+    return handler(new Request(`${BASE_URL}/api/early-birds/auth/sign-up/email`, {
+        method: 'POST',
+        headers: {
+            origin: BASE_URL,
+            'content-type': 'application/json',
+            ...(cookie ? { cookie } : {}),
+        },
+        body: JSON.stringify({ email, name: 'Listener', password: 'listener-password-1' }),
+    }));
+}
+
+function signIn(handler: BridgedHandler, email: string, cookie?: string): Promise<Response> {
+    return handler(new Request(`${BASE_URL}/api/early-birds/auth/sign-in/email`, {
+        method: 'POST',
+        headers: {
+            origin: BASE_URL,
+            'content-type': 'application/json',
+            ...(cookie ? { cookie } : {}),
+        },
+        body: JSON.stringify({ email, password: 'listener-password-1' }),
+    }));
+}
+
+function setCookieEntry(response: Response, name: string): string {
+    const entry = response.headers.getSetCookie()
+        .find((cookie) => cookie.startsWith(`${name}=`));
+    expect(entry, `expected a Set-Cookie for ${name}`).toBeDefined();
+    return entry as string;
+}
+
+function sessionCookieValue(response: Response, name: string): string {
+    const entry = setCookieEntry(response, name);
+    return entry.slice(name.length + 1, entry.indexOf(';'));
+}
+
+async function getSession(handler: BridgedHandler, cookie: string | null) {
+    const response = await handler(new Request(`${BASE_URL}/api/early-birds/auth/get-session`, {
+        headers: cookie ? { cookie } : {},
+    }));
+    expect(response.status).toBe(200);
+    return { response, body: await response.json() as { user?: { email?: string } } | null };
+}
+
+/**
+ * A rejection must come from the bridge itself: generic body, and the only
+ * Set-Cookie output is the dual expiry of both exact session names — never
+ * an auth token, never the rejected value.
+ */
+async function expectBridgeRejection(
+    response: Response,
+    status: 400 | 401,
+    names: ListenerSessionCookieNames,
+) {
+    expect(response.status).toBe(status);
+    const clears = response.headers.getSetCookie();
+    expect(clears).toEqual(listenerSessionClearCookies(names));
+    for (const entry of clears) {
+        expect(entry).toContain('Max-Age=0');
+        expect(entry).toContain('Path=/');
+        expect(entry).toContain('HttpOnly');
+        expect(entry).toContain('SameSite=Lax');
+        expect(entry).toContain('Secure');
+        expect(entry).not.toContain('Domain=');
+    }
+    await expect(response.json()).resolves.toEqual({ error: 'invalid session credentials' });
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('Listener session-cookie bridge over a real Better Auth pipeline', () => {
+    it('mints a byte-identical dual pair with matching security attributes on sign-in', async () => {
+        const state = bridge();
+        const response = await signUp(state.handler, 'first@example.test');
+        expect(response.status).toBe(200);
+
+        const legacy = setCookieEntry(response, state.names.legacy);
+        const canonical = setCookieEntry(response, state.names.canonical);
+        expect(canonical).toBe(`${state.names.canonical}${legacy.slice(state.names.legacy.length)}`);
+        for (const entry of [legacy, canonical]) {
+            expect(entry).toContain('HttpOnly');
+            expect(entry).toContain('Secure');
+            expect(entry).toContain('SameSite=Lax');
+            expect(entry).toContain('Path=/');
+            expect(entry).toContain('Max-Age=');
+            expect(entry).not.toContain('Domain=');
+        }
+        expect(state.database.session).toHaveLength(1);
+    });
+
+    it('accepts legacy-only and identical dual sessions, rejects canonical-only', async () => {
+        const state = bridge();
+        const response = await signUp(state.handler, 'continuity@example.test');
+        const legacy = sessionCookieValue(response, state.names.legacy);
+        const canonical = sessionCookieValue(response, state.names.canonical);
+        expect(canonical).toBe(legacy);
+
+        // Legacy-only is the rollback window: existing clients keep working.
+        const legacyOnly = await getSession(state.handler, `${state.names.legacy}=${legacy}`);
+        expect(legacyOnly.body?.user?.email).toBe('continuity@example.test');
+
+        const dual = await getSession(
+            state.handler,
+            `${state.names.canonical}=${canonical}; ${state.names.legacy}=${legacy}`,
+        );
+        expect(dual.body?.user?.email).toBe('continuity@example.test');
+
+        // Canonical-only is NOT rollback-compatible: rejected before Better Auth.
+        const canonicalOnly = await state.handler(
+            new Request(`${BASE_URL}/api/early-birds/auth/get-session`, {
+                headers: { cookie: `${state.names.canonical}=${canonical}` },
+            }),
+        );
+        await expectBridgeRejection(canonicalOnly, 401, state.names);
+    });
+
+    it('rejects conflicts, duplicates and malformed cookies before Better Auth', async () => {
+        const state = bridge();
+        const response = await signUp(state.handler, 'guarded@example.test');
+        const legacy = sessionCookieValue(response, state.names.legacy);
+        const other = (await signUp(state.handler, 'other@example.test'))
+            .headers.getSetCookie().map((entry) => entry);
+        const otherLegacy = other.find((entry) => entry.startsWith(`${state.names.legacy}=`))!;
+        const otherValue = otherLegacy.slice(
+            state.names.legacy.length + 1,
+            otherLegacy.indexOf(';'),
+        );
+
+        const rejected: [string, 400 | 401][] = [
+            // Conflicting canonical/legacy values are never arbitrated.
+            [`${state.names.canonical}=${otherValue}; ${state.names.legacy}=${legacy}`, 400],
+            // Duplicate same-name cookies are never silently selected.
+            [`${state.names.canonical}=${legacy}; ${state.names.canonical}=${legacy}`, 400],
+            [`${state.names.legacy}=${legacy}; ${state.names.legacy}=${legacy}`, 400],
+            // Malformed percent encoding must not downgrade to the valid legacy cookie.
+            [`${state.names.canonical}=${legacy.slice(0, 12)}%zz; ${state.names.legacy}=${legacy}`, 400],
+            // Empty and oversized values.
+            [`${state.names.canonical}=; ${state.names.legacy}=${legacy}`, 400],
+            [`${state.names.legacy}=${'a'.repeat(513)}`, 400],
+        ];
+        for (const [cookie, status] of rejected) {
+            const attempt = await state.handler(
+                new Request(`${BASE_URL}/api/early-birds/auth/get-session`, {
+                    headers: { cookie },
+                }),
+            );
+            await expectBridgeRejection(attempt, status, state.names);
+        }
+        expect(state.database.session).toHaveLength(2);
+
+        // A well-formed but unsigned value still fails Better Auth's own
+        // verification, with the bridge passing it through untouched.
+        const forged = await getSession(
+            state.handler,
+            `${state.names.legacy}=forged-token-without-signature`,
+        );
+        expect(forged.body).toBeNull();
+    });
+
+    it('never mints a session when sign-in or callback paths carry invalid cookies', async () => {
+        const state = bridge();
+        const duplicate = `${state.names.legacy}=aB3d.tokensig%3D; ${state.names.legacy}=aB3d.tokensig%3D`;
+
+        // Sign-in: the minting path terminates before Better Auth runs.
+        const blockedSignUp = await signUp(state.handler, 'blocked@example.test', duplicate);
+        await expectBridgeRejection(blockedSignUp, 400, state.names);
+        expect(state.database.user).toHaveLength(0);
+        expect(state.database.session).toHaveLength(0);
+
+        // OAuth callback: a GET minting path terminates the same way.
+        const callback = await state.handler(
+            new Request(`${BASE_URL}/api/early-birds/auth/callback/google?state=abc&code=def`, {
+                headers: { origin: BASE_URL, cookie: duplicate },
+            }),
+        );
+        await expectBridgeRejection(callback, 400, state.names);
+        expect(state.database.session).toHaveLength(0);
+
+        // Sign-in recovery: once the client honours the dual expiry and
+        // retries clean, the very next sign-up mints an exact dual pair.
+        const recovered = await signUp(state.handler, 'blocked@example.test');
+        expect(recovered.status).toBe(200);
+        const legacy = setCookieEntry(recovered, state.names.legacy);
+        expect(setCookieEntry(recovered, state.names.canonical))
+            .toBe(`${state.names.canonical}${legacy.slice(state.names.legacy.length)}`);
+        expect(state.database.session).toHaveLength(1);
+    });
+
+    it('keeps two sessions of one account isolated and rejects crossed pairs', async () => {
+        const state = bridge();
+        // Two devices, ONE account: sign-up mints the first session, a real
+        // sign-in of the same account mints an independent second one.
+        const first = sessionCookieValue(
+            await signUp(state.handler, 'listener@example.test'),
+            state.names.legacy,
+        );
+        const second = sessionCookieValue(
+            await signIn(state.handler, 'listener@example.test'),
+            state.names.legacy,
+        );
+        expect(second).not.toBe(first);
+        expect(state.database.user).toHaveLength(1);
+        expect(state.database.session).toHaveLength(2);
+
+        // Both independent tokens validate for the same account.
+        const deviceA = await getSession(
+            state.handler,
+            `${state.names.canonical}=${first}; ${state.names.legacy}=${first}`,
+        );
+        expect(deviceA.body?.user?.email).toBe('listener@example.test');
+        const deviceB = await getSession(state.handler, `${state.names.legacy}=${second}`);
+        expect(deviceB.body?.user?.email).toBe('listener@example.test');
+
+        // Crossing one device's canonical with the other's legacy rejects.
+        const crossed = await state.handler(
+            new Request(`${BASE_URL}/api/early-birds/auth/get-session`, {
+                headers: {
+                    cookie: `${state.names.legacy}=${first}; ${state.names.canonical}=${second}`,
+                },
+            }),
+        );
+        await expectBridgeRejection(crossed, 400, state.names);
+        // Rejection is not revocation: both sessions remain valid afterwards.
+        expect((await getSession(state.handler, `${state.names.legacy}=${first}`))
+            .body?.user?.email).toBe('listener@example.test');
+        expect((await getSession(state.handler, `${state.names.legacy}=${second}`))
+            .body?.user?.email).toBe('listener@example.test');
+    });
+
+    it('clears both cookies with matching scope on sign-out and revokes the session', async () => {
+        const state = bridge();
+        const response = await signUp(state.handler, 'leaving@example.test');
+        const legacy = sessionCookieValue(response, state.names.legacy);
+
+        const signOut = await state.handler(new Request(`${BASE_URL}/api/early-birds/auth/sign-out`, {
+            method: 'POST',
+            headers: {
+                origin: BASE_URL,
+                'content-type': 'application/json',
+                cookie: `${state.names.canonical}=${legacy}; ${state.names.legacy}=${legacy}`,
+            },
+            body: '{}',
+        }));
+        expect(signOut.status).toBe(200);
+        for (const name of [state.names.legacy, state.names.canonical]) {
+            const cleared = setCookieEntry(signOut, name);
+            expect(cleared).toContain(`${name}=;`);
+            expect(cleared).toContain('Max-Age=0');
+            expect(cleared).toContain('Path=/');
+            expect(cleared).toContain('HttpOnly');
+            expect(cleared).toContain('SameSite=Lax');
+            expect(cleared).toContain('Secure');
+        }
+        expect(state.database.session).toHaveLength(0);
+
+        const after = await getSession(state.handler, `${state.names.legacy}=${legacy}`);
+        expect(after.body).toBeNull();
+    });
+
+    it('clears both cookies when sign-out arrives legacy-only (rollback retention)', async () => {
+        const state = bridge();
+        const response = await signUp(state.handler, 'rollback-leaving@example.test');
+        const legacy = sessionCookieValue(response, state.names.legacy);
+
+        const signOut = await state.handler(new Request(`${BASE_URL}/api/early-birds/auth/sign-out`, {
+            method: 'POST',
+            headers: {
+                origin: BASE_URL,
+                'content-type': 'application/json',
+                cookie: `${state.names.legacy}=${legacy}`,
+            },
+            body: '{}',
+        }));
+        expect(signOut.status).toBe(200);
+        expect(state.database.session).toHaveLength(0);
+        for (const name of [state.names.legacy, state.names.canonical]) {
+            expect(setCookieEntry(signOut, name)).toContain('Max-Age=0');
+        }
+    });
+
+    it('rejects a canonical-only sign-out without revoking the session', async () => {
+        const state = bridge();
+        const response = await signUp(state.handler, 'canonical-leaving@example.test');
+        const canonical = sessionCookieValue(response, state.names.canonical);
+
+        const signOut = await state.handler(new Request(`${BASE_URL}/api/early-birds/auth/sign-out`, {
+            method: 'POST',
+            headers: {
+                origin: BASE_URL,
+                'content-type': 'application/json',
+                cookie: `${state.names.canonical}=${canonical}`,
+            },
+            body: '{}',
+        }));
+        await expectBridgeRejection(signOut, 401, state.names);
+        expect(state.database.session).toHaveLength(1);
+    });
+
+    it('recovers a stale canonical cookie stranded by a deploy/rollback/redeploy sequence', async () => {
+        const state = bridge();
+        // The bare handler simulates the pre-bridge rollback image (20406):
+        // the same Better Auth pipeline with no bridge and legacy name only.
+        const legacyHandler: BridgedHandler = (request) => state.auth.handler(request);
+        const signOutRequest = (handler: BridgedHandler, cookie: string) =>
+            handler(new Request(`${BASE_URL}/api/early-birds/auth/sign-out`, {
+                method: 'POST',
+                headers: { origin: BASE_URL, 'content-type': 'application/json', cookie },
+                body: '{}',
+            }));
+
+        // Bridge deploy: sign-up mints the byte-identical dual pair A.
+        const deployed = await signUp(state.handler, 'rollback@example.test');
+        expect(deployed.status).toBe(200);
+        const tokenA = sessionCookieValue(deployed, state.names.legacy);
+        expect(state.database.session).toHaveLength(1);
+
+        // Rollback: the unwrapped legacy handler keeps accepting legacy-only.
+        const rollbackSession = await getSession(legacyHandler, `${state.names.legacy}=${tokenA}`);
+        expect(rollbackSession.body?.user?.email).toBe('rollback@example.test');
+
+        // Old sign-out clears ONLY the legacy name; the canonical cookie
+        // survives in the browser jar untouched.
+        const oldSignOut = await signOutRequest(legacyHandler, `${state.names.legacy}=${tokenA}`);
+        expect(oldSignOut.status).toBe(200);
+        const oldSignOutCookies = oldSignOut.headers.getSetCookie();
+        expect(oldSignOutCookies.some((entry) => entry.startsWith(`${state.names.legacy}=`))).toBe(true);
+        expect(oldSignOutCookies.some((entry) => entry.startsWith(`${state.names.canonical}=`))).toBe(false);
+        expect(state.database.session).toHaveLength(0);
+
+        // Alternate timeline probe: redeploying the bridge right here would
+        // face canonical-only A and answer 401 with the dual expiry, instead
+        // of the unrecoverable 401-without-clear the first bridge revision
+        // produced. (No server mutation: Better Auth never runs.)
+        const canonicalOnly = await state.handler(
+            new Request(`${BASE_URL}/api/early-birds/auth/get-session`, {
+                headers: { cookie: `${state.names.canonical}=${tokenA}` },
+            }),
+        );
+        await expectBridgeRejection(canonicalOnly, 401, state.names);
+
+        // Old re-login: the rollback image ignores the canonical name, so it
+        // mints a fresh legacy-only session B while stale canonical A persists.
+        const oldRelogin = await signIn(
+            legacyHandler,
+            'rollback@example.test',
+            `${state.names.canonical}=${tokenA}`,
+        );
+        expect(oldRelogin.status).toBe(200);
+        const tokenB = sessionCookieValue(oldRelogin, state.names.legacy);
+        expect(tokenB).not.toBe(tokenA);
+        expect(oldRelogin.headers.getSetCookie()
+            .some((entry) => entry.startsWith(`${state.names.canonical}=`))).toBe(false);
+
+        // Redeploy the bridge: stale canonical A plus fresh legacy B is a
+        // conflict. It fails closed and expires BOTH names; session B is not
+        // revoked because Better Auth never ran.
+        const stranded = await state.handler(
+            new Request(`${BASE_URL}/api/early-birds/auth/get-session`, {
+                headers: {
+                    cookie: `${state.names.canonical}=${tokenA}; ${state.names.legacy}=${tokenB}`,
+                },
+            }),
+        );
+        await expectBridgeRejection(stranded, 400, state.names);
+        expect(state.database.session).toHaveLength(1);
+
+        // The browser honours the dual expiry: the next clean sign-in
+        // succeeds and emits the exact byte-identical dual pair again.
+        const recovered = await signIn(state.handler, 'rollback@example.test');
+        expect(recovered.status).toBe(200);
+        const legacy = setCookieEntry(recovered, state.names.legacy);
+        expect(setCookieEntry(recovered, state.names.canonical))
+            .toBe(`${state.names.canonical}${legacy.slice(state.names.legacy.length)}`);
+    });
+
+    it('rotates both cookies coherently when the refresh window elapses', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-08T10:00:00.000Z'));
+        const state = bridge(1);
+        const response = await signUp(state.handler, 'rotating@example.test');
+        const initial = sessionCookieValue(response, state.names.legacy);
+
+        vi.setSystemTime(new Date('2026-08-08T10:00:05.000Z'));
+        const rotated = await getSession(state.handler, `${state.names.legacy}=${initial}`);
+        expect(rotated.body?.user?.email).toBe('rotating@example.test');
+
+        const legacy = setCookieEntry(rotated.response, state.names.legacy);
+        const canonical = setCookieEntry(rotated.response, state.names.canonical);
+        // Rotation re-signs the same token deterministically: values stay
+        // byte-identical and both cookies move together.
+        expect(sessionCookieValue(rotated.response, state.names.legacy)).toBe(initial);
+        expect(canonical).toBe(`${state.names.canonical}${legacy.slice(state.names.legacy.length)}`);
+    });
+});

--- a/src/lib/listener/__tests__/session-cookie-bridge.test.ts
+++ b/src/lib/listener/__tests__/session-cookie-bridge.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+    LISTENER_SESSION_COOKIE,
+    listenerSessionAuthHandler,
+    listenerSessionClearCookies,
+    listenerSessionCookieNames,
+    listenerSessionSetCookieMirrors,
+    mirrorListenerSessionResponse,
+    resolveListenerSessionCookie,
+} from '@/lib/listener/session-cookie-bridge';
+
+const NAMES = listenerSessionCookieNames('hb_earlybird_session');
+const SECURE_NAMES = listenerSessionCookieNames('__Secure-hb_earlybird_session');
+
+// Shape of a Better Auth signed session value on the wire:
+// encodeURIComponent(`${token}.${base64 HMAC}`).
+const VALUE = 'm1V0k2NlR3JlVG9rZW4.x%2B9ab%2Fcd%3D';
+const OTHER_VALUE = '90mV0k2NlR3JlVG9rZW4.qwert%2Fyuiop%3D';
+
+function setCookiesOf(response: Response): string[] {
+    return response.headers.getSetCookie();
+}
+
+describe('Listener session-cookie bridge names', () => {
+    it('derives the canonical name from the resolved legacy name and its security posture', () => {
+        expect(LISTENER_SESSION_COOKIE).toBe('hb_listener_session');
+        expect(NAMES).toEqual({
+            legacy: 'hb_earlybird_session',
+            canonical: 'hb_listener_session',
+            scope: { path: '/', httpOnly: true, sameSite: 'Lax', secure: false },
+        });
+        expect(SECURE_NAMES).toEqual({
+            legacy: '__Secure-hb_earlybird_session',
+            canonical: '__Secure-hb_listener_session',
+            scope: { path: '/', httpOnly: true, sameSite: 'Lax', secure: true },
+        });
+    });
+
+    it('honours the scope Better Auth resolved instead of re-deriving it', () => {
+        const resolved = listenerSessionCookieNames('hb_earlybird_session', {
+            path: '/',
+            httpOnly: true,
+            sameSite: 'Lax',
+            secure: true,
+        });
+        expect(resolved.scope).toEqual({
+            path: '/',
+            httpOnly: true,
+            sameSite: 'Lax',
+            secure: true,
+        });
+    });
+});
+
+describe('listenerSessionClearCookies', () => {
+    it('expires both exact names with the resolved scope and no value or Domain', () => {
+        expect(listenerSessionClearCookies(SECURE_NAMES)).toEqual([
+            `${SECURE_NAMES.legacy}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure`,
+            `${SECURE_NAMES.canonical}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure`,
+        ]);
+    });
+
+    it('matches the non-secure scope when Better Auth resolved plain names', () => {
+        expect(listenerSessionClearCookies(NAMES)).toEqual([
+            `${NAMES.legacy}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax`,
+            `${NAMES.canonical}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax`,
+        ]);
+    });
+});
+
+describe('resolveListenerSessionCookie', () => {
+    it('forwards requests without any session cookie', () => {
+        expect(resolveListenerSessionCookie(null, NAMES))
+            .toEqual({ kind: 'forward', header: null });
+        const header = 'other=1; hb_earlybird_device_id=abc';
+        expect(resolveListenerSessionCookie(header, NAMES))
+            .toEqual({ kind: 'forward', header });
+    });
+
+    it('forwards a legacy-only session unchanged for rollback compatibility', () => {
+        const header = `cart=1; ${NAMES.legacy}=${VALUE}`;
+        expect(resolveListenerSessionCookie(header, NAMES))
+            .toEqual({ kind: 'forward', header });
+    });
+
+    it('forwards a byte-identical dual pair unchanged', () => {
+        const header = `${NAMES.canonical}=${VALUE}; ${NAMES.legacy}=${VALUE}`;
+        expect(resolveListenerSessionCookie(header, NAMES))
+            .toEqual({ kind: 'forward', header });
+    });
+
+    it('rejects a canonical-only session instead of relabelling it as legacy', () => {
+        expect(resolveListenerSessionCookie(
+            `cart=1; ${NAMES.canonical}=${VALUE}; theme=dark`,
+            NAMES,
+        )).toEqual({ kind: 'reject', status: 401 });
+    });
+
+    it('rejects conflicting canonical/legacy values instead of arbitrating', () => {
+        const header = `cart=1; ${NAMES.canonical}=${OTHER_VALUE}; ${NAMES.legacy}=${VALUE}`;
+        expect(resolveListenerSessionCookie(header, NAMES))
+            .toEqual({ kind: 'reject', status: 400 });
+    });
+
+    it('rejects duplicate cookies of either name instead of letting first-wins decide', () => {
+        for (const header of [
+            `${NAMES.canonical}=${VALUE}; ${NAMES.canonical}=${VALUE}`,
+            `${NAMES.canonical}=${VALUE}; ${NAMES.canonical}=${OTHER_VALUE}; ${NAMES.legacy}=${VALUE}`,
+            `${NAMES.legacy}=${VALUE}; ${NAMES.legacy}=${VALUE}`,
+            `${NAMES.legacy}=${VALUE}; ${NAMES.legacy}=${OTHER_VALUE}`,
+        ]) {
+            expect(resolveListenerSessionCookie(header, NAMES), header)
+                .toEqual({ kind: 'reject', status: 400 });
+        }
+    });
+
+    it('rejects malformed percent encoding even alongside a valid cookie', () => {
+        for (const header of [
+            `${NAMES.canonical}=${VALUE.slice(0, 10)}%zz; ${NAMES.legacy}=${VALUE}`,
+            `${NAMES.canonical}=${VALUE}; ${NAMES.legacy}=${VALUE.slice(0, 10)}%2g`,
+            `${NAMES.legacy}=${VALUE.slice(0, 10)}%`,
+        ]) {
+            expect(resolveListenerSessionCookie(header, NAMES), header)
+                .toEqual({ kind: 'reject', status: 400 });
+        }
+    });
+
+    it('rejects empty, non-wire, control-character or oversized session values', () => {
+        for (const header of [
+            `${NAMES.canonical}=; ${NAMES.legacy}=${VALUE}`,
+            `${NAMES.legacy}==${VALUE}`,
+            `${NAMES.legacy}=${'a'.repeat(513)}`,
+            `${NAMES.canonical}=${VALUE}, ${NAMES.canonical}=${OTHER_VALUE}`,
+            // Control characters embedded in a value never match the wire charset.
+            `${NAMES.legacy}=${VALUE.slice(0, 5)}\t${VALUE.slice(5)}`,
+            `${NAMES.canonical}=${VALUE.slice(0, 5)} ${VALUE.slice(5)}; ${NAMES.legacy}=${VALUE}`,
+        ]) {
+            const resolution = resolveListenerSessionCookie(header, NAMES);
+            expect(resolution.kind, header).toBe('reject');
+        }
+    });
+
+    it('rejects an oversized header carrying a session cookie entirely', () => {
+        const filler = `filler=${'f'.repeat(9000)}`;
+        const header = `${NAMES.legacy}=${VALUE}; ${filler}`;
+        expect(resolveListenerSessionCookie(header, NAMES))
+            .toEqual({ kind: 'reject', status: 400 });
+    });
+
+    it('ignores cookies that merely share a prefix with the session names', () => {
+        const header = `${NAMES.legacy}_backup=${VALUE}; ${NAMES.legacy}=${VALUE}`;
+        expect(resolveListenerSessionCookie(header, NAMES))
+            .toEqual({ kind: 'forward', header });
+    });
+});
+
+describe('listenerSessionSetCookieMirrors', () => {
+    it('mirrors a single legacy mint with byte-identical value and attributes', () => {
+        const emitted = `${SECURE_NAMES.legacy}=${VALUE}; Max-Age=2592000; Path=/; HttpOnly; SameSite=Lax; Secure`;
+        expect(listenerSessionSetCookieMirrors([emitted], SECURE_NAMES)).toEqual([
+            `${SECURE_NAMES.canonical}=${VALUE}; Max-Age=2592000; Path=/; HttpOnly; SameSite=Lax; Secure`,
+        ]);
+    });
+
+    it('mirrors a single legacy clear as a dual clear with matching scope', () => {
+        const expired = `${SECURE_NAMES.legacy}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure`;
+        expect(listenerSessionSetCookieMirrors([expired], SECURE_NAMES)).toEqual([
+            `${SECURE_NAMES.canonical}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure`,
+        ]);
+    });
+
+    it('leaves an already byte-identical dual output untouched', () => {
+        const emitted = [
+            `${SECURE_NAMES.legacy}=${VALUE}; Max-Age=2592000; Path=/; HttpOnly; Secure`,
+            `${SECURE_NAMES.canonical}=${VALUE}; Max-Age=2592000; Path=/; HttpOnly; Secure`,
+        ];
+        expect(listenerSessionSetCookieMirrors(emitted, SECURE_NAMES)).toEqual([]);
+    });
+
+    it('never mirrors OAuth state, PKCE, CSRF or other cookies', () => {
+        expect(listenerSessionSetCookieMirrors([
+            `hb_earlybird.state=${VALUE}; Max-Age=300; Path=/; HttpOnly`,
+            `hb_earlybird.pkce=${VALUE}; Max-Age=300; Path=/; HttpOnly`,
+            `${NAMES.legacy}_backup=${VALUE}; Path=/`,
+            'unrelated=1; Path=/',
+        ], NAMES)).toEqual([]);
+    });
+
+    it('fails ambiguous output instead of appending another canonical', () => {
+        const mint = `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`;
+        const ambiguous: string[][] = [
+            // More than one same-name mutation.
+            [mint, `${NAMES.legacy}=${OTHER_VALUE}; Path=/; HttpOnly`],
+            [mint, `${NAMES.canonical}=${VALUE}; Path=/; HttpOnly`, `${NAMES.canonical}=${VALUE}; Path=/; HttpOnly`],
+            // A canonical mutation without a legacy counterpart.
+            [`${NAMES.canonical}=${VALUE}; Path=/; HttpOnly`],
+            // A pair whose values or security attributes differ.
+            [mint, `${NAMES.canonical}=${OTHER_VALUE}; Path=/; HttpOnly`],
+            [mint, `${NAMES.canonical}=${VALUE}; Path=/; HttpOnly; Secure`],
+        ];
+        for (const entries of ambiguous) {
+            expect(listenerSessionSetCookieMirrors(entries, NAMES), entries.join(' | '))
+                .toBeNull();
+        }
+    });
+});
+
+describe('bridge response wrapper', () => {
+    it('appends the canonical mirror while preserving status, body and other headers', async () => {
+        const headers = new Headers({ 'content-type': 'application/json' });
+        headers.append('set-cookie', `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`);
+        headers.append('set-cookie', 'hb_earlybird.state=abc; Path=/; HttpOnly');
+        const response = new Response(JSON.stringify({ ok: true }), { status: 201, headers });
+
+        const mirrored = mirrorListenerSessionResponse(response, NAMES);
+        expect(mirrored.status).toBe(201);
+        expect(mirrored.headers.get('content-type')).toBe('application/json');
+        expect(setCookiesOf(mirrored)).toEqual([
+            `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`,
+            'hb_earlybird.state=abc; Path=/; HttpOnly',
+            `${NAMES.canonical}=${VALUE}; Path=/; HttpOnly`,
+        ]);
+        await expect(mirrored.json()).resolves.toEqual({ ok: true });
+    });
+
+    it('returns the original response when nothing needs mirroring', () => {
+        const response = new Response(null, { status: 204 });
+        expect(mirrorListenerSessionResponse(response, NAMES)).toBe(response);
+    });
+
+    it('replaces ambiguous Better Auth output with a generic 500 and no Set-Cookie', async () => {
+        const headers = new Headers();
+        headers.append('set-cookie', `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`);
+        headers.append('set-cookie', `${NAMES.legacy}=${OTHER_VALUE}; Path=/; HttpOnly`);
+        const response = new Response('secret session body', { status: 200, headers });
+
+        const mirrored = mirrorListenerSessionResponse(response, NAMES);
+        expect(mirrored.status).toBe(500);
+        expect(setCookiesOf(mirrored)).toEqual([]);
+        await expect(mirrored.text()).resolves.not.toContain('secret session body');
+    });
+});
+
+describe('listenerSessionAuthHandler', () => {
+    function mintingHandler() {
+        return vi.fn(async () => {
+            const headers = new Headers();
+            headers.append('set-cookie', `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`);
+            return new Response('ok', { headers });
+        });
+    }
+
+    it('terminates invalid states before the handler, expiring both names generically', async () => {
+        const inner = mintingHandler();
+        const handler = listenerSessionAuthHandler(inner, NAMES);
+
+        for (const [cookie, status] of [
+            [`${NAMES.canonical}=${VALUE}`, 401],
+            [`${NAMES.legacy}=${VALUE}; ${NAMES.legacy}=${VALUE}`, 400],
+            [`${NAMES.canonical}=${OTHER_VALUE}; ${NAMES.legacy}=${VALUE}`, 400],
+            [`${NAMES.legacy}=${VALUE.slice(0, 10)}%zz`, 400],
+        ] as const) {
+            const response = await handler(new Request('https://listen.example.test/x', {
+                headers: { cookie },
+            }));
+            expect(response.status, cookie).toBe(status);
+            // Exactly the two expiry cookies, never an auth token, and the
+            // rejected value is never echoed back.
+            expect(setCookiesOf(response), cookie).toEqual(
+                listenerSessionClearCookies(NAMES),
+            );
+            const body = await response.text();
+            expect(body).not.toContain(VALUE);
+            expect(body).not.toContain(OTHER_VALUE);
+        }
+        expect(inner).not.toHaveBeenCalled();
+    });
+
+    it('expires both names with Secure when the resolved scope is secure', async () => {
+        const handler = listenerSessionAuthHandler(mintingHandler(), SECURE_NAMES);
+        const response = await handler(new Request('https://listen.example.test/x', {
+            headers: { cookie: `${SECURE_NAMES.canonical}=${VALUE}` },
+        }));
+        expect(response.status).toBe(401);
+        expect(setCookiesOf(response)).toEqual([
+            `${SECURE_NAMES.legacy}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure`,
+            `${SECURE_NAMES.canonical}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure`,
+        ]);
+    });
+
+    it('stays recoverable: an accepted state after a rejection still reaches the handler', async () => {
+        const inner = mintingHandler();
+        const handler = listenerSessionAuthHandler(inner, NAMES);
+
+        const rejected = await handler(new Request('https://listen.example.test/x', {
+            headers: { cookie: `${NAMES.canonical}=${VALUE}` },
+        }));
+        expect(rejected.status).toBe(401);
+        expect(inner).not.toHaveBeenCalled();
+
+        // The client honoured the dual expiry and retries with no session
+        // cookie: the minting path runs and mirrors the fresh dual pair.
+        const response = await handler(new Request('https://listen.example.test/x'));
+        expect(response.status).toBe(200);
+        expect(setCookiesOf(response)).toEqual([
+            `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`,
+            `${NAMES.canonical}=${VALUE}; Path=/; HttpOnly`,
+        ]);
+        expect(inner).toHaveBeenCalledOnce();
+    });
+
+    it('forwards accepted states untouched and mirrors the minted pair', async () => {
+        const seenCookies: (string | null)[] = [];
+        const handler = listenerSessionAuthHandler(async (request) => {
+            seenCookies.push(request.headers.get('cookie'));
+            const headers = new Headers();
+            headers.append('set-cookie', `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`);
+            return new Response('ok', { headers });
+        }, NAMES);
+
+        const dual = `${NAMES.canonical}=${VALUE}; ${NAMES.legacy}=${VALUE}`;
+        for (const cookie of [null, `${NAMES.legacy}=${VALUE}`, dual]) {
+            const response = await handler(new Request('https://listen.example.test/x', {
+                headers: cookie ? { cookie } : {},
+            }));
+            expect(response.status).toBe(200);
+            expect(setCookiesOf(response)).toEqual([
+                `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`,
+                `${NAMES.canonical}=${VALUE}; Path=/; HttpOnly`,
+            ]);
+        }
+        expect(seenCookies).toEqual([null, `${NAMES.legacy}=${VALUE}`, dual]);
+    });
+});

--- a/src/lib/listener/session-cookie-bridge.ts
+++ b/src/lib/listener/session-cookie-bridge.ts
@@ -1,0 +1,314 @@
+/**
+ * Canonical Listener session-cookie bridge.
+ *
+ * Better Auth remains the sole session authority: it alone mints, signs,
+ * verifies, rotates and revokes session tokens on the legacy EarlyBird base
+ * path. The signed cookie value Better Auth emits is opaque and its HMAC does
+ * not cover the cookie name, so the value is portable verbatim under a second
+ * name. This module only:
+ *
+ * - mirrors every legacy session `Set-Cookie` Better Auth emits onto the
+ *   canonical Listener name with byte-identical value and attributes, and
+ * - enforces which inbound session-cookie states may reach Better Auth at
+ *   all during the rollback-compatible phase.
+ *
+ * Inbound, exactly three states are accepted: no session cookie, exactly one
+ * legacy-only session cookie, or exactly one canonical plus one byte-identical
+ * legacy cookie. Everything else — canonical-only, duplicate same-name
+ * cookies, conflicting pairs, malformed percent encoding or control
+ * characters, oversized values or an oversized header — terminates with a
+ * generic 400/401 BEFORE Better Auth is invoked, so no ambiguous request can
+ * be silently repaired by better-call's first-wins parser or mint a fresh
+ * session on sign-in/OAuth callback paths.
+ *
+ * Every such rejection also expires BOTH exact session cookie names with
+ * `Max-Age=0` and the resolved secure scope. That is what keeps a
+ * deploy/rollback/redeploy sequence recoverable: a rollback image's sign-out
+ * clears only the legacy name, so a stale canonical cookie would otherwise
+ * 401 forever (or a stale canonical plus a fresh legacy would 400) and no
+ * accepted auth mutation could ever repair it, because every ambiguous state
+ * stops before Better Auth. Clearing both names logs the client out but lets
+ * the next clean sign-in mint a fresh dual pair. The rejected values are
+ * never echoed, parsed or logged — the expiry cookies carry empty values.
+ *
+ * Outbound, mirroring happens only for unambiguous output: exactly one legacy
+ * session mutation and either no canonical mutation or one byte-identical
+ * canonical mutation with identical security attributes. Any other shape
+ * (repeated same-name mutations, mismatched pairs, canonical mutations
+ * without a legacy counterpart) is an internal failure: the response is
+ * replaced by a generic 500 carrying no Set-Cookie at all.
+ *
+ * The value is lexically bounded and validated, but its token contents are
+ * never decoded, interpreted, re-signed or logged here. OAuth state, PKCE and
+ * any other non-session cookies pass through untouched in both directions.
+ */
+
+export const LISTENER_SESSION_COOKIE = 'hb_listener_session';
+
+const SECURE_COOKIE_PREFIX = '__Secure-';
+
+/** Bound cookie-header smuggling without rejecting legitimate other cookies. */
+const MAX_COOKIE_HEADER_LENGTH = 8192;
+/**
+ * A Better Auth signed session value is `encodeURIComponent(token + "." +
+ * base64 HMAC)` and stays well under 200 characters; 512 leaves headroom for
+ * token-format changes without accepting junk.
+ */
+const MAX_SESSION_COOKIE_VALUE_LENGTH = 512;
+/** Characters `encodeURIComponent` can leave on the wire; excludes controls. */
+const WIRE_VALUE_CHARSET = /^[A-Za-z0-9\-_.!~*'()%]+$/;
+const INVALID_PERCENT_ESCAPE = /%(?![0-9A-Fa-f]{2})/;
+
+/**
+ * The cookie scope the bridge must match when it expires session cookies
+ * itself (rejections). Derived from the session cookie attributes Better
+ * Auth actually resolved (`getCookies(auth.options).sessionToken.attributes`)
+ * so an expiry lands on exactly the scope Better Auth minted into. A Domain
+ * is never invented: only an attribute Better Auth itself resolved is copied.
+ */
+export type ListenerSessionCookieScope = {
+    readonly path: string;
+    readonly httpOnly: boolean;
+    readonly sameSite: string;
+    readonly secure: boolean;
+};
+
+export type ListenerSessionCookieNames = {
+    /** Resolved session cookie name Better Auth reads and writes. */
+    readonly legacy: string;
+    /** Canonical Listener name carrying the same opaque value. */
+    readonly canonical: string;
+    /** Resolved scope shared by both names; used for bridge-side expiries. */
+    readonly scope: ListenerSessionCookieScope;
+};
+
+/**
+ * Derives the bridge pair from the session cookie name Better Auth actually
+ * resolved (via `getCookies(auth.options)`), inheriting its `__Secure-`
+ * convention so both names always share one security posture. `scope` should
+ * come from the resolved Better Auth session-cookie attributes; without it
+ * the secure posture follows the name and Better Auth's documented defaults.
+ */
+export function listenerSessionCookieNames(
+    resolvedLegacyName: string,
+    scope?: Partial<ListenerSessionCookieScope>,
+): ListenerSessionCookieNames {
+    const secure = resolvedLegacyName.startsWith(SECURE_COOKIE_PREFIX);
+    return {
+        legacy: resolvedLegacyName,
+        canonical: `${secure ? SECURE_COOKIE_PREFIX : ''}${LISTENER_SESSION_COOKIE}`,
+        scope: {
+            path: scope?.path ?? '/',
+            httpOnly: scope?.httpOnly ?? true,
+            sameSite: scope?.sameSite ?? 'Lax',
+            secure: scope?.secure ?? secure,
+        },
+    };
+}
+
+/**
+ * Builds the dual session-cookie expiry for a bridge-side rejection: both
+ * exact names with empty values, `Max-Age=0` and the resolved scope, so the
+ * client is logged out on whichever names it holds and the next clean
+ * sign-in can mint a fresh dual pair. Never carries a session value and
+ * never adds a Domain attribute.
+ */
+export function listenerSessionClearCookies(
+    names: ListenerSessionCookieNames,
+): string[] {
+    const { path, httpOnly, sameSite, secure } = names.scope;
+    const attributes = [
+        'Max-Age=0',
+        `Path=${path}`,
+        ...(httpOnly ? ['HttpOnly'] : []),
+        `SameSite=${sameSite}`,
+        ...(secure ? ['Secure'] : []),
+    ].join('; ');
+    return [names.legacy, names.canonical].map((name) => `${name}=; ${attributes}`);
+}
+
+/**
+ * Strict inbound verdict. `forward` carries the Cookie header to present to
+ * Better Auth (null when the request had none). `reject` terminates the
+ * request before Better Auth with a generic status: 401 for a well-formed
+ * canonical-only credential that is not accepted during this phase, 400 for
+ * every structurally invalid state.
+ */
+export type ListenerSessionCookieResolution =
+    | { readonly kind: 'forward'; readonly header: string | null }
+    | { readonly kind: 'reject'; readonly status: 400 | 401 };
+
+type CookiePart = {
+    readonly name: string;
+    readonly value: string;
+};
+
+function parseCookieParts(header: string): CookiePart[] {
+    return header.split(';').map((raw) => {
+        const separator = raw.indexOf('=');
+        if (separator < 1) return { name: '', value: '' };
+        return {
+            name: raw.slice(0, separator).trim(),
+            value: raw.slice(separator + 1).trim(),
+        };
+    });
+}
+
+function wellFormedSessionValue(value: string): boolean {
+    return value.length > 0 &&
+        value.length <= MAX_SESSION_COOKIE_VALUE_LENGTH &&
+        WIRE_VALUE_CHARSET.test(value) &&
+        !INVALID_PERCENT_ESCAPE.test(value);
+}
+
+/**
+ * Resolves whether an inbound Cookie header may reach Better Auth under the
+ * bridge policy. Accepted states are forwarded byte-for-byte (Better Auth
+ * ignores the canonical name and reads the legacy one); no state is ever
+ * rewritten or stripped, because repairing an ambiguous header is exactly
+ * what better-call's first-wins parser would do silently.
+ */
+export function resolveListenerSessionCookie(
+    header: string | null,
+    names: ListenerSessionCookieNames,
+): ListenerSessionCookieResolution {
+    const forward: ListenerSessionCookieResolution = { kind: 'forward', header };
+    if (!header) return forward;
+
+    const parts = parseCookieParts(header);
+    const legacyParts = parts.filter((part) => part.name === names.legacy);
+    const canonicalParts = parts.filter((part) => part.name === names.canonical);
+    if (legacyParts.length === 0 && canonicalParts.length === 0) return forward;
+
+    const reject = (status: 400 | 401): ListenerSessionCookieResolution =>
+        ({ kind: 'reject', status });
+
+    if (
+        header.length > MAX_COOKIE_HEADER_LENGTH ||
+        legacyParts.length > 1 ||
+        canonicalParts.length > 1 ||
+        legacyParts.some((part) => !wellFormedSessionValue(part.value)) ||
+        canonicalParts.some((part) => !wellFormedSessionValue(part.value))
+    ) return reject(400);
+
+    const legacy = legacyParts[0];
+    const canonical = canonicalParts[0];
+    // A well-formed canonical credential without its legacy counterpart is
+    // not accepted during the rollback-compatible phase.
+    if (!legacy) return reject(401);
+    // Conflicting values are never arbitrated between.
+    if (canonical && canonical.value !== legacy.value) return reject(400);
+    return forward;
+}
+
+/**
+ * Mirrors the legacy session `Set-Cookie` onto the canonical name with the
+ * value and all attributes byte-identical, under the strict output policy:
+ *
+ * - exactly one legacy mutation and no canonical mutation: one canonical
+ *   mirror is appended (this covers mint, rotation and clear alike);
+ * - exactly one legacy and one canonical mutation that are byte-identical
+ *   apart from the name: the output is already dual, nothing is appended;
+ * - no session mutation at all: nothing is appended.
+ *
+ * Returns null for every ambiguous shape — repeated same-name mutations, a
+ * canonical mutation without a legacy counterpart, or a pair whose value or
+ * security attributes differ. Callers must treat null as an internal failure
+ * and emit no session cookie at all. Cookies with any other name (OAuth
+ * state, PKCE, CSRF, unrelated) are never inspected beyond the name match.
+ */
+export function listenerSessionSetCookieMirrors(
+    setCookies: readonly string[],
+    names: ListenerSessionCookieNames,
+): string[] | null {
+    const nameOf = (entry: string): string => {
+        const separator = entry.indexOf('=');
+        return separator < 1 ? '' : entry.slice(0, separator);
+    };
+    const legacyMutations = setCookies.filter((entry) => nameOf(entry) === names.legacy);
+    const canonicalMutations = setCookies.filter((entry) => nameOf(entry) === names.canonical);
+
+    if (legacyMutations.length > 1 || canonicalMutations.length > 1) return null;
+    const legacy = legacyMutations[0];
+    const canonical = canonicalMutations[0];
+    if (!legacy) return canonical ? null : [];
+    if (!canonical) return [`${names.canonical}${legacy.slice(names.legacy.length)}`];
+    const identical = canonical.slice(names.canonical.length) ===
+        legacy.slice(names.legacy.length);
+    return identical ? [] : null;
+}
+
+/**
+ * Generic rejection: no token or cookie detail, but both exact session
+ * cookie names are expired so a stale canonical or legacy cookie left by a
+ * deploy/rollback/redeploy sequence cannot lock the client out of recovery.
+ */
+function rejectionResponse(
+    status: 400 | 401,
+    names: ListenerSessionCookieNames,
+): Response {
+    const headers = new Headers({
+        'content-type': 'application/json',
+        'cache-control': 'private, no-store',
+    });
+    for (const clear of listenerSessionClearCookies(names)) {
+        headers.append('set-cookie', clear);
+    }
+    return new Response(JSON.stringify({ error: 'invalid session credentials' }), {
+        status,
+        headers,
+    });
+}
+
+/** Generic internal failure: ambiguous output must not reach the client. */
+function ambiguousOutputResponse(): Response {
+    return new Response(JSON.stringify({ error: 'internal error' }), {
+        status: 500,
+        headers: {
+            'content-type': 'application/json',
+            'cache-control': 'private, no-store',
+        },
+    });
+}
+
+/**
+ * Applies the outbound bridge policy: appends the canonical mirror of a
+ * single legacy session `Set-Cookie`, or replaces the whole response with a
+ * generic 500 when Better Auth's session-cookie output is ambiguous.
+ */
+export function mirrorListenerSessionResponse(
+    response: Response,
+    names: ListenerSessionCookieNames,
+): Response {
+    const mirrors = listenerSessionSetCookieMirrors(response.headers.getSetCookie(), names);
+    if (mirrors === null) return ambiguousOutputResponse();
+    if (mirrors.length === 0) return response;
+    const headers = new Headers(response.headers);
+    for (const mirror of mirrors) headers.append('set-cookie', mirror);
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    });
+}
+
+/**
+ * Wraps a Better Auth handler so every request/response pair crosses the
+ * bridge. Invalid inbound session-cookie states terminate with a generic
+ * 400/401 (expiring both session cookie names) before the handler runs, so no
+ * ambiguous request can mint, rotate or clear a session; ambiguous outbound
+ * output fails closed with a generic 500 carrying no Set-Cookie at all. The
+ * wrapped handler stays the only code that touches sessions.
+ */
+export function listenerSessionAuthHandler(
+    handler: (request: Request) => Promise<Response>,
+    names: ListenerSessionCookieNames,
+): (request: Request) => Promise<Response> {
+    return async (request) => {
+        const resolution = resolveListenerSessionCookie(request.headers.get('cookie'), names);
+        if (resolution.kind === 'reject') {
+            return rejectionResponse(resolution.status, names);
+        }
+        return mirrorListenerSessionResponse(await handler(request), names);
+    };
+}


### PR DESCRIPTION
## Outcome

Adds the rollback-compatible canonical Listener session-cookie bridge while keeping Better Auth as the sole mint/sign/verify/revoke authority.

## Safety properties

- accepts only no session, legacy-only, or byte-identical dual session cookies;
- rejects canonical-only, duplicates, malformed values, and conflicting pairs before Better Auth;
- mirrors only exact unambiguous Better Auth session mutations;
- expires both exact names on rejected stale state so deploy/rollback/redeploy and synthetic test-login recover without manual cookie clearing;
- forwards no rejected token, internal body, unrelated cookie, OAuth/PKCE state, or PII;
- preserves legacy base path/callbacks and existing sessions during the compatibility window.

## Evidence

- 67 focused bridge/auth/test-login tests;
- 1309 full tests (19 standard skips);
- TypeScript and ESLint quiet;
- production build;
- independent adversarial review approved after fixing the rollback and test-login recovery blockers;
- diff check clean.

## Scope / risk / rollback

Listener-only namespace and staging test-login code. No event, LiveKit, audio, payment-provider, schema, or runtime configuration change. This PR does not deploy anything. Roll back by reverting this commit; the legacy cookie remains authoritative throughout this phase.
