### PR TITLE
test(listener): add fail-closed external ten-client smoke harness

### DIFF
--- a/docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
+++ b/docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
@@ -1,0 +1,259 @@
+# First external Listener HLS smoke
+
+This is the only approved first network step for Listener capacity evidence. It
+drives exactly ten media-plane clients from one external host for a sixty-second
+soak. It is media-plane evidence only: it is not end-to-end Listener capacity
+evidence, and it proves nothing about 3,000/4,000/5,000-listener capacity and
+does not authorize those profiles.
+
+The target is the isolated stream origin on `mona`, which still shares the host
+and physical interface with `live.harmonicbeacon.com`. Do not run this while an
+event is active. Never run a shard, the canary or the monitor from `mona`.
+
+## Fixed safety boundary
+
+- Wrapper: `tools/early-birds-hls-load/run-staging-smoke.mjs`.
+- Policy: `policies/listener-staging-smoke-10.json`.
+- Exact origin: `https://stream.harmonicbeacon.com`.
+- Profile: ten clients, two starts/second, sixty-second soak, one shard, at
+  most 28 request starts/second.
+- Conservative media budget: about 4.5 Mbit/s; no capacity claim follows.
+- The wrapper refuses a network run without a current signed manifest, a
+  decoded external canary and a target monitor. It polls both status files every
+  two seconds and, on the first failing or stale check, sends exactly one
+  `SIGINT` to the load child, preserving `ABORTED` evidence.
+
+All signed URLs and status files are exactly mode `0600` regular files (never
+symlinks), remain outside Git and must never be passed in a command line, issue
+or chat. Status files contain only booleans, bounded numeric telemetry, fixed
+thresholds, timing and a hashed host fingerprint — never hostnames, URLs,
+labels, raw Prometheus/Alertmanager payloads or secrets.
+
+The software never claims `GO`. The wrapper, monitor and canary only report
+`PASS`/`FAIL`/`ABORTED` evidence; the named human target observer owns the
+`GO`/`NO-GO` decision.
+
+## Roles and terminals
+
+Use two operators, or one operator with three visible terminals:
+
+1. **Target observer:** watches `mona`, Prometheus/Alertmanager, the decoded
+   canary and public Listener/live health. This person owns the go/no-go call.
+2. **Generator operator:** runs the target monitor, the decoded canary and the
+   ten-client wrapper on one NTP-synchronized external host (`daimonmatrix`,
+   never `mona`) and can interrupt them immediately.
+
+The monitor, the canary and the wrapper must run co-located on that single
+external generator host: the wrapper reads both status files from local disk
+and rejects any status whose hashed host fingerprint differs from its own host.
+They may not be split across different external hosts.
+
+Open local-only SSH tunnels for both loopback observability services from the
+external host:
+
+```bash
+ssh -N -L 19090:127.0.0.1:9090 -L 19093:127.0.0.1:9093 mona
+```
+
+or as two separate sessions:
+
+```bash
+ssh -N -L 19090:127.0.0.1:9090 mona   # Prometheus, loopback on mona
+ssh -N -L 19093:127.0.0.1:9093 mona   # Alertmanager, loopback on mona
+```
+
+Start the external monitor on the generator host. It checks staging readiness,
+stream health and unchanged live readiness, queries Alertmanager directly for
+readiness and active non-silenced alerts, queries Prometheus separately for
+firing rules, evaluates the immediate stop thresholds from direct instant
+queries (host CPU, memory, root disk, egress, TCP retransmits, interface
+errors/drops, origin up and the deployed decoded canary) and maintains an
+in-process restart/OOM baseline for the exact isolated Listener and origin
+containers:
+
+```bash
+node tools/early-birds-hls-load/external-target-monitor.mjs \
+  --prometheus-url http://127.0.0.1:19090 \
+  --alertmanager-url http://127.0.0.1:19093 \
+  --status-file /secure/listener-smoke-monitor.json
+```
+
+Both URLs must be uncredentialed loopback tunnel origins; anything else is
+refused. Every Prometheus scalar query must return exactly one finite result —
+a missing, duplicated, ambiguous, `NaN` or `Inf` result fails the probe. A
+failing or unreachable Prometheus or Alertmanager fails the probe closed; the
+monitor never infers Alertmanager health from Prometheus.
+
+### Restart/OOM preflight blocker
+
+The restart/OOM baseline requires cAdvisor `container_start_time_seconds` and
+`container_oom_events_total` for exactly
+`earlybirds-preview-listener-1` and `earlybirds-preview-beacon-stream-1`, each
+resolving to exactly one finite series. Before scheduling load, run the monitor
+with `--once` (it probes twice: baseline plus verification) and confirm a
+`PASS` status with `restartBaselineEstablished: true`,
+`containerRestartsObserved: 0` and `oomEventsDelta: 0`. If those container
+metrics are absent or ambiguous, the monitor keeps reporting `FAIL` — that is
+the exact preflight blocker. Resolve it on the observability stack first; the
+monitor never silently claims zero restarts. Because the baseline is
+in-process, a restarted monitor reports `FAIL` again until it has re-established
+and verified a fresh baseline, and the wrapper rejects such a status.
+
+### Actual-mona preflight: per-container cAdvisor series
+
+Verified on `mona` (read-only inspection): Prometheus currently exposes **only
+the root cgroup** for `container_start_time_seconds` and
+`container_oom_events_total`; the exact Listener/origin queries return empty
+vectors. cAdvisor logs repeatedly report that it cannot find
+`/rootfs/var/lib/docker/image/overlayfs/.../mount-id`. The cause is that the
+cAdvisor `/:/rootfs` bind lacked recursive slave propagation after the Docker
+storage topology changed, so storage-driver mounts never became visible inside
+the container. The checked-in fix mounts `/:/rootfs:ro,rslave` (the same
+propagation node-exporter already uses); it changes only the isolated
+observability cAdvisor container and no event or runtime container.
+
+Until that fix is running on `mona`, the ten-client smoke **cannot start**: the
+monitor's exact container queries return empty vectors, every probe reports
+`FAIL`, and the wrapper refuses the network run. There is no fallback — no
+Docker CLI/API read, no inferred zero, no weakened restart/OOM evidence.
+
+Before any load, the operator must:
+
+1. Obtain explicit human approval and recreate **only** cAdvisor on `mona`
+   (see `ops/early-birds/runbook/README.md`, "cAdvisor mount propagation").
+   Do not recreate Prometheus, Alertmanager, node-exporter, the canary or any
+   event/runtime container.
+2. Through the loopback SSH tunnel, confirm each of the four exact queries
+   returns exactly one finite series, not an empty vector:
+
+   ```bash
+   for query in \
+     'container_start_time_seconds{name="earlybirds-preview-listener-1"}' \
+     'container_start_time_seconds{name="earlybirds-preview-beacon-stream-1"}' \
+     'container_oom_events_total{name="earlybirds-preview-listener-1"}' \
+     'container_oom_events_total{name="earlybirds-preview-beacon-stream-1"}'
+   do
+     curl -fsS 'http://127.0.0.1:19090/api/v1/query' --get --data-urlencode "query=$query"
+   done
+   ```
+3. Only then run the monitor `--once` preflight above. An empty vector at any
+   step is a hard blocker: stop and resolve observability first; never treat
+   missing series as zero restarts or zero OOM events.
+
+## Five-minute baseline
+
+The five-minute baseline is a human/operator requirement observed on the
+monitor and dashboards; no software in this slice measures or attests the five
+minutes, and a sixty-second result can never demonstrate it. For five
+uninterrupted minutes before scheduling load, require:
+
+- the monitor status to remain `PASS` and refresh at least every fifteen
+  seconds (which includes: Listener staging readiness, stream health and live
+  readiness all passing; the deployed decoded canary at `1`; zero firing
+  Prometheus rules; Alertmanager ready with zero active non-silenced alerts;
+  no container restart or OOM event);
+- CPU below 50%, memory below 70%, root free space above 30%;
+- TCP retransmits below 1%, zero interface errors/drops and egress below
+  1.5 Gbit/s.
+
+Any failed sample resets the five-minute baseline. Do not continue by treating
+a recovered failure as part of the same clean baseline.
+
+## Signed manifest and external decoded canary
+
+After the clean baseline, mint a new origin playlist signature on the staging
+control plane using the existing root-only signing secret. Put only the signed
+URL in `/secure/listener-smoke-manifest-url` on the external generator, a
+regular file at exactly mode `0600` (not a symlink). The URL must be written
+less than thirty seconds before the wrapper starts, use the canonical
+`/v1/hls/<artifact>/live.m3u8` path and remain valid through the end of the
+65-second ramp-plus-soak.
+
+Run the external canary on the same generator host. It fetches the attested
+manifest and uses FFmpeg to decode six seconds; it never prints a URL or
+decoder error:
+
+```bash
+node tools/early-birds-hls-load/external-decoded-canary.mjs \
+  --manifest-url-file /secure/listener-smoke-manifest-url \
+  --status-file /secure/listener-smoke-canary.json
+```
+
+Require a fresh `PASS`, decoded seconds at least six and manifest age at most
+eighteen seconds before starting the load. Keep the process running throughout
+the load. Stop it after the load completes; the five-minute recovery continues
+to use the target monitor and deployed canary.
+
+## Dry-run and sixty-second network run
+
+Choose one run ID and a UTC start far enough ahead to complete the dry-run,
+mint/distribute the signed URL and obtain a passing external canary. The network
+start must still be within the short signed-URL lifetime.
+
+```bash
+node tools/early-birds-hls-load/run-staging-smoke.mjs \
+  --run-id listener-smoke-YYYYMMDD-a \
+  --start-at YYYY-MM-DDTHH:MM:SS.000Z \
+  --evidence /secure/listener-smoke-plan.json \
+  --dry-run
+```
+
+Copy the exact printed confirmation. Record the numeric UTC offset from
+`timedatectl timesync-status`; its absolute value must be at most 100 ms. Use a
+new evidence path for the network run:
+
+```bash
+EARLY_BIRDS_GENERATOR_ROLE=external-load-generator \
+node tools/early-birds-hls-load/run-staging-smoke.mjs \
+  --run-id listener-smoke-YYYYMMDD-a \
+  --start-at YYYY-MM-DDTHH:MM:SS.000Z \
+  --evidence /secure/listener-smoke-result.json \
+  --manifest-url-file /secure/listener-smoke-manifest-url \
+  --canary-status-file /secure/listener-smoke-canary.json \
+  --monitor-status-file /secure/listener-smoke-monitor.json \
+  --clock-offset-ms MEASURED_OFFSET \
+  --confirm 'EXACT DRY-RUN CONFIRMATION'
+```
+
+## Immediate abort thresholds
+
+The generator operator sends `SIGINT` immediately when any condition below is
+observed. The monitor evaluates the same thresholds on every sample and the
+wrapper re-verifies them from the monitor status, so a breached threshold also
+aborts the wrapper automatically. Do not wait for an alert's `for` interval:
+
+- staging readiness, stream health, live readiness or either canary fails;
+- any Prometheus rule fires, or Alertmanager shows any active non-silenced
+  alert or is not ready;
+- request errors or rebuffer-equivalent fetch misses exceed 1%;
+- manifest p95 exceeds 1 second or segment p95 exceeds 2 seconds;
+- any generator scheduling miss, manifest sequence regression, playlist-window
+  miss, signed-URL failure or allowlist escape;
+- host CPU reaches 50%, memory 70%, root free space falls to 30%;
+- egress reaches 1.5 Gbit/s, TCP retransmits reach 1%, or the interface reports
+  any error/drop;
+- the isolated Listener or origin container restarts or records an OOM event;
+- any event/live degradation or doubt about event safety.
+
+The wrapper also aborts automatically, exactly once, when its external canary
+or target monitor status becomes failing/stale. Automatic abort does not
+replace the target observer.
+
+## Five-minute recovery and decision
+
+The five-minute recovery is likewise a human/operator requirement. After load
+exits, stop the external decoded-canary loop and keep the target monitor
+running for five minutes. Require all baseline signals to remain clean, the
+deployed decoded canary to remain `1`, zero new container restarts or OOM
+events and no delayed Telegram alert. Aggregate and review the mode-`0600`
+evidence only after that recovery window.
+
+The target observer records `GO` only when the shard evidence is `PASS`, all
+ten clients complete, scheduling misses are zero, latency/error/fetch gates
+pass, and both the human-observed five-minute baseline and five-minute
+recovery were clean. Otherwise record `NO-GO`, retain the redacted evidence,
+and do not increase load. A `PASS` from the software alone is never a `GO`.
+
+Before any larger run, add and review intermediate profiles. The required order
+starts 10 → 50 → 100 → 250; each step needs its own narrower policy, external
+generators with measured ingress capacity, and a separate monitored go/no-go.

--- a/docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
+++ b/docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
@@ -1,5 +1,11 @@
 # First external Listener HLS smoke
 
+**Status: code-complete but runtime-blocked. This smoke is not ready to
+execute.** The fail-closed harness, monitor, canary and policy are complete and
+tested, but the restart/OOM preflight blocker below is unresolved on `mona`:
+no supported per-container restart/OOM observer exists yet. No monitored smoke
+may run until one is implemented and verified (see "Runtime blocker" below).
+
 This is the only approved first network step for Listener capacity evidence. It
 drives exactly ten media-plane clients from one external host for a sixty-second
 soak. It is media-plane evidence only: it is not end-to-end Listener capacity
@@ -86,59 +92,74 @@ monitor never infers Alertmanager health from Prometheus.
 
 ### Restart/OOM preflight blocker
 
-The restart/OOM baseline requires cAdvisor `container_start_time_seconds` and
-`container_oom_events_total` for exactly
+The restart/OOM baseline requires per-container `container_start_time_seconds`
+and `container_oom_events_total` series (currently expected from cAdvisor) for
+exactly
 `earlybirds-preview-listener-1` and `earlybirds-preview-beacon-stream-1`, each
 resolving to exactly one finite series. Before scheduling load, run the monitor
 with `--once` (it probes twice: baseline plus verification) and confirm a
 `PASS` status with `restartBaselineEstablished: true`,
 `containerRestartsObserved: 0` and `oomEventsDelta: 0`. If those container
 metrics are absent or ambiguous, the monitor keeps reporting `FAIL` — that is
-the exact preflight blocker. Resolve it on the observability stack first; the
-monitor never silently claims zero restarts. Because the baseline is
+the exact preflight blocker, and it is currently unresolved on `mona` (see
+"Runtime blocker" below). The monitor never silently claims zero restarts.
+Because the baseline is
 in-process, a restarted monitor reports `FAIL` again until it has re-established
 and verified a fresh baseline, and the wrapper rejects such a status.
 
-### Actual-mona preflight: per-container cAdvisor series
+### Runtime blocker: no supported per-container restart/OOM observer
 
 Verified on `mona` (read-only inspection): Prometheus currently exposes **only
 the root cgroup** for `container_start_time_seconds` and
 `container_oom_events_total`; the exact Listener/origin queries return empty
 vectors. cAdvisor logs repeatedly report that it cannot find
-`/rootfs/var/lib/docker/image/overlayfs/.../mount-id`. The cause is that the
-cAdvisor `/:/rootfs` bind lacked recursive slave propagation after the Docker
-storage topology changed, so storage-driver mounts never became visible inside
-the container. The checked-in fix mounts `/:/rootfs:ro,rslave` (the same
-propagation node-exporter already uses); it changes only the isolated
-observability cAdvisor container and no event or runtime container.
+`/rootfs/var/lib/docker/image/overlayfs/layerdb/mounts/.../mount-id`.
 
-Until that fix is running on `mona`, the ten-client smoke **cannot start**: the
+An earlier diagnosis blamed missing recursive slave propagation on the
+cAdvisor `/:/rootfs` bind. An independent audit **disproved** it:
+
+- the running cAdvisor container already has `/` -> `/rootfs` with
+  `Propagation=rslave` and still hits the `mount-id` errors;
+- Docker 29.6.2 on `mona` uses the containerd image store
+  (`driver-type=io.containerd.snapshotter.v1`, `Driver=overlayfs`);
+- `/var/lib/docker/image` has no legacy `layerdb`, and
+  `docker inspect .GraphDriver` is null.
+
+The actual cause is that the current cAdvisor is incompatible with Docker's
+containerd image store for these per-container series. Mount propagation was
+never the problem, and the incorrect checked-in rslave change has been
+reverted. **Recreating or restarting cAdvisor is not a fix and must never be
+treated as one** — with any mount propagation flag it keeps exposing only the
+root cgroup for these series.
+
+Therefore the ten-client smoke **cannot start** and stays blocked: the
 monitor's exact container queries return empty vectors, every probe reports
 `FAIL`, and the wrapper refuses the network run. There is no fallback — no
-Docker CLI/API read, no inferred zero, no weakened restart/OOM evidence.
+Docker CLI/API read, no inferred zero, no weakened restart/OOM evidence. No
+monitored smoke may run until a supported, read-only per-container
+restart/OOM observer is implemented and verified on `mona`. Candidate options
+are listed in `ops/early-birds/runbook/README.md` ("Per-container restart/OOM
+observability blocker"); none may be implemented, restarted or deployed
+without explicit operational approval.
 
-Before any load, the operator must:
+Only after such an observer is deployed and verified, the operator confirms —
+through the loopback SSH tunnel — that each of the four exact queries returns
+exactly one finite series, not an empty vector:
 
-1. Obtain explicit human approval and recreate **only** cAdvisor on `mona`
-   (see `ops/early-birds/runbook/README.md`, "cAdvisor mount propagation").
-   Do not recreate Prometheus, Alertmanager, node-exporter, the canary or any
-   event/runtime container.
-2. Through the loopback SSH tunnel, confirm each of the four exact queries
-   returns exactly one finite series, not an empty vector:
+```bash
+for query in \
+  'container_start_time_seconds{name="earlybirds-preview-listener-1"}' \
+  'container_start_time_seconds{name="earlybirds-preview-beacon-stream-1"}' \
+  'container_oom_events_total{name="earlybirds-preview-listener-1"}' \
+  'container_oom_events_total{name="earlybirds-preview-beacon-stream-1"}'
+do
+  curl -fsS 'http://127.0.0.1:19090/api/v1/query' --get --data-urlencode "query=$query"
+done
+```
 
-   ```bash
-   for query in \
-     'container_start_time_seconds{name="earlybirds-preview-listener-1"}' \
-     'container_start_time_seconds{name="earlybirds-preview-beacon-stream-1"}' \
-     'container_oom_events_total{name="earlybirds-preview-listener-1"}' \
-     'container_oom_events_total{name="earlybirds-preview-beacon-stream-1"}'
-   do
-     curl -fsS 'http://127.0.0.1:19090/api/v1/query' --get --data-urlencode "query=$query"
-   done
-   ```
-3. Only then run the monitor `--once` preflight above. An empty vector at any
-   step is a hard blocker: stop and resolve observability first; never treat
-   missing series as zero restarts or zero OOM events.
+Only then run the monitor `--once` preflight above. An empty vector at any
+step is a hard blocker: stop and resolve observability first; never treat
+missing series as zero restarts or zero OOM events.
 
 ## Five-minute baseline
 
@@ -201,6 +222,15 @@ node tools/early-birds-hls-load/run-staging-smoke.mjs \
 Copy the exact printed confirmation. Record the numeric UTC offset from
 `timedatectl timesync-status`; its absolute value must be at most 100 ms. Use a
 new evidence path for the network run:
+
+The network wrapper serializes runs for the same Unix account through the one
+non-configurable host path
+`/tmp/harmonic-beacon-listener-smoke-10-network-run.lock`. A present lock —
+active, stale or ambiguous — refuses the run before preflight or child spawn.
+After verifying that no wrapper is running, an operator may remove a stale
+lock before the rehearsal; never remove or replace it while a run is active.
+This is local coordination, not cross-host attestation: procedure must still
+authorize exactly one generator host.
 
 ```bash
 EARLY_BIRDS_GENERATOR_ROLE=external-load-generator \

--- a/ops/early-birds/runbook/README.md
+++ b/ops/early-birds/runbook/README.md
@@ -58,6 +58,63 @@ critical threshold, persistent 5xx/rebuffer evidence, retransmits ≥1%, or a
 healthy origin whose direct egress remains the bottleneck. It is not activated
 solely from an advertised NIC speed.
 
+## Per-container restart/OOM observability blocker
+
+Per-container `container_start_time_seconds` and `container_oom_events_total`
+series for the isolated Listener and origin containers are a hard prerequisite
+for the Listener external smoke (see
+`docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md`). On `mona`, Prometheus
+currently exposes only the root cgroup for these series and the exact
+per-container queries return empty vectors; cAdvisor logs that it cannot find
+`/rootfs/var/lib/docker/image/overlayfs/layerdb/mounts/.../mount-id`.
+
+An earlier change blamed missing recursive slave propagation on the cAdvisor
+`/:/rootfs` bind and was **reverted as incorrect**: an independent audit showed
+the running cAdvisor container already has `/` -> `/rootfs` with
+`Propagation=rslave` and still hits the same errors. Docker 29.6.2 on `mona`
+uses the containerd image store (`driver-type=io.containerd.snapshotter.v1`,
+`Driver=overlayfs`); `/var/lib/docker/image` has no legacy `layerdb` and
+`docker inspect .GraphDriver` is null. The real cause is that the current
+cAdvisor is incompatible with Docker's containerd image store for these
+per-container series.
+
+**Recreating or restarting cAdvisor is not a fix and must never be proposed or
+treated as one** — no mount propagation flag changes this. No monitored smoke
+may run until a supported, read-only per-container restart/OOM observer is
+implemented and verified on `mona`. Until then the smoke stays
+runtime-blocked (its harness is code-complete and fails closed on the missing
+series).
+
+Candidate future options, for evaluation only — none may be implemented,
+restarted or deployed without explicit operational approval:
+
+1. A minimal read-only Docker Engine observer that watches the Engine event
+   stream and container state (restart counts, OOM-killed status) for exactly
+   the isolated Listener and origin containers and exports the required
+   Prometheus series. This needs read-only access to the Docker socket, which
+   is root-equivalent on the host, so it is acceptable only with an explicit
+   threat model: dedicated least-privilege observer, read-only socket mount,
+   no write API calls.
+2. A proven containerd-compatible per-container collector — for example a
+   cAdvisor release verified against the containerd image store, or a
+   containerd-native metrics source — validated read-only in a throwaway
+   container on `mona` before any change to the checked-in observability
+   stack.
+3. Any other observer only if it keeps the same fail-closed contract: exactly
+   one finite series per exact container query, no inferred zeros, no
+   weakened restart/OOM evidence.
+
+Whatever is chosen, verification is unchanged: the four exact per-container
+queries must each return exactly one finite series before any load, and empty
+vectors remain a hard blocker, never a reason to proceed.
+
+The bounded ten-client wrapper also requires its fixed local lock at
+`/tmp/harmonic-beacon-listener-smoke-10-network-run.lock`. The path has no CLI
+or environment override. A pre-existing lock refuses the run; verify no
+wrapper is active before removing a stale one, and never manipulate it during
+a run. This serializes one trusted Unix account on one generator only; it does
+not enforce a global limit across hosts.
+
 ## Stop switch and rollback
 
 To stop only the EarlyBird stream origin:

--- a/tools/early-birds-hls-load/README.md
+++ b/tools/early-birds-hls-load/README.md
@@ -46,7 +46,8 @@ runtime code.
 - Whole-run request-error and fetch-miss tolerances cannot exceed 10%; derived
   rolling-window gates are capped at 20% and in-run circuit breakers at 25%,
   regardless of a custom profile.
-- The signed manifest URL lives only in a group/world-inaccessible file. That
+- The signed manifest URL lives only in a regular file at exactly mode `0600`
+  (never a symlink or device), bounded in size. That
   file is refreshed from disk at least once per second so a separate approved control
   plane can rotate short-lived URLs without giving the harness a signing key.
 - Every staging shard records an externally measured UTC clock offset within
@@ -103,6 +104,22 @@ contains runtime measurements or claims a network request.
 See [`docs/ops/EARLY_BIRDS_HLS_LOAD_SOAK.md`](../../docs/ops/EARLY_BIRDS_HLS_LOAD_SOAK.md)
 for the distributed procedure, stop conditions and evidence interpretation.
 
+The first real request is deliberately narrower than the general harness. Use
+`run-staging-smoke.mjs` and the checked-in `listener-staging-smoke-10` policy;
+that wrapper fixes the exact origin, ten clients, one shard and sixty-second
+soak. A staging network invocation also requires a fresh private signed
+manifest file plus continuously refreshed external decoded-canary and target
+monitor status files, all exactly mode `0600` regular files produced on the
+same external host as the wrapper. The target monitor queries Alertmanager
+(`--alertmanager-url`, default `http://127.0.0.1:19093`) and Prometheus
+(`--prometheus-url`, default `http://127.0.0.1:19090`) through separate
+uncredentialed loopback SSH tunnels, evaluates the immediate host thresholds
+directly and maintains an in-process restart/OOM baseline for the isolated
+Listener and origin containers. The wrapper polls both status files every two
+seconds and aborts the load child exactly once on the first failing or stale
+check. See
+[`LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md`](../../docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md).
+
 ## Development verification
 
 ```bash
@@ -115,5 +132,6 @@ ranges and declared gaps. It rejects master playlists, encrypted media and
 LL-HLS parts instead of silently undercounting them; this says nothing about the
 opaque media encoding.
 
-The test suite uses only a tiny loopback synthetic origin. It never contacts
-staging, production, DNS or external media.
+The test suite uses only a tiny loopback synthetic origin plus in-process fake
+HTTP responders for the Prometheus/Alertmanager monitor probes. It never
+contacts staging, production, DNS or external media.

--- a/tools/early-birds-hls-load/external-decoded-canary.mjs
+++ b/tools/early-birds-hls-load/external-decoded-canary.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { decodeManifest, parseManifest } from '../../ops/early-birds/canary/canary-exporter.mjs';
+import { assertAllowedUrl } from './src/contracts.mjs';
+import {
+  EXTERNAL_CANARY_KIND,
+  EXTERNAL_CANARY_ROLE,
+  SIGNED_MANIFEST_MAX_BYTES,
+  SMOKE_ORIGIN,
+  SMOKE_TARGET_ID,
+  assertExternalHost,
+  readPrivateFile,
+  writePrivateJsonAtomic,
+} from './src/smoke-safety.mjs';
+
+function option(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  if (index < 0) return fallback;
+  if (!args[index + 1] || args[index + 1].startsWith('--')) throw new Error(`${name} requires a value`);
+  return args[index + 1];
+}
+
+async function probe(manifestPath, hostHash) {
+  const now = new Date();
+  const base = {
+    schemaVersion: 1,
+    kind: EXTERNAL_CANARY_KIND,
+    role: EXTERNAL_CANARY_ROLE,
+    status: 'FAIL',
+    external: true,
+    targetId: SMOKE_TARGET_ID,
+    targetOrigin: SMOKE_ORIGIN,
+    hostHash,
+    observedAt: now.toISOString(),
+    decodedAudio: false,
+    decodedSeconds: 0,
+    manifestAgeSeconds: null,
+  };
+  try {
+    const { text } = await readPrivateFile(manifestPath, 'signed manifest', SIGNED_MANIFEST_MAX_BYTES);
+    const manifestUrl = text.trim();
+    assertAllowedUrl(manifestUrl, [SMOKE_ORIGIN]);
+    const response = await fetch(manifestUrl, {
+      cache: 'no-store',
+      redirect: 'error',
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error('manifest unavailable');
+    if (response.headers.get('x-harmonic-beacon-environment') !== 'early-birds-staging') {
+      throw new Error('staging attestation missing');
+    }
+    const manifest = await response.text();
+    const { manifestAgeSeconds } = parseManifest(manifest);
+    await decodeManifest(manifest);
+    return {
+      ...base,
+      status: manifestAgeSeconds <= 18 ? 'PASS' : 'FAIL',
+      observedAt: new Date().toISOString(),
+      decodedAudio: true,
+      decodedSeconds: 6,
+      manifestAgeSeconds,
+    };
+  } catch {
+    return { ...base, observedAt: new Date().toISOString() };
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const known = new Set(['--manifest-url-file', '--status-file', '--interval-ms', '--once']);
+  for (const argument of args.filter((value) => value.startsWith('--'))) {
+    if (!known.has(argument)) throw new Error(`unknown option ${argument}`);
+  }
+  const manifestPath = option(args, '--manifest-url-file');
+  const statusPath = option(args, '--status-file');
+  const intervalMs = Number(option(args, '--interval-ms', '30000'));
+  if (!manifestPath || !statusPath) throw new Error('--manifest-url-file and --status-file are required');
+  if (!Number.isSafeInteger(intervalMs) || intervalMs < 5_000 || intervalMs > 30_000) {
+    throw new Error('--interval-ms must be between 5000 and 30000');
+  }
+  const hostHash = assertExternalHost();
+  let stopping = false;
+  process.once('SIGINT', () => { stopping = true; });
+  process.once('SIGTERM', () => { stopping = true; });
+  do {
+    const status = await probe(manifestPath, hostHash);
+    await writePrivateJsonAtomic(statusPath, status);
+    process.stdout.write(`External decoded canary: ${status.status}\n`);
+    if (args.includes('--once')) break;
+    await delay(intervalMs, undefined, { ref: true });
+  } while (!stopping);
+}
+
+main().catch((error) => {
+  process.stderr.write(`External decoded canary refused: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/tools/early-birds-hls-load/external-target-monitor.mjs
+++ b/tools/early-birds-hls-load/external-target-monitor.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { assertExternalHost, writePrivateJsonAtomic } from './src/smoke-safety.mjs';
+import { createContainerBaseline, loopbackTunnelOrigin, probeMonitor } from './src/target-probe.mjs';
+
+function option(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  if (index < 0) return fallback;
+  if (!args[index + 1] || args[index + 1].startsWith('--')) throw new Error(`${name} requires a value`);
+  return args[index + 1];
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const known = new Set([
+    '--prometheus-url', '--alertmanager-url', '--status-file', '--interval-ms', '--once',
+  ]);
+  for (const argument of args.filter((value) => value.startsWith('--'))) {
+    if (!known.has(argument)) throw new Error(`unknown option ${argument}`);
+  }
+  const statusPath = option(args, '--status-file');
+  const prometheus = loopbackTunnelOrigin(
+    option(args, '--prometheus-url', 'http://127.0.0.1:19090'),
+    'Prometheus',
+  );
+  const alertmanager = loopbackTunnelOrigin(
+    option(args, '--alertmanager-url', 'http://127.0.0.1:19093'),
+    'Alertmanager',
+  );
+  const intervalMs = Number(option(args, '--interval-ms', '5000'));
+  if (!statusPath) throw new Error('--status-file is required');
+  if (!Number.isSafeInteger(intervalMs) || intervalMs < 2_000 || intervalMs > 10_000) {
+    throw new Error('--interval-ms must be between 2000 and 10000');
+  }
+  const hostHash = assertExternalHost();
+  const baseline = createContainerBaseline();
+  let stopping = false;
+  process.once('SIGINT', () => { stopping = true; });
+  process.once('SIGTERM', () => { stopping = true; });
+  // A passing status requires an established restart/OOM baseline verified by
+  // a later matching sample, so --once deliberately probes twice.
+  const minimumProbes = args.includes('--once') ? 2 : 1;
+  let probes = 0;
+  do {
+    const status = await probeMonitor({
+      prometheusOrigin: prometheus,
+      alertmanagerOrigin: alertmanager,
+      hostHash,
+      baseline,
+    });
+    await writePrivateJsonAtomic(statusPath, status);
+    process.stdout.write(`External target monitor: ${status.status}\n`);
+    probes += 1;
+    if (args.includes('--once') && probes >= minimumProbes) break;
+    await delay(intervalMs, undefined, { ref: true });
+  } while (!stopping);
+}
+
+main().catch((error) => {
+  process.stderr.write(`External target monitor refused: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/tools/early-birds-hls-load/package.json
+++ b/tools/early-birds-hls-load/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "External, bounded, format-neutral HLS load and soak evidence harness",
   "scripts": {
-    "check": "node --check run.mjs && node --check aggregate.mjs && node --check verify-planned.mjs && node --check src/contracts.mjs && node --check src/runner.mjs",
+    "check": "node --check run.mjs && node --check run-staging-smoke.mjs && node --check external-decoded-canary.mjs && node --check external-target-monitor.mjs && node --check aggregate.mjs && node --check verify-planned.mjs && node --check src/contracts.mjs && node --check src/runner.mjs && node --check src/smoke-safety.mjs && node --check src/target-probe.mjs && node --check src/smoke-guard.mjs",
     "test": "node --test test/*.test.mjs"
   },
   "engines": {

--- a/tools/early-birds-hls-load/package.json
+++ b/tools/early-birds-hls-load/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "External, bounded, format-neutral HLS load and soak evidence harness",
   "scripts": {
-    "check": "node --check run.mjs && node --check run-staging-smoke.mjs && node --check external-decoded-canary.mjs && node --check external-target-monitor.mjs && node --check aggregate.mjs && node --check verify-planned.mjs && node --check src/contracts.mjs && node --check src/runner.mjs && node --check src/smoke-safety.mjs && node --check src/target-probe.mjs && node --check src/smoke-guard.mjs",
+    "check": "node --check run.mjs && node --check run-staging-smoke.mjs && node --check external-decoded-canary.mjs && node --check external-target-monitor.mjs && node --check aggregate.mjs && node --check verify-planned.mjs && node --check src/contracts.mjs && node --check src/runner.mjs && node --check src/smoke-safety.mjs && node --check src/target-probe.mjs && node --check src/smoke-guard.mjs && node --check src/network-run-lock.mjs",
     "test": "node --test test/*.test.mjs"
   },
   "engines": {

--- a/tools/early-birds-hls-load/policies/listener-staging-smoke-10.json
+++ b/tools/early-birds-hls-load/policies/listener-staging-smoke-10.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "targets": [
+    {
+      "id": "listener-staging-smoke-10",
+      "environment": "staging",
+      "production": false,
+      "attestation": {
+        "header": "x-harmonic-beacon-environment",
+        "value": "early-birds-staging"
+      },
+      "origins": [
+        "https://stream.harmonicbeacon.com"
+      ],
+      "limits": {
+        "maxClients": 10,
+        "maxRampPerSecond": 2,
+        "maxSoakSeconds": 60,
+        "maxShardCount": 1,
+        "minManifestIntervalMs": 3000,
+        "maxInflightPerShard": 16,
+        "maxSegmentsPerPoll": 6,
+        "maxRequestsPerSecond": 28,
+        "maxManifestBytes": 262144,
+        "maxSegmentBytes": 4194304,
+        "maxClockOffsetMs": 100
+      }
+    }
+  ]
+}

--- a/tools/early-birds-hls-load/run-staging-smoke.mjs
+++ b/tools/early-birds-hls-load/run-staging-smoke.mjs
@@ -6,6 +6,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { buildPlan, selectTarget } from './src/contracts.mjs';
+import { acquireNetworkRunLock, NETWORK_RUN_LOCK_PATH } from './src/network-run-lock.mjs';
 import { startStatusGuard } from './src/smoke-guard.mjs';
 import {
   SIGNED_MANIFEST_MAX_BYTES,
@@ -37,6 +38,12 @@ For the exact ten-client network smoke, remove --dry-run and add:
 
 This wrapper fixes the target, origin, profile and shard count. It cannot run
 more than ten clients or target any host other than the isolated stream origin.
+A network run first takes an exclusive local lock on this generator host, so two
+wrappers on the same host and Unix account cannot overlap. Its one absolute
+path is not configurable; the lock is refused — never deleted — when it is
+already held or stale. Do not manually remove or replace it during a run.
+The lock is local to one host: a single trusted authorized generator is an
+operational precondition that this code cannot enforce across hosts.
 `);
 }
 
@@ -121,48 +128,82 @@ async function main() {
     '--evidence', resolve(evidence),
   ];
   let guard = null;
-  let child;
-  if (dryRun) {
-    childArgs.push('--dry-run');
-  } else {
-    const manifestPath = option(args, '--manifest-url-file');
-    const canaryPath = option(args, '--canary-status-file');
-    const monitorPath = option(args, '--monitor-status-file');
-    const clockOffset = option(args, '--clock-offset-ms');
-    const confirmation = option(args, '--confirm');
-    if (!manifestPath || !canaryPath || !monitorPath || clockOffset === null || !confirmation) {
-      throw new Error('network smoke requires signed manifest, external canary, target monitor, clock offset and confirmation');
+  let child = null;
+  let lock = null;
+  let signalName = null;
+  const onSignal = (name) => {
+    if (signalName) return;
+    signalName = name;
+    // Stop the guard first so an in-flight status check can never abort or
+    // kill during shutdown; then forward the interrupt to the load child.
+    guard?.stop();
+    child?.kill('SIGINT');
+  };
+  try {
+    if (dryRun) {
+      childArgs.push('--dry-run');
+    } else {
+      const manifestPath = option(args, '--manifest-url-file');
+      const canaryPath = option(args, '--canary-status-file');
+      const monitorPath = option(args, '--monitor-status-file');
+      const clockOffset = option(args, '--clock-offset-ms');
+      const confirmation = option(args, '--confirm');
+      if (!manifestPath || !canaryPath || !monitorPath || clockOffset === null || !confirmation) {
+        throw new Error('network smoke requires signed manifest, external canary, target monitor, clock offset and confirmation');
+      }
+      // The exclusive local lock is taken before any precondition read or
+      // child spawn and is held through child exit and guard stop, so two
+      // wrappers on this host can never overlap a network run. A held, stale
+      // or ambiguous lock refuses the run; it is never deleted by a non-owner.
+      lock = await acquireNetworkRunLock({
+        path: NETWORK_RUN_LOCK_PATH,
+        runId,
+      });
+      process.on('SIGINT', onSignal);
+      process.on('SIGTERM', onSignal);
+      await readPreconditions({
+        manifestPath,
+        canaryPath,
+        monitorPath,
+        plan,
+        target,
+        checkFileFreshness: true,
+      });
+      childArgs.push(
+        '--manifest-url-file', resolve(manifestPath),
+        '--clock-offset-ms', clockOffset,
+        '--confirm', confirmation,
+        '--external-generator',
+      );
+      guard = startStatusGuard({
+        check: () => readPreconditions({ manifestPath, canaryPath, monitorPath, plan, target }),
+        onAbort: () => child?.kill('SIGINT'),
+      });
     }
-    await readPreconditions({
-      manifestPath,
-      canaryPath,
-      monitorPath,
-      plan,
-      target,
-      checkFileFreshness: true,
+    if (signalName) {
+      // Interrupted between lock acquisition and spawn: no load ever started.
+      process.exitCode = 130;
+      return;
+    }
+    child = spawn(process.execPath, childArgs, { stdio: 'inherit', env: process.env });
+    // A guard abort between precondition validation and spawn is delivered here,
+    // so the child can never run unguarded after a failed status.
+    if (guard?.aborted) child.kill('SIGINT');
+    const exitCode = await new Promise((resolveExit, reject) => {
+      child.once('error', reject);
+      child.once('exit', (code, signal) => resolveExit(code ?? (signal ? 130 : 1)));
     });
-    childArgs.push(
-      '--manifest-url-file', resolve(manifestPath),
-      '--clock-offset-ms', clockOffset,
-      '--confirm', confirmation,
-      '--external-generator',
-    );
-    guard = startStatusGuard({
-      check: () => readPreconditions({ manifestPath, canaryPath, monitorPath, plan, target }),
-      onAbort: () => child?.kill('SIGINT'),
-    });
+    if (guard) guard.stop();
+    process.exitCode = signalName ? 130 : exitCode;
+  } finally {
+    // Deterministic cleanup on every path — validation error, spawn error,
+    // signal/abort and normal exit: park the guard, drop the signal handlers
+    // and release only the lock this process owns.
+    guard?.stop();
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
+    if (lock) await lock.release();
   }
-
-  child = spawn(process.execPath, childArgs, { stdio: 'inherit', env: process.env });
-  // A guard abort between precondition validation and spawn is delivered here,
-  // so the child can never run unguarded after a failed status.
-  if (guard?.aborted) child.kill('SIGINT');
-  const exitCode = await new Promise((resolveExit, reject) => {
-    child.once('error', reject);
-    child.once('exit', (code, signal) => resolveExit(code ?? (signal ? 130 : 1)));
-  });
-  if (guard) guard.stop();
-  process.exitCode = exitCode;
 }
 
 main().catch((error) => {

--- a/tools/early-birds-hls-load/run-staging-smoke.mjs
+++ b/tools/early-birds-hls-load/run-staging-smoke.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildPlan, selectTarget } from './src/contracts.mjs';
+import { startStatusGuard } from './src/smoke-guard.mjs';
+import {
+  SIGNED_MANIFEST_MAX_BYTES,
+  SMOKE_TARGET_ID,
+  readJsonStatus,
+  readPrivateFile,
+  validateNetworkSmokePreconditions,
+} from './src/smoke-safety.mjs';
+
+const toolRoot = dirname(fileURLToPath(import.meta.url));
+const policyPath = resolve(toolRoot, 'policies/listener-staging-smoke-10.json');
+const profilesPath = resolve(toolRoot, 'profiles.json');
+
+function option(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  if (index < 0) return fallback;
+  if (!args[index + 1] || args[index + 1].startsWith('--')) throw new Error(`${name} requires a value`);
+  return args[index + 1];
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node tools/early-birds-hls-load/run-staging-smoke.mjs \\
+    --run-id RUN_ID --start-at UTC --evidence PATH --dry-run
+
+For the exact ten-client network smoke, remove --dry-run and add:
+  --manifest-url-file FILE --canary-status-file FILE --monitor-status-file FILE \\
+  --clock-offset-ms NUMBER --confirm "EXACT DRY-RUN CONFIRMATION"
+
+This wrapper fixes the target, origin, profile and shard count. It cannot run
+more than ten clients or target any host other than the isolated stream origin.
+`);
+}
+
+async function readDocuments() {
+  const [policy, profiles] = await Promise.all([
+    readFile(policyPath, 'utf8').then(JSON.parse),
+    readFile(profilesPath, 'utf8').then(JSON.parse),
+  ]);
+  return { policy, profiles };
+}
+
+async function readPreconditions({
+  manifestPath,
+  canaryPath,
+  monitorPath,
+  plan,
+  target,
+  checkFileFreshness = false,
+}) {
+  const [{ text, details }, canaryStatus, monitorStatus] = await Promise.all([
+    readPrivateFile(manifestPath, 'signed manifest', SIGNED_MANIFEST_MAX_BYTES),
+    readJsonStatus(canaryPath, 'external decoded canary status'),
+    readJsonStatus(monitorPath, 'target monitor status'),
+  ]);
+  const values = {
+    plan,
+    target,
+    manifest: {
+      value: text.trim(),
+      writtenAtMs: checkFileFreshness ? details.mtimeMs : null,
+    },
+    canaryStatus,
+    monitorStatus,
+  };
+  validateNetworkSmokePreconditions(values);
+  return values;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    return;
+  }
+  const known = new Set([
+    '--run-id', '--start-at', '--evidence', '--dry-run', '--manifest-url-file',
+    '--canary-status-file', '--monitor-status-file', '--clock-offset-ms', '--confirm',
+  ]);
+  for (const argument of args.filter((value) => value.startsWith('--'))) {
+    if (!known.has(argument)) throw new Error(`unknown option ${argument}`);
+  }
+  const dryRun = args.includes('--dry-run');
+  const runId = option(args, '--run-id');
+  const startAt = option(args, '--start-at');
+  const evidence = option(args, '--evidence');
+  if (!runId || !startAt || !evidence) throw new Error('--run-id, --start-at and --evidence are required');
+
+  const { policy, profiles } = await readDocuments();
+  const target = selectTarget(policy, SMOKE_TARGET_ID);
+  const profile = profiles.profiles?.['staging-smoke'];
+  const plan = buildPlan({
+    runId,
+    profileName: 'staging-smoke',
+    profile,
+    target,
+    shardIndex: 0,
+    shardCount: 1,
+    startAt,
+    networkRun: !dryRun,
+  });
+
+  const childArgs = [
+    resolve(toolRoot, 'run.mjs'),
+    '--profiles', profilesPath,
+    '--policy', policyPath,
+    '--target', SMOKE_TARGET_ID,
+    '--profile', 'staging-smoke',
+    '--run-id', runId,
+    '--start-at', startAt,
+    '--shard-index', '0',
+    '--shard-count', '1',
+    '--evidence', resolve(evidence),
+  ];
+  let guard = null;
+  let child;
+  if (dryRun) {
+    childArgs.push('--dry-run');
+  } else {
+    const manifestPath = option(args, '--manifest-url-file');
+    const canaryPath = option(args, '--canary-status-file');
+    const monitorPath = option(args, '--monitor-status-file');
+    const clockOffset = option(args, '--clock-offset-ms');
+    const confirmation = option(args, '--confirm');
+    if (!manifestPath || !canaryPath || !monitorPath || clockOffset === null || !confirmation) {
+      throw new Error('network smoke requires signed manifest, external canary, target monitor, clock offset and confirmation');
+    }
+    await readPreconditions({
+      manifestPath,
+      canaryPath,
+      monitorPath,
+      plan,
+      target,
+      checkFileFreshness: true,
+    });
+    childArgs.push(
+      '--manifest-url-file', resolve(manifestPath),
+      '--clock-offset-ms', clockOffset,
+      '--confirm', confirmation,
+      '--external-generator',
+    );
+    guard = startStatusGuard({
+      check: () => readPreconditions({ manifestPath, canaryPath, monitorPath, plan, target }),
+      onAbort: () => child?.kill('SIGINT'),
+    });
+  }
+
+  child = spawn(process.execPath, childArgs, { stdio: 'inherit', env: process.env });
+  // A guard abort between precondition validation and spawn is delivered here,
+  // so the child can never run unguarded after a failed status.
+  if (guard?.aborted) child.kill('SIGINT');
+  const exitCode = await new Promise((resolveExit, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => resolveExit(code ?? (signal ? 130 : 1)));
+  });
+  if (guard) guard.stop();
+  process.exitCode = exitCode;
+}
+
+main().catch((error) => {
+  process.stderr.write(`Ten-client smoke refused: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/tools/early-birds-hls-load/run.mjs
+++ b/tools/early-birds-hls-load/run.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 import { constants } from 'node:fs';
-import { access, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { buildPlan, selectTarget, sha256 } from './src/contracts.mjs';
 import { plannedEvidence, runShard } from './src/runner.mjs';
+import { SIGNED_MANIFEST_MAX_BYTES, readPrivateFile } from './src/smoke-safety.mjs';
 
 const toolRoot = dirname(fileURLToPath(import.meta.url));
 
@@ -88,10 +89,8 @@ async function assertNewFile(path) {
 }
 
 async function readManifestUrl(path) {
-  const details = await stat(path);
-  if (!details.isFile()) throw new Error('manifest URL source must be a regular file');
-  if ((details.mode & 0o077) !== 0) throw new Error('manifest URL source must not be group/world accessible');
-  const value = (await readFile(path, 'utf8')).trim();
+  const { text } = await readPrivateFile(path, 'manifest URL source', SIGNED_MANIFEST_MAX_BYTES);
+  const value = text.trim();
   if (!value || value.includes('\n') || value.includes('\r')) {
     throw new Error('manifest URL source must contain exactly one URL');
   }

--- a/tools/early-birds-hls-load/src/network-run-lock.mjs
+++ b/tools/early-birds-hls-load/src/network-run-lock.mjs
@@ -1,0 +1,89 @@
+// Exclusive local network-run lock for the ten-client Listener smoke.
+//
+// Scope and honest limits: this lock serializes wrapper processes on ONE
+// generator host, so two concurrent wrappers started on the same trusted host
+// can never drive more than the exact ten clients together. It is a local
+// filesystem primitive only: it cannot see, let alone stop, a wrapper on a
+// different host, so it does NOT cryptographically guarantee a global
+// aggregate client limit. A single trusted, authorized generator host remains
+// an operational precondition enforced by procedure and host inspection, not
+// by this code.
+//
+// The primitive is atomic creation (O_EXCL), mode 0600, with no secrets in
+// the file. A pre-existing lock — active, stale or ambiguous — is refused
+// outright: the wrapper never inspects PIDs, never guesses staleness and
+// never deletes a lock it did not create. Only the operator may remove a
+// leftover lock after verifying no smoke is running. During a run, operators
+// must not remove or replace it: release rechecks the exact bytes before
+// unlinking, but Node has no portable FD-scoped unlink/flock that can make a
+// human replacement between those operations impossible.
+
+import { chmod, open, readFile, unlink } from 'node:fs/promises';
+
+export const NETWORK_RUN_LOCK_KIND = 'harmonic-beacon-listener-smoke-network-run-lock';
+/** One host-wide path: production callers cannot select a second lock domain. */
+export const NETWORK_RUN_LOCK_PATH = '/tmp/harmonic-beacon-listener-smoke-10-network-run.lock';
+
+function lockContents({ runId, pid, acquiredAtMs }) {
+  return `${JSON.stringify({
+    schemaVersion: 1,
+    kind: NETWORK_RUN_LOCK_KIND,
+    runId,
+    pid,
+    acquiredAt: new Date(acquiredAtMs).toISOString(),
+  })}\n`;
+}
+
+export async function acquireNetworkRunLock({
+  path,
+  runId,
+  pid = process.pid,
+  acquiredAtMs = Date.now(),
+}) {
+  if (typeof path !== 'string' || path.length === 0) {
+    throw new Error('network run lock path is required');
+  }
+  const contents = lockContents({ runId, pid, acquiredAtMs });
+  let handle;
+  try {
+    handle = await open(path, 'wx', 0o600);
+  } catch (error) {
+    if (error?.code === 'EEXIST') {
+      // Stale or ambiguous state is refused, never resolved: deleting or
+      // reusing a foreign lock could put two concurrent network runs on the
+      // origin. The operator must verify no smoke is running and remove the
+      // file manually.
+      throw new Error(
+        'network run lock already exists on this host; refusing to start: '
+        + 'another smoke wrapper may be active. If none is running, verify '
+        + 'the lock owner is gone and remove the lock file manually',
+      );
+    }
+    throw new Error(`cannot create network run lock: ${error?.message ?? String(error)}`);
+  }
+  try {
+    await handle.writeFile(contents);
+  } finally {
+    await handle.close();
+  }
+  await chmod(path, 0o600);
+  let released = false;
+  return {
+    path,
+    async release() {
+      if (released) return;
+      released = true;
+      let current;
+      try {
+        current = await readFile(path, 'utf8');
+      } catch {
+        return; // Already gone; nothing deterministic left to clean up.
+      }
+      if (current !== contents) {
+        // Replaced or foreign lock: it is not ours to remove.
+        return;
+      }
+      await unlink(path);
+    },
+  };
+}

--- a/tools/early-birds-hls-load/src/smoke-guard.mjs
+++ b/tools/early-birds-hls-load/src/smoke-guard.mjs
@@ -1,6 +1,8 @@
 // Polls the external safety statuses while the load child runs. On the first
 // failed or stale check it aborts exactly once, promptly and deterministically,
-// and never prints status contents or error details.
+// and never prints status contents or error details. stop() parks the guard:
+// no further tick runs and an in-flight check that later rejects emits no
+// abort and never invokes onAbort.
 export function startStatusGuard({
   check,
   onAbort,
@@ -10,16 +12,20 @@ export function startStatusGuard({
   writeImpl = (line) => process.stderr.write(line),
 }) {
   let aborted = false;
+  let stopped = false;
   let busy = false;
   const abort = () => {
-    if (aborted) return;
+    // A check that was already in flight when stop() ran must never emit an
+    // abort or invoke onAbort: the load child has already exited by then and
+    // the wrapper is shutting down cleanly.
+    if (aborted || stopped) return;
     aborted = true;
     clearIntervalImpl(timer);
     writeImpl('Smoke safety status became stale or failed; aborting without printing sensitive details.\n');
     onAbort();
   };
   const tick = () => {
-    if (aborted || busy) return;
+    if (aborted || stopped || busy) return;
     busy = true;
     Promise.resolve()
       .then(check)
@@ -30,10 +36,14 @@ export function startStatusGuard({
   timer.unref?.();
   return {
     stop() {
+      stopped = true;
       clearIntervalImpl(timer);
     },
     get aborted() {
       return aborted;
+    },
+    get stopped() {
+      return stopped;
     },
   };
 }

--- a/tools/early-birds-hls-load/src/smoke-guard.mjs
+++ b/tools/early-birds-hls-load/src/smoke-guard.mjs
@@ -1,0 +1,39 @@
+// Polls the external safety statuses while the load child runs. On the first
+// failed or stale check it aborts exactly once, promptly and deterministically,
+// and never prints status contents or error details.
+export function startStatusGuard({
+  check,
+  onAbort,
+  intervalMs = 2_000,
+  setIntervalImpl = setInterval,
+  clearIntervalImpl = clearInterval,
+  writeImpl = (line) => process.stderr.write(line),
+}) {
+  let aborted = false;
+  let busy = false;
+  const abort = () => {
+    if (aborted) return;
+    aborted = true;
+    clearIntervalImpl(timer);
+    writeImpl('Smoke safety status became stale or failed; aborting without printing sensitive details.\n');
+    onAbort();
+  };
+  const tick = () => {
+    if (aborted || busy) return;
+    busy = true;
+    Promise.resolve()
+      .then(check)
+      .catch(abort)
+      .finally(() => { busy = false; });
+  };
+  const timer = setIntervalImpl(tick, intervalMs);
+  timer.unref?.();
+  return {
+    stop() {
+      clearIntervalImpl(timer);
+    },
+    get aborted() {
+      return aborted;
+    },
+  };
+}

--- a/tools/early-birds-hls-load/src/smoke-safety.mjs
+++ b/tools/early-birds-hls-load/src/smoke-safety.mjs
@@ -214,6 +214,10 @@ export function validateNetworkSmokePreconditions({
   // The canary and monitor status files are read from local disk, so both
   // safety producers must be co-located with this wrapper on one external
   // host. Identical fingerprints on a second host would fail this check too.
+  // The fingerprint is a truncated hostname hash, not a cryptographic
+  // attestation: it catches misplaced producers but cannot prove topology, so
+  // the runbook still requires a trusted operator and external inspection of
+  // the generator host.
   assert(/^[a-f0-9]{12}$/.test(expectedHostHash), 'local host fingerprint is invalid');
   assert(canaryStatus.hostHash === expectedHostHash
     && monitorStatus.hostHash === expectedHostHash,
@@ -230,6 +234,12 @@ export async function readJsonStatus(path, label) {
 }
 
 export function assertExternalHost(host = hostname()) {
+  // Defense-in-depth only, NOT cryptographic topology proof: this rejects
+  // mona-like hostnames and derives a non-cryptographic hash of the local
+  // hostname. It cannot prove where a safety producer really ran — a renamed
+  // or misconfigured host passes silently. A trusted operator plus external
+  // inspection of the generator host (documented in the runbook) remains
+  // required; do not weaken the rejection below.
   const labels = String(host).trim().toLowerCase().replace(/\.+$/, '').split('.');
   assert(!labels.some((label) => label === 'mona' || label.startsWith('mona-')),
     'external safety process is forbidden from mona');

--- a/tools/early-birds-hls-load/src/smoke-safety.mjs
+++ b/tools/early-birds-hls-load/src/smoke-safety.mjs
@@ -1,0 +1,244 @@
+import { constants } from 'node:fs';
+import { chmod, rename, writeFile, access, readFile, lstat } from 'node:fs/promises';
+import { hostname } from 'node:os';
+
+import { assertAllowedUrl, sha256 } from './contracts.mjs';
+
+export const SMOKE_TARGET_ID = 'listener-staging-smoke-10';
+export const SMOKE_ORIGIN = 'https://stream.harmonicbeacon.com';
+export const EXTERNAL_CANARY_KIND = 'harmonic-beacon-external-decoded-canary';
+export const TARGET_MONITOR_KIND = 'harmonic-beacon-listener-target-monitor';
+export const EXTERNAL_CANARY_ROLE = 'decoded-canary';
+export const TARGET_MONITOR_ROLE = 'target-monitor';
+export const CANARY_MAX_AGE_MS = 45_000;
+export const MONITOR_MAX_AGE_MS = 15_000;
+export const SIGNED_MANIFEST_MAX_BYTES = 4_096;
+export const STATUS_MAX_BYTES = 16_384;
+
+// Immediate stop thresholds for the ten-client smoke. The monitor applies them
+// and the wrapper re-verifies them, so neither side can weaken them silently.
+export const MONITOR_THRESHOLDS = Object.freeze({
+  maxCpuUsedRatio: 0.5,
+  maxMemoryUsedRatio: 0.7,
+  minRootFreeRatio: 0.3,
+  maxEgressBitsPerSecond: 1_500_000_000,
+  maxTcpRetransmitRatio: 0.01,
+  maxInterfaceErrorsDrops: 0,
+});
+
+const MAX_ALERT_COUNT = 10_000;
+const MAX_RESTART_OBSERVATIONS = 1_000;
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function parseTimestamp(value, field) {
+  const milliseconds = Date.parse(String(value ?? ''));
+  assert(Number.isFinite(milliseconds), `${field} must be a valid timestamp`);
+  return milliseconds;
+}
+
+export async function readPrivateFile(path, label, maxBytes = STATUS_MAX_BYTES) {
+  assert(typeof path === 'string' && path.length > 0, `${label} file is required`);
+  assert(Number.isSafeInteger(maxBytes) && maxBytes > 0, `${label} size bound is invalid`);
+  try {
+    await access(path, constants.R_OK);
+  } catch {
+    throw new Error(`cannot read ${label} file`);
+  }
+  // lstat never follows a symlink, so a symlink, device or other non-regular
+  // source is refused instead of being silently dereferenced.
+  const details = await lstat(path);
+  assert(details.isFile(), `${label} source must be a regular file, not a symlink or device`);
+  assert((details.mode & 0o777) === 0o600, `${label} source mode must be exactly 0600`);
+  assert(details.size <= maxBytes, `${label} source exceeds the ${maxBytes} byte bound`);
+  return { text: await readFile(path, 'utf8'), details };
+}
+
+export function validateFreshSignedManifest({
+  value,
+  allowedOrigins,
+  nowMs = Date.now(),
+  requiredThroughMs,
+  writtenAtMs = null,
+}) {
+  assert(typeof value === 'string' && value.trim() === value && value.length > 0,
+    'signed manifest file must contain exactly one URL');
+  assert(!value.includes('\n') && !value.includes('\r'),
+    'signed manifest file must contain exactly one URL');
+  const url = assertAllowedUrl(value, allowedOrigins);
+  assert(/^\/v1\/hls\/[a-z0-9][a-z0-9._-]{0,127}\/live\.m3u8$/.test(url.pathname),
+    'signed manifest path is not the canonical media-playlist path');
+  const keys = [...url.searchParams.keys()].sort();
+  assert(JSON.stringify(keys) === JSON.stringify(['exp', 'sig']),
+    'signed manifest must contain only exp and sig');
+  const expiresAtSeconds = Number(url.searchParams.get('exp'));
+  const signature = url.searchParams.get('sig') ?? '';
+  assert(Number.isSafeInteger(expiresAtSeconds), 'signed manifest expiry is invalid');
+  assert(/^[A-Za-z0-9_-]{32,}$/.test(signature), 'signed manifest signature shape is invalid');
+  const expiresAtMs = expiresAtSeconds * 1000;
+  assert(expiresAtMs > nowMs, 'signed manifest is expired');
+  assert(expiresAtMs >= requiredThroughMs, 'signed manifest expires before smoke recovery begins');
+  assert(expiresAtMs <= nowMs + 130_000, 'signed manifest expiry exceeds the bounded origin TTL');
+  if (writtenAtMs !== null) {
+    assert(writtenAtMs <= nowMs + 5_000 && nowMs - writtenAtMs <= 30_000,
+      'signed manifest file was not refreshed in the last 30 seconds');
+  }
+  return { origin: url.origin, expiresAtMs };
+}
+
+function validateCommonStatus(status, { kind, role, maxAgeMs, nowMs, label }) {
+  assert(status && typeof status === 'object', `${label} status is required`);
+  assert(status.schemaVersion === 1 && status.kind === kind, `${label} status schema is invalid`);
+  assert(status.role === role, `${label} status role is invalid`);
+  assert(status.status === 'PASS', `${label} is not passing`);
+  assert(status.external === true, `${label} must attest external execution`);
+  assert(status.targetId === SMOKE_TARGET_ID && status.targetOrigin === SMOKE_ORIGIN,
+    `${label} target does not match the ten-client smoke`);
+  assert(/^[a-f0-9]{12}$/.test(String(status.hostHash ?? '')),
+    `${label} host fingerprint is invalid`);
+  const observedAtMs = parseTimestamp(status.observedAt, `${label}.observedAt`);
+  assert(observedAtMs <= nowMs + 5_000, `${label} status is from the future`);
+  assert(nowMs - observedAtMs <= maxAgeMs, `${label} status is stale`);
+}
+
+function boundedCount(value, field, maximum) {
+  assert(Number.isSafeInteger(value) && value >= 0 && value <= maximum,
+    `${field} must be a bounded count`);
+}
+
+function boundedRatio(value, field, minimum, maximum) {
+  assert(typeof value === 'number' && Number.isFinite(value)
+    && value >= minimum && value <= maximum,
+  `${field} must be a finite number between ${minimum} and ${maximum}`);
+}
+
+export function validateExternalCanaryStatus(status, nowMs = Date.now()) {
+  validateCommonStatus(status, {
+    kind: EXTERNAL_CANARY_KIND,
+    role: EXTERNAL_CANARY_ROLE,
+    maxAgeMs: CANARY_MAX_AGE_MS,
+    nowMs,
+    label: 'external decoded canary',
+  });
+  assert(status.decodedAudio === true, 'external decoded canary did not decode audio');
+  boundedCount(status.decodedSeconds, 'external decoded canary decoded seconds', 600);
+  assert(status.decodedSeconds >= 6, 'external decoded canary did not decode six seconds');
+  assert(Number.isFinite(status.manifestAgeSeconds)
+    && status.manifestAgeSeconds >= 0 && status.manifestAgeSeconds <= 18,
+  'external decoded canary manifest is stale');
+  return status;
+}
+
+export function validateTargetMonitorStatus(status, nowMs = Date.now()) {
+  validateCommonStatus(status, {
+    kind: TARGET_MONITOR_KIND,
+    role: TARGET_MONITOR_ROLE,
+    maxAgeMs: MONITOR_MAX_AGE_MS,
+    nowMs,
+    label: 'target monitor',
+  });
+  assert(status.listenerReady === true && status.streamHealthy === true
+    && status.liveReady === true && status.originUp === true && status.canaryOk === true,
+  'target monitor has a failed health check');
+  assert(status.alertmanagerReady === true, 'target monitor Alertmanager is not ready');
+  boundedCount(status.activeAlerts, 'target monitor active alerts', MAX_ALERT_COUNT);
+  boundedCount(status.prometheusFiringAlerts, 'target monitor firing alerts', MAX_ALERT_COUNT);
+  assert(status.activeAlerts === 0 && status.prometheusFiringAlerts === 0,
+    'target monitor reports active alerts');
+  // The declared thresholds must equal the fixed smoke policy exactly; a
+  // monitor running with weaker limits can never produce an accepted PASS.
+  const declared = status.thresholds;
+  assert(declared && typeof declared === 'object'
+    && Object.keys(declared).length === Object.keys(MONITOR_THRESHOLDS).length
+    && Object.entries(MONITOR_THRESHOLDS).every(([key, value]) => declared[key] === value),
+  'target monitor thresholds differ from the fixed smoke policy');
+  // Bounded direct telemetry at the immediate stop thresholds. A monitor PASS
+  // with an out-of-policy value is rejected here as well.
+  boundedRatio(status.cpuUsedRatio, 'target monitor CPU used ratio', 0, 1);
+  assert(status.cpuUsedRatio < MONITOR_THRESHOLDS.maxCpuUsedRatio,
+    'target monitor CPU used ratio reached the immediate stop threshold');
+  boundedRatio(status.memoryUsedRatio, 'target monitor memory used ratio', 0, 1);
+  assert(status.memoryUsedRatio < MONITOR_THRESHOLDS.maxMemoryUsedRatio,
+    'target monitor memory used ratio reached the immediate stop threshold');
+  boundedRatio(status.rootFreeRatio, 'target monitor root free ratio', 0, 1);
+  assert(status.rootFreeRatio > MONITOR_THRESHOLDS.minRootFreeRatio,
+    'target monitor root free ratio reached the immediate stop threshold');
+  boundedRatio(status.egressBitsPerSecond, 'target monitor egress bits/s', 0, 1e12);
+  assert(status.egressBitsPerSecond < MONITOR_THRESHOLDS.maxEgressBitsPerSecond,
+    'target monitor egress reached the immediate stop threshold');
+  boundedRatio(status.tcpRetransmitRatio, 'target monitor TCP retransmit ratio', 0, 1);
+  assert(status.tcpRetransmitRatio < MONITOR_THRESHOLDS.maxTcpRetransmitRatio,
+    'target monitor TCP retransmit ratio reached the immediate stop threshold');
+  boundedCount(status.interfaceErrorsDrops, 'target monitor interface errors/drops', 1e9);
+  assert(status.interfaceErrorsDrops === MONITOR_THRESHOLDS.maxInterfaceErrorsDrops,
+    'target monitor reports interface errors or drops');
+  // A status that has not established and verified a restart/OOM baseline can
+  // never be accepted; nor can one that observed a restart or OOM kill.
+  assert(status.restartBaselineEstablished === true,
+    'target monitor has not established a restart/OOM baseline');
+  boundedCount(status.containerRestartsObserved, 'target monitor container restarts',
+    MAX_RESTART_OBSERVATIONS);
+  boundedCount(status.oomEventsDelta, 'target monitor OOM events', MAX_RESTART_OBSERVATIONS);
+  assert(status.containerRestartsObserved === 0 && status.oomEventsDelta === 0,
+    'target monitor observed a container restart or OOM event');
+  return status;
+}
+
+export function validateNetworkSmokePreconditions({
+  plan,
+  target,
+  manifest,
+  canaryStatus,
+  monitorStatus,
+  nowMs = Date.now(),
+  expectedHostHash = assertExternalHost(),
+}) {
+  assert(plan?.profileName === 'staging-smoke', 'dedicated smoke accepts only staging-smoke');
+  assert(plan.profile?.clients === 10 && plan.profile?.soakSeconds === 60
+    && plan.profile?.rampPerSecond === 2 && plan.shardCount === 1,
+  'dedicated smoke plan must remain exactly ten clients for sixty seconds');
+  assert(target?.id === SMOKE_TARGET_ID && target?.limits?.maxClients === 10,
+    'dedicated smoke policy is not capped at ten clients');
+  assert(target.origins.length === 1 && target.origins[0] === SMOKE_ORIGIN,
+    'dedicated smoke origin allowlist differs');
+  validateFreshSignedManifest({
+    ...manifest,
+    allowedOrigins: target.origins,
+    nowMs,
+    requiredThroughMs: Date.parse(plan.endAt) + 10_000,
+  });
+  validateExternalCanaryStatus(canaryStatus, nowMs);
+  validateTargetMonitorStatus(monitorStatus, nowMs);
+  // The canary and monitor status files are read from local disk, so both
+  // safety producers must be co-located with this wrapper on one external
+  // host. Identical fingerprints on a second host would fail this check too.
+  assert(/^[a-f0-9]{12}$/.test(expectedHostHash), 'local host fingerprint is invalid');
+  assert(canaryStatus.hostHash === expectedHostHash
+    && monitorStatus.hostHash === expectedHostHash,
+  'external canary and target monitor must run on this external host');
+}
+
+export async function readJsonStatus(path, label) {
+  const { text } = await readPrivateFile(path, label);
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${label} file is not valid JSON`);
+  }
+}
+
+export function assertExternalHost(host = hostname()) {
+  const labels = String(host).trim().toLowerCase().replace(/\.+$/, '').split('.');
+  assert(!labels.some((label) => label === 'mona' || label.startsWith('mona-')),
+    'external safety process is forbidden from mona');
+  return sha256(String(host)).slice(0, 12);
+}
+
+export async function writePrivateJsonAtomic(path, value) {
+  const temporaryPath = `${path}.tmp-${process.pid}`;
+  await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600, flag: 'w' });
+  await chmod(temporaryPath, 0o600);
+  await rename(temporaryPath, path);
+}

--- a/tools/early-birds-hls-load/src/target-probe.mjs
+++ b/tools/early-birds-hls-load/src/target-probe.mjs
@@ -1,0 +1,299 @@
+import {
+  MONITOR_THRESHOLDS,
+  SMOKE_ORIGIN,
+  SMOKE_TARGET_ID,
+  TARGET_MONITOR_KIND,
+  TARGET_MONITOR_ROLE,
+} from './smoke-safety.mjs';
+
+export const LISTENER_READY_URL = 'https://earlybirds-staging.harmonicbeacon.com/api/health/ready';
+export const STREAM_HEALTH_URL = `${SMOKE_ORIGIN}/healthz`;
+export const LIVE_READY_URL = 'https://live.harmonicbeacon.com/api/health/ready';
+export const STAGING_ATTESTATION = 'early-birds-staging';
+
+// Exact isolated staging containers on the target host, from the checked-in
+// earlybirds-preview Compose project. Never participant or event containers.
+export const LISTENER_CONTAINER = 'earlybirds-preview-listener-1';
+export const ORIGIN_CONTAINER = 'earlybirds-preview-beacon-stream-1';
+
+// Instant Prometheus queries. Every query must yield exactly one vector
+// element; an empty, duplicated or non-finite result fails the probe. Host
+// scalars aggregate in PromQL so multi-device cardinality cannot silently
+// pick one interface or core.
+export const MONITOR_QUERIES = Object.freeze({
+  cpuUsedRatio: '1 - avg(rate(node_cpu_seconds_total{mode="idle"}[1m]))',
+  memoryUsedRatio: '1 - (sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes))',
+  rootFreeRatio: 'sum(node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay"})'
+    + ' / sum(node_filesystem_size_bytes{mountpoint="/",fstype!~"tmpfs|overlay"})',
+  egressBitsPerSecond:
+    'sum(rate(node_network_transmit_bytes_total{device!~"lo|docker.*|veth.*"}[2m])) * 8',
+  tcpRetransmitRatio: 'sum(rate(node_netstat_Tcp_RetransSegs[2m]))'
+    + ' / clamp_min(sum(rate(node_netstat_Tcp_OutSegs[2m])), 1)',
+  interfaceErrorsDrops:
+    'sum(node_network_transmit_errs_total{device!~"lo|docker.*|veth.*"})'
+    + ' + sum(node_network_receive_errs_total{device!~"lo|docker.*|veth.*"})'
+    + ' + sum(node_network_transmit_drop_total{device!~"lo|docker.*|veth.*"})'
+    + ' + sum(node_network_receive_drop_total{device!~"lo|docker.*|veth.*"})',
+  originUp: 'up{job="beacon-stream"}',
+  canaryOk: 'beacon_stream_canary_ok',
+  listenerStartSeconds: `container_start_time_seconds{name="${LISTENER_CONTAINER}"}`,
+  originStartSeconds: `container_start_time_seconds{name="${ORIGIN_CONTAINER}"}`,
+  listenerOomEvents: `container_oom_events_total{name="${LISTENER_CONTAINER}"}`,
+  originOomEvents: `container_oom_events_total{name="${ORIGIN_CONTAINER}"}`,
+});
+
+export function loopbackTunnelOrigin(value, label) {
+  let url;
+  try {
+    url = new URL(String(value));
+  } catch {
+    throw new Error(`${label} must be an uncredentialed loopback SSH tunnel origin`);
+  }
+  if (url.protocol !== 'http:' || !['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname)
+    || url.username || url.password || url.pathname !== '/' || url.search || url.hash) {
+    throw new Error(`${label} must be an uncredentialed loopback SSH tunnel origin`);
+  }
+  return url.origin;
+}
+
+async function fetchJson(fetchImpl, url) {
+  const response = await fetchImpl(url, {
+    cache: 'no-store',
+    redirect: 'error',
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error('monitoring query failed');
+  try {
+    return await response.json();
+  } catch {
+    throw new Error('monitoring query returned malformed JSON');
+  }
+}
+
+// Exactly one unambiguous, finite vector element or a thrown refusal. Missing,
+// duplicated, NaN and +/-Inf results can never become a passing scalar.
+export async function queryPrometheusScalar(fetchImpl, prometheusOrigin, query) {
+  const url = `${prometheusOrigin}/api/v1/query?query=${encodeURIComponent(query)}`;
+  const body = await fetchJson(fetchImpl, url);
+  if (body?.status !== 'success' || body?.data?.resultType !== 'vector'
+    || !Array.isArray(body.data.result)) {
+    throw new Error('Prometheus query response is malformed');
+  }
+  if (body.data.result.length !== 1) {
+    throw new Error('Prometheus query result is missing or ambiguous');
+  }
+  const point = body.data.result[0]?.value;
+  if (!Array.isArray(point) || point.length !== 2) {
+    throw new Error('Prometheus query sample is malformed');
+  }
+  const value = Number(point[1]);
+  if (!Number.isFinite(value)) throw new Error('Prometheus query sample is not finite');
+  return value;
+}
+
+export async function fetchPrometheusFiringAlerts(fetchImpl, prometheusOrigin) {
+  const body = await fetchJson(fetchImpl, `${prometheusOrigin}/api/v1/alerts`);
+  if (body?.status !== 'success' || !Array.isArray(body?.data?.alerts)) {
+    throw new Error('Prometheus alerts response is malformed');
+  }
+  return body.data.alerts.filter((alert) => alert?.state === 'firing').length;
+}
+
+// Alertmanager is queried directly; its health is never inferred from
+// Prometheus. Any malformed, missing or failed response fails closed.
+export async function fetchAlertmanagerState(fetchImpl, alertmanagerOrigin) {
+  const status = await fetchJson(fetchImpl, `${alertmanagerOrigin}/api/v2/status`);
+  const ready = status?.cluster?.status === 'ready';
+  const alerts = await fetchJson(
+    fetchImpl,
+    `${alertmanagerOrigin}/api/v2/alerts?active=true&silenced=false&inhibited=false`,
+  );
+  if (!Array.isArray(alerts) || alerts.length > 10_000) {
+    throw new Error('Alertmanager alerts response is malformed');
+  }
+  let activeAlerts = 0;
+  for (const alert of alerts) {
+    const state = alert?.status?.state;
+    if (typeof state !== 'string') throw new Error('Alertmanager alert entry is malformed');
+    const silenced = Array.isArray(alert.status.silencedBy) && alert.status.silencedBy.length > 0;
+    const inhibited = Array.isArray(alert.status.inhibitedBy) && alert.status.inhibitedBy.length > 0;
+    if (state === 'active' && !silenced && !inhibited) activeAlerts += 1;
+  }
+  return { ready, activeAlerts };
+}
+
+async function fetchHealth(fetchImpl, url, stagingAttestation) {
+  try {
+    const response = await fetchImpl(url, {
+      cache: 'no-store',
+      redirect: 'error',
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) return false;
+    if (stagingAttestation
+      && response.headers.get('x-harmonic-beacon-environment') !== stagingAttestation) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// In-process restart/OOM baseline for the exact isolated Listener and origin
+// containers. The first sample only establishes the baseline; a PASS requires
+// a later sample that still matches it. A changed start timestamp or an
+// increased OOM counter is latched and fails every subsequent probe.
+export function createContainerBaseline() {
+  return {
+    established: false,
+    verified: false,
+    startSeconds: null,
+    oomEvents: null,
+    restartsObserved: 0,
+    oomEventsDelta: 0,
+  };
+}
+
+export function observeContainerBaseline(baseline, sample) {
+  const starts = [sample.listenerStartSeconds, sample.originStartSeconds];
+  const ooms = [sample.listenerOomEvents, sample.originOomEvents];
+  if (!baseline.established) {
+    baseline.established = true;
+    baseline.startSeconds = starts;
+    baseline.oomEvents = ooms;
+    return;
+  }
+  starts.forEach((value, index) => {
+    if (value !== baseline.startSeconds[index]) {
+      baseline.restartsObserved += 1;
+      baseline.startSeconds[index] = value;
+      baseline.verified = false;
+    }
+  });
+  ooms.forEach((value, index) => {
+    const delta = value - baseline.oomEvents[index];
+    if (delta > 0) {
+      baseline.oomEventsDelta += delta;
+      baseline.verified = false;
+    }
+    if (delta !== 0) baseline.oomEvents[index] = value;
+  });
+  if (baseline.restartsObserved === 0 && baseline.oomEventsDelta === 0) {
+    baseline.verified = true;
+  }
+}
+
+function withinImmediateThresholds(scalars) {
+  return scalars.cpuUsedRatio < MONITOR_THRESHOLDS.maxCpuUsedRatio
+    && scalars.memoryUsedRatio < MONITOR_THRESHOLDS.maxMemoryUsedRatio
+    && scalars.rootFreeRatio > MONITOR_THRESHOLDS.minRootFreeRatio
+    && scalars.egressBitsPerSecond < MONITOR_THRESHOLDS.maxEgressBitsPerSecond
+    && scalars.tcpRetransmitRatio < MONITOR_THRESHOLDS.maxTcpRetransmitRatio
+    && scalars.interfaceErrorsDrops === MONITOR_THRESHOLDS.maxInterfaceErrorsDrops
+    && scalars.canaryOk === 1
+    && scalars.originUp === 1;
+}
+
+// One monitor sample. The returned status carries only bounded numerics,
+// booleans, the hashed host fingerprint, timing and the fixed thresholds;
+// never raw Prometheus/Alertmanager payloads, labels, URLs or hostnames.
+export async function probeMonitor({
+  fetchImpl = fetch,
+  prometheusOrigin,
+  alertmanagerOrigin,
+  hostHash,
+  baseline,
+  healthUrls = {
+    listenerReady: LISTENER_READY_URL,
+    streamHealthy: STREAM_HEALTH_URL,
+    liveReady: LIVE_READY_URL,
+  },
+}) {
+  const base = {
+    schemaVersion: 1,
+    kind: TARGET_MONITOR_KIND,
+    role: TARGET_MONITOR_ROLE,
+    status: 'FAIL',
+    external: true,
+    targetId: SMOKE_TARGET_ID,
+    targetOrigin: SMOKE_ORIGIN,
+    hostHash,
+    observedAt: new Date().toISOString(),
+    listenerReady: false,
+    streamHealthy: false,
+    liveReady: false,
+    originUp: false,
+    canaryOk: false,
+    prometheusFiringAlerts: null,
+    alertmanagerReady: false,
+    activeAlerts: null,
+    cpuUsedRatio: null,
+    memoryUsedRatio: null,
+    rootFreeRatio: null,
+    egressBitsPerSecond: null,
+    tcpRetransmitRatio: null,
+    interfaceErrorsDrops: null,
+    restartBaselineEstablished: baseline.verified,
+    containerRestartsObserved: baseline.restartsObserved,
+    oomEventsDelta: baseline.oomEventsDelta,
+    thresholds: { ...MONITOR_THRESHOLDS },
+  };
+  try {
+    const scalarNames = Object.keys(MONITOR_QUERIES);
+    const [listenerReady, streamHealthy, liveReady, alertmanager, firingAlerts, ...scalarValues] = (
+      await Promise.all([
+        fetchHealth(fetchImpl, healthUrls.listenerReady, STAGING_ATTESTATION),
+        fetchHealth(fetchImpl, healthUrls.streamHealthy, STAGING_ATTESTATION),
+        fetchHealth(fetchImpl, healthUrls.liveReady, null),
+        fetchAlertmanagerState(fetchImpl, alertmanagerOrigin),
+        fetchPrometheusFiringAlerts(fetchImpl, prometheusOrigin),
+        ...scalarNames.map((name) => queryPrometheusScalar(
+          fetchImpl,
+          prometheusOrigin,
+          MONITOR_QUERIES[name],
+        )),
+      ])
+    );
+    const scalars = Object.fromEntries(scalarNames.map((name, index) => [name, scalarValues[index]]));
+    observeContainerBaseline(baseline, {
+      listenerStartSeconds: scalars.listenerStartSeconds,
+      originStartSeconds: scalars.originStartSeconds,
+      listenerOomEvents: scalars.listenerOomEvents,
+      originOomEvents: scalars.originOomEvents,
+    });
+    const passed = listenerReady && streamHealthy && liveReady
+      && alertmanager.ready && alertmanager.activeAlerts === 0 && firingAlerts === 0
+      && withinImmediateThresholds(scalars)
+      && baseline.verified
+      && baseline.restartsObserved === 0 && baseline.oomEventsDelta === 0;
+    return {
+      ...base,
+      status: passed ? 'PASS' : 'FAIL',
+      observedAt: new Date().toISOString(),
+      listenerReady,
+      streamHealthy,
+      liveReady,
+      originUp: scalars.originUp === 1,
+      canaryOk: scalars.canaryOk === 1,
+      prometheusFiringAlerts: firingAlerts,
+      alertmanagerReady: alertmanager.ready,
+      activeAlerts: alertmanager.activeAlerts,
+      cpuUsedRatio: scalars.cpuUsedRatio,
+      memoryUsedRatio: scalars.memoryUsedRatio,
+      rootFreeRatio: scalars.rootFreeRatio,
+      egressBitsPerSecond: scalars.egressBitsPerSecond,
+      tcpRetransmitRatio: scalars.tcpRetransmitRatio,
+      interfaceErrorsDrops: scalars.interfaceErrorsDrops,
+      restartBaselineEstablished: baseline.verified,
+      containerRestartsObserved: baseline.restartsObserved,
+      oomEventsDelta: baseline.oomEventsDelta,
+    };
+  } catch {
+    return {
+      ...base,
+      observedAt: new Date().toISOString(),
+      restartBaselineEstablished: baseline.verified,
+      containerRestartsObserved: baseline.restartsObserved,
+      oomEventsDelta: baseline.oomEventsDelta,
+    };
+  }
+}

--- a/tools/early-birds-hls-load/test/network-run-lock.test.mjs
+++ b/tools/early-birds-hls-load/test/network-run-lock.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { access, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { NETWORK_RUN_LOCK_KIND, acquireNetworkRunLock } from '../src/network-run-lock.mjs';
+
+async function tempLockPath() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'network-run-lock-'));
+  return path.join(directory, 'smoke.lock');
+}
+
+test('acquire creates a mode-0600 lock and a concurrent second acquire is refused', async () => {
+  const lockPath = await tempLockPath();
+  const first = await acquireNetworkRunLock({ path: lockPath, runId: 'run-a', pid: 4321 });
+  const details = await stat(lockPath);
+  assert.equal(details.mode & 0o777, 0o600);
+  assert.equal(details.isFile(), true);
+  const contents = JSON.parse(await readFile(lockPath, 'utf8'));
+  assert.equal(contents.kind, NETWORK_RUN_LOCK_KIND);
+  assert.equal(contents.runId, 'run-a');
+  assert.equal(contents.pid, 4321);
+  await assert.rejects(
+    acquireNetworkRunLock({ path: lockPath, runId: 'run-b' }),
+    /network run lock already exists/,
+  );
+  // The refused second acquire leaves the original lock untouched.
+  assert.equal(JSON.parse(await readFile(lockPath, 'utf8')).runId, 'run-a');
+  await first.release();
+  await assert.rejects(access(lockPath), /ENOENT/);
+});
+
+test('a stale or ambiguous pre-existing lock is refused and never deleted', async () => {
+  const lockPath = await tempLockPath();
+  const stale = '{"stale":true}\n';
+  await writeFile(lockPath, stale, { mode: 0o600 });
+  await assert.rejects(
+    acquireNetworkRunLock({ path: lockPath, runId: 'run-c' }),
+    /network run lock already exists/,
+  );
+  assert.equal(await readFile(lockPath, 'utf8'), stale);
+});
+
+test('a later run proceeds after a clean release', async () => {
+  const lockPath = await tempLockPath();
+  const first = await acquireNetworkRunLock({ path: lockPath, runId: 'run-d' });
+  await first.release();
+  const second = await acquireNetworkRunLock({ path: lockPath, runId: 'run-e' });
+  assert.equal(JSON.parse(await readFile(lockPath, 'utf8')).runId, 'run-e');
+  await second.release();
+  await assert.rejects(access(lockPath), /ENOENT/);
+});
+
+test('release removes only the lock this process wrote', async () => {
+  const lockPath = await tempLockPath();
+  const lock = await acquireNetworkRunLock({ path: lockPath, runId: 'run-f' });
+  const replaced = '{"replaced":true}\n';
+  await writeFile(lockPath, replaced);
+  await lock.release();
+  assert.equal(await readFile(lockPath, 'utf8'), replaced);
+  await lock.release(); // Releasing twice stays a safe no-op.
+  assert.equal(await readFile(lockPath, 'utf8'), replaced);
+});
+
+test('release tolerates a lock that is already gone', async () => {
+  const lockPath = await tempLockPath();
+  const lock = await acquireNetworkRunLock({ path: lockPath, runId: 'run-g' });
+  await lock.release();
+  await lock.release();
+  await assert.rejects(access(lockPath), /ENOENT/);
+});
+
+test('a lock path is required', async () => {
+  await assert.rejects(acquireNetworkRunLock({ path: '', runId: 'run-h' }), /lock path is required/);
+});

--- a/tools/early-birds-hls-load/test/run-staging-smoke.test.mjs
+++ b/tools/early-birds-hls-load/test/run-staging-smoke.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { access, mkdtemp } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  acquireNetworkRunLock,
+  NETWORK_RUN_LOCK_PATH,
+} from '../src/network-run-lock.mjs';
+
+const wrapperPath = fileURLToPath(new URL('../run-staging-smoke.mjs', import.meta.url));
+
+function runWrapper(args) {
+  return new Promise((resolveRun) => {
+    const child = spawn(process.execPath, [wrapperPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', (error) => resolveRun({ code: -1, stdout, stderr: stderr + error.message }));
+    child.on('close', (code) => resolveRun({ code, stdout, stderr }));
+  });
+}
+
+function baseArgs(directory) {
+  return [
+    '--run-id', 'lock-test-run',
+    '--start-at', new Date(Date.now() + 120_000).toISOString(),
+    '--evidence', path.join(directory, 'evidence.json'),
+  ];
+}
+
+function networkArgs(directory) {
+  return [
+    ...baseArgs(directory),
+    '--manifest-url-file', path.join(directory, 'missing-manifest'),
+    '--canary-status-file', path.join(directory, 'missing-canary.json'),
+    '--monitor-status-file', path.join(directory, 'missing-monitor.json'),
+    '--clock-offset-ms', '0',
+    '--confirm', 'test-confirmation',
+  ];
+}
+
+// These tests never run network load: every network-mode invocation below is
+// refused either at the lock or at the missing precondition files, before any
+// load child is spawned.
+test('a concurrent second wrapper is refused at the lock before spawning any load', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'staging-smoke-wrapper-'));
+  const held = await acquireNetworkRunLock({ path: NETWORK_RUN_LOCK_PATH, runId: 'first-run' });
+  try {
+    const result = await runWrapper(networkArgs(directory));
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /network run lock already exists/);
+    // The refusal precedes the precondition reads: the missing signed
+    // manifest is never even reported.
+    assert.doesNotMatch(result.stderr, /signed manifest/);
+    // No load child ever ran, so no evidence was produced.
+    await assert.rejects(access(path.join(directory, 'evidence.json')), /ENOENT/);
+  } finally {
+    await held.release();
+  }
+});
+
+test('a later run passes the lock after a clean release and still fails closed', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'staging-smoke-wrapper-'));
+  const held = await acquireNetworkRunLock({ path: NETWORK_RUN_LOCK_PATH, runId: 'first-run' });
+  await held.release();
+  const result = await runWrapper(networkArgs(directory));
+  assert.equal(result.code, 1);
+  // The lock was acquired; the run now fails closed on the missing
+  // precondition file instead of on the lock.
+  assert.match(result.stderr, /cannot read signed manifest file/);
+  assert.doesNotMatch(result.stderr, /network run lock/);
+  // The validation-error path released the lock deterministically.
+  await assert.rejects(access(NETWORK_RUN_LOCK_PATH), /ENOENT/);
+});
+
+test('a wrapper that acquires the lock itself refuses a second wrapper until it exits', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'staging-smoke-wrapper-'));
+  const first = await runWrapper(networkArgs(directory));
+  // The first wrapper failed closed on preconditions and released its lock,
+  // so a following invocation is again refused only on preconditions.
+  assert.equal(first.code, 1);
+  assert.match(first.stderr, /cannot read signed manifest file/);
+  await assert.rejects(access(NETWORK_RUN_LOCK_PATH), /ENOENT/);
+});
+
+test('dry-run plans without the network lock even while another run holds it', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'staging-smoke-wrapper-'));
+  const held = await acquireNetworkRunLock({ path: NETWORK_RUN_LOCK_PATH, runId: 'other-run' });
+  try {
+    const result = await runWrapper([...baseArgs(directory), '--dry-run']);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /Status: PLANNED/);
+    await access(path.join(directory, 'evidence.json'));
+  } finally {
+    await held.release();
+  }
+});
+
+test('the production CLI refuses attempts to select a second lock path', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'staging-smoke-wrapper-'));
+  const bypass = path.join(directory, 'bypass.lock');
+  const result = await runWrapper([
+    ...baseArgs(directory),
+    '--dry-run',
+    '--lock-file', bypass,
+  ]);
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /unknown option --lock-file/);
+  await assert.rejects(access(bypass), /ENOENT/);
+});

--- a/tools/early-birds-hls-load/test/smoke-guard.test.mjs
+++ b/tools/early-birds-hls-load/test/smoke-guard.test.mjs
@@ -86,4 +86,30 @@ test('passing checks never abort and stop() leaves the guard quiet', async () =>
   assert.equal(aborts, 0);
   assert.equal(checks, 2);
   assert.equal(guard.aborted, false);
+  assert.equal(guard.stopped, true);
+});
+
+test('an in-flight rejection after stop() emits no abort and never kills', async () => {
+  const timers = fakeTimer();
+  let aborts = 0;
+  let writes = 0;
+  let rejectCheck;
+  const guard = startStatusGuard({
+    check: () => new Promise((unused, reject) => { rejectCheck = reject; }),
+    onAbort: () => { aborts += 1; },
+    ...timers,
+    writeImpl: () => { writes += 1; },
+  });
+  timers.tick(); // Starts one check that is still in flight.
+  await new Promise((resolve) => setImmediate(resolve));
+  guard.stop(); // The load child has exited; the guard is parked.
+  rejectCheck(new Error('status failed after stop'));
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  timers.tick();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(aborts, 0);
+  assert.equal(writes, 0);
+  assert.equal(guard.aborted, false);
+  assert.equal(guard.stopped, true);
 });

--- a/tools/early-birds-hls-load/test/smoke-guard.test.mjs
+++ b/tools/early-birds-hls-load/test/smoke-guard.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { startStatusGuard } from '../src/smoke-guard.mjs';
+
+function fakeTimer() {
+  const handles = [];
+  return {
+    setIntervalImpl: (fn) => {
+      const handle = { fn, cleared: false, unref() { return this; } };
+      handles.push(handle);
+      return handle;
+    },
+    clearIntervalImpl: (handle) => { handle.cleared = true; },
+    tick: (index = 0) => {
+      if (!handles[index].cleared) handles[index].fn();
+    },
+    handles,
+  };
+}
+
+test('guard aborts exactly once on the first failed check', async () => {
+  const timers = fakeTimer();
+  let aborts = 0;
+  let checks = 0;
+  const guard = startStatusGuard({
+    check: async () => {
+      checks += 1;
+      throw new Error('stale');
+    },
+    onAbort: () => { aborts += 1; },
+    ...timers,
+    writeImpl: () => {},
+  });
+  timers.tick();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  timers.tick();
+  timers.tick();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(aborts, 1);
+  assert.equal(checks, 1);
+  assert.equal(guard.aborted, true);
+  assert.equal(timers.handles[0].cleared, true);
+});
+
+test('concurrent overlapping checks cannot double-abort', async () => {
+  const timers = fakeTimer();
+  let aborts = 0;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const guard = startStatusGuard({
+    check: async () => {
+      await gate;
+      throw new Error('failed');
+    },
+    onAbort: () => { aborts += 1; },
+    ...timers,
+    writeImpl: () => {},
+  });
+  timers.tick();
+  timers.tick(); // ignored while the first check is still in flight
+  release();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(aborts, 1);
+  assert.equal(guard.aborted, true);
+});
+
+test('passing checks never abort and stop() leaves the guard quiet', async () => {
+  const timers = fakeTimer();
+  let aborts = 0;
+  let checks = 0;
+  const guard = startStatusGuard({
+    check: async () => { checks += 1; },
+    onAbort: () => { aborts += 1; },
+    ...timers,
+    writeImpl: () => {},
+  });
+  timers.tick();
+  await new Promise((resolve) => setImmediate(resolve));
+  timers.tick();
+  await new Promise((resolve) => setImmediate(resolve));
+  guard.stop();
+  timers.tick();
+  assert.equal(aborts, 0);
+  assert.equal(checks, 2);
+  assert.equal(guard.aborted, false);
+});

--- a/tools/early-birds-hls-load/test/smoke-safety.test.mjs
+++ b/tools/early-birds-hls-load/test/smoke-safety.test.mjs
@@ -1,0 +1,290 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { chmod, mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { buildPlan, selectTarget } from '../src/contracts.mjs';
+import {
+  EXTERNAL_CANARY_KIND,
+  EXTERNAL_CANARY_ROLE,
+  MONITOR_THRESHOLDS,
+  SMOKE_ORIGIN,
+  SMOKE_TARGET_ID,
+  TARGET_MONITOR_KIND,
+  TARGET_MONITOR_ROLE,
+  assertExternalHost,
+  readJsonStatus,
+  readPrivateFile,
+  validateFreshSignedManifest,
+  validateNetworkSmokePreconditions,
+} from '../src/smoke-safety.mjs';
+
+const toolRoot = new URL('../', import.meta.url);
+const policy = JSON.parse(await readFile(new URL('policies/listener-staging-smoke-10.json', toolRoot)));
+const profiles = JSON.parse(await readFile(new URL('profiles.json', toolRoot)));
+const TEST_HOST_HASH = '0123456789ab';
+
+function fixture(nowMs = Date.now()) {
+  const target = selectTarget(policy, SMOKE_TARGET_ID);
+  const plan = buildPlan({
+    runId: 'smoke-safety-test',
+    profileName: 'staging-smoke',
+    profile: profiles.profiles['staging-smoke'],
+    target,
+    shardIndex: 0,
+    shardCount: 1,
+    startAt: new Date(nowMs + 20_000).toISOString(),
+    networkRun: true,
+    nowMs,
+  });
+  const common = {
+    schemaVersion: 1,
+    status: 'PASS',
+    external: true,
+    targetId: SMOKE_TARGET_ID,
+    targetOrigin: SMOKE_ORIGIN,
+    hostHash: TEST_HOST_HASH,
+    observedAt: new Date(nowMs).toISOString(),
+  };
+  return {
+    plan,
+    target,
+    manifest: {
+      value: `${SMOKE_ORIGIN}/v1/hls/approved-v2/live.m3u8?exp=${Math.floor((nowMs + 120_000) / 1000)}&sig=${'a'.repeat(43)}`,
+      writtenAtMs: nowMs,
+    },
+    canaryStatus: {
+      ...common,
+      kind: EXTERNAL_CANARY_KIND,
+      role: EXTERNAL_CANARY_ROLE,
+      decodedAudio: true,
+      decodedSeconds: 6,
+      manifestAgeSeconds: 1,
+    },
+    monitorStatus: {
+      ...common,
+      kind: TARGET_MONITOR_KIND,
+      role: TARGET_MONITOR_ROLE,
+      listenerReady: true,
+      streamHealthy: true,
+      liveReady: true,
+      originUp: true,
+      canaryOk: true,
+      prometheusFiringAlerts: 0,
+      alertmanagerReady: true,
+      activeAlerts: 0,
+      cpuUsedRatio: 0.2,
+      memoryUsedRatio: 0.4,
+      rootFreeRatio: 0.6,
+      egressBitsPerSecond: 500_000_000,
+      tcpRetransmitRatio: 0.001,
+      interfaceErrorsDrops: 0,
+      restartBaselineEstablished: true,
+      containerRestartsObserved: 0,
+      oomEventsDelta: 0,
+      thresholds: { ...MONITOR_THRESHOLDS },
+    },
+    nowMs,
+    expectedHostHash: TEST_HOST_HASH,
+  };
+}
+
+test('dedicated policy can authorize exactly ten clients and no more', () => {
+  const target = selectTarget(policy, SMOKE_TARGET_ID);
+  assert.deepEqual(target.origins, [SMOKE_ORIGIN]);
+  assert.equal(target.limits.maxClients, 10);
+  assert.equal(target.limits.maxShardCount, 1);
+  assert.equal(target.limits.maxSoakSeconds, 60);
+  assert.equal(target.limits.maxRequestsPerSecond, 28);
+  assert.throws(() => buildPlan({
+    runId: 'smoke-eleven-refused',
+    profileName: 'unsafe-smoke',
+    profile: { ...profiles.profiles['staging-smoke'], clients: 11 },
+    target,
+    shardIndex: 0,
+    shardCount: 1,
+    startAt: '2030-01-01T00:00:00.000Z',
+    networkRun: false,
+  }), /clients exceed the target policy/);
+});
+
+test('fresh signed manifest is exact-origin, canonical, recently written and long-lived enough', () => {
+  const values = fixture();
+  assert.doesNotThrow(() => validateNetworkSmokePreconditions(values));
+  assert.throws(() => validateFreshSignedManifest({
+    ...values.manifest,
+    value: values.manifest.value.replace(SMOKE_ORIGIN, 'https://attacker.example'),
+    allowedOrigins: values.target.origins,
+    nowMs: values.nowMs,
+    requiredThroughMs: Date.parse(values.plan.endAt) + 10_000,
+  }), /escaped the exact target allowlist/);
+  assert.throws(() => validateFreshSignedManifest({
+    ...values.manifest,
+    value: `${SMOKE_ORIGIN}/v1/hls/approved-v2/live.m3u8?exp=${Math.floor((values.nowMs - 1) / 1000)}&sig=${'a'.repeat(43)}`,
+    allowedOrigins: values.target.origins,
+    nowMs: values.nowMs,
+    requiredThroughMs: Date.parse(values.plan.endAt) + 10_000,
+  }), /expired/);
+  assert.throws(() => validateFreshSignedManifest({
+    ...values.manifest,
+    writtenAtMs: values.nowMs - 31_000,
+    allowedOrigins: values.target.origins,
+    nowMs: values.nowMs,
+    requiredThroughMs: Date.parse(values.plan.endAt) + 10_000,
+  }), /not refreshed/);
+});
+
+test('network smoke cannot start or continue without fresh external canary and monitor', () => {
+  const values = fixture();
+  assert.throws(() => validateNetworkSmokePreconditions({ ...values, canaryStatus: undefined }),
+    /external decoded canary status is required/);
+  assert.throws(() => validateNetworkSmokePreconditions({ ...values, monitorStatus: undefined }),
+    /target monitor status is required/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    canaryStatus: { ...values.canaryStatus, observedAt: new Date(values.nowMs - 46_000).toISOString() },
+  }), /canary status is stale/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, activeAlerts: 1 },
+  }), /active alerts/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, liveReady: false },
+  }), /failed health check/);
+});
+
+test('safety producers refuse execution on mona', () => {
+  assert.throws(() => assertExternalHost('mona'), /forbidden from mona/);
+  assert.throws(() => assertExternalHost('mona-01.example'), /forbidden from mona/);
+  assert.match(assertExternalHost('daimonmatrix'), /^[a-f0-9]{12}$/);
+});
+
+test('dedicated CLI refuses a network run before spawning load when safety files are absent', async () => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'listener-smoke-refusal-'));
+  const startAt = new Date(Date.now() + 20_000).toISOString();
+  const child = spawn(process.execPath, [
+    new URL('../run-staging-smoke.mjs', import.meta.url).pathname,
+    '--run-id', 'missing-safety-files',
+    '--start-at', startAt,
+    '--evidence', path.join(temporaryRoot, 'must-not-exist.json'),
+    '--clock-offset-ms', '1',
+    '--confirm', 'not-reached',
+  ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  let output = '';
+  child.stdout.on('data', (chunk) => { output += chunk; });
+  child.stderr.on('data', (chunk) => { output += chunk; });
+  const [exitCode] = await once(child, 'exit');
+  assert.equal(exitCode, 1);
+  assert.match(output, /requires signed manifest, external canary, target monitor/);
+  await assert.rejects(readFile(path.join(temporaryRoot, 'must-not-exist.json')), /ENOENT/);
+});
+
+test('wrapper rejects Alertmanager failures, firing alerts and threshold-breaching telemetry', () => {
+  const values = fixture();
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, alertmanagerReady: false },
+  }), /Alertmanager is not ready/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, activeAlerts: 1 },
+  }), /active alerts/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, prometheusFiringAlerts: 1 },
+  }), /active alerts/);
+  for (const [field, value, pattern] of [
+    ['cpuUsedRatio', MONITOR_THRESHOLDS.maxCpuUsedRatio, /CPU used ratio/],
+    ['memoryUsedRatio', MONITOR_THRESHOLDS.maxMemoryUsedRatio, /memory used ratio/],
+    ['rootFreeRatio', MONITOR_THRESHOLDS.minRootFreeRatio, /root free ratio/],
+    ['egressBitsPerSecond', MONITOR_THRESHOLDS.maxEgressBitsPerSecond, /egress/],
+    ['tcpRetransmitRatio', MONITOR_THRESHOLDS.maxTcpRetransmitRatio, /retransmit/],
+    ['interfaceErrorsDrops', 1, /interface errors or drops/],
+    ['cpuUsedRatio', Number.NaN, /finite number/],
+    ['egressBitsPerSecond', Number.POSITIVE_INFINITY, /finite number/],
+  ]) {
+    assert.throws(() => validateNetworkSmokePreconditions({
+      ...values,
+      monitorStatus: { ...values.monitorStatus, [field]: value },
+    }), pattern, `${field}=${value} must be rejected`);
+  }
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: {
+      ...values.monitorStatus,
+      thresholds: { ...MONITOR_THRESHOLDS, maxCpuUsedRatio: 0.9 },
+    },
+  }), /thresholds differ/);
+});
+
+test('wrapper rejects a monitor without a verified restart/OOM baseline or with observed restarts', () => {
+  const values = fixture();
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, restartBaselineEstablished: false },
+  }), /has not established a restart\/OOM baseline/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, containerRestartsObserved: 1 },
+  }), /restart or OOM event/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, oomEventsDelta: 2 },
+  }), /restart or OOM event/);
+});
+
+test('status roles, target identity and co-located host fingerprints are enforced', () => {
+  const values = fixture();
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    canaryStatus: { ...values.canaryStatus, role: TARGET_MONITOR_ROLE },
+  }), /canary status role is invalid/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, targetOrigin: 'https://live.harmonicbeacon.com' },
+  }), /target does not match/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    canaryStatus: { ...values.canaryStatus, hostHash: 'ffffffffffff' },
+  }), /must run on this external host/);
+  assert.throws(() => validateNetworkSmokePreconditions({
+    ...values,
+    monitorStatus: { ...values.monitorStatus, hostHash: 'ffffffffffff' },
+  }), /must run on this external host/);
+});
+
+test('private inputs require a regular file with exact mode 0600 and bounded size', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'listener-smoke-input-'));
+  const accepted = path.join(root, 'accepted.json');
+  await writeFile(accepted, '{"ok":true}\n', { mode: 0o600 });
+  const { text } = await readPrivateFile(accepted, 'test input');
+  assert.equal(text, '{"ok":true}\n');
+
+  for (const mode of [0o640, 0o644, 0o400, 0o700]) {
+    const candidate = path.join(root, `mode-${mode.toString(8)}.json`);
+    await writeFile(candidate, '{}\n', { mode: 0o600 });
+    await chmod(candidate, mode);
+    await assert.rejects(readPrivateFile(candidate, 'test input'), /exactly 0600/);
+  }
+
+  const linked = path.join(root, 'linked.json');
+  await symlink(accepted, linked);
+  await assert.rejects(readPrivateFile(linked, 'test input'), /regular file/);
+
+  const directory = path.join(root, 'directory');
+  await mkdir(directory, { mode: 0o700 });
+  await assert.rejects(readPrivateFile(directory, 'test input'), /regular file/);
+
+  const oversized = path.join(root, 'oversized.json');
+  await writeFile(oversized, `${'x'.repeat(20_000)}\n`, { mode: 0o600 });
+  await assert.rejects(readPrivateFile(oversized, 'test input'), /byte bound/);
+  await assert.rejects(readJsonStatus(oversized, 'test status'), /byte bound/);
+  await assert.rejects(
+    readPrivateFile(oversized, 'signed manifest', 4_096),
+    /byte bound/,
+  );
+});

--- a/tools/early-birds-hls-load/test/target-monitor.test.mjs
+++ b/tools/early-birds-hls-load/test/target-monitor.test.mjs
@@ -1,0 +1,269 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MONITOR_THRESHOLDS, validateTargetMonitorStatus } from '../src/smoke-safety.mjs';
+import {
+  LISTENER_READY_URL,
+  LIVE_READY_URL,
+  MONITOR_QUERIES,
+  STREAM_HEALTH_URL,
+  createContainerBaseline,
+  loopbackTunnelOrigin,
+  probeMonitor,
+} from '../src/target-probe.mjs';
+
+const TEST_HOST_HASH = '0123456789ab';
+const PROMETHEUS = 'http://127.0.0.1:19090';
+const ALERTMANAGER = 'http://127.0.0.1:19093';
+const HEALTH_URLS = [LISTENER_READY_URL, STREAM_HEALTH_URL, LIVE_READY_URL];
+
+const DEFAULT_SCALARS = {
+  cpuUsedRatio: 0.2,
+  memoryUsedRatio: 0.4,
+  rootFreeRatio: 0.6,
+  egressBitsPerSecond: 500_000_000,
+  tcpRetransmitRatio: 0.001,
+  interfaceErrorsDrops: 0,
+  originUp: 1,
+  canaryOk: 1,
+  listenerStartSeconds: 1_700_000_000,
+  originStartSeconds: 1_700_000_100,
+  listenerOomEvents: 0,
+  originOomEvents: 0,
+};
+
+function fakeJsonResponse(body, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+  };
+}
+
+function vectorResult(values) {
+  return {
+    status: 'success',
+    data: {
+      resultType: 'vector',
+      result: values.map((value) => ({ metric: {}, value: [1_700_000_000, String(value)] })),
+    },
+  };
+}
+
+// Fully in-process fake: routes by URL and reads `state` live so a test can
+// change telemetry between probes. No socket is ever opened.
+function makeFetch(state) {
+  return async (url) => {
+    const text = String(url);
+    if (state.failUrls?.(text)) throw new Error('injected connection failure');
+    if (HEALTH_URLS.some((healthUrl) => text.startsWith(healthUrl))) {
+      const ok = state.healthOk !== false;
+      return {
+        ok,
+        status: ok ? 200 : 503,
+        headers: {
+          get: (name) => (name === 'x-harmonic-beacon-environment' && ok
+            ? 'early-birds-staging'
+            : null),
+        },
+      };
+    }
+    if (text.includes('/api/v2/status')) {
+      if (state.alertmanagerStatusError) return fakeJsonResponse({}, { ok: false, status: 500 });
+      return fakeJsonResponse(state.alertmanagerStatus ?? { cluster: { status: 'ready' } });
+    }
+    if (text.includes('/api/v2/alerts')) {
+      return fakeJsonResponse(state.alertmanagerAlerts ?? []);
+    }
+    if (text.includes('/api/v1/alerts')) {
+      return fakeJsonResponse({
+        status: 'success',
+        data: { alerts: state.firingAlerts ?? [] },
+      });
+    }
+    if (text.includes('/api/v1/query')) {
+      const query = new URL(text).searchParams.get('query');
+      const name = Object.keys(MONITOR_QUERIES).find((key) => MONITOR_QUERIES[key] === query);
+      assert.ok(name, `unexpected query ${query}`);
+      if (state.scalarResults && name in state.scalarResults) {
+        return fakeJsonResponse(state.scalarResults[name]);
+      }
+      const value = state.scalars && name in state.scalars
+        ? state.scalars[name]
+        : DEFAULT_SCALARS[name];
+      return fakeJsonResponse(vectorResult([value]));
+    }
+    throw new Error(`unexpected URL ${text}`);
+  };
+}
+
+async function probeTwice(state = {}) {
+  const baseline = createContainerBaseline();
+  const options = {
+    fetchImpl: makeFetch(state),
+    prometheusOrigin: PROMETHEUS,
+    alertmanagerOrigin: ALERTMANAGER,
+    hostHash: TEST_HOST_HASH,
+    baseline,
+  };
+  const first = await probeMonitor(options);
+  const second = await probeMonitor(options);
+  return { first, second, baseline };
+}
+
+test('loopback tunnel origins are validated exactly', () => {
+  assert.equal(loopbackTunnelOrigin('http://127.0.0.1:19090', 'Prometheus'), 'http://127.0.0.1:19090');
+  assert.equal(loopbackTunnelOrigin('http://[::1]:19093/', 'Alertmanager'), 'http://[::1]:19093');
+  for (const bad of [
+    'https://127.0.0.1:19090',
+    'http://user:pass@127.0.0.1:19090',
+    'http://mona.example:9090',
+    'http://127.0.0.1:19090/api',
+    'http://127.0.0.1:19090?x=1',
+    'not-a-url',
+  ]) {
+    assert.throws(() => loopbackTunnelOrigin(bad, 'Prometheus'), /loopback SSH tunnel origin/);
+  }
+});
+
+test('a healthy target passes only after the restart/OOM baseline is verified', async () => {
+  const { first, second } = await probeTwice();
+  assert.equal(first.status, 'FAIL');
+  assert.equal(first.restartBaselineEstablished, false);
+  assert.throws(() => validateTargetMonitorStatus(first), /not passing|baseline/);
+  assert.equal(second.status, 'PASS');
+  assert.equal(second.restartBaselineEstablished, true);
+  assert.equal(second.containerRestartsObserved, 0);
+  assert.equal(second.oomEventsDelta, 0);
+  assert.deepEqual(second.thresholds, { ...MONITOR_THRESHOLDS });
+  assert.doesNotThrow(() => validateTargetMonitorStatus(second));
+  // The status must not leak hostnames, URLs, labels or raw payloads.
+  const serialized = JSON.stringify(second);
+  assert.ok(!/harmonicbeacon|127\.0\.0\.1|19090|19093|container_|node_/.test(serialized.replace(
+    /https:\/\/stream\.harmonicbeacon\.com/,
+    '',
+  )));
+});
+
+test('Alertmanager unavailable, unready, firing or malformed fails closed', async () => {
+  const unavailable = await probeTwice({ failUrls: (url) => url.includes('/api/v2/') });
+  assert.equal(unavailable.second.status, 'FAIL');
+  assert.equal(unavailable.second.alertmanagerReady, false);
+
+  const settling = await probeTwice({ alertmanagerStatus: { cluster: { status: 'settling' } } });
+  assert.equal(settling.second.status, 'FAIL');
+  assert.equal(settling.second.alertmanagerReady, false);
+
+  const firing = await probeTwice({
+    alertmanagerAlerts: [{ status: { state: 'active', silencedBy: [], inhibitedBy: [] } }],
+  });
+  assert.equal(firing.second.status, 'FAIL');
+  assert.equal(firing.second.activeAlerts, 1);
+
+  const silenced = await probeTwice({
+    alertmanagerAlerts: [{ status: { state: 'active', silencedBy: ['abc'], inhibitedBy: [] } }],
+  });
+  assert.equal(silenced.second.status, 'PASS');
+  assert.equal(silenced.second.activeAlerts, 0);
+
+  const notAnArray = await probeTwice({ alertmanagerAlerts: { alerts: [] } });
+  assert.equal(notAnArray.second.status, 'FAIL');
+
+  const malformedEntry = await probeTwice({ alertmanagerAlerts: [{ unexpected: true }] });
+  assert.equal(malformedEntry.second.status, 'FAIL');
+
+  const failedStatus = await probeTwice({ alertmanagerStatusError: true });
+  assert.equal(failedStatus.second.status, 'FAIL');
+
+  const malformedStatus = await probeTwice({ alertmanagerStatus: [1, 2, 3] });
+  assert.equal(malformedStatus.second.status, 'FAIL');
+});
+
+test('firing Prometheus rules fail even when Alertmanager is quiet', async () => {
+  const { second } = await probeTwice({ firingAlerts: [{ state: 'firing' }, { state: 'pending' }] });
+  assert.equal(second.status, 'FAIL');
+  assert.equal(second.prometheusFiringAlerts, 1);
+});
+
+test('missing, ambiguous or non-finite scalar results fail closed', async () => {
+  for (const name of Object.keys(DEFAULT_SCALARS)) {
+    const missing = await probeTwice({ scalarResults: { [name]: vectorResult([]) } });
+    assert.equal(missing.second.status, 'FAIL', `${name} missing must fail`);
+    const ambiguous = await probeTwice({ scalarResults: { [name]: vectorResult([1, 1]) } });
+    assert.equal(ambiguous.second.status, 'FAIL', `${name} ambiguous must fail`);
+    const notFinite = await probeTwice({ scalarResults: { [name]: vectorResult(['NaN']) } });
+    assert.equal(notFinite.second.status, 'FAIL', `${name} NaN must fail`);
+    const infinite = await probeTwice({ scalarResults: { [name]: vectorResult(['+Inf']) } });
+    assert.equal(infinite.second.status, 'FAIL', `${name} Inf must fail`);
+  }
+});
+
+test('immediate stop thresholds are enforced at their exact edges', async () => {
+  const edges = [
+    ['cpuUsedRatio', MONITOR_THRESHOLDS.maxCpuUsedRatio, 0.499],
+    ['memoryUsedRatio', MONITOR_THRESHOLDS.maxMemoryUsedRatio, 0.699],
+    ['rootFreeRatio', MONITOR_THRESHOLDS.minRootFreeRatio, 0.301],
+    ['egressBitsPerSecond', MONITOR_THRESHOLDS.maxEgressBitsPerSecond, 1_499_999_999],
+    ['tcpRetransmitRatio', MONITOR_THRESHOLDS.maxTcpRetransmitRatio, 0.0099],
+    ['interfaceErrorsDrops', 1, 0],
+    ['canaryOk', 0, 1],
+    ['originUp', 0, 1],
+  ];
+  for (const [name, failingValue, passingValue] of edges) {
+    const failing = await probeTwice({ scalars: { [name]: failingValue } });
+    assert.equal(failing.second.status, 'FAIL', `${name}=${failingValue} must fail`);
+    const passing = await probeTwice({ scalars: { [name]: passingValue } });
+    assert.equal(passing.second.status, 'PASS', `${name}=${passingValue} must pass`);
+  }
+});
+
+test('a changed container start timestamp is latched as a restart', async () => {
+  const state = { scalars: {} };
+  const baseline = createContainerBaseline();
+  const options = {
+    fetchImpl: makeFetch(state),
+    prometheusOrigin: PROMETHEUS,
+    alertmanagerOrigin: ALERTMANAGER,
+    hostHash: TEST_HOST_HASH,
+    baseline,
+  };
+  await probeMonitor(options);
+  const clean = await probeMonitor(options);
+  assert.equal(clean.status, 'PASS');
+  state.scalars.listenerStartSeconds = DEFAULT_SCALARS.listenerStartSeconds + 60;
+  const restarted = await probeMonitor(options);
+  assert.equal(restarted.status, 'FAIL');
+  assert.equal(restarted.containerRestartsObserved, 1);
+  assert.throws(() => validateTargetMonitorStatus(restarted), /restart or OOM|not passing/);
+  // The latch persists: later samples cannot quietly re-pass.
+  const latched = await probeMonitor(options);
+  assert.equal(latched.status, 'FAIL');
+  assert.equal(latched.containerRestartsObserved, 1);
+});
+
+test('an increased container OOM counter fails closed with a bounded delta', async () => {
+  const state = { scalars: {} };
+  const baseline = createContainerBaseline();
+  const options = {
+    fetchImpl: makeFetch(state),
+    prometheusOrigin: PROMETHEUS,
+    alertmanagerOrigin: ALERTMANAGER,
+    hostHash: TEST_HOST_HASH,
+    baseline,
+  };
+  await probeMonitor(options);
+  assert.equal((await probeMonitor(options)).status, 'PASS');
+  state.scalars.originOomEvents = 2;
+  const oomed = await probeMonitor(options);
+  assert.equal(oomed.status, 'FAIL');
+  assert.equal(oomed.oomEventsDelta, 2);
+});
+
+test('a degraded health endpoint fails the probe without sensitive detail', async () => {
+  const { second } = await probeTwice({ healthOk: false });
+  assert.equal(second.status, 'FAIL');
+  assert.equal(second.listenerReady, false);
+  assert.equal(second.streamHealthy, false);
+  assert.equal(second.liveReady, false);
+});


### PR DESCRIPTION
## Outcome

Adds a dormant, reproducible first external Listener HLS smoke harness fixed at exactly 10 clients for 60 seconds, plus fail-closed target monitoring and an honest runbook.

## Safety

- exact non-production staging target/origin allowlist;
- fixed 10 clients, one shard, 60 seconds, ramp 2; no CLI override;
- one non-configurable host lock prevents overlapping wrappers for the same Unix account;
- private 0600 manifest/status inputs and signed-URL redaction;
- external decoded canary plus staging/stream/live/Prometheus/Alertmanager guard;
- aborts on stale telemetry, readiness, alert, restart/OOM, threshold, or event-safety doubt;
- mona-like generators refused; external topology remains a trusted operator precondition, not overclaimed as cryptographic proof.

## Current runtime blocker

No network load was run. Docker 29.6.2 on mona uses the containerd image store, while the existing cAdvisor cannot provide the exact per-container restart/OOM series. The harness fails closed and the runbook explicitly prohibits proceeding, recreating cAdvisor, or weakening evidence until a supported observer is approved and verified.

## Evidence

- 51/51 load-tool tests;
- 9/9 EarlyBird ops tests;
- syntax and diff checks green;
- independent adversarial review approved after removing a false rslave fix, adding aggregate locking, fixing the guard stop race, removing lock-path override, and documenting the residual TOCTOU/trusted-operation boundary.

## Runtime impact / rollback

This PR adds only manually invoked tooling, tests and documentation. It changes no Compose, app route, event, LiveKit, audio or runtime service and executes nothing on merge. Rollback is a normal revert of the four commits.
