### PR TITLE
feat(listener): project canonical Founder eligibility

### DIFF
--- a/contracts/early-bird-authority/v2/README.md
+++ b/contracts/early-bird-authority/v2/README.md
@@ -1,0 +1,32 @@
+# EarlyBird authority membership read contract v2
+
+This additive private read contract exposes two independent facts to Listener:
+
+- the current membership and its server-authoritative `access_allowed` decision;
+- the account's durable Founder price eligibility, when one has been earned.
+
+`GET /api/internal/v2/early-bird-memberships/{account_id}` requires the same private
+`Authorization: Bearer ...` and `X-HB-Service-Key-Id` credentials as v1. Successful membership
+responses and the generic `membership_not_found` response use `Cache-Control: private, no-store`.
+Authentication, disabled-service and path-validation failures retain FastAPI's existing generic
+error handling. The browser must never call this endpoint.
+
+`founder_price_eligibility: null` means that the existing account has not earned Founder pricing.
+A non-null object records the immutable canonical USD 2/month offer earned by a confirmed paid
+activation. It does not mean that a membership is active, that a payment succeeded recently, or
+that access is allowed. Only `access_allowed` authorizes listening. Cancellation, expiry, refund or
+revocation can therefore coexist with retained Founder price eligibility.
+
+Free access, welcome access, invitations, Free For All, checkout redirects and incomplete or
+terminal provider events without a prior confirmed activation never create eligibility.
+`membership_revision` continues to version membership/access state; it is not an eligibility
+revision. The response contains no name, email, OAuth material, payment history, provider event or
+subscription identifier, stream URL or secret.
+
+Every membership/access writer must either take the account row lock or update the account revision
+before commit. The v2 read takes a shared account lock so membership and eligibility cannot be
+observed across different committed writer states, while concurrent reads remain possible.
+
+The v1 membership endpoint remains available unchanged for rollback. Invitation redemption and
+checkout creation remain on the v1 authority contract; this directory versions only the read
+shape added by v2.

--- a/contracts/early-bird-authority/v2/SHA256SUMS
+++ b/contracts/early-bird-authority/v2/SHA256SUMS
@@ -1,0 +1,3 @@
+42a2dd7f1e74e295a073efd785e9eae05a27d74bf14cfcf44294f8eb83716d68  README.md
+d7e19379aaa071ee34260e2e26cdab2fa0927e27765d7b52e22a9b403c864d4c  membership.fixture.json
+52bb0b8bb7a1545e6ae9c806d94b4e19b3e74c2bec4d58546987e74aa67afa82  membership.schema.json

--- a/contracts/early-bird-authority/v2/membership.fixture.json
+++ b/contracts/early-bird-authority/v2/membership.fixture.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "early-bird-authority.membership.v2",
+  "account_id": "account_synthetic_founder_0001",
+  "membership_revision": 2,
+  "state": "EXPIRED",
+  "source": "PAYPAL",
+  "access_allowed": false,
+  "effective_at": "2026-08-06T12:00:00Z",
+  "paid_through": "2026-09-06T12:00:00Z",
+  "grace_until": null,
+  "offer": {
+    "code": "EARLY_BIRDS_FOUNDERS_V1",
+    "revision": 1
+  },
+  "provider": "paypal",
+  "current_price": {
+    "currency": "USD",
+    "amount_minor": 200
+  },
+  "free_entitlement_consumed": true,
+  "reason_code": "SUBSCRIPTION_CANCELLED",
+  "founder_price_eligibility": {
+    "offer": {
+      "code": "EARLY_BIRDS_FOUNDERS_V1",
+      "revision": 1
+    },
+    "canonical_price": {
+      "currency": "USD",
+      "amount_minor": 200
+    },
+    "billing_period": "MONTHLY",
+    "granted_at": "2026-08-06T12:00:00Z"
+  }
+}

--- a/contracts/early-bird-authority/v2/membership.schema.json
+++ b/contracts/early-bird-authority/v2/membership.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harmonicbeacon.com/contracts/early-bird-authority/v2/membership.schema.json",
+  "title": "EarlyBird canonical membership and Founder price eligibility v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "account_id",
+    "membership_revision",
+    "state",
+    "source",
+    "access_allowed",
+    "effective_at",
+    "paid_through",
+    "grace_until",
+    "offer",
+    "provider",
+    "current_price",
+    "free_entitlement_consumed",
+    "reason_code",
+    "founder_price_eligibility"
+  ],
+  "properties": {
+    "schema_version": {"const": "early-bird-authority.membership.v2"},
+    "account_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$"
+    },
+    "membership_revision": {"type": "integer", "minimum": 1},
+    "state": {
+      "enum": [
+        "PENDING",
+        "ACTIVE",
+        "GRACE",
+        "CANCELLED_PENDING_END",
+        "EXPIRED",
+        "REFUNDED",
+        "REVOKED"
+      ]
+    },
+    "source": {"type": ["string", "null"], "enum": ["FREE", "PAYPAL", "MERCADO_PAGO", null]},
+    "access_allowed": {"type": "boolean"},
+    "effective_at": {"type": "string", "format": "date-time"},
+    "paid_through": {"type": ["string", "null"], "format": "date-time"},
+    "grace_until": {"type": ["string", "null"], "format": "date-time"},
+    "offer": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code", "revision"],
+          "properties": {
+            "code": {"const": "EARLY_BIRDS_FOUNDERS_V1"},
+            "revision": {"type": "integer", "minimum": 1}
+          }
+        }
+      ]
+    },
+    "provider": {"type": ["string", "null"], "enum": ["paypal", "mercado_pago", null]},
+    "current_price": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["currency", "amount_minor"],
+          "properties": {
+            "currency": {"enum": ["USD", "ARS"]},
+            "amount_minor": {"type": "integer", "minimum": 1}
+          }
+        }
+      ]
+    },
+    "free_entitlement_consumed": {"type": "boolean"},
+    "reason_code": {"type": "string", "minLength": 1, "maxLength": 64},
+    "founder_price_eligibility": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["offer", "canonical_price", "billing_period", "granted_at"],
+          "properties": {
+            "offer": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["code", "revision"],
+              "properties": {
+                "code": {"const": "EARLY_BIRDS_FOUNDERS_V1"},
+                "revision": {"type": "integer", "minimum": 1}
+              }
+            },
+            "canonical_price": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["currency", "amount_minor"],
+              "properties": {
+                "currency": {"const": "USD"},
+                "amount_minor": {"const": 200}
+              }
+            },
+            "billing_period": {"const": "MONTHLY"},
+            "granted_at": {"type": "string", "format": "date-time"}
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/architecture/LISTENER_FOUNDER_ELIGIBILITY.md
+++ b/docs/architecture/LISTENER_FOUNDER_ELIGIBILITY.md
@@ -1,0 +1,61 @@
+# Listener Founder price eligibility projection
+
+## Boundary
+
+PMP Myth Bot is the only authority that can grant the lifetime Founding Listener price. Its private
+membership read v2 is versioned in `contracts/early-bird-authority/v2` and was introduced by backend
+merge `3febc1d525adf150bfdd75fd2b98b04771cb79b7`.
+
+Listener stores a positive-only projection of that evidence in
+`early_bird_founder_eligibility_projections`. This row is deliberately separate from the v1
+membership projection:
+
+- it has no membership revision and never participates in stream authorization;
+- its hash covers only the canonical eligibility object;
+- RFC 3339 timestamps are normalized to UTC millisecond precision before hashing and storage;
+- the first positive value is immutable;
+- `null` never deletes or downgrades an existing positive value;
+- Free, welcome access, invitations and Free For All never create the row.
+
+The existing membership push route, public page, access resolver, leases and presentation remain
+unchanged. Founder eligibility alone cannot grant listening access or produce a Purchase event.
+
+## Reconciliation
+
+An authenticated server-side caller may request:
+
+```text
+POST /api/internal/v1/early-bird-founder-eligibilities/{account_id}/reconcile
+Authorization: Bearer <Listener membership service token>
+X-HB-Service-Key-Id: <current key id>
+```
+
+The route authenticates and verifies the local opaque account before contacting the authority. It
+then performs a bounded, no-store GET of the private v2 membership document and applies only
+`founder_price_eligibility` transactionally.
+
+Successful outcomes are:
+
+- `ABSENT`: the authority returned `null` and no local positive evidence exists;
+- `APPLIED`: the first canonical positive evidence was stored;
+- `REPLAYED`: the exact evidence already exists.
+
+Conflicting positive evidence, positive-to-null transitions and an authority 404 for an existing
+local account return 409 and preserve local state. Authority timeout, authentication failure, 5xx,
+oversized or malformed bodies and account mismatches return a generic 503 without mutation.
+Unknown local accounts return 404 before outbound I/O. Unexpected database failures return a
+generic 500 and roll back the transaction.
+
+The endpoint is not invoked by page rendering, OAuth, stream lease creation or the v1 push route.
+Automation can be added later as an operations worker without changing the evidence semantics.
+`observed_at` records the first successful local observation and is intentionally unchanged on replay.
+
+## Migration and rollback
+
+The migration is forward-only and additive. Deploying code before the migration is prohibited;
+deploy applies the migration before selecting an image. Rolling the application image back is safe
+because older code ignores the new table. The table is retained during rollback so positive
+eligibility evidence is never destroyed.
+
+This subsystem belongs only to the isolated Listener product. It does not modify weekend events,
+LiveKit, event tickets, tapestry, event audio or Proyección del Mito.

--- a/prisma/migrations/20260808090000_early_bird_founder_eligibility_projection/migration.sql
+++ b/prisma/migrations/20260808090000_early_bird_founder_eligibility_projection/migration.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "early_bird_founder_eligibility_projections" (
+    "account_id" TEXT NOT NULL,
+    "offer_code" VARCHAR(128) NOT NULL,
+    "offer_revision" INTEGER NOT NULL,
+    "currency" CHAR(3) NOT NULL,
+    "amount_minor" INTEGER NOT NULL,
+    "billing_period" VARCHAR(32) NOT NULL,
+    "granted_at" TIMESTAMP(3) NOT NULL,
+    "eligibility_hash" CHAR(64) NOT NULL,
+    "observed_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "early_bird_founder_eligibility_projections_pkey" PRIMARY KEY ("account_id"),
+    CONSTRAINT "early_bird_founder_eligibility_offer_code_check"
+        CHECK ("offer_code" = 'EARLY_BIRDS_FOUNDERS_V1'),
+    CONSTRAINT "early_bird_founder_eligibility_offer_revision_check"
+        CHECK ("offer_revision" >= 1),
+    CONSTRAINT "early_bird_founder_eligibility_currency_check"
+        CHECK ("currency" = 'USD'),
+    CONSTRAINT "early_bird_founder_eligibility_amount_check"
+        CHECK ("amount_minor" = 200),
+    CONSTRAINT "early_bird_founder_eligibility_period_check"
+        CHECK ("billing_period" = 'MONTHLY'),
+    CONSTRAINT "early_bird_founder_eligibility_hash_check"
+        CHECK ("eligibility_hash" ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX "early_bird_founder_eligibility_projections_granted_at_idx"
+    ON "early_bird_founder_eligibility_projections"("granted_at");
+
+ALTER TABLE "early_bird_founder_eligibility_projections"
+    ADD CONSTRAINT "early_bird_founder_eligibility_projections_account_id_fkey"
+    FOREIGN KEY ("account_id") REFERENCES "early_bird_users"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -442,12 +442,13 @@ model EarlyBirdUser {
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")
 
-  identities   EarlyBirdIdentity[]
-  authSessions EarlyBirdAuthSession[]
-  membership   EarlyBirdMembershipProjection?
-  freeSchedule EarlyBirdFreeSchedule?
-  welcomeAccess EarlyBirdWelcomeAccess?
-  streamLeases EarlyBirdStreamLease[]
+  identities         EarlyBirdIdentity[]
+  authSessions       EarlyBirdAuthSession[]
+  membership         EarlyBirdMembershipProjection?
+  founderEligibility EarlyBirdFounderEligibilityProjection?
+  freeSchedule       EarlyBirdFreeSchedule?
+  welcomeAccess      EarlyBirdWelcomeAccess?
+  streamLeases       EarlyBirdStreamLease[]
 
   @@map("early_bird_users")
 }
@@ -542,6 +543,27 @@ model EarlyBirdMembershipProjection {
 
   @@index([state, paidThrough])
   @@map("early_bird_membership_projections")
+}
+
+// Positive-only projection of the canonical, lifetime Founder price evidence.
+// It is deliberately separate from membership/access revisions and authorizes
+// nothing by itself.
+model EarlyBirdFounderEligibilityProjection {
+  accountId       String        @id @map("account_id")
+  account         EarlyBirdUser @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  offerCode       String        @map("offer_code") @db.VarChar(128)
+  offerRevision   Int           @map("offer_revision")
+  currency        String        @db.Char(3)
+  amountMinor     Int           @map("amount_minor")
+  billingPeriod   String        @map("billing_period") @db.VarChar(32)
+  grantedAt       DateTime      @map("granted_at")
+  eligibilityHash String        @map("eligibility_hash") @db.Char(64)
+  observedAt      DateTime      @map("observed_at")
+  createdAt       DateTime      @default(now()) @map("created_at")
+  updatedAt       DateTime      @updatedAt @map("updated_at")
+
+  @@index([grantedAt])
+  @@map("early_bird_founder_eligibility_projections")
 }
 
 // Account-bound ordinary Free access. This is deliberately independent from

--- a/scripts/verify-early-bird-contracts.py
+++ b/scripts/verify-early-bird-contracts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify byte-exact copies of both canonical EarlyBird v1 contracts."""
+"""Verify byte-exact copies of the canonical EarlyBird contracts."""
 
 import hashlib
 from pathlib import Path
@@ -8,6 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACTS = (
     ROOT / "contracts/early-bird-authority/v1",
+    ROOT / "contracts/early-bird-authority/v2",
     ROOT / "contracts/early-bird-membership/v1",
 )
 

--- a/src/app/api/internal/v1/early-bird-founder-eligibilities/[accountId]/reconcile/__tests__/route.test.ts
+++ b/src/app/api/internal/v1/early-bird-founder-eligibilities/[accountId]/reconcile/__tests__/route.test.ts
@@ -1,0 +1,145 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    authorize: vi.fn(),
+    findAccount: vi.fn(),
+    readMembership: vi.fn(),
+    apply: vi.fn(),
+}));
+
+vi.mock('@/lib/early-birds/service-auth', () => ({
+    authorizeEarlyBirdMembershipService: mocks.authorize,
+}));
+vi.mock('@/lib/db', () => ({
+    prisma: { earlyBirdUser: { findUnique: mocks.findAccount } },
+}));
+vi.mock('@/lib/early-birds/membership-gateway', async (importOriginal) => ({
+    ...await importOriginal<typeof import('@/lib/early-birds/membership-gateway')>(),
+    earlyBirdMembershipReader: () => ({ readMembership: mocks.readMembership }),
+}));
+vi.mock('@/lib/early-birds/founder-eligibility', async (importOriginal) => ({
+    ...await importOriginal<typeof import('@/lib/early-birds/founder-eligibility')>(),
+    applyFounderEligibilityProjection: mocks.apply,
+}));
+
+import { FounderEligibilityConflictError } from '@/lib/early-birds/founder-eligibility';
+import { EarlyBirdMembershipGatewayUnavailableError } from '@/lib/early-birds/membership-gateway';
+
+import { POST } from '../route';
+
+const ACCOUNT = 'listener-1';
+const eligibility = {
+    offer: { code: 'EARLY_BIRDS_FOUNDERS_V1', revision: 1 },
+    canonical_price: { currency: 'USD', amount_minor: 200 },
+    billing_period: 'MONTHLY',
+    granted_at: '2026-08-06T12:00:00Z',
+};
+const canonical = {
+    schema_version: 'early-bird-authority.membership.v2',
+    account_id: ACCOUNT,
+    membership_revision: 2,
+    state: 'EXPIRED',
+    source: 'PAYPAL',
+    access_allowed: false,
+    effective_at: '2026-08-06T12:00:00Z',
+    paid_through: '2026-09-06T12:00:00Z',
+    grace_until: null,
+    offer: { code: 'EARLY_BIRDS_FOUNDERS_V1', revision: 1 },
+    provider: 'paypal',
+    current_price: { currency: 'USD', amount_minor: 200 },
+    free_entitlement_consumed: true,
+    reason_code: 'SUBSCRIPTION_CANCELLED',
+    founder_price_eligibility: eligibility,
+};
+
+function request(headers: Record<string, string> = {}) {
+    return new NextRequest(
+        `http://beacon-app:3000/api/internal/v1/early-bird-founder-eligibilities/${ACCOUNT}/reconcile`,
+        {
+            method: 'POST',
+            headers: {
+                authorization: 'Bearer secret-not-logged',
+                'x-hb-service-key-id': 'current',
+                ...headers,
+            },
+        },
+    );
+}
+
+const params = { params: Promise.resolve({ accountId: ACCOUNT }) };
+
+describe('private Founder eligibility reconciliation route', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.authorize.mockReturnValue(true);
+        mocks.findAccount.mockResolvedValue({ id: ACCOUNT });
+        mocks.readMembership.mockResolvedValue({ ok: true, membership: canonical });
+        mocks.apply.mockResolvedValue('APPLIED');
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    it('authenticates before local lookup or outbound authority access', async () => {
+        mocks.authorize.mockReturnValue(false);
+        const response = await POST(request(), params);
+        expect(response.status).toBe(401);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(mocks.findAccount).not.toHaveBeenCalled();
+        expect(mocks.readMembership).not.toHaveBeenCalled();
+        expect(mocks.apply).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown local account without contacting the authority', async () => {
+        mocks.findAccount.mockResolvedValue(null);
+        const response = await POST(request(), params);
+        expect(response.status).toBe(404);
+        expect(mocks.readMembership).not.toHaveBeenCalled();
+    });
+
+    it.each(['ABSENT', 'APPLIED', 'REPLAYED'] as const)('returns only the sanitized %s outcome', async (outcome) => {
+        mocks.apply.mockResolvedValue(outcome);
+        if (outcome === 'ABSENT') {
+            mocks.readMembership.mockResolvedValue({
+                ok: true,
+                membership: { ...canonical, founder_price_eligibility: null },
+            });
+        }
+        const response = await POST(request(), params);
+        expect(response.status).toBe(200);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(await response.json()).toEqual({
+            schema_version: 'listener-founder-eligibility-reconciliation.result.v1',
+            outcome,
+            founder_price_eligible: outcome !== 'ABSENT',
+        });
+        expect(mocks.apply).toHaveBeenCalledWith(
+            ACCOUNT,
+            outcome === 'ABSENT' ? null : eligibility,
+        );
+    });
+
+    it('maps authority absence and durable evidence conflict to generic 409', async () => {
+        mocks.readMembership.mockResolvedValue({ ok: false, reason: 'not-found' });
+        const absent = await POST(request(), params);
+        expect(absent.status).toBe(409);
+
+        mocks.readMembership.mockResolvedValue({ ok: true, membership: canonical });
+        mocks.apply.mockRejectedValue(new FounderEligibilityConflictError());
+        const conflict = await POST(request(), params);
+        expect(conflict.status).toBe(409);
+        expect(await conflict.json()).toEqual({ error: 'Founder eligibility reconciliation conflict.' });
+    });
+
+    it('maps authority and database failures without leaking their material', async () => {
+        mocks.readMembership.mockRejectedValue(new EarlyBirdMembershipGatewayUnavailableError());
+        const authority = await POST(request(), params);
+        expect(authority.status).toBe(503);
+        expect(await authority.json()).toEqual({ error: 'Founder eligibility authority unavailable.' });
+
+        mocks.readMembership.mockResolvedValue({ ok: true, membership: canonical });
+        mocks.apply.mockRejectedValue(new Error('subscription secret provider body'));
+        const database = await POST(request(), params);
+        expect(database.status).toBe(500);
+        expect(JSON.stringify(await database.json())).not.toContain('subscription secret provider body');
+    });
+});

--- a/src/app/api/internal/v1/early-bird-founder-eligibilities/[accountId]/reconcile/route.ts
+++ b/src/app/api/internal/v1/early-bird-founder-eligibilities/[accountId]/reconcile/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { prisma } from '@/lib/db';
+import {
+    applyFounderEligibilityProjection,
+    FounderEligibilityAccountNotFoundError,
+    FounderEligibilityConflictError,
+} from '@/lib/early-birds/founder-eligibility';
+import {
+    earlyBirdMembershipReader,
+    EarlyBirdMembershipGatewayUnavailableError,
+} from '@/lib/early-birds/membership-gateway';
+import { isEarlyBirdAccountId } from '@/lib/early-birds/account-id';
+import { authorizeEarlyBirdMembershipService } from '@/lib/early-birds/service-auth';
+
+export const dynamic = 'force-dynamic';
+
+const NO_STORE = { 'Cache-Control': 'private, no-store' };
+
+function response(body: unknown, status = 200): NextResponse {
+    return NextResponse.json(body, { status, headers: NO_STORE });
+}
+
+function authorized(request: NextRequest): boolean {
+    return authorizeEarlyBirdMembershipService(
+        request.headers.get('authorization'),
+        request.headers.get('x-hb-service-key-id'),
+    );
+}
+
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ accountId: string }> },
+): Promise<NextResponse> {
+    if (!authorized(request)) return response({ error: 'Service authentication failed.' }, 401);
+    const { accountId } = await params;
+    if (!isEarlyBirdAccountId(accountId)) return response({ error: 'Resource not found.' }, 404);
+
+    try {
+        const account = await prisma.earlyBirdUser.findUnique({
+            where: { id: accountId },
+            select: { id: true },
+        });
+        if (!account) return response({ error: 'Resource not found.' }, 404);
+    } catch {
+        console.error('[founder-eligibility] local account lookup failed');
+        return response({ error: 'Founder eligibility reconciliation unavailable.' }, 500);
+    }
+
+    let canonical;
+    try {
+        canonical = await earlyBirdMembershipReader().readMembership(accountId);
+    } catch (error) {
+        if (!(error instanceof EarlyBirdMembershipGatewayUnavailableError)) {
+            console.error('[founder-eligibility] unexpected authority read failure');
+        }
+        return response({ error: 'Founder eligibility authority unavailable.' }, 503);
+    }
+    if (!canonical.ok) {
+        return response({ error: 'Founder eligibility reconciliation conflict.' }, 409);
+    }
+
+    try {
+        const outcome = await applyFounderEligibilityProjection(
+            accountId,
+            canonical.membership.founder_price_eligibility,
+        );
+        return response({
+            schema_version: 'listener-founder-eligibility-reconciliation.result.v1',
+            outcome,
+            founder_price_eligible: canonical.membership.founder_price_eligibility !== null,
+        });
+    } catch (error) {
+        if (error instanceof FounderEligibilityAccountNotFoundError) {
+            return response({ error: 'Resource not found.' }, 404);
+        }
+        if (error instanceof FounderEligibilityConflictError) {
+            return response({ error: 'Founder eligibility reconciliation conflict.' }, 409);
+        }
+        console.error('[founder-eligibility] projection failed without authority material');
+        return response({ error: 'Founder eligibility reconciliation unavailable.' }, 500);
+    }
+}

--- a/src/lib/early-birds/__tests__/founder-eligibility-contract.test.ts
+++ b/src/lib/early-birds/__tests__/founder-eligibility-contract.test.ts
@@ -1,0 +1,238 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+    HttpEarlyBirdMembershipGateway,
+} from '../membership-gateway';
+import {
+    EarlyBirdMembershipContractError,
+    parseCanonicalAuthorityMembershipV2,
+} from '../membership-contract';
+
+const CONTRACT = resolve(process.cwd(), 'contracts/early-bird-authority/v2');
+const fixture = JSON.parse(readFileSync(`${CONTRACT}/membership.fixture.json`, 'utf8')) as Record<string, unknown>;
+const active: Record<string, unknown> = {
+    ...fixture,
+    account_id: 'listener-1',
+    state: 'ACTIVE',
+    access_allowed: true,
+    effective_at: '2026-08-08T12:00:00Z',
+    paid_through: '2027-08-08T12:00:00Z',
+    reason_code: 'PAYMENT_SUCCEEDED',
+};
+
+function cancellableResponse(status: number, headers: Record<string, string> = {}) {
+    let cancelled = false;
+    const response = new Response(new ReadableStream<Uint8Array>({
+        pull(controller) {
+            controller.enqueue(new Uint8Array([0x7b]));
+        },
+        cancel() {
+            cancelled = true;
+        },
+    }, { highWaterMark: 0 }), { status, headers });
+    return { response, wasCancelled: () => cancelled };
+}
+
+describe('canonical Founder membership read v2', () => {
+    it('parses the byte-vendored positive fixture and a Free null eligibility', () => {
+        expect(parseCanonicalAuthorityMembershipV2(fixture).founder_price_eligibility)
+            .toEqual({
+                ...(fixture.founder_price_eligibility as object),
+                granted_at: '2026-08-06T12:00:00.000Z',
+            });
+        expect(parseCanonicalAuthorityMembershipV2({
+            ...active,
+            source: 'FREE',
+            provider: null,
+            current_price: null,
+            founder_price_eligibility: null,
+        }).founder_price_eligibility).toBeNull();
+    });
+
+    it.each([
+        ['extra top-level field', { ...active, email: 'private@example.invalid' }],
+        ['missing eligibility', Object.fromEntries(Object.entries(active).filter(([key]) => key !== 'founder_price_eligibility'))],
+        ['wrong currency', {
+            ...active,
+            founder_price_eligibility: {
+                ...(active.founder_price_eligibility as object),
+                canonical_price: { currency: 'ARS', amount_minor: 200 },
+            },
+        }],
+        ['wrong amount', {
+            ...active,
+            founder_price_eligibility: {
+                ...(active.founder_price_eligibility as object),
+                canonical_price: { currency: 'USD', amount_minor: 201 },
+            },
+        }],
+        ['wrong period', {
+            ...active,
+            founder_price_eligibility: {
+                ...(active.founder_price_eligibility as object),
+                billing_period: 'YEARLY',
+            },
+        }],
+        ['impossible calendar date', {
+            ...active,
+            founder_price_eligibility: {
+                ...(active.founder_price_eligibility as object),
+                granted_at: '2026-02-30T12:00:00Z',
+            },
+        }],
+        ['invalid hour', {
+            ...active,
+            founder_price_eligibility: {
+                ...(active.founder_price_eligibility as object),
+                granted_at: '2026-08-06T24:00:00Z',
+            },
+        }],
+        ['unsafe revision', {
+            ...active,
+            founder_price_eligibility: {
+                ...(active.founder_price_eligibility as object),
+                offer: { code: 'EARLY_BIRDS_FOUNDERS_V1', revision: Number.MAX_SAFE_INTEGER + 1 },
+            },
+        }],
+        ['paid access without eligibility', { ...active, founder_price_eligibility: null }],
+    ])('rejects %s', (_label, payload) => {
+        expect(() => parseCanonicalAuthorityMembershipV2(payload))
+            .toThrow(EarlyBirdMembershipContractError);
+    });
+
+    it('accepts RFC 3339 offsets and canonicalizes equivalent instants to UTC milliseconds', () => {
+        const withOffset = parseCanonicalAuthorityMembershipV2({
+            ...active,
+            effective_at: '2026-08-08T09:00:00-03:00',
+            paid_through: '2027-08-08T09:00:00.000000000-03:00',
+            founder_price_eligibility: {
+                ...(active.founder_price_eligibility as object),
+                granted_at: '2026-08-06T09:00:00-03:00',
+            },
+        });
+        const withFraction = parseCanonicalAuthorityMembershipV2({
+            ...active,
+            founder_price_eligibility: {
+                ...(active.founder_price_eligibility as object),
+                granted_at: '2026-08-06T12:00:00.000000000Z',
+            },
+        });
+        expect(withOffset.founder_price_eligibility?.granted_at)
+            .toBe('2026-08-06T12:00:00.000Z');
+        expect(withOffset.effective_at).toBe('2026-08-08T12:00:00.000Z');
+        expect(withOffset.paid_through).toBe('2027-08-08T12:00:00.000Z');
+        expect(withFraction.founder_price_eligibility?.granted_at)
+            .toBe('2026-08-06T12:00:00.000Z');
+    });
+
+    it.each([
+        ['effective_at', { effective_at: '2026-02-30T12:00:00Z' }],
+        ['paid_through', { paid_through: '2027-02-30T12:00:00Z' }],
+        ['grace_until', { grace_until: '2026-08-08T12:00:00+24:00' }],
+    ])('rejects invalid v2 %s while leaving the legacy v1 parser unchanged', (_label, override) => {
+        expect(() => parseCanonicalAuthorityMembershipV2({ ...active, ...override }))
+            .toThrow(EarlyBirdMembershipContractError);
+    });
+
+    it('uses the exact private GET and rejects mismatches or oversized bodies', async () => {
+        const request = vi.fn().mockResolvedValue(new Response(JSON.stringify(active), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        }));
+        const gateway = new HttpEarlyBirdMembershipGateway({
+            baseUrl: 'http://pmp-myth-api:8765',
+            keyId: '2026-08-current',
+            token: 's'.repeat(43),
+        }, request);
+
+        await expect(gateway.readMembership('listener-1')).resolves.toMatchObject({
+            ok: true,
+            membership: { account_id: 'listener-1' },
+        });
+        expect(request).toHaveBeenCalledWith(
+            'http://pmp-myth-api:8765/api/internal/v2/early-bird-memberships/listener-1',
+            expect.objectContaining({
+                method: 'GET',
+                redirect: 'error',
+                cache: 'no-store',
+                headers: expect.objectContaining({
+                    authorization: `Bearer ${'s'.repeat(43)}`,
+                    'x-hb-service-key-id': '2026-08-current',
+                }),
+            }),
+        );
+
+        request.mockResolvedValueOnce(new Response(JSON.stringify({ ...active, account_id: 'other' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        }));
+        await expect(gateway.readMembership('listener-1')).rejects.toThrow('unavailable');
+
+        const oversized = cancellableResponse(200, {
+            'content-type': 'application/json',
+            'content-length': String(65 * 1024),
+        });
+        request.mockResolvedValueOnce(oversized.response);
+        await expect(gateway.readMembership('listener-1')).rejects.toThrow('unavailable');
+        expect(oversized.wasCancelled()).toBe(true);
+    });
+
+    it('distinguishes canonical not-found and fails closed on other statuses', async () => {
+        const notFound = cancellableResponse(404);
+        const request = vi.fn().mockResolvedValue(notFound.response);
+        const gateway = new HttpEarlyBirdMembershipGateway({
+            baseUrl: 'https://authority.example.test',
+            keyId: 'current',
+            token: 's'.repeat(43),
+        }, request);
+        await expect(gateway.readMembership('listener-1')).resolves.toEqual({
+            ok: false,
+            reason: 'not-found',
+        });
+        expect(notFound.wasCancelled()).toBe(true);
+
+        const unauthorized = cancellableResponse(401);
+        request.mockResolvedValueOnce(unauthorized.response);
+        await expect(gateway.readMembership('listener-1')).rejects.toThrow('unavailable');
+        expect(unauthorized.wasCancelled()).toBe(true);
+
+        const wrongContentType = cancellableResponse(200, { 'content-type': 'text/html' });
+        request.mockResolvedValueOnce(wrongContentType.response);
+        await expect(gateway.readMembership('listener-1')).rejects.toThrow('unavailable');
+        expect(wrongContentType.wasCancelled()).toBe(true);
+    });
+
+    it('cancels an undeclared chunked body as soon as it exceeds 64 KiB', async () => {
+        let pulls = 0;
+        let cancelled = false;
+        const body = new ReadableStream<Uint8Array>({
+            pull(controller) {
+                pulls += 1;
+                if (pulls <= 4) {
+                    controller.enqueue(new Uint8Array(24 * 1024).fill(0x20));
+                } else {
+                    controller.close();
+                }
+            },
+            cancel() {
+                cancelled = true;
+            },
+        }, { highWaterMark: 0 });
+        const request = vi.fn().mockResolvedValue(new Response(body, {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        }));
+        const gateway = new HttpEarlyBirdMembershipGateway({
+            baseUrl: 'https://authority.example.test',
+            keyId: 'current',
+            token: 's'.repeat(43),
+        }, request);
+
+        await expect(gateway.readMembership('listener-1')).rejects.toThrow('unavailable');
+        expect(cancelled).toBe(true);
+        expect(pulls).toBe(3);
+    });
+});

--- a/src/lib/early-birds/__tests__/founder-eligibility.postgres.test.ts
+++ b/src/lib/early-birds/__tests__/founder-eligibility.postgres.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { prisma } from '@/lib/db';
+
+import {
+    applyFounderEligibilityProjection,
+    FounderEligibilityConflictError,
+} from '../founder-eligibility';
+import type { FounderPriceEligibility } from '../membership-contract';
+
+const postgres = process.env.LISTENER_TEST_DATABASE_URL ? describe : describe.skip;
+const accountIds = ['listener-founder-pg-identical', 'listener-founder-pg-conflict'];
+const eligibility: FounderPriceEligibility = {
+    offer: { code: 'EARLY_BIRDS_FOUNDERS_V1', revision: 1 },
+    canonical_price: { currency: 'USD', amount_minor: 200 },
+    billing_period: 'MONTHLY',
+    granted_at: '2026-08-06T12:00:00Z',
+};
+
+postgres('Founder eligibility PostgreSQL convergence', () => {
+    beforeAll(async () => {
+        await prisma.earlyBirdUser.createMany({
+            data: accountIds.map((id, index) => ({
+                id,
+                name: `Synthetic Listener ${index}`,
+                email: `founder-pg-${index}@example.invalid`,
+                emailVerified: true,
+            })),
+            skipDuplicates: true,
+        });
+    });
+
+    afterAll(async () => {
+        await prisma.earlyBirdUser.deleteMany({ where: { id: { in: accountIds } } });
+        await prisma.$disconnect();
+    });
+
+    it('converges concurrent identical evidence to one positive row', async () => {
+        const outcomes = await Promise.all([
+            applyFounderEligibilityProjection(accountIds[0], eligibility),
+            applyFounderEligibilityProjection(accountIds[0], eligibility),
+        ]);
+        expect(outcomes.sort()).toEqual(['APPLIED', 'REPLAYED']);
+        await expect(prisma.earlyBirdFounderEligibilityProjection.count({
+            where: { accountId: accountIds[0] },
+        })).resolves.toBe(1);
+    });
+
+    it('preserves one winner when concurrent positive evidence conflicts', async () => {
+        const conflicting: FounderPriceEligibility = {
+            ...eligibility,
+            offer: { ...eligibility.offer, revision: 2 },
+        };
+        const results = await Promise.allSettled([
+            applyFounderEligibilityProjection(accountIds[1], eligibility),
+            applyFounderEligibilityProjection(accountIds[1], conflicting),
+        ]);
+        expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+        const rejected = results.find((result) => result.status === 'rejected');
+        expect(rejected).toMatchObject({ reason: expect.any(FounderEligibilityConflictError) });
+        await expect(prisma.earlyBirdFounderEligibilityProjection.count({
+            where: { accountId: accountIds[1] },
+        })).resolves.toBe(1);
+    });
+});

--- a/src/lib/early-birds/__tests__/founder-eligibility.test.ts
+++ b/src/lib/early-birds/__tests__/founder-eligibility.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tx = vi.hoisted(() => ({
+    $queryRaw: vi.fn(),
+    earlyBirdFounderEligibilityProjection: {
+        findUnique: vi.fn(),
+        create: vi.fn(),
+    },
+}));
+const prisma = vi.hoisted(() => ({
+    $transaction: vi.fn((callback: (client: typeof tx) => unknown) => callback(tx)),
+}));
+
+vi.mock('@/lib/db', () => ({ prisma }));
+
+import {
+    applyFounderEligibilityProjection,
+    FounderEligibilityAccountNotFoundError,
+    FounderEligibilityConflictError,
+    founderEligibilityHash,
+} from '../founder-eligibility';
+import type { FounderPriceEligibility } from '../membership-contract';
+
+const NOW = new Date('2026-08-08T12:00:00Z');
+const eligibility: FounderPriceEligibility = {
+    offer: { code: 'EARLY_BIRDS_FOUNDERS_V1', revision: 1 },
+    canonical_price: { currency: 'USD', amount_minor: 200 },
+    billing_period: 'MONTHLY',
+    granted_at: '2026-08-06T12:00:00Z',
+};
+
+function row(overrides: Record<string, unknown> = {}) {
+    return {
+        accountId: 'listener-1',
+        offerCode: eligibility.offer.code,
+        offerRevision: eligibility.offer.revision,
+        currency: eligibility.canonical_price.currency,
+        amountMinor: eligibility.canonical_price.amount_minor,
+        billingPeriod: eligibility.billing_period,
+        grantedAt: new Date(eligibility.granted_at),
+        eligibilityHash: founderEligibilityHash(eligibility),
+        observedAt: NOW,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    } as never;
+}
+
+describe('positive-only Founder eligibility projection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        tx.$queryRaw.mockResolvedValue([{ id: 'listener-1' }]);
+        tx.earlyBirdFounderEligibilityProjection.findUnique.mockResolvedValue(null);
+        tx.earlyBirdFounderEligibilityProjection.create.mockResolvedValue(row());
+    });
+
+    it('returns ABSENT without writing when canonical evidence is null', async () => {
+        await expect(applyFounderEligibilityProjection('listener-1', null, NOW))
+            .resolves.toBe('ABSENT');
+        expect(tx.earlyBirdFounderEligibilityProjection.create).not.toHaveBeenCalled();
+    });
+
+    it('applies the first positive evidence and replays exact evidence', async () => {
+        await expect(applyFounderEligibilityProjection('listener-1', eligibility, NOW))
+            .resolves.toBe('APPLIED');
+        expect(tx.earlyBirdFounderEligibilityProjection.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                accountId: 'listener-1',
+                currency: 'USD',
+                amountMinor: 200,
+                billingPeriod: 'MONTHLY',
+                eligibilityHash: founderEligibilityHash(eligibility),
+            }),
+        });
+
+        tx.earlyBirdFounderEligibilityProjection.findUnique.mockResolvedValue(row());
+        await expect(applyFounderEligibilityProjection('listener-1', eligibility, NOW))
+            .resolves.toBe('REPLAYED');
+    });
+
+    it('replays equivalent timestamp spellings after UTC millisecond normalization', async () => {
+        tx.earlyBirdFounderEligibilityProjection.findUnique.mockResolvedValue(row());
+        const equivalents = [
+            '2026-08-06T09:00:00-03:00',
+            '2026-08-06T12:00:00.000Z',
+            '2026-08-06T12:00:00.000000000Z',
+        ];
+        for (const grantedAt of equivalents) {
+            await expect(applyFounderEligibilityProjection('listener-1', {
+                ...eligibility,
+                granted_at: grantedAt,
+            }, NOW)).resolves.toBe('REPLAYED');
+        }
+    });
+
+    it('preserves positive evidence against null or a conflicting positive payload', async () => {
+        tx.earlyBirdFounderEligibilityProjection.findUnique.mockResolvedValue(row());
+        await expect(applyFounderEligibilityProjection('listener-1', null, NOW))
+            .rejects.toBeInstanceOf(FounderEligibilityConflictError);
+        await expect(applyFounderEligibilityProjection('listener-1', {
+            ...eligibility,
+            offer: { ...eligibility.offer, revision: 2 },
+        }, NOW)).rejects.toBeInstanceOf(FounderEligibilityConflictError);
+        expect(tx.earlyBirdFounderEligibilityProjection.create).not.toHaveBeenCalled();
+    });
+
+    it('fails before any evidence lookup when the local account is absent', async () => {
+        tx.$queryRaw.mockResolvedValue([]);
+        await expect(applyFounderEligibilityProjection('missing', eligibility, NOW))
+            .rejects.toBeInstanceOf(FounderEligibilityAccountNotFoundError);
+        expect(tx.earlyBirdFounderEligibilityProjection.findUnique).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/early-birds/founder-eligibility.ts
+++ b/src/lib/early-birds/founder-eligibility.ts
@@ -1,0 +1,104 @@
+import { createHash } from 'node:crypto';
+
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/db';
+
+import {
+    canonicalRfc3339Instant,
+    type FounderPriceEligibility,
+} from './membership-contract';
+import { jcsCanonicalize } from './membership';
+
+export type FounderEligibilityProjectionOutcome = 'ABSENT' | 'APPLIED' | 'REPLAYED';
+
+export class FounderEligibilityConflictError extends Error {
+    constructor() {
+        super('Canonical Founder price eligibility conflicts with durable local evidence');
+        this.name = 'FounderEligibilityConflictError';
+    }
+}
+
+export class FounderEligibilityAccountNotFoundError extends Error {
+    constructor() {
+        super('Listener account does not exist');
+        this.name = 'FounderEligibilityAccountNotFoundError';
+    }
+}
+
+function normalizedEligibility(value: FounderPriceEligibility): FounderPriceEligibility {
+    if (
+        value.offer.code !== 'EARLY_BIRDS_FOUNDERS_V1'
+        || !Number.isSafeInteger(value.offer.revision)
+        || value.offer.revision < 1
+        || value.canonical_price.currency !== 'USD'
+        || value.canonical_price.amount_minor !== 200
+        || value.billing_period !== 'MONTHLY'
+    ) {
+        throw new FounderEligibilityConflictError();
+    }
+    try {
+        return {
+            ...value,
+            granted_at: canonicalRfc3339Instant(value.granted_at, 'Founder granted_at'),
+        };
+    } catch {
+        throw new FounderEligibilityConflictError();
+    }
+}
+
+export function founderEligibilityHash(eligibility: FounderPriceEligibility): string {
+    return createHash('sha256')
+        .update(jcsCanonicalize(normalizedEligibility(eligibility)))
+        .digest('hex');
+}
+
+export async function applyFounderEligibilityProjection(
+    accountId: string,
+    rawEligibility: FounderPriceEligibility | null,
+    observedAt = new Date(),
+): Promise<FounderEligibilityProjectionOutcome> {
+    return prisma.$transaction(async (tx) => {
+        const accounts = await tx.$queryRaw<Array<{ id: string }>>(
+            Prisma.sql`SELECT "id" FROM "early_bird_users" WHERE "id" = ${accountId} FOR UPDATE`,
+        );
+        if (accounts.length !== 1) throw new FounderEligibilityAccountNotFoundError();
+
+        const existing = await tx.earlyBirdFounderEligibilityProjection.findUnique({
+            where: { accountId },
+        });
+        if (rawEligibility === null) {
+            if (existing) throw new FounderEligibilityConflictError();
+            return 'ABSENT';
+        }
+
+        const eligibility = normalizedEligibility(rawEligibility);
+        const eligibilityHash = founderEligibilityHash(eligibility);
+        if (existing) {
+            const exact = existing.eligibilityHash === eligibilityHash
+                && existing.offerCode === eligibility.offer.code
+                && existing.offerRevision === eligibility.offer.revision
+                && existing.currency === eligibility.canonical_price.currency
+                && existing.amountMinor === eligibility.canonical_price.amount_minor
+                && existing.billingPeriod === eligibility.billing_period
+                && existing.grantedAt.toISOString() === new Date(eligibility.granted_at).toISOString();
+            if (!exact) throw new FounderEligibilityConflictError();
+            return 'REPLAYED';
+        }
+
+        await tx.earlyBirdFounderEligibilityProjection.create({
+            data: {
+                accountId,
+                offerCode: eligibility.offer.code,
+                offerRevision: eligibility.offer.revision,
+                currency: eligibility.canonical_price.currency,
+                amountMinor: eligibility.canonical_price.amount_minor,
+                billingPeriod: eligibility.billing_period,
+                grantedAt: new Date(eligibility.granted_at),
+                eligibilityHash,
+                observedAt,
+            },
+        });
+        return 'APPLIED';
+    });
+}

--- a/src/lib/early-birds/membership-contract.ts
+++ b/src/lib/early-birds/membership-contract.ts
@@ -10,6 +10,7 @@ const AUTHORITY_KEYS = [
     'grace_until', 'membership_revision', 'offer', 'paid_through', 'provider', 'reason_code',
     'schema_version', 'source', 'state',
 ] as const;
+const AUTHORITY_V2_KEYS = [...AUTHORITY_KEYS, 'founder_price_eligibility'] as const;
 const STATES = [
     'PENDING', 'ACTIVE', 'GRACE', 'CANCELLED_PENDING_END', 'EXPIRED', 'REFUNDED', 'REVOKED',
 ] as const;
@@ -23,11 +24,24 @@ export class EarlyBirdMembershipContractError extends Error {
     }
 }
 
-type CanonicalAuthorityMembership = Omit<EarlyBirdMembershipProjectionCommand, 'schema_version'> & {
+export type CanonicalAuthorityMembership = Omit<EarlyBirdMembershipProjectionCommand, 'schema_version'> & {
     schema_version: 'early-bird-authority.membership.v1';
     access_allowed: boolean;
     free_entitlement_consumed: boolean;
 };
+
+export type FounderPriceEligibility = {
+    offer: { code: 'EARLY_BIRDS_FOUNDERS_V1'; revision: number };
+    canonical_price: { currency: 'USD'; amount_minor: 200 };
+    billing_period: 'MONTHLY';
+    granted_at: string;
+};
+
+export type CanonicalAuthorityMembershipV2 =
+    Omit<CanonicalAuthorityMembership, 'schema_version'> & {
+        schema_version: 'early-bird-authority.membership.v2';
+        founder_price_eligibility: FounderPriceEligibility | null;
+    };
 
 function record(value: unknown, label: string): Record<string, unknown> {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -58,6 +72,47 @@ function instant(value: unknown, field: string, nullable = false): string | null
     return value;
 }
 
+export function canonicalRfc3339Instant(value: unknown, field: string): string {
+    if (typeof value !== 'string') {
+        throw new EarlyBirdMembershipContractError(`${field} must be an RFC 3339 date-time`);
+    }
+    const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|[+-]\d{2}:\d{2})$/.exec(value);
+    if (!match) {
+        throw new EarlyBirdMembershipContractError(`${field} must be an RFC 3339 date-time`);
+    }
+    const [, yearRaw, monthRaw, dayRaw, hourRaw, minuteRaw, secondRaw, , offset] = match;
+    const year = Number(yearRaw);
+    const month = Number(monthRaw);
+    const day = Number(dayRaw);
+    const hour = Number(hourRaw);
+    const minute = Number(minuteRaw);
+    const second = Number(secondRaw);
+    const offsetHour = offset === 'Z' ? 0 : Number(offset.slice(1, 3));
+    const offsetMinute = offset === 'Z' ? 0 : Number(offset.slice(4, 6));
+    const daysInMonth = month >= 1 && month <= 12
+        ? new Date(Date.UTC(year, month, 0)).getUTCDate()
+        : 0;
+    if (
+        day < 1 || day > daysInMonth
+        || hour > 23 || minute > 59 || second > 59
+        || offsetHour > 23 || offsetMinute > 59
+    ) {
+        throw new EarlyBirdMembershipContractError(`${field} must be an RFC 3339 date-time`);
+    }
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) {
+        throw new EarlyBirdMembershipContractError(`${field} must be an RFC 3339 date-time`);
+    }
+    // PostgreSQL/Prisma stores this projection at millisecond precision. One
+    // canonical UTC representation prevents equivalent wire forms from
+    // producing different durable evidence hashes.
+    return new Date(parsed).toISOString();
+}
+
+function canonicalNullableRfc3339Instant(value: unknown, field: string): string | null {
+    return value === null ? null : canonicalRfc3339Instant(value, field);
+}
+
 function offer(value: unknown): EarlyBirdMembershipProjectionCommand['offer'] {
     if (value === null) return null;
     const input = record(value, 'offer');
@@ -80,6 +135,32 @@ function price(value: unknown): EarlyBirdMembershipProjectionCommand['current_pr
     return {
         currency: input.currency as 'USD' | 'ARS',
         amount_minor: input.amount_minor as number,
+    };
+}
+
+function founderPriceEligibility(value: unknown): FounderPriceEligibility | null {
+    if (value === null) return null;
+    const input = record(value, 'founder_price_eligibility');
+    exactKeys(input, ['billing_period', 'canonical_price', 'granted_at', 'offer']);
+
+    const parsedOffer = offer(input.offer);
+    if (parsedOffer === null) {
+        throw new EarlyBirdMembershipContractError('Founder price eligibility offer is invalid');
+    }
+    const canonicalPrice = record(input.canonical_price, 'founder canonical_price');
+    exactKeys(canonicalPrice, ['amount_minor', 'currency']);
+    if (canonicalPrice.currency !== 'USD' || canonicalPrice.amount_minor !== 200) {
+        throw new EarlyBirdMembershipContractError('Founder canonical_price is invalid');
+    }
+    if (input.billing_period !== 'MONTHLY') {
+        throw new EarlyBirdMembershipContractError('Founder billing_period is invalid');
+    }
+    const grantedAt = canonicalRfc3339Instant(input.granted_at, 'Founder granted_at');
+    return {
+        offer: parsedOffer,
+        canonical_price: { currency: 'USD', amount_minor: 200 },
+        billing_period: 'MONTHLY',
+        granted_at: grantedAt,
     };
 }
 
@@ -154,6 +235,44 @@ export function parseCanonicalAuthorityMembership(value: unknown): CanonicalAuth
     if (membership.access_allowed !== canonicalAccessAllowed(membership)) {
         throw new EarlyBirdMembershipContractError(
             'Authority access decision contradicts membership state or time bounds',
+        );
+    }
+    return membership;
+}
+
+export function parseCanonicalAuthorityMembershipV2(value: unknown): CanonicalAuthorityMembershipV2 {
+    const input = record(value, 'authority membership v2');
+    exactKeys(input, AUTHORITY_V2_KEYS);
+    if (input.schema_version !== 'early-bird-authority.membership.v2') {
+        throw new EarlyBirdMembershipContractError('Unsupported authority membership schema');
+    }
+    if (typeof input.access_allowed !== 'boolean' || typeof input.free_entitlement_consumed !== 'boolean') {
+        throw new EarlyBirdMembershipContractError('Authority membership booleans are invalid');
+    }
+    const eligibility = founderPriceEligibility(input.founder_price_eligibility);
+    const shared = common(input);
+    const membership: CanonicalAuthorityMembershipV2 = {
+        schema_version: input.schema_version,
+        ...shared,
+        effective_at: canonicalRfc3339Instant(input.effective_at, 'effective_at'),
+        paid_through: canonicalNullableRfc3339Instant(input.paid_through, 'paid_through'),
+        grace_until: canonicalNullableRfc3339Instant(input.grace_until, 'grace_until'),
+        access_allowed: input.access_allowed,
+        free_entitlement_consumed: input.free_entitlement_consumed,
+        founder_price_eligibility: eligibility,
+    };
+    if (membership.access_allowed !== canonicalAccessAllowed(membership)) {
+        throw new EarlyBirdMembershipContractError(
+            'Authority access decision contradicts membership state or time bounds',
+        );
+    }
+    if (
+        membership.access_allowed
+        && (membership.source === 'PAYPAL' || membership.source === 'MERCADO_PAGO')
+        && eligibility === null
+    ) {
+        throw new EarlyBirdMembershipContractError(
+            'Paid access is missing canonical Founder price eligibility',
         );
     }
     return membership;

--- a/src/lib/early-birds/membership-gateway.ts
+++ b/src/lib/early-birds/membership-gateway.ts
@@ -4,6 +4,8 @@ import { isEarlyBirdAccountId } from './account-id';
 import {
     authorityMembershipCommand,
     parseCanonicalAuthorityMembership,
+    parseCanonicalAuthorityMembershipV2,
+    type CanonicalAuthorityMembershipV2,
 } from './membership-contract';
 import {
     applyMembershipProjection,
@@ -12,6 +14,52 @@ import {
 
 const INVITATION_TOKEN = /^ebi_v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 const REQUEST_TIMEOUT_MS = 5_000;
+const MAX_AUTHORITY_RESPONSE_BYTES = 64 * 1024;
+
+async function cancelResponseBody(response: Response): Promise<void> {
+    await response.body?.cancel().catch(() => undefined);
+}
+
+async function boundedResponseText(response: Response): Promise<string> {
+    const declaredLength = response.headers.get('content-length');
+    if (declaredLength !== null) {
+        if (!/^\d+$/.test(declaredLength) || Number(declaredLength) > MAX_AUTHORITY_RESPONSE_BYTES) {
+            await cancelResponseBody(response);
+            throw new EarlyBirdMembershipGatewayUnavailableError();
+        }
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) return '';
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            totalBytes += value.byteLength;
+            if (totalBytes > MAX_AUTHORITY_RESPONSE_BYTES) {
+                await reader.cancel().catch(() => undefined);
+                throw new EarlyBirdMembershipGatewayUnavailableError();
+            }
+            chunks.push(value);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+
+    const body = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+        body.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    try {
+        return new TextDecoder('utf-8', { fatal: true }).decode(body);
+    } catch {
+        throw new EarlyBirdMembershipGatewayUnavailableError();
+    }
+}
 
 export type CanonicalFreeRedemptionResult =
     | {
@@ -27,6 +75,14 @@ export interface EarlyBirdMembershipGateway {
         accountId: string;
         opaqueInvitation: string;
     }): Promise<CanonicalFreeRedemptionResult>;
+}
+
+export type CanonicalMembershipReadResult =
+    | { ok: true; membership: CanonicalAuthorityMembershipV2 }
+    | { ok: false; reason: 'not-found' };
+
+export interface EarlyBirdMembershipReader {
+    readMembership(accountId: string): Promise<CanonicalMembershipReadResult>;
 }
 
 export class EarlyBirdMembershipGatewayUnavailableError extends Error {
@@ -62,7 +118,7 @@ function redemptionIdempotencyKey(accountId: string, invitation: string): string
     return `early-bird-invitation-redeem:${digest}`;
 }
 
-export class HttpEarlyBirdMembershipGateway implements EarlyBirdMembershipGateway {
+export class HttpEarlyBirdMembershipGateway implements EarlyBirdMembershipGateway, EarlyBirdMembershipReader {
     constructor(
         private readonly config: GatewayConfig = gatewayConfig(),
         private readonly request: typeof fetch = fetch,
@@ -117,16 +173,77 @@ export class HttpEarlyBirdMembershipGateway implements EarlyBirdMembershipGatewa
             clearTimeout(timeout);
         }
     }
+
+    async readMembership(accountId: string): Promise<CanonicalMembershipReadResult> {
+        if (!isEarlyBirdAccountId(accountId)) throw new EarlyBirdMembershipGatewayUnavailableError();
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+        try {
+            const response = await this.request(
+                `${this.config.baseUrl}/api/internal/v2/early-bird-memberships/${encodeURIComponent(accountId)}`,
+                {
+                    method: 'GET',
+                    redirect: 'error',
+                    cache: 'no-store',
+                    signal: controller.signal,
+                    headers: {
+                        accept: 'application/json',
+                        authorization: `Bearer ${this.config.token}`,
+                        'x-hb-service-key-id': this.config.keyId,
+                    },
+                },
+            );
+            if (response.status === 404) {
+                await cancelResponseBody(response);
+                return { ok: false, reason: 'not-found' };
+            }
+            if (!response.ok) {
+                await cancelResponseBody(response);
+                throw new EarlyBirdMembershipGatewayUnavailableError();
+            }
+            const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
+            if (contentType !== 'application/json') {
+                await cancelResponseBody(response);
+                throw new EarlyBirdMembershipGatewayUnavailableError();
+            }
+            const raw = await boundedResponseText(response);
+            let body: unknown;
+            try {
+                body = JSON.parse(raw) as unknown;
+            } catch {
+                throw new EarlyBirdMembershipGatewayUnavailableError();
+            }
+            const membership = parseCanonicalAuthorityMembershipV2(body);
+            if (membership.account_id !== accountId) {
+                throw new EarlyBirdMembershipGatewayUnavailableError();
+            }
+            return { ok: true, membership };
+        } catch (error) {
+            if (error instanceof EarlyBirdMembershipGatewayUnavailableError) throw error;
+            throw new EarlyBirdMembershipGatewayUnavailableError();
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
 }
 
 let gatewayOverride: EarlyBirdMembershipGateway | null = null;
+let readerOverride: EarlyBirdMembershipReader | null = null;
 
 export function setEarlyBirdMembershipGatewayForTests(gateway: EarlyBirdMembershipGateway | null): void {
     gatewayOverride = gateway;
 }
 
+export function setEarlyBirdMembershipReaderForTests(reader: EarlyBirdMembershipReader | null): void {
+    readerOverride = reader;
+}
+
 export function earlyBirdMembershipGateway(): EarlyBirdMembershipGateway {
     return gatewayOverride ?? new HttpEarlyBirdMembershipGateway();
+}
+
+export function earlyBirdMembershipReader(): EarlyBirdMembershipReader {
+    return readerOverride ?? new HttpEarlyBirdMembershipGateway();
 }
 
 /** The browser's opaque invitation is consumed only by the canonical authority. */


### PR DESCRIPTION
## Outcome

Consumes the canonical backend membership read v2 without coupling Listener page availability to PMP Myth Bot. It stores lifetime Founder price evidence as a positive-only durable projection that never authorizes listening by itself.

## Changes

- vendors the backend v2 contract byte-exactly and extends verification
- adds an additive forward-only projection table
- adds a bounded, authenticated private reconciliation route
- preserves v1 access, pages, leases, OAuth, audio, LiveKit and weekend event behavior
- normalizes RFC 3339 evidence and fails closed on conflicts or malformed authority responses

## Evidence

- 1,338 unit/integration tests passed; 21 skipped
- 2 real PostgreSQL concurrency tests passed
- TypeScript, ESLint and production build passed
- all 16 migrations applied from an empty PostgreSQL database
- v1/v2 contract verifier: 17 byte-exact files
- independent adversarial review: approved, no blockers

## Risk and rollback

The route is dormant until an authenticated operations caller invokes it. The migration is additive. Roll back the application image while retaining the table/evidence; older code ignores it. No deployment is included.

## Scope guardrail

No changes to live.harmonicbeacon.com, event rooms, LiveKit, event audio, tapestry, playlist-bot or Proyección del Mito.