### PR TITLE
fix(listener): support playback mode keyboard navigation

### DIFF
--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -98,6 +98,89 @@ function preferredDropLanguage(
     return englishDropIn ? 'en' : 'es';
 }
 
+function ListenerPlaybackModeSelector({
+    value,
+    introLabel,
+    beaconLabel,
+    groupLabel,
+    introDisabled,
+    beaconDisabled,
+    onChange,
+}: {
+    value: PlaybackMode;
+    introLabel: string;
+    beaconLabel: string;
+    groupLabel: string;
+    introDisabled: boolean;
+    beaconDisabled: boolean;
+    onChange: (mode: PlaybackMode) => void;
+}) {
+    const introButton = useRef<HTMLButtonElement>(null);
+    const beaconButton = useRef<HTMLButtonElement>(null);
+    const modes: PlaybackMode[] = ['intro', 'beacon'];
+    const disabled = { intro: introDisabled, beacon: beaconDisabled };
+    const buttons = { intro: introButton, beacon: beaconButton };
+    const enabledModes = modes.filter((mode) => !disabled[mode]);
+    const tabStop = enabledModes.includes(value) ? value : enabledModes[0];
+
+    function selectAndFocus(mode: PlaybackMode) {
+        if (disabled[mode]) return;
+        onChange(mode);
+        buttons[mode].current?.focus();
+    }
+
+    function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>, current: PlaybackMode) {
+        if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) return;
+        event.preventDefault();
+        if (enabledModes.length === 0) return;
+
+        if (event.key === 'Home') {
+            selectAndFocus(enabledModes[0]);
+            return;
+        }
+        if (event.key === 'End') {
+            selectAndFocus(enabledModes[enabledModes.length - 1]);
+            return;
+        }
+
+        const currentIndex = enabledModes.indexOf(current);
+        const direction = event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 : -1;
+        const nextIndex = currentIndex < 0
+            ? 0
+            : (currentIndex + direction + enabledModes.length) % enabledModes.length;
+        selectAndFocus(enabledModes[nextIndex]);
+    }
+
+    return (
+        <div className="listener-mode" role="radiogroup" aria-label={groupLabel}>
+            <button
+                ref={introButton}
+                type="button"
+                role="radio"
+                aria-checked={value === 'intro'}
+                tabIndex={tabStop === 'intro' ? 0 : -1}
+                onClick={() => onChange('intro')}
+                onKeyDown={(event) => handleKeyDown(event, 'intro')}
+                disabled={introDisabled}
+            >
+                <span>{introLabel}</span>
+            </button>
+            <button
+                ref={beaconButton}
+                type="button"
+                role="radio"
+                aria-checked={value === 'beacon'}
+                tabIndex={tabStop === 'beacon' ? 0 : -1}
+                onClick={() => onChange('beacon')}
+                onKeyDown={(event) => handleKeyDown(event, 'beacon')}
+                disabled={beaconDisabled}
+            >
+                <span>{beaconLabel}</span>
+            </button>
+        </div>
+    );
+}
+
 export default function ListenerPlayer({
     dropIns,
 }: {
@@ -1079,26 +1162,15 @@ export default function ListenerPlayer({
                     {phaseLabel}
                 </p>}
 
-                <div className="listener-mode" role="radiogroup" aria-label={copy.mode}>
-                    <button
-                        type="button"
-                        role="radio"
-                        aria-checked={playbackMode === 'intro'}
-                        onClick={() => selectPlaybackMode('intro')}
-                        disabled={transportActive || transportBusy || !selectedDropAvailable}
-                    >
-                        <span>{copy.withIntro}</span>
-                    </button>
-                    <button
-                        type="button"
-                        role="radio"
-                        aria-checked={playbackMode === 'beacon'}
-                        onClick={() => selectPlaybackMode('beacon')}
-                        disabled={transportActive || transportBusy}
-                    >
-                        <span>{copy.beaconOnly}</span>
-                    </button>
-                </div>
+                <ListenerPlaybackModeSelector
+                    value={playbackMode}
+                    introLabel={copy.withIntro}
+                    beaconLabel={copy.beaconOnly}
+                    groupLabel={copy.mode}
+                    introDisabled={transportActive || transportBusy || !selectedDropAvailable}
+                    beaconDisabled={transportActive || transportBusy}
+                    onChange={selectPlaybackMode}
+                />
 
                 <div className="listener-details">
                     {availableDropCount > 1 && !transportActive && (

--- a/src/components/early-birds/__tests__/ListenerTransport.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerTransport.test.tsx
@@ -130,6 +130,69 @@ describe('Listener one-action playlist transport', () => {
             .toHaveAttribute('aria-checked', 'true'));
     });
 
+    it('uses one roving tab stop and selects playback modes with arrow keys', async () => {
+        prepareMedia();
+        renderPlayer();
+        await waitForListen();
+        const intro = screen.getByRole('radio', { name: /With introduction/ });
+        const beacon = screen.getByRole('radio', { name: /Beacon only/ });
+
+        expect(intro).toHaveAttribute('tabindex', '0');
+        expect(beacon).toHaveAttribute('tabindex', '-1');
+        intro.focus();
+
+        fireEvent.keyDown(intro, { key: 'ArrowRight' });
+        expect(beacon).toHaveFocus();
+        expect(beacon).toHaveAttribute('aria-checked', 'true');
+        expect(beacon).toHaveAttribute('tabindex', '0');
+        expect(intro).toHaveAttribute('tabindex', '-1');
+
+        fireEvent.keyDown(beacon, { key: 'ArrowDown' });
+        expect(intro).toHaveFocus();
+        expect(intro).toHaveAttribute('aria-checked', 'true');
+
+        fireEvent.keyDown(intro, { key: 'ArrowLeft' });
+        expect(beacon).toHaveFocus();
+        expect(beacon).toHaveAttribute('aria-checked', 'true');
+
+        fireEvent.keyDown(beacon, { key: 'ArrowUp' });
+        expect(intro).toHaveFocus();
+        expect(intro).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to the first and last playback mode with Home and End', async () => {
+        prepareMedia();
+        renderPlayer();
+        await waitForListen();
+        const intro = screen.getByRole('radio', { name: /With introduction/ });
+        const beacon = screen.getByRole('radio', { name: /Beacon only/ });
+
+        intro.focus();
+        fireEvent.keyDown(intro, { key: 'End' });
+        expect(beacon).toHaveFocus();
+        expect(beacon).toHaveAttribute('aria-checked', 'true');
+
+        fireEvent.keyDown(beacon, { key: 'Home' });
+        expect(intro).toHaveFocus();
+        expect(intro).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('keeps the available Beacon mode as the only tab stop when no intro exists', async () => {
+        prepareMedia();
+        renderPlayer({ es: null, en: null });
+        await waitForListen();
+        const intro = screen.getByRole('radio', { name: /With introduction/ });
+        const beacon = screen.getByRole('radio', { name: /Beacon only/ });
+
+        expect(intro).toBeDisabled();
+        expect(intro).toHaveAttribute('tabindex', '-1');
+        expect(beacon).toHaveAttribute('tabindex', '0');
+        beacon.focus();
+        fireEvent.keyDown(beacon, { key: 'ArrowRight' });
+        expect(beacon).toHaveFocus();
+        expect(beacon).toHaveAttribute('aria-checked', 'true');
+    });
+
     it('pauses and resumes the intro at the same position', async () => {
         const { play, pause } = prepareMedia();
         renderPlayer();


### PR DESCRIPTION
## Outcome

Completes native radio-group keyboard behavior for the Listener playback-mode selector while preserving its existing click behavior and playback decisions.

## Behavior

- exactly one enabled radio participates in Tab order
- Arrow keys wrap across enabled modes
- Home/End select first/last enabled mode
- focus follows selection
- unavailable intro is skipped

## Evidence

- 14/14 focused Listener transport tests
- TypeScript and scoped ESLint green
- diff-check clean
- implementation review confirms no media-controller, stream, event, LiveKit, audio asset, codec, buffer, fade or routing changes

## Risk / rollback

UI-only accessibility behavior in two files. Revert commit 95eb60a if keyboard behavior regresses. No deployment included.