### PR TITLE
chore(listener): vendor Mercado Pago checkout v2 contract

### DIFF
--- a/contracts/early-bird-checkout/v2/README.md
+++ b/contracts/early-bird-checkout/v2/README.md
@@ -1,0 +1,18 @@
+# EarlyBird checkout command v2
+
+This private contract is separate from the byte-vendored `early-bird-authority` membership-read
+family. It adds the Mercado Pago checkout input required by
+`POST /api/internal/v2/early-bird-checkouts` without changing authority v1 or v2.
+
+Mercado Pago requires a normalized `payer_email`. Its plaintext is transient: the backend sends
+it only in the provider request and excludes it from authority responses, checkout bindings,
+provider events, jobs and logs. The durable intent hash includes only keyed HMAC evidence, so a
+retry with another payer fails closed without making the address recoverable. Keep the previous
+signing key until pending checkout intents have completed or expired before rotating it.
+The command is restricted to
+`provider=mercado_pago`; PayPal continues to use the authority v1 checkout command.
+
+The route remains protected by the private EarlyBird authority credentials and the independent
+paid-checkout gate. Provider configuration is TEST-only and disabled by default.
+The authority v1 checkout route fails closed for Mercado Pago because it cannot carry the required
+transient payer email; PayPal remains on v1 without semantic changes.

--- a/contracts/early-bird-checkout/v2/SHA256SUMS
+++ b/contracts/early-bird-checkout/v2/SHA256SUMS
@@ -1,0 +1,3 @@
+a0008e822c60c4d8b7804da90c411c7f07a1b0457b74192260a5d8a14617a191  README.md
+128a8b6e1e91604db276ba4b9e4bc8f592ddacadffec19b2d2f037f1dc8d9c87  checkout-create.fixture.json
+1e3cbcc19b723ba5fb52ee9b4134533c8ae6f4626d9d884787f5d6585aa5156a  checkout-create.schema.json

--- a/contracts/early-bird-checkout/v2/checkout-create.fixture.json
+++ b/contracts/early-bird-checkout/v2/checkout-create.fixture.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "early-bird-checkout.checkout-create.v2",
+  "account_id": "acct_listener_synthetic_0001",
+  "provider": "mercado_pago",
+  "payer_email": "listener@example.test",
+  "return_url": "https://listen.harmonicbeacon.com/membership/return",
+  "cancel_url": "https://listen.harmonicbeacon.com/membership/cancel"
+}

--- a/contracts/early-bird-checkout/v2/checkout-create.schema.json
+++ b/contracts/early-bird-checkout/v2/checkout-create.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harmonicbeacon.com/contracts/early-bird-checkout/v2/checkout-create.schema.json",
+  "title": "EarlyBird Mercado Pago checkout creation command v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "account_id", "provider", "payer_email", "return_url", "cancel_url"],
+  "properties": {
+    "schema_version": {"const": "early-bird-checkout.checkout-create.v2"},
+    "account_id": {"type": "string", "pattern": "^acct_[A-Za-z0-9_-]{16,128}$"},
+    "provider": {"const": "mercado_pago"},
+    "payer_email": {"type": "string", "minLength": 3, "maxLength": 320, "pattern": "^[^@\\sA-Z]+@[^@\\sA-Z]+$"},
+    "return_url": {"type": "string", "format": "uri", "pattern": "^https://", "maxLength": 2048},
+    "cancel_url": {"type": "string", "format": "uri", "pattern": "^https://", "maxLength": 2048}
+  }
+}

--- a/docs/plans/EARLY_BIRDS.md
+++ b/docs/plans/EARLY_BIRDS.md
@@ -437,6 +437,22 @@ The product is for all audiences. The service requests only the account and
 payment information required for the selected access path and does not create
 age-specific profiles.
 
+### 10.1 Vendored contract status
+
+The webapp vendors byte-exact copies of the canonical backend contracts under
+`contracts/` and verifies them with `npm run contract:early-birds:verify`:
+
+- `contracts/early-bird-authority/v1` and `contracts/early-bird-membership/v1`:
+  the membership-read and redemption family.
+- `contracts/early-bird-checkout/v2`: the Mercado Pago checkout command for
+  `POST /api/internal/v2/early-bird-checkouts`, vendored byte-exact from
+  backend commit `f4b19a5dee8b2054a59284c719450f72d99af8aa` (draft PR
+  SairaAsua/proyecciones-mito#54). The provider remains TEST-only and disabled
+  by default; no public checkout UI or sales activation is part of this slice.
+  Mandatory external gate before any paid activation: real Mercado Pago TEST
+  proof that `/preapproval/search?q=hb_<external_reference>` returns the exact
+  created preapproval.
+
 ## 11. Fast Forward development lane
 
 The purpose of isolation is to make development fast, not to reproduce the

--- a/scripts/verify-early-bird-contracts.py
+++ b/scripts/verify-early-bird-contracts.py
@@ -9,6 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CONTRACTS = (
     ROOT / "contracts/early-bird-authority/v1",
     ROOT / "contracts/early-bird-authority/v2",
+    ROOT / "contracts/early-bird-checkout/v2",
     ROOT / "contracts/early-bird-membership/v1",
 )
 


### PR DESCRIPTION
## Outcome

Vendors the Founding Listener Mercado Pago checkout command v2 byte-for-byte from backend draft SairaAsua/proyecciones-mito#54 at `f4b19a5dee8b2054a59284c719450f72d99af8aa` and extends the existing Listener contract verifier.

## Scope

- Adds `contracts/early-bird-checkout/v2` unchanged.
- Verifies checkout v2 alongside authority v1/v2 and membership v1.
- Records provenance and the external acceptance gate in `docs/plans/EARLY_BIRDS.md`.
- Does not add checkout UI, enable providers or activate sales.

## Evidence

- Recursive diff against the backend source is empty.
- `npm run contract:early-birds:verify`: 20 byte-exact files.
- Both JSON documents parse; verifier compiles; diff check is clean.
- Rebased on current upstream `early-birds@196886923a421aa90662b143e3241e2dda18a16f`.

## Gate

Keep this draft until backend #54 is frozen or merged. Mercado Pago remains TEST-only/default-off. Before any activation, a real TEST account must prove that `/preapproval/search?q=hb_<external_reference>` returns the exact preapproval.

No event, LiveKit, tapestry, playlist, audio, production or deploy file changed. Tracks #200.