### PR TITLE
refactor(listener): isolate public presentation from event UI

### DIFF
--- a/docs/plans/EARLY_BIRDS.md
+++ b/docs/plans/EARLY_BIRDS.md
@@ -355,6 +355,26 @@ The media test ladder is mandatory and intentionally incremental:
 
 A failure at one level is fixed there before testing the next.
 
+### 8.1 Listener presentation isolation
+
+Listener components never consume the event visual primitives
+(`event-shell`/`event-button`/`event-alert`/`event-field`); they use additive
+`.listener-*` mirrors in `src/app/globals.css` so future event UI changes
+cannot restyle Listener surfaces (issues #213, #198). The `.event-*` rules
+remain untouched for event pages. Automated evidence:
+
+- `src/components/early-birds/__tests__/listener-visual-isolation.test.tsx` —
+  representative public/access Listener branches render `.listener-*`
+  classes, error states use the styled
+  `listener-alert--danger`/`listener-alert--error` variants, and the access
+  card keeps one contextual primary action. Source inspection confirms no
+  borrowed event visual primitive remains in Listener components.
+- `e2e/tests/early-birds-responsive.spec.ts` — Spanish and explicit English
+  browser-language paths, ≥ 44 px touch targets on real Listener controls,
+  the reduced-motion path without nonessential looping animation, exactly one
+  enabled primary transport action in the ready state, and no media elements
+  or artifact requests on the public pre-access surface.
+
 ## 9. Identity and session contract
 
 EarlyBird identity is not staff identity and not an event ticket identity.

--- a/e2e/tests/early-birds-responsive.spec.ts
+++ b/e2e/tests/early-birds-responsive.spec.ts
@@ -2,7 +2,7 @@ import { AxeBuilder } from '@axe-core/playwright';
 import { expect, test, type Locator, type Page, type TestInfo } from '@playwright/test';
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
-const MEDIA_PATH = /\/api\/(?:early-birds\/(?:stream|drop-ins)|listener\/(?:stream|drop-ins))|\.(?:m3u8|m4a|aac|mp3|ogg|wav)(?:[?#]|$)/i;
+const MEDIA_PATH = /\/api\/(?:early-birds\/(?:stream|drop-ins)|listener\/(?:stream|drop-ins))|\.(?:m3u8|m4s|m4a|aac|mp3|ogg|wav)(?:[?#]|$)/i;
 const PROJECT_IP: Record<string, string> = {
     w1440: '198.51.100.10',
     w1024: '198.51.100.11',
@@ -54,9 +54,84 @@ test.describe('Listener responsive and accessibility boundary', () => {
         await expect(page.getByRole('heading', { name: 'Recuerda tu centro armónico.' })).toBeVisible();
         await expectTouchTarget(page.getByRole('link', { name: 'Entrar al Beacon' }), 'Entrar al Beacon');
         await expectNoHorizontalScroll(page);
+        // One clear contextual primary action: the hero entry CTA, with no
+        // competing primary action inside the anonymous access card.
+        await expect(page.locator('.listener-public-hero__cta')).toHaveCount(1);
+        await expect(page.locator('.listener-access__card .listener-button--primary')).toHaveCount(0);
         await expect(page.locator('audio, video')).toHaveCount(0);
         expect(mediaRequests).toEqual([]);
         await expectAccessible(page, testInfo, 'listener-public');
+    });
+
+    test('public access controls keep the 44px touch floor', async ({ page }) => {
+        await page.goto('/listener');
+        const stagingSubmit = page.getByRole('button', { name: /staging/i });
+        test.skip(
+            await stagingSubmit.count() === 0,
+            'staging team entry surface is not enabled in this stack',
+        );
+        await expectTouchTarget(stagingSubmit, 'staging entry submit');
+        await expectTouchTarget(
+            page.getByLabel(/Cuenta sintética|Synthetic account/i),
+            'synthetic account input',
+        );
+    });
+
+    test('reduced motion removes nonessential Listener animation', async ({ page }) => {
+        await page.emulateMedia({ reducedMotion: 'reduce' });
+        await page.goto('/listener');
+        await expect(page.getByRole('heading', { name: 'Recuerda tu centro armónico.' })).toBeVisible();
+
+        for (const selector of [
+            '.listener-field__aurora',
+            '.listener-field__orbit--outer',
+            '.listener-field__orbit--inner',
+            '.listener-field__core',
+            '.listener-field__point',
+        ]) {
+            const animationName = await page.locator(selector).first().evaluate(
+                (element) => getComputedStyle(element).animationName,
+            );
+            expect(animationName, `${selector} still animates under reduced motion`).toBe('none');
+        }
+
+        const looping = await page.evaluate(() => {
+            const names: string[] = [];
+            document.querySelectorAll('*').forEach((element) => {
+                const style = getComputedStyle(element);
+                if (
+                    style.animationName !== 'none'
+                    && style.animationIterationCount === 'infinite'
+                    && style.animationPlayState === 'running'
+                ) {
+                    names.push(`${element.tagName}.${String(element.className)}`);
+                }
+            });
+            return names;
+        });
+        expect(looping, 'nonessential looping animation survives reduced motion').toEqual([]);
+    });
+
+    test.describe('explicit English browser language', () => {
+        test.use({ locale: 'en-US' });
+
+        test('renders the English Listener with no media before authorization', async ({ page }, testInfo) => {
+            const mediaRequests: string[] = [];
+            page.on('request', (request) => {
+                if (MEDIA_PATH.test(new URL(request.url()).pathname)) mediaRequests.push(request.url());
+            });
+
+            await page.goto('/listener');
+            await expect(page.getByRole('heading', { name: 'Remember your harmonic center.' })).toBeVisible();
+            // <html lang> is only browser-derived on the canonical listener
+            // host (root layout); the preview host keeps the event default, so
+            // the English evidence here is the rendered Listener copy itself.
+            await expectTouchTarget(page.getByRole('link', { name: 'Enter the Beacon' }), 'Enter the Beacon');
+            await expectNoHorizontalScroll(page);
+            await expect(page.locator('audio, video')).toHaveCount(0);
+            expect(mediaRequests).toEqual([]);
+            await expectAccessible(page, testInfo, 'listener-public-en');
+        });
     });
 
     test('authorized one-action Listener stays in bounds with accessible touch targets', async ({ page }, testInfo) => {
@@ -79,6 +154,14 @@ test.describe('Listener responsive and accessibility boundary', () => {
         const account = page.locator('.listener-account > summary');
         await expect(account).toHaveAttribute('aria-label', 'Cuenta');
         await expectTouchTarget(account, 'Cuenta');
+
+        // One clear contextual primary action in the ready state.
+        await expect(page.locator('.listener-experience')).toHaveAttribute('data-phase', 'ready');
+        const primary = page.locator('.listener-transport__primary');
+        await expect(primary).toHaveCount(1);
+        await expect(primary).toBeEnabled();
+        await expect(primary).toHaveAccessibleName('Escuchar');
+        await expectTouchTarget(primary, 'Escuchar');
         await expectAccessible(page, testInfo, 'listener-authorized');
     });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1871,6 +1871,170 @@ body {
   line-height: 1.65;
 }
 
+/* --------------------------------------------
+   LISTENER PAGE SHELL / ACTIONS / ALERTS / FIELDS
+   Listener-scoped mirrors of the event visual
+   primitives so future event UI changes cannot
+   restyle Listener surfaces (issues #213, #198).
+   Event rules above remain untouched.
+   -------------------------------------------- */
+
+.listener-page-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--night);
+  position: relative;
+}
+
+.listener-page-shell::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 15% 10%, rgba(158, 114, 255, 0.05) 0%, transparent 50%),
+    radial-gradient(ellipse at 85% 80%, rgba(124, 234, 255, 0.04) 0%, transparent 50%);
+}
+
+.listener-page-shell::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0.18;
+  background-image:
+    radial-gradient(circle at 15% 27%, var(--gold) 0 1px, transparent 1.5px),
+    radial-gradient(circle at 72% 18%, var(--cyan) 0 1px, transparent 1.5px),
+    radial-gradient(circle at 84% 76%, var(--pink) 0 1px, transparent 1.5px);
+  background-size: 270px 270px, 390px 390px, 330px 330px;
+}
+
+.listener-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 48px;
+  padding: 0 24px;
+  border-radius: 999px;
+  font-family: var(--font-space-mono), monospace;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background-color 0.3s ease;
+  border: 1px solid transparent;
+  position: relative;
+  overflow: hidden;
+}
+
+.listener-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.listener-button--primary {
+  color: var(--night);
+  background: linear-gradient(105deg, var(--gold), var(--lime) 56%, var(--cyan));
+  box-shadow: 0 8px 28px rgba(124, 234, 255, 0.12), 0 0 20px rgba(255, 216, 117, 0.15);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.listener-button--primary:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 12px 36px rgba(124, 234, 255, 0.18), 0 0 28px rgba(255, 216, 117, 0.22);
+}
+
+.listener-button--primary:active {
+  transform: translateY(0) scale(0.99);
+}
+
+.listener-button--secondary {
+  color: var(--cream);
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--border-subtle);
+}
+
+.listener-button--secondary:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--border-strong);
+}
+
+.listener-button--ghost {
+  color: var(--text-secondary);
+  background: transparent;
+  border-color: transparent;
+  /* Listener controls stay at the 44px touch floor; the event ghost is 36px. */
+  min-height: 44px;
+  padding: 0 12px;
+}
+
+.listener-button--ghost:hover {
+  color: var(--cream);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.listener-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none !important;
+}
+
+.listener-alert {
+  padding: 14px 18px;
+  border-radius: 14px;
+  font-size: 13px;
+  line-height: 1.6;
+  border: 1px solid transparent;
+}
+
+.listener-alert--danger,
+.listener-alert--error {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+.listener-input {
+  width: 100%;
+  height: 48px;
+  padding: 0 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: rgba(7, 18, 15, 0.6);
+  color: var(--paper);
+  font-size: 15px;
+  font-family: var(--font-syne), system-ui, sans-serif;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.listener-input::placeholder {
+  color: var(--muted);
+}
+
+.listener-input:focus {
+  outline: none;
+  border-color: var(--pink);
+  box-shadow: 0 0 0 3px rgba(255, 143, 200, 0.1), 0 0 16px rgba(255, 143, 200, 0.08);
+}
+
+.listener-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .listener-button {
+    min-height: 44px;
+    padding: 0 18px;
+    font-size: 12px;
+  }
+}
+
 @media (max-width: 760px) {
   .listener-campfire { opacity: 0.72; }
   .listener-shell__frame { padding-inline: 1rem; }
@@ -1911,4 +2075,9 @@ body {
   .listener-field__orbit,
   .listener-field__core,
   .listener-field__point { animation: none; }
+
+  .listener-button,
+  .listener-input { transition: none; }
+
+  .listener-button:hover { transform: none; }
 }

--- a/src/components/early-birds/EarlyBirdLanding.tsx
+++ b/src/components/early-birds/EarlyBirdLanding.tsx
@@ -145,7 +145,7 @@ export default function EarlyBirdLanding(props: Props) {
                                     : copy.accessUnavailable}</p>
                                 <a
                                     href={LISTENER_NAMESPACE.canonical.home}
-                                    className="event-button event-button--secondary w-full"
+                                    className="listener-button listener-button--secondary w-full"
                                 >
                                     {copy.retryAccess}
                                 </a>
@@ -163,11 +163,11 @@ export default function EarlyBirdLanding(props: Props) {
                             <div className="space-y-5">
                                 <p className="text-sm text-[var(--text-secondary)]">{copy.signedIn}</p>
                                 {props.entitled ? (
-                                    <a href={LISTENER_NAMESPACE.canonical.home} className="event-button event-button--primary inline-flex w-full">
+                                    <a href={LISTENER_NAMESPACE.canonical.home} className="listener-button listener-button--primary inline-flex w-full">
                                         {copy.enter}
                                     </a>
                                 ) : props.invitationAvailable ? (
-                                    <a href={callbackURL} className="event-button event-button--primary inline-flex w-full">
+                                    <a href={callbackURL} className="listener-button listener-button--primary inline-flex w-full">
                                         {copy.redeem}
                                     </a>
                                 ) : (
@@ -198,7 +198,7 @@ export default function EarlyBirdLanding(props: Props) {
                                         type="button"
                                         onClick={() => signIn(provider)}
                                         disabled={busy !== null}
-                                        className="event-button event-button--secondary w-full"
+                                        className="listener-button listener-button--secondary w-full"
                                     >
                                         {busy === provider
                                             ? copy.signingIn
@@ -233,7 +233,7 @@ export default function EarlyBirdLanding(props: Props) {
                                                 <button
                                                     type="submit"
                                                     disabled={busy !== null}
-                                                    className="event-button event-button--secondary w-full"
+                                                    className="listener-button listener-button--secondary w-full"
                                                 >
                                                     {busy === 'email' ? copy.magicLinkSending : copy.magicLinkSend}
                                                 </button>

--- a/src/components/early-birds/EarlyBirdUnavailable.tsx
+++ b/src/components/early-birds/EarlyBirdUnavailable.tsx
@@ -22,7 +22,7 @@ export default function EarlyBirdUnavailable() {
     const text = copy[locale];
 
     return (
-        <main className="event-shell">
+        <main className="listener-page-shell">
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-8 sm:px-10 sm:py-10">
                 <header className="flex items-center justify-between gap-4">
                     <BrandLockup href={LISTENER_NAMESPACE.canonical.home} />

--- a/src/components/early-birds/FreeInvitationRedeemer.tsx
+++ b/src/components/early-birds/FreeInvitationRedeemer.tsx
@@ -44,7 +44,7 @@ export default function FreeInvitationRedeemer() {
     }
 
     return (
-        <main className="event-shell">
+        <main className="listener-page-shell">
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-lg flex-col justify-center gap-8 px-6 py-12">
                 <header className="flex items-center justify-between gap-4">
                     <BrandLockup href={LISTENER_NAMESPACE.canonical.home} />
@@ -53,12 +53,12 @@ export default function FreeInvitationRedeemer() {
                     <p className="font-mono text-xs tracking-[0.22em] text-[var(--gold)]">{copy.eyebrow}</p>
                     <h1 className="font-serif text-4xl font-normal leading-tight">{copy.heading}</h1>
                     <p className="text-sm leading-6 text-[var(--text-secondary)]">{copy.body}</p>
-                    {error && <p role="alert" className="event-alert event-alert--danger">{copy.error}</p>}
+                    {error && <p role="alert" className="listener-alert listener-alert--danger">{copy.error}</p>}
                     <button
                         type="button"
                         disabled={busy}
                         onClick={redeem}
-                        className="event-button event-button--primary w-full"
+                        className="listener-button listener-button--primary w-full"
                     >
                         {busy ? copy.activating : copy.action}
                     </button>

--- a/src/components/early-birds/FreeWindowSetup.tsx
+++ b/src/components/early-birds/FreeWindowSetup.tsx
@@ -119,7 +119,7 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
                 <div className="listener-free-window__actions">
                     <button
                         type="button"
-                        className="event-button event-button--primary w-full"
+                        className="listener-button listener-button--primary w-full"
                         disabled={!timeZone || busy !== null}
                         onClick={() => select('now')}
                     >
@@ -127,7 +127,7 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
                     </button>
                     <button
                         type="button"
-                        className="event-button event-button--secondary w-full"
+                        className="listener-button listener-button--secondary w-full"
                         disabled={!timeZone || busy !== null}
                         onClick={() => setChoosing(true)}
                     >
@@ -145,7 +145,7 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
                     <p><span>{copy.freeTimeZone}</span> · {timeZone}</p>
                     <button
                         type="button"
-                        className="event-button event-button--primary w-full"
+                        className="listener-button listener-button--primary w-full"
                         disabled={!timeZone || busy !== null || localStartMinute(time) === null}
                         onClick={() => select('custom')}
                     >
@@ -153,7 +153,7 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
                     </button>
                     <button
                         type="button"
-                        className="event-button event-button--secondary w-full"
+                        className="listener-button listener-button--secondary w-full"
                         disabled={busy !== null}
                         onClick={() => setChoosing(false)}
                     >
@@ -162,7 +162,7 @@ export default function FreeWindowSetup({ state }: { state: SerializedEarlyBirdF
                 </div>
             )}
 
-            {error && <p role="alert" className="event-alert event-alert--error">{copy.freeScheduleError}</p>}
+            {error && <p role="alert" className="listener-alert listener-alert--error">{copy.freeScheduleError}</p>}
         </div>
     );
 }

--- a/src/components/early-birds/SyntheticTeamEntryForm.tsx
+++ b/src/components/early-birds/SyntheticTeamEntryForm.tsx
@@ -65,7 +65,7 @@ export default function SyntheticTeamEntryForm({
                     autoComplete="off"
                     value={name}
                     onChange={(event) => setName(event.target.value)}
-                    className="event-field mt-1"
+                    className="listener-input mt-1"
                 />
             </label>
             <label className="block text-xs text-[var(--text-secondary)]">
@@ -79,7 +79,7 @@ export default function SyntheticTeamEntryForm({
                     placeholder="name@e2e.invalid"
                     value={email}
                     onChange={(event) => setEmail(event.target.value)}
-                    className="event-field mt-1"
+                    className="listener-input mt-1"
                 />
             </label>
             <label className="block text-xs text-[var(--text-secondary)]">
@@ -92,11 +92,11 @@ export default function SyntheticTeamEntryForm({
                     autoComplete="off"
                     value={accessCode}
                     onChange={(event) => setAccessCode(event.target.value)}
-                    className="event-field mt-1"
+                    className="listener-input mt-1"
                 />
             </label>
-            {failed && <p role="alert" className="event-alert event-alert--danger">{copy.failed}</p>}
-            <button type="submit" disabled={busy} className="event-button event-button--ghost w-full">
+            {failed && <p role="alert" className="listener-alert listener-alert--danger">{copy.failed}</p>}
+            <button type="submit" disabled={busy} className="listener-button listener-button--ghost w-full">
                 {busy ? copy.entering : copy.enter}
             </button>
         </form>

--- a/src/components/early-birds/WelcomeAccessAction.tsx
+++ b/src/components/early-birds/WelcomeAccessAction.tsx
@@ -39,13 +39,13 @@ export default function WelcomeAccessAction() {
             <p>{copy.welcomeDescription}</p>
             <button
                 type="button"
-                className="event-button event-button--primary w-full"
+                className="listener-button listener-button--primary w-full"
                 disabled={busy}
                 onClick={start}
             >
                 {busy ? copy.welcomeStarting : copy.welcomeListen}
             </button>
-            {error && <p role="alert" className="event-alert event-alert--error">{copy.welcomeError}</p>}
+            {error && <p role="alert" className="listener-alert listener-alert--error">{copy.welcomeError}</p>}
         </div>
     );
 }

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LocaleProvider } from '@/context/LocaleContext';
+import type { SerializedEarlyBirdFreeWindowState } from '@/lib/early-birds/free-window';
+
+const refresh = vi.hoisted(() => vi.fn());
+const signInSocial = vi.hoisted(() => vi.fn());
+const signInMagicLink = vi.hoisted(() => vi.fn());
+const signOut = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh }) }));
+vi.mock('@/lib/early-birds/auth-client', () => ({
+    earlyBirdAuthClient: { signIn: { social: signInSocial, magicLink: signInMagicLink }, signOut },
+}));
+vi.mock('@/components/brand/BrandLockup', () => ({
+    default: ({ href }: { href: string }) => <a href={href}>Harmonic Beacon</a>,
+}));
+
+import EarlyBirdLanding from '../EarlyBirdLanding';
+import EarlyBirdUnavailable from '../EarlyBirdUnavailable';
+import FreeInvitationRedeemer from '../FreeInvitationRedeemer';
+import FreeWindowSetup from '../FreeWindowSetup';
+import SyntheticTeamEntryForm from '../SyntheticTeamEntryForm';
+import WelcomeAccessAction from '../WelcomeAccessAction';
+
+const EVENT_VISUAL_CLASS = /event-(shell|button|alert|field|card)/;
+
+const emptyFreeWindow: SerializedEarlyBirdFreeWindowState = {
+    configured: false,
+    active: false,
+    timeZone: null,
+    localStartMinute: null,
+    selectedAt: null,
+    changeAllowedAt: null,
+    canChange: true,
+    activeStart: null,
+    activeEnd: null,
+    nextStart: null,
+    nextEnd: null,
+};
+
+function renderLanding(overrides: Partial<React.ComponentProps<typeof EarlyBirdLanding>> = {}) {
+    return render(
+        <LocaleProvider initialLocale="en">
+            <EarlyBirdLanding
+                signedIn={false}
+                entitled={false}
+                serviceUnavailable={null}
+                invitationAvailable={false}
+                authError={false}
+                providers={{ google: true, apple: true }}
+                emailMagicLinkAvailable={false}
+                syntheticTeamEntryAvailable={false}
+                freeWindow={emptyFreeWindow}
+                welcome={{ available: false, active: false, used: false, startedAt: null, endsAt: null }}
+                membership={{ kind: 'none', state: 'none' }}
+                serverNow="2026-08-07T15:00:00.000Z"
+                {...overrides}
+            />
+        </LocaleProvider>,
+    );
+}
+
+describe('Listener visual isolation from event surfaces (issues #213, #198)', () => {
+    beforeEach(() => {
+        refresh.mockReset();
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 400 })));
+    });
+    afterEach(() => {
+        cleanup();
+        vi.unstubAllGlobals();
+    });
+
+    it('globals.css defines additive listener-scoped mirrors of the borrowed event primitives', () => {
+        const css = readFileSync('src/app/globals.css', 'utf8');
+        for (const rule of [
+            '.listener-page-shell',
+            '.listener-button--primary',
+            '.listener-button--secondary',
+            '.listener-button--ghost',
+            '.listener-alert--danger',
+            '.listener-alert--error',
+            '.listener-input',
+        ]) {
+            expect(css, `globals.css is missing ${rule}`).toContain(rule);
+        }
+    });
+
+    it('standalone Listener pages render the listener page shell, never the event shell', () => {
+        const unavailable = render(
+            <LocaleProvider initialLocale="es"><EarlyBirdUnavailable /></LocaleProvider>,
+        );
+        expect(unavailable.container.querySelector('main')).toHaveClass('listener-page-shell');
+        expect(unavailable.container.innerHTML).not.toMatch(EVENT_VISUAL_CLASS);
+        unavailable.unmount();
+
+        const redeemer = render(
+            <LocaleProvider initialLocale="en"><FreeInvitationRedeemer /></LocaleProvider>,
+        );
+        expect(redeemer.container.querySelector('main')).toHaveClass('listener-page-shell');
+        expect(redeemer.container.innerHTML).not.toMatch(EVENT_VISUAL_CLASS);
+    });
+
+    it('invitation redemption keeps one contextual primary listener action and a styled danger alert', async () => {
+        render(<LocaleProvider initialLocale="en"><FreeInvitationRedeemer /></LocaleProvider>);
+
+        const action = screen.getByRole('button', { name: 'Activate invitation' });
+        expect(action).toHaveClass('listener-button', 'listener-button--primary');
+
+        await userEvent.click(action);
+        const alert = await screen.findByRole('alert');
+        expect(alert).toHaveClass('listener-alert', 'listener-alert--danger');
+    });
+
+    it('Free schedule errors surface through the styled listener error alert variant', async () => {
+        render(
+            <LocaleProvider initialLocale="en"><FreeWindowSetup state={emptyFreeWindow} /></LocaleProvider>,
+        );
+
+        const primary = await waitFor(() => screen.getByRole('button', { name: 'Listen free now' }));
+        expect(primary).toHaveClass('listener-button', 'listener-button--primary');
+        expect(screen.getByRole('button', { name: 'Choose another time' }))
+            .toHaveClass('listener-button', 'listener-button--secondary');
+
+        await userEvent.click(primary);
+        const alert = await screen.findByRole('alert');
+        // `event-alert--error` never had a rule; the listener-scoped variant does.
+        expect(alert).toHaveClass('listener-alert', 'listener-alert--error');
+    });
+
+    it('welcome access errors surface through the styled listener error alert variant', async () => {
+        render(<LocaleProvider initialLocale="es"><WelcomeAccessAction /></LocaleProvider>);
+
+        const action = screen.getByRole('button', { name: 'Escuchar ahora' });
+        expect(action).toHaveClass('listener-button', 'listener-button--primary');
+
+        await userEvent.click(action);
+        const alert = await screen.findByRole('alert');
+        expect(alert).toHaveClass('listener-alert', 'listener-alert--error');
+    });
+
+    it('the staging team entry form uses listener fields, alert and button classes only', async () => {
+        render(<LocaleProvider initialLocale="en"><SyntheticTeamEntryForm /></LocaleProvider>);
+
+        expect(screen.getByLabelText('Test name')).toHaveClass('listener-input');
+        expect(screen.getByLabelText('Synthetic account')).toHaveClass('listener-input');
+        expect(screen.getByLabelText('Temporary access code')).toHaveClass('listener-input');
+        expect(screen.getByRole('button', { name: 'Enter staging' }))
+            .toHaveClass('listener-button', 'listener-button--ghost');
+
+        await userEvent.type(screen.getByLabelText('Test name'), 'Team Listener');
+        await userEvent.type(screen.getByLabelText('Synthetic account'), 'team.listener@e2e.invalid');
+        await userEvent.type(
+            screen.getByLabelText('Temporary access code'),
+            'team-staging-access-code-0000000000000001',
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Enter staging' }));
+
+        const alert = await screen.findByRole('alert');
+        expect(alert).toHaveClass('listener-alert', 'listener-alert--danger');
+    });
+
+    it('the public landing actions use listener button classes and keep one contextual primary action', () => {
+        const anonymous = renderLanding();
+        expect(screen.getByRole('button', { name: 'Continue with Google' }))
+            .toHaveClass('listener-button', 'listener-button--secondary');
+        expect(anonymous.container.innerHTML).not.toMatch(EVENT_VISUAL_CLASS);
+        // The anonymous surface offers no competing primary action inside the access card.
+        expect(
+            anonymous.container.querySelectorAll('.listener-access__card .listener-button--primary'),
+        ).toHaveLength(0);
+        anonymous.unmount();
+
+        const entitled = renderLanding({ signedIn: true, entitled: true });
+        const primaries = entitled.container.querySelectorAll(
+            '.listener-access__card .listener-button--primary',
+        );
+        expect(primaries).toHaveLength(1);
+        expect(primaries[0]).toHaveTextContent('Enter the Beacon');
+        expect(entitled.container.innerHTML).not.toMatch(EVENT_VISUAL_CLASS);
+    });
+});

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -5,7 +5,9 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const MEDIA_FILE_SHA256 = {
-    'src/components/early-birds/ListenerPlayer.tsx': '7b0f6f4e75e6b1c84ad65bb3ccbb08c32759dd591bcc51048a0cfe3b71dd8b78',
+    // Re-pinned after the accepted radio-keyboard accessibility-only refactor
+    // in PR #252. Playback, media sources and signal processing were untouched.
+    'src/components/early-birds/ListenerPlayer.tsx': 'fdf787402e94cc97a3b29b9291dc63e52b7a859d1ff9e9c505c99fe3aba720b1',
     'src/lib/early-birds/stream.ts': 'e386413874e5ad799e17607e2b030851cc7baadea48161191c7daecb45183bea',
     'src/lib/early-birds/drop-ins.ts': '3b0d18c2c8548aa3ee917ece726cbca4b6d253ea3b4941a8424f8bcbfb8922e2',
     'src/app/api/early-birds/stream/lease/route.ts': 'd858affc655c6df6607e76470508a59c3ebd442744bc12e5da334729fcb5d660',


### PR DESCRIPTION
Closes the implementation slice of #213 and advances #198.

## Scope
- replaces the remaining borrowed event visual primitives on Listener-only surfaces with additive listener-scoped styles
- preserves every existing event selector and shared brand token
- adds ES/EN responsive, touch-target, reduced-motion, accessibility, and public pre-access media-boundary evidence
- restores the frozen media guard after the already-merged PR #252 radio-keyboard-only refactor

## Safety boundary
- no ListenerPlayer runtime change
- no audio, stream, HLS, LiveKit, event page, API, database, deployment, or production change
- no change to live.harmonicbeacon.com or weekend events

## Evidence
- npm test: 1348 passed, 21 skipped
- npm run lint: passed
- npx tsc --noEmit: passed
- responsive browser gate: 16 public variants passed across 1440/1024/390/320
- authenticated one-action browser gate: 4 variants passed against the isolated local E2E PostgreSQL fixture
- production build completed as part of both Playwright runs
- git diff --check: passed

## Rollback
Revert commits a66374b and 9fc4c5b. The changes are additive Listener styles and tests only.