### PR TITLE
feat(listener): observe session cookie migration states

### DIFF
--- a/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
+++ b/docs/architecture/LISTENER_NAMESPACE_MIGRATION.md
@@ -1,7 +1,10 @@
 # EarlyBird to Listener namespace migration
 
 Status: phases 1, 2A and the invitation-cookie phase 2B are integrated and
-deployed on the isolated Listener at `20406da`. This migration is deliberately additive.
+deployed on the isolated Listener at `20406da`. The Listener session-cookie
+bridge (PR #249, head `b6fbac3`) is integrated via `f665f58` but NOT deployed;
+its deploy, the session-cookie observation window and the dual-write support
+window have not started. This migration is deliberately additive.
 `EarlyBird` is an offer and cohort name; `Listener` is the durable product and
 technical namespace.
 
@@ -185,6 +188,80 @@ Rollback of the bridge itself removes only the wrapper: the legacy-only path
 is byte-identical to `20406`, no database, environment or cookie migration is
 required, and canonical cookies left behind are expired by the dual-clear on
 the next rejected request or sit harmlessly unread.
+
+### Session-cookie compatibility observability
+
+The bridge ships with an aggregate-only observation slice
+(`src/lib/listener/session-cookie-observability.ts`) that sizes the
+rollback-compatible support window. Both session resolvers — the auth-handler
+bridge wrapper and `currentEarlyBirdSession` — inspect every inbound Cookie
+header through the same pure `inspectListenerSessionCookie(header, names)`,
+which returns `{ state, resolution }`; the enforced resolution is
+byte-identical to the pre-observability bridge, and recording is fail-soft
+inside try/catch so an observer failure can never change an auth outcome.
+
+Metric contract (fixed, no external labels ever accepted):
+
+- `beacon_listener_session_cookie_observations_total{state="..."}` — counter
+  with exactly one label, `state`, over a closed allowlist of nine states;
+- `beacon_listener_session_cookie_observer_process_start_time_seconds` —
+  unlabeled gauge with the Unix epoch seconds at which this observer process
+  created its registry.
+
+Categories and classification precedence (first match wins):
+
+1. `none` — no relevant session cookie (or no Cookie header at all);
+2. `oversized_header` — the whole Cookie header exceeds 8192 characters;
+3. `duplicate_name` — either relevant name appears more than once;
+4. `oversized_value` — a relevant value exceeds 512 characters;
+5. `malformed_value` — a relevant value is empty, off the wire charset or
+   carries a bad percent escape;
+6. `canonical_only` — a well-formed canonical cookie without its legacy
+   counterpart (rejected 401 during this phase);
+7. `conflicting_pair` — canonical and legacy values differ (rejected 400);
+8. `legacy_only` — exactly one legacy cookie (forwarded; the rollback window);
+9. `dual_identical` — a byte-identical canonical/legacy pair (forwarded).
+
+Counters measure resolver INVOCATIONS, not unique users, browsers or
+sessions: one navigation may invoke a resolver several times and one session
+is observed on every request, so multiple observations per navigation are
+expected. Recording is limited to the exact canonical Listener Host so
+staging and synthetic rehearsals cannot contaminate the support-window
+series. Even on that host these are raw cookie-shape observations before
+cryptographic session verification: a public client can inflate them, so
+they are conservative migration safety signals and must never automatically
+permit or block a cutover without the correlated provider and rollback
+evidence required above. The registry is per process/replica, resets on process restart and
+saturates at `Number.MAX_SAFE_INTEGER`; the start-time gauge separates
+epochs. A current zero therefore cannot prove seven quiet days: snapshots
+must be archived externally per epoch, and any restart or gap without an
+archived snapshot invalidates window continuity.
+
+Privacy: only aggregate counts and the process-start epoch are stored or
+rendered. No cookie, header, user, session, account, IP or user-agent value
+ever reaches the registry or the exposition.
+
+Loopback runbook: the exposition is served GET-only by
+`/api/internal/v1/listener/session-cookie-observations`, which answers 404 on
+any request Host other than the canonical Listener host (the request Host
+header, never a forwarded one) and `Cache-Control: private, no-store`. The
+public Listener nginx templates deliberately do not expose or proxy this
+path; read it from the host with:
+
+```sh
+curl -fsS -H 'Host: listen.harmonicbeacon.com' \
+  http://127.0.0.1:13000/api/internal/v1/listener/session-cookie-observations
+```
+
+This source slice neither connects Prometheus nor starts or certifies the
+support window; scraping, alerting and window bookkeeping are private ops
+wiring reserved for a later, separately authorized slice.
+
+The accepted #210 policy remains in force: physical `early_bird_*` tables,
+applied migrations and v1 cross-repository wire identifiers are historical
+compatibility surfaces and must not be renamed, and the
+canonical-only/basePath/prefix cutover stays gated by a deployed support
+window, real Google and rollback acceptance, and the remaining callbacks.
 
 ## Phase 4: environment and operations
 

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -218,6 +218,10 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.equal((listener.match(/location = \/sitemap\.xml/g) ?? []).length, 1);
   assert.doesNotMatch(listener, /location \^~ \/api\/listener\/public-discovery\//);
   assert.doesNotMatch(listener, /location \^~ \/api\/listener\//);
+  // The internal session-cookie observations exposition is loopback-only:
+  // the public Listener template must never expose or proxy it.
+  assert.doesNotMatch(listener, /session-cookie-observations/);
+  assert.doesNotMatch(listener, /location \^~ \/api\/internal\//);
   assert.doesNotMatch(listener, /api\/early-birds\/(test-login|membership)/);
   assert.doesNotMatch(listener, /api\/listener\/(test-login|membership)/);
   assert.doesNotMatch(listener, /location \^~ \/early-birds\//);
@@ -322,6 +326,7 @@ test('public Listener certificate bootstrap is HTTP-only and fail closed', async
   assert.match(source, /location \/\.well-known\/acme-challenge\//);
   assert.match(source, /location \/ \{\s*return 503;/);
   assert.doesNotMatch(source, /listen 443|ssl_certificate|proxy_pass/);
+  assert.doesNotMatch(source, /session-cookie-observations/);
 });
 
 test('production Listener HTTPS validation remains fail closed', async () => {

--- a/src/app/api/internal/v1/listener/session-cookie-observations/__tests__/route.test.ts
+++ b/src/app/api/internal/v1/listener/session-cookie-observations/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ render: vi.fn() }));
+vi.mock('@/lib/listener/session-cookie-observability', async (importOriginal) => {
+    const original = await importOriginal<typeof import('@/lib/listener/session-cookie-observability')>();
+    mocks.render.mockImplementation(original.renderListenerSessionCookieObservations);
+    return {
+        ...original,
+        renderListenerSessionCookieObservations: mocks.render,
+    };
+});
+
+import { GET } from '../route';
+import {
+    LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC,
+    LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC,
+    LISTENER_SESSION_COOKIE_STATES,
+    recordListenerSessionCookieObservation,
+} from '@/lib/listener/session-cookie-observability';
+
+const PATH = '/api/internal/v1/listener/session-cookie-observations';
+
+function request(host: string | null, headers: Record<string, string> = {}): NextRequest {
+    return new NextRequest(`http://beacon-app:3000${PATH}`, {
+        headers: { ...(host === null ? {} : { host }), ...headers },
+    });
+}
+
+describe('Listener session-cookie observations route', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('serves the fixed Prometheus exposition on the canonical Listener host', async () => {
+        recordListenerSessionCookieObservation('dual_identical');
+        const response = GET(request('listen.harmonicbeacon.com'));
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toBe('text/plain; version=0.0.4; charset=utf-8');
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+
+        const body = await response.text();
+        for (const state of LISTENER_SESSION_COOKIE_STATES) {
+            expect(body).toContain(`${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC}{state="${state}"}`);
+        }
+        const labelSets = [...body.matchAll(/\{([^}]*)\}/g)].map((match) => match[1]);
+        expect(labelSets).toHaveLength(LISTENER_SESSION_COOKIE_STATES.length);
+        for (const labelSet of labelSets) expect(labelSet).toMatch(/^state="[a-z_]+"$/);
+        expect(body).toMatch(new RegExp(`^${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} \\d+$`, 'm'));
+    });
+
+    it('accepts the canonical host with an optional port', async () => {
+        const response = GET(request('listen.harmonicbeacon.com:443'));
+        expect(response.status).toBe(200);
+    });
+
+    it('answers 404 on any other host and never trusts a forwarded host', async () => {
+        for (const host of [
+            'live.harmonicbeacon.com',
+            'earlybirds-staging.harmonicbeacon.com',
+            'beacon-app:3000',
+            'listen.harmonicbeacon.com.attacker.invalid',
+        ]) {
+            const response = GET(request(host));
+            expect(response.status, host).toBe(404);
+            expect(response.headers.get('cache-control')).toBe('private, no-store');
+            await expect(response.json()).resolves.toEqual({ error: 'Resource not found.' });
+        }
+        // A forwarded header never substitutes for the request Host.
+        const spoofed = GET(request('live.harmonicbeacon.com', {
+            'x-forwarded-host': 'listen.harmonicbeacon.com',
+        }));
+        expect(spoofed.status).toBe(404);
+        const missing = GET(request(null, { 'x-forwarded-host': 'listen.harmonicbeacon.com' }));
+        expect(missing.status).toBe(404);
+    });
+
+    it('answers a generic 503 when its own observer fails', async () => {
+        mocks.render.mockImplementationOnce(() => {
+            throw new Error('observer down');
+        });
+        const response = GET(request('listen.harmonicbeacon.com'));
+        expect(response.status).toBe(503);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        const body = await response.text();
+        expect(body).not.toContain('observer down');
+        expect(JSON.parse(body)).toEqual({ error: 'Session-cookie observations unavailable.' });
+    });
+
+    it('is GET-only and touches no database, auth or request metadata', async () => {
+        const routeModule = await import('../route');
+        expect('POST' in routeModule).toBe(false);
+        // No authorization, cookie, body or query material is read: the Host
+        // header alone decides, and the exposition is fixed aggregate state.
+        const source = await import('node:fs/promises')
+            .then((fs) => fs.readFile(new URL('../route.ts', import.meta.url), 'utf8'));
+        expect(source).not.toMatch(/@\/lib\/db|prisma|service-auth|authorization|cookies\(\)/);
+    });
+});

--- a/src/app/api/internal/v1/listener/session-cookie-observations/route.ts
+++ b/src/app/api/internal/v1/listener/session-cookie-observations/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { isCanonicalListenerHost } from '@/lib/listener/public-discovery';
+import { renderListenerSessionCookieObservations } from '@/lib/listener/session-cookie-observability';
+
+export const dynamic = 'force-dynamic';
+
+const NO_STORE = { 'Cache-Control': 'private, no-store' };
+
+/**
+ * Aggregate Listener session-cookie compatibility observations for the
+ * rollback-support window. GET-only, loopback-operated: the public nginx
+ * templates do not expose this path, and the route additionally answers 404
+ * on any Host other than the canonical Listener host (the request Host
+ * header, never a forwarded one). No database, no authentication, no request
+ * metadata and no dynamic labels: the output is the fixed nine-state counter
+ * exposition plus the process-start gauge, and it carries no cookie, header,
+ * user, session, account, IP or user-agent material.
+ */
+export function GET(request: NextRequest): Response {
+    if (!isCanonicalListenerHost(request.headers)) {
+        return NextResponse.json({ error: 'Resource not found.' }, { status: 404, headers: NO_STORE });
+    }
+    try {
+        return new Response(renderListenerSessionCookieObservations(), {
+            status: 200,
+            headers: {
+                'content-type': 'text/plain; version=0.0.4; charset=utf-8',
+                'cache-control': 'private, no-store',
+            },
+        });
+    } catch {
+        return NextResponse.json(
+            { error: 'Session-cookie observations unavailable.' },
+            { status: 503, headers: NO_STORE },
+        );
+    }
+}

--- a/src/lib/early-birds/__tests__/auth-session-observation.test.ts
+++ b/src/lib/early-birds/__tests__/auth-session-observation.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ getSession: vi.fn() }));
+
+// Better Auth is stubbed at the module boundary currentEarlyBirdSession
+// actually imports: the resolver under test crosses the real session-cookie
+// inspector, observability recording and fail-closed path, with no database
+// or network involved.
+vi.mock('better-auth/minimal', () => ({
+    betterAuth: () => ({ api: { getSession: mocks.getSession }, options: {} }),
+}));
+vi.mock('better-auth/adapters/prisma', () => ({ prismaAdapter: () => ({}) }));
+vi.mock('better-auth/cookies', () => ({
+    getCookies: () => ({
+        sessionToken: {
+            name: '__Secure-hb_earlybird_session',
+            attributes: { path: '/', httpOnly: true, sameSite: 'lax', secure: true },
+        },
+    }),
+}));
+vi.mock('@/lib/db', () => ({ prisma: {} }));
+
+import { currentEarlyBirdSession } from '@/lib/early-birds/auth';
+import { listenerSessionCookieNames } from '@/lib/listener/session-cookie-bridge';
+import { snapshotListenerSessionCookieObservations } from '@/lib/listener/session-cookie-observability';
+import * as observability from '@/lib/listener/session-cookie-observability';
+
+const NAMES = listenerSessionCookieNames('__Secure-hb_earlybird_session');
+const VALUE = 'm1V0k2NlR3JlVG9rZW4.x%2B9ab%2Fcd%3D';
+
+describe('currentEarlyBirdSession session-cookie observation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.getSession.mockResolvedValue(null);
+    });
+
+    it('records exactly one observation per resolver invocation', async () => {
+        const before = snapshotListenerSessionCookieObservations();
+
+        // Forwarded state: Better Auth runs (stubbed) and the fail-closed
+        // null shape is unchanged.
+        await expect(currentEarlyBirdSession(new Headers({
+            host: 'listen.harmonicbeacon.com',
+            cookie: `${NAMES.legacy}=${VALUE}`,
+        }))).resolves.toBeNull();
+        expect(mocks.getSession).toHaveBeenCalledOnce();
+
+        // Rejected state: fails closed before Better Auth, still one observation.
+        await expect(currentEarlyBirdSession(new Headers({
+            host: 'listen.harmonicbeacon.com',
+            cookie: `${NAMES.canonical}=${VALUE}`,
+        }))).resolves.toBeNull();
+        expect(mocks.getSession).toHaveBeenCalledOnce();
+
+        const after = snapshotListenerSessionCookieObservations();
+        expect(after.counts.legacy_only - before.counts.legacy_only).toBe(1);
+        expect(after.counts.canonical_only - before.counts.canonical_only).toBe(1);
+        expect(after.startedAtSeconds).toBe(before.startedAtSeconds);
+    });
+
+    it('preserves the resolver result byte-for-byte when Better Auth answers', async () => {
+        const expiresAt = new Date('2026-09-01T00:00:00.000Z');
+        mocks.getSession.mockResolvedValue({
+            user: { id: 'user-1', name: 'Listener', email: 'listener@example.test', image: null },
+            session: { id: 'session-1', expiresAt },
+        });
+        await expect(currentEarlyBirdSession(new Headers({
+            host: 'listen.harmonicbeacon.com',
+            cookie: `${NAMES.canonical}=${VALUE}; ${NAMES.legacy}=${VALUE}`,
+        }))).resolves.toEqual({
+            user: { id: 'user-1', name: 'Listener', email: 'listener@example.test', image: null },
+            session: { id: 'session-1', expiresAt },
+        });
+    });
+
+    it('does not count staging resolver invocations', async () => {
+        const before = snapshotListenerSessionCookieObservations();
+        await expect(currentEarlyBirdSession(new Headers({
+            host: 'earlybirds-staging.harmonicbeacon.com',
+            cookie: `${NAMES.legacy}=${VALUE}`,
+        }))).resolves.toBeNull();
+        expect(snapshotListenerSessionCookieObservations().counts).toEqual(before.counts);
+    });
+
+    it('keeps accepted and rejected resolver behavior unchanged if observation throws', async () => {
+        const expiresAt = new Date('2026-09-01T00:00:00.000Z');
+        const session = {
+            user: { id: 'user-1', name: 'Listener', email: 'listener@example.test', image: null },
+            session: { id: 'session-1', expiresAt },
+        };
+        mocks.getSession.mockResolvedValue(session);
+        const spy = vi
+            .spyOn(observability, 'recordListenerSessionCookieObservation')
+            .mockImplementation(() => {
+                throw new Error('observer down');
+            });
+        try {
+            await expect(currentEarlyBirdSession(new Headers({
+                host: 'listen.harmonicbeacon.com',
+                cookie: `${NAMES.legacy}=${VALUE}`,
+            }))).resolves.toEqual(session);
+            expect(mocks.getSession).toHaveBeenCalledOnce();
+
+            await expect(currentEarlyBirdSession(new Headers({
+                host: 'listen.harmonicbeacon.com',
+                cookie: `${NAMES.canonical}=${VALUE}`,
+            }))).resolves.toBeNull();
+            expect(mocks.getSession).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledTimes(2);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+});

--- a/src/lib/early-birds/auth.ts
+++ b/src/lib/early-birds/auth.ts
@@ -7,11 +7,13 @@ import { magicLink } from 'better-auth/plugins';
 import { prisma } from '@/lib/db';
 import {
     LISTENER_SESSION_COOKIE,
+    inspectListenerSessionCookie,
     listenerSessionAuthHandler,
     listenerSessionCookieNames,
-    resolveListenerSessionCookie,
     type ListenerSessionCookieNames,
 } from '@/lib/listener/session-cookie-bridge';
+import { recordListenerSessionCookieObservation } from '@/lib/listener/session-cookie-observability';
+import { isCanonicalListenerHost } from '@/lib/listener/public-discovery';
 import {
     listenerRuntimeBundle,
     listenerRuntimeFlag,
@@ -297,11 +299,20 @@ export async function currentEarlyBirdSession(
     const resolvedHeaders = suppliedHeaders ?? new Headers(await requestHeaders());
     // The same strict inbound policy as the route handler: ambiguous
     // session-cookie states never reach Better Auth, they fail closed here.
-    const resolution = resolveListenerSessionCookie(
+    // Exactly one aggregate observation is recorded per resolver invocation;
+    // the metric counts invocations, not unique users, browsers or sessions,
+    // so multiple observations per navigation are expected. Recording is
+    // fail-soft and can never change the fail-closed outcome below.
+    const inspection = inspectListenerSessionCookie(
         resolvedHeaders.get('cookie'),
         earlyBirdSessionCookieNames(),
     );
-    if (resolution.kind === 'reject') return null;
+    if (isCanonicalListenerHost(resolvedHeaders)) {
+        try {
+            recordListenerSessionCookieObservation(inspection.state);
+        } catch { /* Observation must never affect session resolution. */ }
+    }
+    if (inspection.resolution.kind === 'reject') return null;
     const result = await earlyBirdAuth().api.getSession({ headers: resolvedHeaders });
     if (!result) return null;
 

--- a/src/lib/listener/__tests__/session-cookie-bridge.integration.test.ts
+++ b/src/lib/listener/__tests__/session-cookie-bridge.integration.test.ts
@@ -9,6 +9,7 @@ import {
     listenerSessionCookieNames,
     type ListenerSessionCookieNames,
 } from '@/lib/listener/session-cookie-bridge';
+import { snapshotListenerSessionCookieObservations } from '@/lib/listener/session-cookie-observability';
 
 type MemoryRow = Record<string, unknown>;
 type BridgedHandler = (request: Request) => Promise<Response>;
@@ -55,13 +56,19 @@ function bridge(updateAge = 60 * 60 * 24) {
     };
 }
 
-function signUp(handler: BridgedHandler, email: string, cookie?: string): Promise<Response> {
+function signUp(
+    handler: BridgedHandler,
+    email: string,
+    cookie?: string,
+    host?: string,
+): Promise<Response> {
     return handler(new Request(`${BASE_URL}/api/early-birds/auth/sign-up/email`, {
         method: 'POST',
         headers: {
             origin: BASE_URL,
             'content-type': 'application/json',
             ...(cookie ? { cookie } : {}),
+            ...(host ? { host } : {}),
         },
         body: JSON.stringify({ email, name: 'Listener', password: 'listener-password-1' }),
     }));
@@ -91,9 +98,12 @@ function sessionCookieValue(response: Response, name: string): string {
     return entry.slice(name.length + 1, entry.indexOf(';'));
 }
 
-async function getSession(handler: BridgedHandler, cookie: string | null) {
+async function getSession(handler: BridgedHandler, cookie: string | null, host?: string) {
     const response = await handler(new Request(`${BASE_URL}/api/early-birds/auth/get-session`, {
-        headers: cookie ? { cookie } : {},
+        headers: {
+            ...(cookie ? { cookie } : {}),
+            ...(host ? { host } : {}),
+        },
     }));
     expect(response.status).toBe(200);
     return { response, body: await response.json() as { user?: { email?: string } } | null };
@@ -449,5 +459,48 @@ describe('Listener session-cookie bridge over a real Better Auth pipeline', () =
         // byte-identical and both cookies move together.
         expect(sessionCookieValue(rotated.response, state.names.legacy)).toBe(initial);
         expect(canonical).toBe(`${state.names.canonical}${legacy.slice(state.names.legacy.length)}`);
+    });
+});
+
+describe('Listener session-cookie observability over the real pipeline', () => {
+    it('the auth handler records exactly one observation per invocation', async () => {
+        const state = bridge();
+        const before = snapshotListenerSessionCookieObservations();
+
+        // Sign-up with no session cookie: one invocation, state `none`.
+        const response = await signUp(
+            state.handler,
+            'observed@example.test',
+            undefined,
+            'listen.harmonicbeacon.com',
+        );
+        expect(response.status).toBe(200);
+        const legacy = sessionCookieValue(response, state.names.legacy);
+
+        // One dual-pair get-session: one invocation, state `dual_identical`.
+        const dual = await getSession(
+            state.handler,
+            `${state.names.canonical}=${legacy}; ${state.names.legacy}=${legacy}`,
+            'listen.harmonicbeacon.com',
+        );
+        expect(dual.body?.user?.email).toBe('observed@example.test');
+
+        // One canonical-only rejection: one invocation, state `canonical_only`,
+        // with the dual-clear behavior unchanged.
+        const rejected = await state.handler(
+            new Request(`${BASE_URL}/api/early-birds/auth/get-session`, {
+                headers: {
+                    host: 'listen.harmonicbeacon.com',
+                    cookie: `${state.names.canonical}=${legacy}`,
+                },
+            }),
+        );
+        await expectBridgeRejection(rejected, 401, state.names);
+
+        const after = snapshotListenerSessionCookieObservations();
+        expect(after.counts.none - before.counts.none).toBe(1);
+        expect(after.counts.dual_identical - before.counts.dual_identical).toBe(1);
+        expect(after.counts.canonical_only - before.counts.canonical_only).toBe(1);
+        expect(after.startedAtSeconds).toBe(before.startedAtSeconds);
     });
 });

--- a/src/lib/listener/__tests__/session-cookie-bridge.test.ts
+++ b/src/lib/listener/__tests__/session-cookie-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
     LISTENER_SESSION_COOKIE,
+    inspectListenerSessionCookie,
     listenerSessionAuthHandler,
     listenerSessionClearCookies,
     listenerSessionCookieNames,
@@ -9,6 +10,11 @@ import {
     mirrorListenerSessionResponse,
     resolveListenerSessionCookie,
 } from '@/lib/listener/session-cookie-bridge';
+import {
+    LISTENER_SESSION_COOKIE_STATES,
+    snapshotListenerSessionCookieObservations,
+} from '@/lib/listener/session-cookie-observability';
+import * as observability from '@/lib/listener/session-cookie-observability';
 
 const NAMES = listenerSessionCookieNames('hb_earlybird_session');
 const SECURE_NAMES = listenerSessionCookieNames('__Secure-hb_earlybird_session');
@@ -331,5 +337,156 @@ describe('listenerSessionAuthHandler', () => {
             ]);
         }
         expect(seenCookies).toEqual([null, `${NAMES.legacy}=${VALUE}`, dual]);
+    });
+});
+
+describe('inspectListenerSessionCookie', () => {
+    type Resolution = ReturnType<typeof resolveListenerSessionCookie>;
+    type State = ReturnType<typeof inspectListenerSessionCookie>['state'];
+    const oversizedValue = `${NAMES.legacy}=${'a'.repeat(513)}`;
+    const oversizedHeader = `${NAMES.legacy}=${VALUE}; filler=${'f'.repeat(9000)}`;
+
+    // The full state matrix: every inspection state with the exact resolution
+    // the bridge enforces for it.
+    const matrix: [string, string | null, Resolution][] = [
+        ['none', null, { kind: 'forward', header: null }],
+        ['none', 'cart=1; theme=dark', { kind: 'forward', header: 'cart=1; theme=dark' }],
+        ['legacy_only', `${NAMES.legacy}=${VALUE}`, { kind: 'forward', header: `${NAMES.legacy}=${VALUE}` }],
+        [
+            'dual_identical',
+            `${NAMES.canonical}=${VALUE}; ${NAMES.legacy}=${VALUE}`,
+            { kind: 'forward', header: `${NAMES.canonical}=${VALUE}; ${NAMES.legacy}=${VALUE}` },
+        ],
+        ['canonical_only', `${NAMES.canonical}=${VALUE}`, { kind: 'reject', status: 401 }],
+        [
+            'conflicting_pair',
+            `${NAMES.canonical}=${OTHER_VALUE}; ${NAMES.legacy}=${VALUE}`,
+            { kind: 'reject', status: 400 },
+        ],
+        ['duplicate_name', `${NAMES.legacy}=${VALUE}; ${NAMES.legacy}=${VALUE}`, { kind: 'reject', status: 400 }],
+        ['malformed_value', `${NAMES.legacy}=${VALUE.slice(0, 10)}%zz`, { kind: 'reject', status: 400 }],
+        ['oversized_value', oversizedValue, { kind: 'reject', status: 400 }],
+        ['oversized_header', oversizedHeader, { kind: 'reject', status: 400 }],
+    ];
+
+    it.each(matrix)('classifies %s with the exact bridge resolution', (state, header, resolution) => {
+        const inspection = inspectListenerSessionCookie(header, NAMES);
+        expect(inspection.state).toBe(state);
+        expect(inspection.resolution).toEqual(resolution);
+        // resolveListenerSessionCookie is a pure delegation to the inspector.
+        expect(resolveListenerSessionCookie(header, NAMES)).toEqual(resolution);
+    });
+
+    it('covers exactly the closed observability allowlist', () => {
+        const states = new Set(matrix.map(([state]) => state));
+        expect([...states].sort()).toEqual([...LISTENER_SESSION_COOKIE_STATES].sort());
+    });
+
+    it('applies the documented precedence when several states overlap', () => {
+        const cases: [string, string, State][] = [
+            // An oversized header wins over duplicates and malformed values.
+            ['oversized_header', `${oversizedHeader}; ${NAMES.legacy}=${VALUE}`, 'oversized_header'],
+            // A duplicate wins over an oversized or malformed value.
+            ['duplicate_name', `${NAMES.legacy}=${'a'.repeat(513)}; ${NAMES.legacy}=${VALUE.slice(0, 10)}%zz`, 'duplicate_name'],
+            // An oversized value wins over bad percent encoding.
+            ['oversized_value', `${NAMES.legacy}=${'a'.repeat(510)}%zz`, 'oversized_value'],
+            // A malformed value wins over the canonical-only policy state.
+            ['malformed_value', `${NAMES.canonical}=${VALUE.slice(0, 10)}%2g`, 'malformed_value'],
+            // A well-formed pair conflict outranks nothing else: it needs both names.
+            ['conflicting_pair', `${NAMES.legacy}=${VALUE}; ${NAMES.canonical}=${OTHER_VALUE}`, 'conflicting_pair'],
+        ];
+        for (const [expected, header] of cases) {
+            expect(inspectListenerSessionCookie(header, NAMES).state, header).toBe(expected);
+        }
+    });
+});
+
+describe('listenerSessionAuthHandler observability', () => {
+    it('records exactly one observation per invocation with the inspected state', async () => {
+        const before = snapshotListenerSessionCookieObservations();
+        const handler = listenerSessionAuthHandler(async () => new Response('ok'), NAMES);
+
+        await handler(new Request('https://listen.harmonicbeacon.com/x', {
+            headers: { host: 'listen.harmonicbeacon.com' },
+        }));
+        await handler(new Request('https://listen.harmonicbeacon.com/x', {
+            headers: { host: 'listen.harmonicbeacon.com', cookie: `${NAMES.legacy}=${VALUE}` },
+        }));
+        await handler(new Request('https://listen.harmonicbeacon.com/x', {
+            headers: { host: 'listen.harmonicbeacon.com', cookie: `${NAMES.canonical}=${VALUE}` },
+        }));
+
+        const after = snapshotListenerSessionCookieObservations();
+        expect(after.counts.none - before.counts.none).toBe(1);
+        expect(after.counts.legacy_only - before.counts.legacy_only).toBe(1);
+        expect(after.counts.canonical_only - before.counts.canonical_only).toBe(1);
+        expect(after.startedAtSeconds).toBe(before.startedAtSeconds);
+    });
+
+    it('does not mix staging or synthetic-host traffic into the support window', async () => {
+        const before = snapshotListenerSessionCookieObservations();
+        const handler = listenerSessionAuthHandler(async () => new Response('ok'), NAMES);
+        await handler(new Request('https://earlybirds-staging.harmonicbeacon.com/x', {
+            headers: {
+                host: 'earlybirds-staging.harmonicbeacon.com',
+                cookie: `${NAMES.legacy}=${VALUE}`,
+            },
+        }));
+        expect(snapshotListenerSessionCookieObservations().counts).toEqual(before.counts);
+    });
+
+    it('fails soft when the observer throws: rejections stay byte-identical', async () => {
+        const inner = vi.fn(async () => new Response('ok'));
+        const handler = listenerSessionAuthHandler(inner, NAMES);
+        const spy = vi
+            .spyOn(observability, 'recordListenerSessionCookieObservation')
+            .mockImplementation(() => {
+                throw new Error('observer down');
+            });
+        try {
+            const response = await handler(new Request('https://listen.example.test/x', {
+                headers: {
+                    host: 'listen.harmonicbeacon.com',
+                    cookie: `${NAMES.canonical}=${VALUE}`,
+                },
+            }));
+            expect(spy).toHaveBeenCalledOnce();
+            expect(response.status).toBe(401);
+            expect(setCookiesOf(response)).toEqual(listenerSessionClearCookies(NAMES));
+            await expect(response.json()).resolves.toEqual({ error: 'invalid session credentials' });
+            expect(inner).not.toHaveBeenCalled();
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('fails soft when the observer throws: accepted states still reach the handler', async () => {
+        const headers = new Headers();
+        headers.append('set-cookie', `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`);
+        const inner = vi.fn(async () => new Response('ok', { headers }));
+        const handler = listenerSessionAuthHandler(inner, NAMES);
+        const spy = vi
+            .spyOn(observability, 'recordListenerSessionCookieObservation')
+            .mockImplementation(() => {
+                throw new Error('observer down');
+            });
+        try {
+            const response = await handler(new Request('https://listen.example.test/x', {
+                headers: {
+                    host: 'listen.harmonicbeacon.com',
+                    cookie: `${NAMES.legacy}=${VALUE}`,
+                },
+            }));
+            expect(spy).toHaveBeenCalledOnce();
+            expect(response.status).toBe(200);
+            expect(setCookiesOf(response)).toEqual([
+                `${NAMES.legacy}=${VALUE}; Path=/; HttpOnly`,
+                `${NAMES.canonical}=${VALUE}; Path=/; HttpOnly`,
+            ]);
+            await expect(response.text()).resolves.toBe('ok');
+            expect(inner).toHaveBeenCalledOnce();
+        } finally {
+            spy.mockRestore();
+        }
     });
 });

--- a/src/lib/listener/__tests__/session-cookie-observability.test.ts
+++ b/src/lib/listener/__tests__/session-cookie-observability.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC,
+    LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC,
+    LISTENER_SESSION_COOKIE_STATES,
+    recordListenerSessionCookieObservation,
+    renderListenerSessionCookieObservations,
+    snapshotListenerSessionCookieObservations,
+} from '@/lib/listener/session-cookie-observability';
+
+const REGISTRY_DESCRIPTION = 'harmonic-beacon.listener.session-cookie-observations';
+
+type Registry = {
+    startedAtSeconds: number;
+    counts: Record<string, number>;
+};
+
+// Vitest evaluates the module in a separate realm whose `Symbol.for` registry
+// is realm-local, so the test reaches the shared globalThis slot by symbol
+// description instead of by `Symbol.for` identity.
+function internalRegistry(): Registry {
+    const symbol = Object.getOwnPropertySymbols(globalThis)
+        .find((candidate) => candidate.description === REGISTRY_DESCRIPTION);
+    expect(symbol, 'registry symbol on globalThis').toBeDefined();
+    return (globalThis as Record<symbol, Registry>)[symbol as symbol];
+}
+
+describe('Listener session-cookie observability registry', () => {
+    it('exposes exactly the closed nine-state allowlist', () => {
+        expect(LISTENER_SESSION_COOKIE_STATES).toEqual([
+            'none',
+            'legacy_only',
+            'dual_identical',
+            'canonical_only',
+            'conflicting_pair',
+            'duplicate_name',
+            'malformed_value',
+            'oversized_value',
+            'oversized_header',
+        ]);
+    });
+
+    it('counts every allowlisted state and keeps a stable series order', () => {
+        const before = snapshotListenerSessionCookieObservations();
+        for (const state of LISTENER_SESSION_COOKIE_STATES) {
+            recordListenerSessionCookieObservation(state);
+        }
+        recordListenerSessionCookieObservation('dual_identical');
+        const after = snapshotListenerSessionCookieObservations();
+
+        expect(Object.keys(after.counts)).toEqual([...LISTENER_SESSION_COOKIE_STATES]);
+        for (const state of LISTENER_SESSION_COOKIE_STATES) {
+            expect(after.counts[state]).toBe(before.counts[state] + (state === 'dual_identical' ? 2 : 1));
+        }
+    });
+
+    it('exposes all nine series including zero values in snapshots and render', () => {
+        const snapshot = snapshotListenerSessionCookieObservations();
+        for (const state of LISTENER_SESSION_COOKIE_STATES) {
+            expect(snapshot.counts[state]).toBeGreaterThanOrEqual(0);
+        }
+        const render = renderListenerSessionCookieObservations();
+        for (const state of LISTENER_SESSION_COOKIE_STATES) {
+            expect(render).toMatch(
+                new RegExp(`^${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC}\\{state="${state}"\\} \\d+$`, 'm'),
+            );
+        }
+    });
+
+    it('discards unknown states without throwing', () => {
+        const before = snapshotListenerSessionCookieObservations();
+        expect(() => {
+            recordListenerSessionCookieObservation('unknown_state');
+            recordListenerSessionCookieObservation('');
+            recordListenerSessionCookieObservation('state","x="1');
+            recordListenerSessionCookieObservation(undefined as unknown as string);
+        }).not.toThrow();
+        expect(snapshotListenerSessionCookieObservations().counts).toEqual(before.counts);
+    });
+
+    it('keeps snapshot and render nonthrowing if the process-local registry is corrupted', () => {
+        const holder = internalRegistry() as unknown as { counts: unknown };
+        const saved = holder.counts;
+        try {
+            holder.counts = null;
+            expect(() => snapshotListenerSessionCookieObservations()).not.toThrow();
+            expect(snapshotListenerSessionCookieObservations().counts)
+                .toEqual(Object.fromEntries(LISTENER_SESSION_COOKIE_STATES.map((state) => [state, 0])));
+            expect(() => renderListenerSessionCookieObservations()).not.toThrow();
+            expect(renderListenerSessionCookieObservations())
+                .toContain(`${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC}{state="none"} 0`);
+        } finally {
+            holder.counts = saved;
+        }
+    });
+
+    it('is monotonic and saturates at Number.MAX_SAFE_INTEGER', () => {
+        const counts = internalRegistry().counts;
+        const saved = counts.legacy_only;
+        try {
+            recordListenerSessionCookieObservation('legacy_only');
+            expect(counts.legacy_only).toBe(saved + 1);
+
+            counts.legacy_only = Number.MAX_SAFE_INTEGER - 1;
+            recordListenerSessionCookieObservation('legacy_only');
+            expect(counts.legacy_only).toBe(Number.MAX_SAFE_INTEGER);
+            recordListenerSessionCookieObservation('legacy_only');
+            expect(counts.legacy_only).toBe(Number.MAX_SAFE_INTEGER);
+        } finally {
+            counts.legacy_only = saved + 1;
+        }
+    });
+
+    it('keeps one registry and a stable process start epoch across the process', () => {
+        const first = snapshotListenerSessionCookieObservations();
+        const second = snapshotListenerSessionCookieObservations();
+        expect(second.startedAtSeconds).toBe(first.startedAtSeconds);
+        expect(Number.isInteger(first.startedAtSeconds)).toBe(true);
+        expect(first.startedAtSeconds).toBeGreaterThan(0);
+        expect(internalRegistry().startedAtSeconds).toBe(first.startedAtSeconds);
+    });
+
+    it('renders valid text exposition with only the fixed state label and gauge', () => {
+        const render = renderListenerSessionCookieObservations();
+        expect(render.endsWith('\n')).toBe(true);
+        const lines = render.trimEnd().split('\n');
+        expect(lines[0]).toBe(`# HELP ${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC} Listener session-cookie compatibility states observed by session resolver invocations (aggregate per process; not unique users, browsers or sessions).`);
+        expect(lines[1]).toBe(`# TYPE ${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC} counter`);
+        for (const [index, state] of LISTENER_SESSION_COOKIE_STATES.entries()) {
+            expect(lines[2 + index]).toMatch(
+                new RegExp(`^${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC}\\{state="${state}"\\} \\d+$`),
+            );
+        }
+        const tail = lines.slice(2 + LISTENER_SESSION_COOKIE_STATES.length);
+        expect(tail).toEqual([
+            `# HELP ${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} Unix epoch seconds when this observer process created its session-cookie observation registry.`,
+            `# TYPE ${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} gauge`,
+            `${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} ${snapshotListenerSessionCookieObservations().startedAtSeconds}`,
+        ]);
+    });
+
+    it('renders no cookie, header, user, session, account, IP or UA material', () => {
+        const render = renderListenerSessionCookieObservations();
+        // Every label set is exactly one fixed `state` label over the allowlist.
+        const labelSets = [...render.matchAll(/\{([^}]*)\}/g)].map((match) => match[1]);
+        expect(labelSets).toHaveLength(LISTENER_SESSION_COOKIE_STATES.length);
+        for (const labelSet of labelSets) {
+            expect(labelSet).toMatch(/^state="(none|legacy_only|dual_identical|canonical_only|conflicting_pair|duplicate_name|malformed_value|oversized_value|oversized_header)"$/);
+        }
+        // No request-shaped material can appear: values are only integers.
+        for (const line of render.trimEnd().split('\n')) {
+            expect(line).toMatch(/^(# (HELP|TYPE) [a-z_]+ .+|[a-z_]+(\{state="[a-z_]+"\})? \d+)$/);
+        }
+    });
+});

--- a/src/lib/listener/session-cookie-bridge.ts
+++ b/src/lib/listener/session-cookie-bridge.ts
@@ -43,6 +43,12 @@
  * any other non-session cookies pass through untouched in both directions.
  */
 
+import {
+    recordListenerSessionCookieObservation,
+    type ListenerSessionCookieState,
+} from '@/lib/listener/session-cookie-observability';
+import { isCanonicalListenerHost } from '@/lib/listener/public-discovery';
+
 export const LISTENER_SESSION_COOKIE = 'hb_listener_session';
 
 const SECURE_COOKIE_PREFIX = '__Secure-';
@@ -162,43 +168,88 @@ function wellFormedSessionValue(value: string): boolean {
 }
 
 /**
- * Resolves whether an inbound Cookie header may reach Better Auth under the
- * bridge policy. Accepted states are forwarded byte-for-byte (Better Auth
- * ignores the canonical name and reads the legacy one); no state is ever
- * rewritten or stripped, because repairing an ambiguous header is exactly
- * what better-call's first-wins parser would do silently.
+ * Pure inbound inspection: the aggregate compatibility `state` observed for
+ * observability plus the strict `resolution` the bridge enforces. The state
+ * classification is closed and ordered by precedence:
+ *
+ * 1. no relevant session cookie (or no header at all) -> `none`;
+ * 2. oversized whole Cookie header -> `oversized_header`;
+ * 3. a duplicate of either relevant name -> `duplicate_name`;
+ * 4. a relevant value over 512 characters -> `oversized_value`;
+ * 5. an empty, non-wire-charset or bad-percent relevant value -> `malformed_value`;
+ * 6. a well-formed canonical cookie without its legacy counterpart -> `canonical_only`;
+ * 7. a canonical/legacy pair whose values differ -> `conflicting_pair`;
+ * 8. exactly one legacy cookie -> `legacy_only`;
+ * 9. a byte-identical canonical/legacy pair -> `dual_identical`.
+ *
+ * `resolveListenerSessionCookie` is exactly this inspection's `resolution`.
  */
-export function resolveListenerSessionCookie(
+export type ListenerSessionCookieInspection = {
+    readonly state: ListenerSessionCookieState;
+    readonly resolution: ListenerSessionCookieResolution;
+};
+
+/**
+ * Resolves whether an inbound Cookie header may reach Better Auth under the
+ * bridge policy, and classifies the aggregate compatibility state observed.
+ * Accepted states are forwarded byte-for-byte (Better Auth ignores the
+ * canonical name and reads the legacy one); no state is ever rewritten or
+ * stripped, because repairing an ambiguous header is exactly what
+ * better-call's first-wins parser would do silently.
+ */
+export function inspectListenerSessionCookie(
     header: string | null,
     names: ListenerSessionCookieNames,
-): ListenerSessionCookieResolution {
+): ListenerSessionCookieInspection {
     const forward: ListenerSessionCookieResolution = { kind: 'forward', header };
-    if (!header) return forward;
+    if (!header) return { state: 'none', resolution: forward };
 
     const parts = parseCookieParts(header);
     const legacyParts = parts.filter((part) => part.name === names.legacy);
     const canonicalParts = parts.filter((part) => part.name === names.canonical);
-    if (legacyParts.length === 0 && canonicalParts.length === 0) return forward;
+    if (legacyParts.length === 0 && canonicalParts.length === 0) {
+        return { state: 'none', resolution: forward };
+    }
 
     const reject = (status: 400 | 401): ListenerSessionCookieResolution =>
         ({ kind: 'reject', status });
 
-    if (
-        header.length > MAX_COOKIE_HEADER_LENGTH ||
-        legacyParts.length > 1 ||
-        canonicalParts.length > 1 ||
-        legacyParts.some((part) => !wellFormedSessionValue(part.value)) ||
-        canonicalParts.some((part) => !wellFormedSessionValue(part.value))
-    ) return reject(400);
+    if (header.length > MAX_COOKIE_HEADER_LENGTH) {
+        return { state: 'oversized_header', resolution: reject(400) };
+    }
+    if (legacyParts.length > 1 || canonicalParts.length > 1) {
+        return { state: 'duplicate_name', resolution: reject(400) };
+    }
+    const relevant = [...legacyParts, ...canonicalParts];
+    if (relevant.some((part) => part.value.length > MAX_SESSION_COOKIE_VALUE_LENGTH)) {
+        return { state: 'oversized_value', resolution: reject(400) };
+    }
+    if (relevant.some((part) => !wellFormedSessionValue(part.value))) {
+        return { state: 'malformed_value', resolution: reject(400) };
+    }
 
     const legacy = legacyParts[0];
     const canonical = canonicalParts[0];
     // A well-formed canonical credential without its legacy counterpart is
     // not accepted during the rollback-compatible phase.
-    if (!legacy) return reject(401);
+    if (!legacy) return { state: 'canonical_only', resolution: reject(401) };
     // Conflicting values are never arbitrated between.
-    if (canonical && canonical.value !== legacy.value) return reject(400);
-    return forward;
+    if (canonical && canonical.value !== legacy.value) {
+        return { state: 'conflicting_pair', resolution: reject(400) };
+    }
+    return { state: canonical ? 'dual_identical' : 'legacy_only', resolution: forward };
+}
+
+/**
+ * Resolves whether an inbound Cookie header may reach Better Auth under the
+ * bridge policy. Pure delegation to `inspectListenerSessionCookie`; the
+ * resolution behavior is byte-identical to the pre-observability bridge.
+ */
+export function resolveListenerSessionCookie(
+    header: string | null,
+    names: ListenerSessionCookieNames,
+): ListenerSessionCookieResolution {
+    return inspectListenerSessionCookie(header, names).resolution;
 }
 
 /**
@@ -299,15 +350,24 @@ export function mirrorListenerSessionResponse(
  * ambiguous request can mint, rotate or clear a session; ambiguous outbound
  * output fails closed with a generic 500 carrying no Set-Cookie at all. The
  * wrapped handler stays the only code that touches sessions.
+ *
+ * Each invocation also records the inspected aggregate compatibility state
+ * for observability. Recording is fail-soft: an observer failure can never
+ * change the resolution, the handler invocation, or the response.
  */
 export function listenerSessionAuthHandler(
     handler: (request: Request) => Promise<Response>,
     names: ListenerSessionCookieNames,
 ): (request: Request) => Promise<Response> {
     return async (request) => {
-        const resolution = resolveListenerSessionCookie(request.headers.get('cookie'), names);
-        if (resolution.kind === 'reject') {
-            return rejectionResponse(resolution.status, names);
+        const inspection = inspectListenerSessionCookie(request.headers.get('cookie'), names);
+        if (isCanonicalListenerHost(request.headers)) {
+            try {
+                recordListenerSessionCookieObservation(inspection.state);
+            } catch { /* Observation must never affect authentication. */ }
+        }
+        if (inspection.resolution.kind === 'reject') {
+            return rejectionResponse(inspection.resolution.status, names);
         }
         return mirrorListenerSessionResponse(await handler(request), names);
     };

--- a/src/lib/listener/session-cookie-observability.ts
+++ b/src/lib/listener/session-cookie-observability.ts
@@ -1,0 +1,158 @@
+/**
+ * Listener session-cookie compatibility observability.
+ *
+ * A process-local, in-memory registry that counts how often the Listener
+ * session resolvers (the auth-handler bridge and `currentEarlyBirdSession`)
+ * observe each inbound session-cookie compatibility state. It exists to size
+ * the rollback-compatible dual-cookie support window; it is deliberately
+ * aggregate-only:
+ *
+ * - exactly one fixed label, `state`, over a closed allowlist of nine states;
+ *   no external labels are ever accepted, and
+ * - no cookie, header, user, session, account, IP or user-agent value is ever
+ *   stored or rendered.
+ *
+ * Counters measure resolver INVOCATIONS, not unique users, browsers or
+ * sessions: one navigation can invoke a resolver several times, and one
+ * session is observed on every request. The registry is per process/replica
+ * and resets on restart; the unlabeled process-start gauge separates epochs,
+ * and snapshots must be archived externally per epoch to establish any
+ * continuity (a current zero cannot prove seven quiet days).
+ *
+ * The registry lives on `globalThis` under a `Symbol.for` key so a module
+ * reload (development hot reload, test re-import) shares one registry per
+ * process instead of resetting it. Recording, snapshots and rendering are
+ * bounded, synchronous and nonthrowing: observation must never affect
+ * authentication behavior.
+ */
+
+export const LISTENER_SESSION_COOKIE_STATES = [
+    'none',
+    'legacy_only',
+    'dual_identical',
+    'canonical_only',
+    'conflicting_pair',
+    'duplicate_name',
+    'malformed_value',
+    'oversized_value',
+    'oversized_header',
+] as const;
+
+export type ListenerSessionCookieState = typeof LISTENER_SESSION_COOKIE_STATES[number];
+
+export const LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC =
+    'beacon_listener_session_cookie_observations_total';
+export const LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC =
+    'beacon_listener_session_cookie_observer_process_start_time_seconds';
+
+const REGISTRY_KEY = Symbol.for('harmonic-beacon.listener.session-cookie-observations');
+const PROCESS_START_SECONDS = Math.floor(Date.now() / 1000);
+
+type ListenerSessionCookieObservationRegistry = {
+    /** Unix epoch seconds when this process first created the registry. */
+    readonly startedAtSeconds: number;
+    readonly counts: Record<ListenerSessionCookieState, number>;
+};
+
+export type ListenerSessionCookieObservationSnapshot = {
+    readonly startedAtSeconds: number;
+    readonly counts: Record<ListenerSessionCookieState, number>;
+};
+
+function emptyCounts(): Record<ListenerSessionCookieState, number> {
+    return Object.fromEntries(
+        LISTENER_SESSION_COOKIE_STATES.map((state) => [state, 0]),
+    ) as Record<ListenerSessionCookieState, number>;
+}
+
+function registry(): ListenerSessionCookieObservationRegistry {
+    const scope = globalThis as Record<symbol, ListenerSessionCookieObservationRegistry | undefined>;
+    let existing = scope[REGISTRY_KEY];
+    if (!existing) {
+        existing = {
+            startedAtSeconds: PROCESS_START_SECONDS,
+            counts: emptyCounts(),
+        };
+        scope[REGISTRY_KEY] = existing;
+    }
+    return existing;
+}
+
+/**
+ * Records one resolver observation of an inbound session-cookie state.
+ * Unknown states are discarded, increments saturate at
+ * `Number.MAX_SAFE_INTEGER`, and any observer failure is swallowed: this call
+ * must never change an auth outcome.
+ */
+export function recordListenerSessionCookieObservation(state: string): void {
+    try {
+        const counts = registry().counts;
+        if (!Object.hasOwn(counts, state)) return;
+        const known = state as ListenerSessionCookieState;
+        counts[known] = Math.min(counts[known] + 1, Number.MAX_SAFE_INTEGER);
+    } catch { /* Observation is best-effort and must never throw. */ }
+}
+
+/**
+ * A copy of the current registry: all nine series in stable allowlist order
+ * (including zero values) plus the stable process-start epoch.
+ */
+export function snapshotListenerSessionCookieObservations(): ListenerSessionCookieObservationSnapshot {
+    try {
+        const current = registry();
+        const counts = emptyCounts();
+        for (const state of LISTENER_SESSION_COOKIE_STATES) {
+            const value = current.counts[state];
+            counts[state] = Number.isSafeInteger(value) && value >= 0 ? value : 0;
+        }
+        const startedAtSeconds = Number.isSafeInteger(current.startedAtSeconds) &&
+            current.startedAtSeconds > 0
+            ? current.startedAtSeconds
+            : PROCESS_START_SECONDS;
+        return { startedAtSeconds, counts };
+    } catch {
+        return { startedAtSeconds: PROCESS_START_SECONDS, counts: emptyCounts() };
+    }
+}
+
+/**
+ * Prometheus text exposition (0.0.4) of the registry. Every line is fixed
+ * except the aggregate numbers; the only label is `state` over the closed
+ * allowlist, so no request material can ever reach the output.
+ */
+export function renderListenerSessionCookieObservations(): string {
+    try {
+        const snapshot = snapshotListenerSessionCookieObservations();
+        const lines = [
+            `# HELP ${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC} Listener session-cookie compatibility states observed by session resolver invocations (aggregate per process; not unique users, browsers or sessions).`,
+            `# TYPE ${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC} counter`,
+        ];
+        for (const state of LISTENER_SESSION_COOKIE_STATES) {
+            lines.push(`${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC}{state="${state}"} ${snapshot.counts[state]}`);
+        }
+        lines.push(
+            `# HELP ${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} Unix epoch seconds when this observer process created its session-cookie observation registry.`,
+            `# TYPE ${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} gauge`,
+            `${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} ${snapshot.startedAtSeconds}`,
+            '',
+        );
+        return lines.join('\n');
+    } catch {
+        // Even a corrupted process-local registry must not affect auth. The
+        // fixed empty exposition remains privacy-safe and identifies this
+        // process epoch; operators must treat the missing prior counts as a
+        // continuity gap rather than evidence of zero legacy use.
+        const lines = LISTENER_SESSION_COOKIE_STATES.map(
+            (state) => `${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC}{state="${state}"} 0`,
+        );
+        return [
+            `# HELP ${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC} Listener session-cookie compatibility states observed by session resolver invocations (aggregate per process; not unique users, browsers or sessions).`,
+            `# TYPE ${LISTENER_SESSION_COOKIE_OBSERVATIONS_METRIC} counter`,
+            ...lines,
+            `# HELP ${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} Unix epoch seconds when this observer process created its session-cookie observation registry.`,
+            `# TYPE ${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} gauge`,
+            `${LISTENER_SESSION_COOKIE_OBSERVER_START_METRIC} ${PROCESS_START_SECONDS}`,
+            '',
+        ].join('\n');
+    }
+}


### PR DESCRIPTION
## Outcome\n\nAdds Listener-only, privacy-safe aggregate observation for the already-integrated session-cookie compatibility bridge. It does not deploy or wire observability, change auth/cookie decisions, or touch events/audio.\n\n## Scope\n\n- nine fixed process-local cookie-shape states; no values, IDs, IP, user agent or dynamic labels\n- exact canonical Listener Host recording only; staging/synthetic traffic is excluded\n- private GET exposition remains unreachable through public Listener nginx templates\n- process epoch and continuity caveats documented; this merge does not start the support window\n- accepted #210 policy keeps applied migrations, physical early_bird_* tables and v1 wire IDs as historical compatibility\n\n## Evidence\n\n- 71 focused Vitest cases\n- 1,383 full tests passed / 21 expected skips\n- 26 preview contracts\n- TypeScript, focused and full ESLint\n- production build\n- independent adversarial review: no P0/P1; both P2 findings corrected\n\n## Safety / rollback\n\nSource-only and Listener-isolated. No deploy, provider call, load, secret, event, LiveKit, playlist, tapestry, media or audio change. Rollback is reverting this single commit; the observer is fail-soft and does not alter auth outcomes.