### PR TITLE
fix(listener): add fail-closed weekly quota rollback bridge

### DIFF
--- a/prisma/migrations/20260808150000_listener_weekly_policy_bridge/migration.sql
+++ b/prisma/migrations/20260808150000_listener_weekly_policy_bridge/migration.sql
@@ -1,0 +1,15 @@
+-- Rollback bridge installed before the personal weekly quota cutover. The
+-- legacy Listener image accepts only legacy-daily-v1; the weekly migration
+-- atomically advances this row so every bridge image fails closed thereafter.
+CREATE TABLE "early_bird_listener_authority_policy" (
+    "id" INTEGER NOT NULL,
+    "policy_version" VARCHAR(32) NOT NULL,
+    "activated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "early_bird_listener_authority_policy_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "early_bird_listener_authority_policy_singleton_check" CHECK ("id" = 1),
+    CONSTRAINT "early_bird_listener_authority_policy_version_check"
+        CHECK ("policy_version" IN ('legacy-daily-v1', 'personal-7-day-v1'))
+);
+
+INSERT INTO "early_bird_listener_authority_policy" ("id", "policy_version")
+VALUES (1, 'legacy-daily-v1');

--- a/src/lib/early-birds/__tests__/policy-bridge.test.ts
+++ b/src/lib/early-birds/__tests__/policy-bridge.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    LEGACY_LISTENER_POLICY_VERSION,
+    legacyListenerPolicyCompatible,
+} from '../access';
+
+describe('Listener legacy policy rollback bridge', () => {
+    it('accepts only the exact pre-cutover policy', () => {
+        expect(legacyListenerPolicyCompatible(LEGACY_LISTENER_POLICY_VERSION)).toBe(true);
+        expect(legacyListenerPolicyCompatible('personal-7-day-v1')).toBe(false);
+        expect(legacyListenerPolicyCompatible(null)).toBe(false);
+    });
+});

--- a/src/lib/early-birds/access.ts
+++ b/src/lib/early-birds/access.ts
@@ -10,6 +10,30 @@ import { freeWindowState, type EarlyBirdFreeWindowState } from './free-window';
 import { membershipAccessDecision, type EarlyBirdAccessDecision } from './membership';
 import { welcomeAccessState, type EarlyBirdWelcomeAccessState } from './welcome-access';
 
+export const LEGACY_LISTENER_POLICY_VERSION = 'legacy-daily-v1' as const;
+
+export class EarlyBirdListenerPolicyMismatchError extends Error {
+    constructor() {
+        super('This Listener image is not compatible with the active access policy');
+        this.name = 'EarlyBirdListenerPolicyMismatchError';
+    }
+}
+
+export function legacyListenerPolicyCompatible(policyVersion: string | null): boolean {
+    return policyVersion === LEGACY_LISTENER_POLICY_VERSION;
+}
+
+async function assertLegacyListenerPolicyCompatible(): Promise<void> {
+    const rows = await prisma.$queryRaw<Array<{ policyVersion: string }>>`
+        SELECT "policy_version" AS "policyVersion"
+        FROM "early_bird_listener_authority_policy"
+        WHERE "id" = 1
+    `;
+    if (!legacyListenerPolicyCompatible(rows[0]?.policyVersion ?? null)) {
+        throw new EarlyBirdListenerPolicyMismatchError();
+    }
+}
+
 export type EarlyBirdListeningAccess = {
     allowed: boolean;
     kind: 'membership' | 'free-window' | 'welcome' | 'denied';
@@ -82,6 +106,12 @@ export async function getEarlyBirdListeningAccess(
     accountId: string,
     now = new Date(),
 ): Promise<EarlyBirdListeningAccess> {
+    // Unit tests exercise the pure legacy decision without a database marker.
+    // Every deployed Listener runs NODE_ENV=production and must prove its
+    // exact policy compatibility before reading legacy schedule/welcome state.
+    if (process.env.NODE_ENV === 'production') {
+        await assertLegacyListenerPolicyCompatible();
+    }
     const [projection, schedule, welcome] = await Promise.all([
         prisma.earlyBirdMembershipProjection.findUnique({ where: { accountId } }),
         prisma.earlyBirdFreeSchedule.findUnique({ where: { accountId } }),


### PR DESCRIPTION
## Purpose\n\nDeploy this exact bridge image before activating the weekly Listener quota. It creates a legacy policy marker and makes the current daily-policy binary fail closed once the marker advances to personal-7-day-v1.\n\n## Scope\n\n- Listener-only policy marker migration\n- production fail-closed compatibility check before legacy schedule/welcome authorization\n- no event, LiveKit, media, audio, payment, or public copy changes\n\n## Evidence\n\n- focused policy/access tests: 6 passed\n- TypeScript: passed\n- Prisma validate: passed\n- real PostgreSQL rehearsal: legacy marker accepted before cutover; personal marker rejected with EarlyBirdListenerPolicyMismatchError after cutover\n\n## Rollback\n\nBefore the weekly migration, the current 20406da Listener image remains valid. After personal-7-day-v1 is activated, this bridge image is the only binary rollback and intentionally fails closed; recovery is roll-forward to the weekly image.\n