### PR TITLE
ops(listener): add isolated PayPal sandbox workbench mode

### DIFF
--- a/docs/operations/LISTENER_UI_FAST_LOOP.md
+++ b/docs/operations/LISTENER_UI_FAST_LOOP.md
@@ -16,6 +16,19 @@ Start or replace the workbench from the `early-birds` worktree:
 scripts/listener-ui-preview.sh start
 ```
 
+For the isolated PayPal sandbox checkout rehearsal, require an account instead
+of Free For All and expose only the PayPal sandbox action in this disposable
+process:
+
+```bash
+LISTENER_UI_PREVIEW_FREE_FOR_ALL=0 \
+LISTENER_UI_PREVIEW_PAYPAL_SANDBOX_CHECKOUT_ENABLED=1 \
+scripts/listener-ui-preview.sh start
+```
+
+The script refuses the ambiguous combination of checkout plus Free For All.
+Neither switch changes the persistent Listener release or event services.
+
 Keep local edits synchronized while iterating:
 
 ```bash

--- a/scripts/listener-ui-preview.sh
+++ b/scripts/listener-ui-preview.sh
@@ -12,6 +12,14 @@ REMOTE_SOURCE="${REMOTE_ROOT}/source"
 REMOTE_NEXT="${REMOTE_ROOT}/next"
 DEV_CONTAINER="listener-ui-dev"
 RELEASE_CONTAINER="earlybirds-preview-listener-1"
+PREVIEW_FREE_FOR_ALL="${LISTENER_UI_PREVIEW_FREE_FOR_ALL:-1}"
+PREVIEW_PAYPAL_CHECKOUT="${LISTENER_UI_PREVIEW_PAYPAL_SANDBOX_CHECKOUT_ENABLED:-0}"
+
+case "$PREVIEW_FREE_FOR_ALL:$PREVIEW_PAYPAL_CHECKOUT" in
+    0:0|0:1|1:0) ;;
+    1:1) echo "PayPal checkout requires Free For All to be disabled." >&2; exit 2 ;;
+    *) echo "Preview switches must be 0 or 1." >&2; exit 2 ;;
+esac
 
 usage() {
     echo "Usage: $0 {start|sync|watch|status|stop|logs}" >&2
@@ -29,7 +37,7 @@ sync_source() {
 }
 
 start_remote() {
-    ssh "$PREVIEW_HOST" "REMOTE_SOURCE='$REMOTE_SOURCE' REMOTE_NEXT='$REMOTE_NEXT' DEV_CONTAINER='$DEV_CONTAINER' RELEASE_CONTAINER='$RELEASE_CONTAINER' bash -s" <<'REMOTE'
+    ssh "$PREVIEW_HOST" "REMOTE_SOURCE='$REMOTE_SOURCE' REMOTE_NEXT='$REMOTE_NEXT' DEV_CONTAINER='$DEV_CONTAINER' RELEASE_CONTAINER='$RELEASE_CONTAINER' PREVIEW_FREE_FOR_ALL='$PREVIEW_FREE_FOR_ALL' PREVIEW_PAYPAL_CHECKOUT='$PREVIEW_PAYPAL_CHECKOUT' bash -s" <<'REMOTE'
 set -euo pipefail
 
 image="$(docker inspect "$RELEASE_CONTAINER" --format '{{.Config.Image}}')"
@@ -58,8 +66,9 @@ docker run -d \
     -e BEACON_GIT_SHA=ui-dev \
     -e EARLY_BIRDS_ENABLED=1 \
     -e BEACON_LISTENER_ENABLED=1 \
-    -e EARLY_BIRDS_FREE_FOR_ALL=1 \
-    -e BEACON_LISTENER_FREE_FOR_ALL=1 \
+    -e EARLY_BIRDS_FREE_FOR_ALL="$PREVIEW_FREE_FOR_ALL" \
+    -e BEACON_LISTENER_FREE_FOR_ALL="$PREVIEW_FREE_FOR_ALL" \
+    -e BEACON_LISTENER_PAYPAL_SANDBOX_CHECKOUT_ENABLED="$PREVIEW_PAYPAL_CHECKOUT" \
     --network earlybirds_preview_db_internal \
     -p 127.0.0.1:13001:3000 \
     -v "$REMOTE_SOURCE/src:/app/src:ro" \


### PR DESCRIPTION
## Outcome

Adds an explicit disposable staging-workbench mode for rehearsing PayPal sandbox checkout with registered synthetic accounts. It does not change the persistent Listener release, public Listener flags, authority flags, event services or live.

## Safety

- Checkout mode requires Free For All OFF.
- The script rejects ambiguous/invalid switch combinations before touching the remote host.
- Defaults remain Free For All ON and checkout OFF for ordinary visual/UI iteration.
- No secrets or payment-provider values are added.

## Verification

- `bash -n scripts/listener-ui-preview.sh`
- invalid FFA+checkout combination exits 2 with the expected fail-closed message
- `git diff --check`

## Rollback

Stop the disposable `listener-ui-dev` container or restart the workbench with default switches. The persistent Listener container and event stack are untouched.