### PR TITLE
docs(listener): define Founder price continuity

### DIFF
--- a/docs/architecture/LISTENER_FOUNDER_ELIGIBILITY.md
+++ b/docs/architecture/LISTENER_FOUNDER_ELIGIBILITY.md
@@ -1,12 +1,21 @@
-# Listener Founder price eligibility projection
+# Listener Founder price continuity projection
+
+> **Product amendment — 2026-08-10:** the positive-only lifetime eligibility
+> implementation described below is superseded and must not be enabled for
+> production commerce. "Lifetime" now means only the uninterrupted lifetime of
+> an active Founder subscription. Once paid-through/grace continuity ends,
+> Founder status and USD 5 eligibility end; later signup uses the current public
+> offer. This document retains the deployed design history so migration and
+> rollback can be reviewed, but the authority and Listener projections require
+> a coordinated forward-only correction before provider activation.
 
 ## Boundary
 
-PMP Myth Bot is the only authority that can grant the lifetime Founding Listener price. Its private
+PMP Myth Bot is the only authority that can project Founding Listener price continuity. Its private
 membership read v2 is versioned in `contracts/early-bird-authority/v2` and was introduced by backend
 merge `3febc1d525adf150bfdd75fd2b98b04771cb79b7`.
 
-Listener stores a positive-only projection of that evidence in
+The historical implementation stores a positive-only projection of that evidence in
 `early_bird_founder_eligibility_projections`. This row is deliberately separate from the v1
 membership projection:
 

--- a/docs/decisions/0004-provider-neutral-earlybird-membership.md
+++ b/docs/decisions/0004-provider-neutral-earlybird-membership.md
@@ -1,6 +1,6 @@
 # Provider-neutral EarlyBird membership
 
-*Accepted 2026-08-06 for the EarlyBirds milestone.*
+*Accepted 2026-08-06 and amended 2026-08-10 for the EarlyBirds milestone.*
 
 ## Decision
 
@@ -9,19 +9,22 @@ MercadoPago and future app-store providers emit one ordered, idempotent
 membership projection. The web app never trusts a success redirect or provider
 payload as access truth.
 
-The founder offer is an immutable USD 5/month offer revision. The right to that
-price is granted only after the first canonical paid activation and remains
-attached for life to the opaque Listener account, independently of email or
-identity provider. Voluntary cancellation ends active access after paid-through
-time but does not remove the account's founder-price eligibility; a later
-reactivation uses the founder offer again. Involuntary payment failure receives
-14 days of grace. Refund, dispute and administrative revoke end access
-immediately without using a browser redirect as commercial truth.
+The founder offer is an immutable USD 5/month offer revision. "Lifetime" means
+that price remains guaranteed only while the canonical Founder subscription is
+active and uninterrupted; it is not a permanent account entitlement. A pending
+cancellation keeps access and Founder status through paid-through time and may
+be reversed before service ends without breaking continuity. Once service
+actually ends, Founder status and price eligibility end. Any later signup uses
+the then-current public offer. Involuntary payment failure receives the approved
+grace period, but terminal failure, refund, chargeback, dispute, fraud or
+administrative termination does not preserve Founder status. Browser redirects
+remain incapable of creating or erasing commercial truth.
 
-Founder-price eligibility, active membership, current listening authorization
-and payment/reconciliation history are separate durable concepts. A checkout
-start, success redirect, failed attempt or unconfirmed provider event grants
-none of them.
+Founder pricing, active membership, current listening authorization and
+payment/reconciliation history remain separate canonical concepts, but Founder
+pricing is continuity-bound rather than an immutable positive-only account
+grant. A checkout start, success redirect, failed attempt or unconfirmed
+provider event grants none of them.
 
 Free invitations are signed, single-use, EarlyBird-scoped, auditable, revocable
 and indefinite until used or revoked. They work in staging and production. A

--- a/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
+++ b/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
@@ -137,8 +137,10 @@ deployed image; later documentation-only commits do not require rebuilding it.
 - #195 remains open: measured external load/CDN rehearsal.
 - #196 remains open only for Apple developer credentials and physical Apple
   acceptance; the real Google callback/logout/relogin passed.
-- #197 is closed: provider-neutral membership and Founder eligibility are
-  integrated. Provider acceptance remains separately tracked by #199/#200/#261.
+- #197 was reopened after the 2026-08-10 product amendment: the former
+  positive-only lifetime eligibility must become continuity-bound before any
+  production provider is enabled. Provider acceptance remains separately
+  tracked by #199/#200/#261.
 - #198 remains open: physical acoustic/accessibility and 60-minute acceptance.
 - #201 is In Progress: the human acceptance matrix.
 - #216's old daily-window acceptance is obsolete; weekly reset/countdown human

--- a/docs/plans/EARLY_BIRDS.md
+++ b/docs/plans/EARLY_BIRDS.md
@@ -56,7 +56,7 @@ change has passed its own audio and operational acceptance.
 | Favor continuity over low latency in the Listener | Accepted | Desktop HLS stays about five segments behind the edge with a 60-second target buffer; Stop and a later Listen rejoin the current configured edge. |
 | Keep intros private | Accepted | Intro progress is device-local. The live stream runs muted underneath and is revealed at the handoff; this is not a realtime mix or crossfader. |
 | Separate ordinary Free from canonical membership | Accepted | Registered Free is a server-authoritative, metered weekly allowance that never fabricates membership or Purchase; canonical memberships/invitations and Free for All remain non-metered. |
-| Preserve the Founder price for life | Accepted | First canonical paid activation grants the opaque account a lifetime right to the USD 5/month founder offer; cancellation ends access but not that price eligibility. |
+| Preserve the Founder price while service remains uninterrupted | Accepted | USD 5/month remains guaranteed only while the canonical Founder subscription stays active or inside its approved grace/paid-through continuity; once service ends, Founder status and pricing end and a later signup uses the current public offer. |
 | Launch Free before paid providers | Accepted | Human acceptance of the complete Free flow is a hard gate before PayPal or MercadoPago can be enabled. Both providers remain disabled by default. |
 | Defer app-store distribution | Accepted | Google Play and Apple App Store wrappers and billing are post-MVP work; the provider-neutral membership authority must leave room for them without making them a launch dependency. |
 | Design for 3,000 concurrent listeners | Accepted | Expand at 4,000 and treat 5,000 as critical; alerts use measured network, CPU, memory, origin and canary health. |
@@ -115,9 +115,10 @@ steps are not safe to execute literally.
 5. They call a shared database, container, host and SFU "zero impact". Shared
    infrastructure is impact; the preview and media origin must be isolated and
    resource-bounded.
-6. They treat a boolean `isFounder` as a lifetime-price contract. Founder-price
-   eligibility requires a versioned offer, first canonical paid activation and
-   durable account-bound commercial evidence separate from active membership.
+6. They treat a boolean `isFounder` as a complete pricing contract. Founder
+   continuity requires a versioned offer, canonical paid activation and
+   ordered paid-through/grace/termination evidence separate from current
+   listening authorization.
 7. They place PWA, three identity providers, root redirects, post-event upsell
    and autonomous social publishing in the first slice. None is required to
    prove that a person can subscribe and listen reliably.
@@ -428,14 +429,16 @@ revocable and valid indefinitely until consumed or revoked. They work in
 staging and production. Upgrading Free to paid consumes the free grant so two
 independent memberships cannot remain active.
 
-"Founder price locked for life" is not a boolean. It is a versioned USD 5/month
-offer grant recording amount/currency, first canonical paid activation and the
-opaque account that owns the durable eligibility. Voluntary cancellation
-preserves access through paid-through time and then ends active access, but the
-same account retains the founder price for a later reactivation. Involuntary
-payment failure receives 14 days of grace. Refund, dispute and administrative
-revocation remove access immediately; they do not authorize the browser to
-invent or erase commercial evidence.
+"Founder price locked for life" means for the uninterrupted lifetime of the
+Founder service, not for the lifetime of the account. It is a versioned USD
+5/month continuity state recording amount/currency, canonical activation and
+the current paid/grace boundary. A pending voluntary cancellation preserves
+access through paid-through time and may be reversed before that boundary
+without losing Founder status. Once service ends, eligibility ends permanently
+and a later signup uses the current public offer. Involuntary payment failure
+receives 14 days of grace. Terminal failure, refund, chargeback, dispute, fraud
+or administrative termination removes access and Founder status; the browser
+cannot invent or erase that commercial evidence.
 
 PayPal and MercadoPago both implement the same contract. MercadoPago charges an
 ARS equivalent derived from the BCRA A3500 reference rate, locks the renewal
@@ -671,7 +674,7 @@ an older USD 2 binary is not a valid rollback target.
 | ID | Accepted decision |
 |---|---|
 | D1 | `EarlyBirds` remains the implementation branch/milestone; public Listener is `listen.harmonicbeacon.com/`, staging migrates to `listen-staging.harmonicbeacon.com`, legacy `/early-birds` paths redirect during cutover, and origin remains `stream.harmonicbeacon.com`. |
-| D2 | USD 5/month founder offer; first canonical paid activation grants lifetime account-bound price eligibility; voluntary cancellation ends access after paid-through but a later reactivation retains that price; 14-day involuntary grace; refund/dispute/admin revoke access immediately. |
+| D2 | USD 5/month founder offer while service remains uninterrupted; pending cancellation retains access and price only through paid-through and can be reversed before service ends; once service ends, later signup uses the then-current public price; 14-day involuntary grace; terminal failure/refund/chargeback/dispute/fraud/admin termination removes access and Founder status. |
 | D3 | Google and Apple through exact stable Better Auth, plus an optional passwordless email magic-link fallback through the existing private mail authority; no Facebook and no implicit account linking. |
 | D4 | Provider-neutral Free, PayPal and MercadoPago grants; Free is single-use, signed, auditable, revocable and consumed by paid upgrade. |
 | D5 | Source-neutral “continuous Beacon stream” wording; never claim whether the source is an instrument, a file or another origin. |


### PR DESCRIPTION
## Outcome

Records the 2026-08-10 product amendment: the Founding Listener offer remains **USD 5/month**, but "lifetime" means only for the uninterrupted lifetime of active Founder service. Once paid-through/grace service ends, Founder status and price eligibility end; a later signup uses the then-current public offer.

## Scope

- Amends the provider-neutral membership decision and EarlyBirds plan.
- Marks the historical positive-only lifetime projection as superseded and unsafe for production activation.
- Reconciles the release-candidate status with reopened #197.
- No runtime, database, contract, provider, event or audio changes.

## Evidence

- Repository pre-commit suite: 169 files passed, 6 skipped; 1,495 tests passed, 28 skipped.
- GitHub issues #197/#199/#200/#307 and milestone EarlyBirds updated.
- Backend corrective work tracked in SairaAsua/proyecciones-mito#66.

Closes no implementation issue: production commerce remains blocked/default-off until #197 and backend #66 are complete.
