### PR TITLE
fix(listener): keep staging OAuth state on payment workbench

### DIFF
--- a/docs/operations/LISTENER_UI_FAST_LOOP.md
+++ b/docs/operations/LISTENER_UI_FAST_LOOP.md
@@ -33,6 +33,14 @@ separate production-mode container on the staging port. Ordinary UI iteration
 continues to use Next development mode. Neither path changes the persistent
 Listener release or event services.
 
+The payment workbench overrides both accepted Listener auth-base aliases to
+`https://earlybirds-staging.harmonicbeacon.com`. OAuth state and session cookies
+are host-only, so login must begin and finish on staging. Inheriting the public
+Listener auth base would redirect Google to `listen.harmonicbeacon.com`, where
+the staging state cookie is deliberately unavailable and the callback fails
+closed with `state_mismatch`. The Google OAuth application must therefore keep
+the exact staging callback registered alongside the public Listener callback.
+
 For the equivalent isolated Mercado Pago TEST rehearsal, select only Mercado
 Pago and keep Free For All disabled:
 

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -93,6 +93,15 @@ test('synthetic guard accepts the example and rejects unsafe effective values', 
   });
 });
 
+test('payment workbench keeps OAuth state and callback on the staging origin', async () => {
+  const source = await readRepository('scripts/listener-ui-preview.sh');
+  assert.match(source, /PREVIEW_ORIGIN="https:\/\/earlybirds-staging\.harmonicbeacon\.com"/);
+  assert.match(source, /set_env_file_value BEACON_LISTENER_AUTH_BASE_URL "\$PREVIEW_ORIGIN"/);
+  assert.match(source, /set_env_file_value EARLY_BIRDS_AUTH_BASE_URL "\$PREVIEW_ORIGIN"/);
+  assert.match(source, /if \[ "\$PREVIEW_PAYPAL_CHECKOUT" = 1 \] \|\| \[ "\$PREVIEW_MERCADO_PAGO_CHECKOUT" = 1 \]/);
+  assert.doesNotMatch(source, /PREVIEW_ORIGIN="https:\/\/listen\.harmonicbeacon\.com"/);
+});
+
 test('compose gates the loopback Listener on a forward-only isolated database migration', async () => {
   const source = await readPreview('compose.yml');
   const env = await readPreview('preview.env.synthetic.example');

--- a/scripts/listener-ui-preview.sh
+++ b/scripts/listener-ui-preview.sh
@@ -15,6 +15,7 @@ RELEASE_CONTAINER="earlybirds-preview-listener-1"
 PREVIEW_FREE_FOR_ALL="${LISTENER_UI_PREVIEW_FREE_FOR_ALL:-1}"
 PREVIEW_PAYPAL_CHECKOUT="${LISTENER_UI_PREVIEW_PAYPAL_SANDBOX_CHECKOUT_ENABLED:-0}"
 PREVIEW_MERCADO_PAGO_CHECKOUT="${LISTENER_UI_PREVIEW_MERCADO_PAGO_TEST_CHECKOUT_ENABLED:-0}"
+PREVIEW_ORIGIN="https://earlybirds-staging.harmonicbeacon.com"
 
 case "$PREVIEW_FREE_FOR_ALL:$PREVIEW_PAYPAL_CHECKOUT:$PREVIEW_MERCADO_PAGO_CHECKOUT" in
     0:0:0|0:1:0|0:0:1|1:0:0) ;;
@@ -39,7 +40,7 @@ sync_source() {
 }
 
 start_remote() {
-    ssh "$PREVIEW_HOST" "REMOTE_SOURCE='$REMOTE_SOURCE' REMOTE_NEXT='$REMOTE_NEXT' DEV_CONTAINER='$DEV_CONTAINER' RELEASE_CONTAINER='$RELEASE_CONTAINER' PREVIEW_FREE_FOR_ALL='$PREVIEW_FREE_FOR_ALL' PREVIEW_PAYPAL_CHECKOUT='$PREVIEW_PAYPAL_CHECKOUT' PREVIEW_MERCADO_PAGO_CHECKOUT='$PREVIEW_MERCADO_PAGO_CHECKOUT' bash -s" <<'REMOTE'
+    ssh "$PREVIEW_HOST" "REMOTE_SOURCE='$REMOTE_SOURCE' REMOTE_NEXT='$REMOTE_NEXT' DEV_CONTAINER='$DEV_CONTAINER' RELEASE_CONTAINER='$RELEASE_CONTAINER' PREVIEW_FREE_FOR_ALL='$PREVIEW_FREE_FOR_ALL' PREVIEW_PAYPAL_CHECKOUT='$PREVIEW_PAYPAL_CHECKOUT' PREVIEW_MERCADO_PAGO_CHECKOUT='$PREVIEW_MERCADO_PAGO_CHECKOUT' PREVIEW_ORIGIN='$PREVIEW_ORIGIN' bash -s" <<'REMOTE'
 set -euo pipefail
 
 image="$(docker inspect "$RELEASE_CONTAINER" --format '{{.Config.Image}}')"
@@ -48,6 +49,13 @@ cleanup() { rm -f "$env_file"; }
 trap cleanup EXIT
 umask 077
 docker inspect "$RELEASE_CONTAINER" | jq -r '.[0].Config.Env[]' > "$env_file"
+
+set_env_file_value() {
+    key="$1"
+    value="$2"
+    sed -i "/^${key}=/d" "$env_file"
+    printf '%s=%s\n' "$key" "$value" >> "$env_file"
+}
 
 install -d -m 0755 "$REMOTE_NEXT"
 sudo chown 1001:1001 "$REMOTE_NEXT"
@@ -62,6 +70,12 @@ command_args=()
 if [ "$PREVIEW_PAYPAL_CHECKOUT" = 1 ] || [ "$PREVIEW_MERCADO_PAGO_CHECKOUT" = 1 ]; then
     # Synthetic team entry is deliberately unavailable under NODE_ENV=development.
     # Payment rehearsal therefore runs the exact built release artifact.
+    # OAuth state and session cookies are host-only. The workbench must initiate
+    # and receive the callback on its own origin; inheriting the persistent
+    # Listener base URL sends Google back to listen.harmonicbeacon.com, where
+    # the staging state cookie is absent and Better Auth correctly rejects it.
+    set_env_file_value BEACON_LISTENER_AUTH_BASE_URL "$PREVIEW_ORIGIN"
+    set_env_file_value EARLY_BIRDS_AUTH_BASE_URL "$PREVIEW_ORIGIN"
     runtime_args=(-e NODE_ENV=production)
     command_args=(node server.js)
 else


### PR DESCRIPTION
## Diagnosis

The payment workbench inherited the persistent Listener auth base. Google therefore returned to `listen.harmonicbeacon.com` while the one-time OAuth state cookie was host-only on `earlybirds-staging.harmonicbeacon.com`, producing a correct fail-closed `state_mismatch`. The public host then correctly exposed no sandbox checkout.

## Change

- replace both canonical and legacy auth-base values in the workbench's private temporary env with the exact staging origin;
- apply the override only to PayPal/MP payment rehearsal mode;
- add a static contract and operational documentation.

## Evidence

- `bash -n scripts/listener-ui-preview.sh`
- preview contract: 30/30 passed
- workbench restarted with only Mercado Pago TEST enabled
- real Google sign-in initiation now emits exact redirect URI `https://earlybirds-staging.harmonicbeacon.com/api/early-birds/auth/callback/google` with state
- persistent Listener, events, audio and production commerce unchanged

Closes #313 after supervised callback + checkout acceptance.
