### PR TITLE
docs(listener): record commercial staging deploy

### DIFF
--- a/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+++ b/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
@@ -1,5 +1,37 @@
 # EarlyBirds isolated staging runtime
 
+## 2026-08-12 commercial lane deployed with Live sales OFF
+
+The isolated Listener now runs merge SHA
+`f571495ff51591fdca5bf51b2c9ab27c1e1eeeb3`, image
+`harmonic-beacon/earlybirds-preview-listener:f571495` and unchanged Prisma
+head `20260810223000_listener_founder_continuity`. The isolated membership
+authority runs merge SHA `7bc2dabd05aa68602bbfe9faa6e29c4e1c081017`
+at unchanged Alembic head `7b4c1e9a2d60`.
+
+- PayPal Live, Mercado Pago Live and both public Listener checkout flags are
+  explicitly disabled. Existing PayPal Sandbox and Mercado Pago TEST lifecycle
+  remain ready in the isolated authority; the staging workbench exposes only
+  Mercado Pago TEST. No real checkout or charge was created during deployment.
+- The stable Listener checkout, cancellation and two signed-webhook boundaries
+  are installed only on `listen.harmonicbeacon.com`. Public checkout returns
+  `404` while disabled, unauthenticated cancellation returns `401`, webhook
+  `GET` returns `405` and unsigned callbacks fail closed while Live providers
+  are disabled.
+- `/`, `/listener/terms`, `/listener/privacy`, liveness and readiness return
+  `200` on the public Listener. The same UI/legal routes return `200` on the
+  exact staging host, whose payment workbench uses the same release image.
+- The origin retained container `ed7ce1c99f79`; event app, playlist bot and
+  LiveKit retained containers `527b5d590844`, `c67664aabcca` and
+  `b81a99a8c3c9`. All remained healthy and no event configuration was changed.
+- Root-owned database, environment and nginx backups are retained under
+  `/mnt/beacon-data/staging-backups/listener-commercial-20260812T052454Z` and
+  `/mnt/beacon-data/staging-backups/listener-commercial-20260812T052916Z`.
+  Binary rollback selects Listener image `0e8ae66` and authority image
+  `ceed7b1e8edc1961c64a809b67f808119857b696`, restores the matched protected
+  environments/nginx files, recreates only the isolated services and reruns
+  health smoke. No schema rollback is required or authorized.
+
 ## 2026-08-11 Founder continuity cutover
 
 The isolated Listener runs runtime SHA


### PR DESCRIPTION
Records the exact Listener and authority SHAs deployed on the isolated staging stack, disabled Live/new-sales state, smoke results, retained event/origin container identities, backups and rollback. Documentation only; no runtime or event file changes.
