### PR TITLE
ops(listener): alert on paid lifecycle health

### DIFF
--- a/ops/early-birds/docker-compose.yml
+++ b/ops/early-birds/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - ./prometheus/alerts.yml:/etc/prometheus/rules/alerts.yml:ro
       - prometheus-data:/prometheus
     ports: [127.0.0.1:9090:9090]
-    networks: [observability, ops_edge]
+    networks: [observability, ops_edge, authority_private]
     deploy:
       resources:
         limits: { cpus: "1.0", memory: 1G }
@@ -144,6 +144,9 @@ networks:
   # a wildcard host port on this bridge.
   ops_edge:
     name: earlybirds_observability_edge
+  authority_private:
+    external: true
+    name: earlybirds_authority_private
 
 volumes:
   prometheus-data:

--- a/ops/early-birds/prometheus/alerts.yml
+++ b/ops/early-birds/prometheus/alerts.yml
@@ -1,4 +1,56 @@
 groups:
+  - name: listener-paid-authority
+    rules:
+      - alert: ListenerAuthorityUnreachable
+        expr: up{job="listener-authority"} == 0
+        for: 2m
+        labels: { severity: critical, service: listener-payments }
+        annotations: { summary: "Listener membership authority is unreachable", runbook: "listener-paid-authority" }
+      - alert: ListenerSandboxProviderUnavailable
+        expr: pmp_listener_provider_ready{environment=~"sandbox|test"} == 0
+        for: 5m
+        labels: { severity: warning, service: listener-payments }
+        annotations: { summary: "A Listener sandbox/test provider is unavailable", runbook: "listener-paid-provider" }
+      - alert: ListenerLiveProviderUnavailableDuringSales
+        expr: pmp_listener_new_sales_enabled == 1 and on() sum(pmp_listener_provider_ready{environment="live"}) < 2
+        for: 2m
+        labels: { severity: critical, service: listener-payments }
+        annotations: { summary: "New sales are enabled while a Live provider is unavailable", runbook: "listener-paid-provider" }
+      - alert: ListenerPaidQueueDelayed
+        expr: pmp_listener_paid_queue_oldest_age_seconds > 120
+        for: 5m
+        labels: { severity: warning, service: listener-payments }
+        annotations: { summary: "Listener paid lifecycle queue is more than two minutes old", runbook: "listener-paid-queue" }
+      - alert: ListenerPaidQueueCritical
+        expr: pmp_listener_paid_queue_oldest_age_seconds > 600
+        for: 2m
+        labels: { severity: critical, service: listener-payments }
+        annotations: { summary: "Listener paid lifecycle queue is more than ten minutes old", runbook: "listener-paid-queue" }
+      - alert: ListenerPaidJobFailed
+        expr: sum(pmp_listener_paid_jobs{status="failed"}) > 0
+        for: 2m
+        labels: { severity: critical, service: listener-payments }
+        annotations: { summary: "A durable Listener paid lifecycle job failed", runbook: "listener-paid-queue" }
+      - alert: ListenerProjectionFailed
+        expr: pmp_listener_paid_jobs{kind="early_birds.beacon.project",status="failed"} > 0
+        for: 1m
+        labels: { severity: critical, service: listener-payments }
+        annotations: { summary: "A canonical Listener membership projection failed", runbook: "listener-paid-projection" }
+      - alert: ListenerWebhookSignatureFailures
+        expr: sum(increase(pmp_listener_paid_requests_total{operation="webhook",outcome="invalid_signature"}[5m])) > 5
+        for: 2m
+        labels: { severity: warning, service: listener-payments }
+        annotations: { summary: "Listener webhook signature failures exceed the warning threshold", runbook: "listener-paid-webhook" }
+      - alert: ListenerWebhookSignatureFailuresCritical
+        expr: sum(increase(pmp_listener_paid_requests_total{operation="webhook",outcome="invalid_signature"}[5m])) > 20
+        for: 1m
+        labels: { severity: critical, service: listener-payments }
+        annotations: { summary: "Listener webhook signature failures exceed the critical threshold", runbook: "listener-paid-webhook" }
+      - alert: ListenerCheckoutProviderErrors
+        expr: sum(increase(pmp_listener_paid_requests_total{operation="checkout",outcome="provider_error"}[5m])) > 0
+        for: 2m
+        labels: { severity: warning, service: listener-payments }
+        annotations: { summary: "Listener checkout provider errors were observed", runbook: "listener-paid-provider" }
   - name: early-birds-origin
     rules:
       - alert: EarlyBirdsOriginUnreachable

--- a/ops/early-birds/prometheus/prometheus.yml
+++ b/ops/early-birds/prometheus/prometheus.yml
@@ -23,6 +23,13 @@ scrape_configs:
     static_configs:
       - targets: [canary-exporter:8081]
 
+  # The membership authority exposes aggregate, label-bounded metrics only on
+  # its internal Compose network. No nginx/public route reaches this target.
+  - job_name: listener-authority
+    metrics_path: /metrics
+    static_configs:
+      - targets: [pmp-myth-api:8765]
+
   - job_name: node
     static_configs:
       - targets: [node-exporter:9100]

--- a/ops/early-birds/runbook/README.md
+++ b/ops/early-birds/runbook/README.md
@@ -58,6 +58,40 @@ critical threshold, persistent 5xx/rebuffer evidence, retransmits ≥1%, or a
 healthy origin whose direct egress remains the bottleneck. It is not activated
 solely from an advertised NIC speed.
 
+## Paid Listener authority
+
+Prometheus joins the authority's existing private Docker network and scrapes
+`pmp-myth-api:8765/metrics`. The authority port remains loopback/private and no
+nginx location exposes metrics. Exported payment labels are fixed provider,
+environment, operation, outcome, job kind and job status values; no account,
+email, provider subscription ID, checkout URL, webhook body or signature is
+exported.
+
+Operational signals cover authority reachability, provider readiness while
+new sales are enabled, the oldest durable paid job, failed lifecycle/projection
+jobs, invalid webhook signatures and checkout provider errors. The request
+counters are process-local; `pmp_listener_paid_observer_process_start_time_seconds`
+separates restart epochs. Database queue gauges remain durable across API
+restarts.
+
+Immediate actions:
+
+- **authority/provider:** turn off new sales in Listener and authority, but
+  leave webhooks, reconciliation and existing membership access running;
+- **queue/projection:** inspect only aggregate job status first, retry or
+  reconcile through the durable authority path, and never infer access from a
+  browser redirect;
+- **webhook signatures:** verify the exact provider environment and registered
+  endpoint before changing a secret; do not log or paste webhook bodies;
+- **recovery:** wait for the matching resolved Telegram notification and a
+  green authority target before reopening sales.
+
+Fault injection uses a synthetic Alertmanager alert with fixed labels and an
+explicit end time, followed by a resolved update. It must never disable the
+origin or any event container. A deliberately missed sandbox webhook is
+repaired by the provider reconciliation worker, then the canonical Listener
+projection is verified before the drill is considered complete.
+
 ## Per-container restart/OOM observability blocker
 
 Per-container `container_start_time_seconds` and `container_oom_events_total`

--- a/ops/early-birds/test/config.test.mjs
+++ b/ops/early-birds/test/config.test.mjs
@@ -15,7 +15,9 @@ test('keeps all metrics and Alertmanager listeners off public interfaces', async
   assert.match(compose, /--path\.sysfs=\/host\/sys/);
   assert.match(compose, /networks: \[observability\]/);
   assert.match(compose, /networks: \[observability, ops_edge\]/g);
+  assert.match(compose, /networks: \[observability, ops_edge, authority_private\]/);
   assert.match(compose, /ops_edge:\s+name: earlybirds_observability_edge/);
+  assert.match(compose, /authority_private:\s+external: true\s+name: earlybirds_authority_private/);
   assert.doesNotMatch(compose, /--web\.enable-lifecycle=false/);
   // Alertmanager may bind inside its private Docker network, but host-published
   // admin/metrics ports must remain loopback-only.
@@ -48,7 +50,20 @@ test('references Telegram and canary credentials as mounted secret files only', 
 test('scrapes node-exporter by the internal Docker DNS name', async () => {
   const prometheus = await read('prometheus/prometheus.yml');
   assert.match(prometheus, /targets: \[node-exporter:9100\]/);
+  assert.match(prometheus, /job_name: listener-authority[\s\S]*targets: \[pmp-myth-api:8765\]/);
   assert.doesNotMatch(prometheus, /host\.docker\.internal/);
+});
+
+test('alerts on paid authority failures without account or provider identifiers', async () => {
+  const alerts = await read('prometheus/alerts.yml');
+  assert.match(alerts, /ListenerAuthorityUnreachable/);
+  assert.match(alerts, /ListenerPaidQueueDelayed/);
+  assert.match(alerts, /ListenerPaidQueueCritical/);
+  assert.match(alerts, /ListenerPaidJobFailed/);
+  assert.match(alerts, /ListenerProjectionFailed/);
+  assert.match(alerts, /ListenerWebhookSignatureFailuresCritical/);
+  assert.match(alerts, /ListenerCheckoutProviderErrors/);
+  assert.doesNotMatch(alerts, /account_id|email|subscription_id|approval_url/);
 });
 
 test('routes warnings hourly and critical alerts immediately every fifteen minutes', async () => {


### PR DESCRIPTION
## Outcome

Wire the isolated Listener payment authority into the existing private Prometheus/Telegram stack and alert on paid lifecycle degradation with mandatory recovery notifications.

## Scope

- private authority scrape over the existing internal Docker network;
- warning/critical rules for reachability, provider readiness during sales, queue age, failed lifecycle/projection jobs, invalid signatures and checkout provider errors;
- fixed-label aggregate signals only; no account, email, provider ID, token, signed URL or webhook body;
- runbook for kill switch, reconciliation and recovery;
- no public metrics route and no event/live/audio changes.

## Gates

- observability node tests: green
- Compose, Prometheus rules/config and Alertmanager validation: green
- complete webapp test suite: 1,536 passed / 30 standard skips
- diff-check: green

Backend metric implementation: SairaAsua/proyecciones-mito#71.
