### PR TITLE
fix(listener): scope paid alerts to actionable state

### DIFF
--- a/ops/early-birds/prometheus/alerts.yml
+++ b/ops/early-birds/prometheus/alerts.yml
@@ -12,7 +12,7 @@ groups:
         labels: { severity: warning, service: listener-payments }
         annotations: { summary: "A Listener sandbox/test provider is unavailable", runbook: "listener-paid-provider" }
       - alert: ListenerLiveProviderUnavailableDuringSales
-        expr: pmp_listener_new_sales_enabled == 1 and on() sum(pmp_listener_provider_ready{environment="live"}) < 2
+        expr: pmp_listener_new_sales_enabled{environment="live"} == 1 and on(provider, environment) pmp_listener_provider_ready{environment="live"} == 0
         for: 2m
         labels: { severity: critical, service: listener-payments }
         annotations: { summary: "New sales are enabled while a Live provider is unavailable", runbook: "listener-paid-provider" }
@@ -27,12 +27,12 @@ groups:
         labels: { severity: critical, service: listener-payments }
         annotations: { summary: "Listener paid lifecycle queue is more than ten minutes old", runbook: "listener-paid-queue" }
       - alert: ListenerPaidJobFailed
-        expr: sum(pmp_listener_paid_jobs{status="failed"}) > 0
+        expr: sum(pmp_listener_paid_jobs_failed_recent) > 0
         for: 2m
         labels: { severity: critical, service: listener-payments }
         annotations: { summary: "A durable Listener paid lifecycle job failed", runbook: "listener-paid-queue" }
       - alert: ListenerProjectionFailed
-        expr: pmp_listener_paid_jobs{kind="early_birds.beacon.project",status="failed"} > 0
+        expr: pmp_listener_paid_jobs_failed_recent{kind="early_birds.beacon.project"} > 0
         for: 1m
         labels: { severity: critical, service: listener-payments }
         annotations: { summary: "A canonical Listener membership projection failed", runbook: "listener-paid-projection" }

--- a/ops/early-birds/runbook/README.md
+++ b/ops/early-birds/runbook/README.md
@@ -72,7 +72,10 @@ new sales are enabled, the oldest durable paid job, failed lifecycle/projection
 jobs, invalid webhook signatures and checkout provider errors. The request
 counters are process-local; `pmp_listener_paid_observer_process_start_time_seconds`
 separates restart epochs. Database queue gauges remain durable across API
-restarts.
+restarts. Queue age includes only due, immediate jobs; scheduled renewal locks
+and checkout-expiry recovery do not page before their `available_at`. Failed-job
+alerts use a rolling 15-minute window, so historical pre-release failures stay
+auditable without remaining permanently active.
 
 Immediate actions:
 


### PR DESCRIPTION
Follow-up to #323 after the first production-shaped scrape.

- Live provider alerts now join the provider/environment-specific Live sales signal.
- Failed-job alerts use only the recent failure gauge.
- Runbook documents why scheduled jobs and historical pre-release failures do not page.

Prometheus/Alertmanager/Compose validation and the full webapp suite are green. No event, audio or public-route changes.
