### PR TITLE
fix(listener): show terminal membership status

### DIFF
--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -62,10 +62,10 @@ export default function EarlyBirdHome({
                             </summary>
                             <div className="listener-account__menu">
                                 <p>{displayName}</p>
-                                {accessKind === 'membership' && (
+                                {membershipCopy && (
                                     <span>{membershipCopy?.title ?? copy.active}</span>
                                 )}
-                                {accessKind === 'membership' && membership.kind === 'founder' && membershipCopy?.detail && (
+                                {membership.kind !== 'none' && membershipCopy?.detail && (
                                     <small>{membershipCopy.detail}</small>
                                 )}
                                 {accessKind === 'membership' && membership.kind === 'founder' && (

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -126,6 +126,24 @@ describe('EarlyBird Listener home access chrome', () => {
         expect(screen.queryByText('MERCADO_PAGO')).not.toBeInTheDocument();
     });
 
+    it('shows a terminal paid status while keeping the account on Free access', () => {
+        render(
+            <LocaleProvider initialLocale="en">
+                <EarlyBirdHome
+                    displayName="Nico"
+                    membership={{ kind: 'paid-status', provider: 'paypal', state: 'refunded' }}
+                    accessKind="free-quota"
+                    dropIns={{ es: null, en: null }}
+                />
+            </LocaleProvider>,
+        );
+
+        expect(screen.getByText('The payment was refunded and Founder access has ended.')).toBeInTheDocument();
+        expect(screen.getByText('You can continue with the Free listening available to your account.')).toBeInTheDocument();
+        expect(screen.queryByText('Founder access')).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Cancel membership' })).not.toBeInTheDocument();
+    });
+
     it('places Free allowance and membership action below the listening surface', () => {
         render(
             <LocaleProvider initialLocale="en">

--- a/src/lib/early-birds/__tests__/membership-presentation.test.ts
+++ b/src/lib/early-birds/__tests__/membership-presentation.test.ts
@@ -76,13 +76,18 @@ describe('public Listener membership presentation', () => {
         });
     });
 
-    it.each(['EXPIRED', 'REFUNDED', 'REVOKED', 'PENDING'] as const)(
-        'removes the Founder badge for terminal or non-authoritative %s membership',
-        (state) => {
+    it.each([
+        ['EXPIRED', 'expired'],
+        ['REFUNDED', 'refunded'],
+        ['REVOKED', 'revoked'],
+        ['PENDING', 'pending'],
+    ] as const)(
+        'removes the Founder badge while preserving the informational %s paid state',
+        (state, expected) => {
             expect(listenerMembershipPresentation(projection({
                 state,
                 founderContinuityState: state === 'PENDING' ? null : 'ENDED',
-            }), NOW)).toEqual({ kind: 'none', state: 'none' });
+            }), NOW)).toEqual({ kind: 'paid-status', provider: 'paypal', state: expected });
         },
     );
 

--- a/src/lib/early-birds/membership-presentation.ts
+++ b/src/lib/early-birds/membership-presentation.ts
@@ -16,6 +16,11 @@ export type ListenerMembershipPresentation =
     | { kind: 'invitation'; state: ListenerMembershipPresentationState }
     | { kind: 'preview'; state: ListenerMembershipPresentationState }
     | {
+        kind: 'paid-status';
+        provider: 'paypal' | 'mercado-pago';
+        state: 'pending' | 'expired' | 'refunded' | 'revoked';
+    }
+    | {
         kind: 'founder';
         provider: 'paypal' | 'mercado-pago';
         state: ListenerMembershipPresentationState;
@@ -56,6 +61,11 @@ export function listenerMembershipPresentation(
     const continuityCurrent = projection.founderContinuityState === 'ACTIVE'
         || projection.founderContinuityState === 'CANCELLED_PENDING_END'
         || projection.founderContinuityState === 'GRACE';
+    const provider = projection.source === 'PAYPAL'
+        ? 'paypal'
+        : projection.source === 'MERCADO_PAGO'
+            ? 'mercado-pago'
+            : null;
     if (
         accessAllowed
         && continuityCurrent
@@ -85,8 +95,16 @@ export function listenerMembershipPresentation(
         };
     }
 
+    if (
+        provider
+        && projection.offerCode === EARLY_BIRDS_FOUNDERS_OFFER
+        && (state === 'pending' || state === 'expired' || state === 'refunded' || state === 'revoked')
+    ) {
+        return { kind: 'paid-status', provider, state };
+    }
+
     // Unknown and incomplete projections fail closed in presentation just as
-    // they do in authorization. Never infer Founder status from an offer,
-    // price, redirect or reason code.
+    // they do in authorization. A terminal paid status is informational only;
+    // it never restores the Founder badge or listening authority.
     return { kind: 'none', state: 'none' };
 }


### PR DESCRIPTION
## Outcome

Keep terminal paid state visible in the signed-in account menu after access falls back to Free, without retaining the Founder badge or membership controls.

## Scope

- normalize pending/expired/refunded/revoked paid projections into an informational-only presentation;
- show provider-neutral terminal copy while  is Free;
- keep unlimited access, cancel/reactivate and Founder identity restricted to current continuity;
- no checkout, audio, event, LiveKit or provider contract changes.

## Verification

- 20 focused tests
- TypeScript
- focused ESLint
- diff check
- physical PayPal Sandbox refund confirmed canonical  before this UX patch.