### PR TITLE
fix(listener): recover a silently stalled media clock

### DIFF
--- a/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+++ b/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
@@ -491,6 +491,11 @@ scripts/early-birds-preview/start.sh /secure/earlybirds-preview.env
 scripts/early-birds-preview/health-smoke.sh /secure/earlybirds-preview.env
 ```
 
+`start.sh` is the ordinary Listener release path. It migrates and recreates
+the application only; it never rebuilds, recreates or restarts the audio
+origin. This separation is a release invariant: a short app/control-plane
+deployment must not interrupt an already playing HLS stream.
+
 Startup is fail closed:
 
 1. preview PostgreSQL must become healthy;
@@ -503,6 +508,16 @@ Listener `/api/health` liveness, Listener `/api/health/ready` database
 readiness, stream `/healthz` liveness on loopback, and stream `/readyz` inside
 its private container network. It does not claim playback or decoded-audio
 acceptance.
+
+Creating or changing the isolated origin is a separate maintenance operation:
+
+```bash
+scripts/early-birds-preview/start-origin.sh /secure/earlybirds-preview.env
+```
+
+That command must be announced as an origin maintenance window and followed
+immediately by the health smoke and decoded-audio canary. It is never part of
+an ordinary UI/API release.
 
 To rerun the idempotent forward migration separately:
 
@@ -676,15 +691,16 @@ Normal stop retains all preview data:
 scripts/early-birds-preview/stop.sh /secure/earlybirds-preview.env
 ```
 
-Incident rollback stops the two public-serving components while retaining
-PostgreSQL for diagnosis and a forward fix:
+Ordinary app rollback stops only Listener while retaining PostgreSQL and the
+approved long-lived origin for diagnosis and a forward fix:
 
 ```bash
 scripts/early-birds-preview/rollback.sh /secure/earlybirds-preview.env
 ```
 
 Set `EARLY_BIRDS_ENABLED=0` and `EARLY_BIRDS_FREE_FOR_ALL=0` before the next
-start. None of these scripts uses
+start. If the origin itself is diagnosed as faulty, use the separately scoped
+`ops/early-birds/scripts/stop-stream.sh` command. None of these scripts uses
 `docker compose down`, deletes a volume, or targets the event/live project.
 
 ## Staging release gate

--- a/docs/operations/LISTENER_AUDIO_CONTINUITY.md
+++ b/docs/operations/LISTENER_AUDIO_CONTINUITY.md
@@ -1,0 +1,63 @@
+# Listener audio continuity
+
+This runbook covers the Listener-only 24/7 Beacon stream. It does not apply to
+event playback, LiveKit, playlist-bot or `live.harmonicbeacon.com`.
+
+## 2026-08-09 incident
+
+The reported silence began during a preview deployment. Host evidence shows
+that manifest, heartbeat and access-state calls returned 502 for roughly 21
+seconds while the Listener was recreated; the same operation also recreated
+the isolated stream origin. The affected hls.js media clock then stopped
+advancing without delivering a fatal/stalled event. Server-side visualization
+polling continued with that frozen program time until the analysis endpoint
+correctly rejected it as stale.
+
+Analysis-frame traffic is not proof of audible playback. The decisive signal
+is advancement of the active `HTMLMediaElement.currentTime` together with its
+ready/network state and HLS lifecycle.
+
+## Runtime recovery
+
+While Beacon playback is requested, visible and not inside an introduction,
+the client samples the media clock every five seconds. Fifteen seconds without
+progress produces one bounded diagnostic and enters the existing three-attempt
+recovery path. Recovery:
+
+1. marks presence idle;
+2. verifies the existing lease and generation;
+3. destroys the one stalled hls.js instance;
+4. reattaches the verified manifest, even when the URL is unchanged;
+5. seeks to the current live position, calls `play()`, then marks presence
+   listening again.
+
+It does not mint a second lease for an active generation, construct a second
+audio graph or modify codec, buffer, gain, fades, routing or assets. Stop,
+displacement and denied access remain terminal.
+
+The browser emits `listener:playback-diagnostic` and a matching console warning
+only when recovery begins. The payload is fixed and contains transport/action,
+media state, range counts/endpoints, lease generation/sequence, bounded HLS
+error enums and visibility. It never contains account/email, lease ID, IP,
+cookie/token/header, user agent, signed URL or output-device fingerprint.
+
+## Deployment invariant
+
+`scripts/early-birds-preview/start.sh` migrates/recreates only Listener.
+`rollback.sh` stops only Listener. Neither ordinary command may target the
+long-lived origin. Origin maintenance uses the explicit `start-origin.sh` or
+`ops/early-birds/scripts/stop-stream.sh` lane, with an announced window and a
+decoded-audio canary. None of these commands targets the event project.
+
+## Acceptance
+
+For a release candidate, verify Beacon-only and intro handoff on Chrome,
+Firefox, Android Chrome and iPhone Safari. Include foreground, one
+background/foreground cycle and speakers/headphones when available. Perform a
+60-minute physical listen on at least one representative mobile device.
+
+For deterministic recovery evidence in staging, interrupt only the Listener
+control plane for less than 30 seconds while the independent origin remains
+healthy. The same client must reconnect at the live position with one audible
+source and one quota presence interval. Do not perform this exercise while an
+event is active and do not restart the origin to simulate it.

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -412,7 +412,7 @@ test('production Listener HTTPS validation remains fail closed', async () => {
   assert.match(env, /^EARLY_BIRDS_STREAM_ORIGIN=https:\/\/stream\.harmonicbeacon\.com$/m);
 });
 
-test('smoke and rollback contracts cover both probes without deleting state', async () => {
+test('smoke covers both probes while ordinary app rollback preserves the origin and state', async () => {
   const smoke = await readRepository('scripts/early-birds-preview/health-smoke.sh');
   assert.match(smoke, /api\/health"/);
   assert.match(smoke, /databaseSchemaVersion/);
@@ -424,8 +424,14 @@ test('smoke and rollback contracts cover both probes without deleting state', as
   assert.match(smoke, /State\.ExitCode/);
 
   const rollback = await readRepository('scripts/early-birds-preview/rollback.sh');
-  assert.match(rollback, /stop listener beacon-stream/);
-  assert.doesNotMatch(rollback, /preview_compose_command[^\n]*stop[^\n]*postgres|\bdown\b|volume rm/);
+  assert.match(rollback, /stop listener/);
+  assert.doesNotMatch(rollback, /preview_compose_command[^\n]*stop[^\n]*(postgres|beacon-stream)|\bdown\b|volume rm/);
+  const start = await readRepository('scripts/early-birds-preview/start.sh');
+  assert.match(start, /up -d --build listener/);
+  assert.doesNotMatch(start, /up[^\n]*listener[^\n]*beacon-stream|up[^\n]*beacon-stream[^\n]*listener/);
+  const startOrigin = await readRepository('scripts/early-birds-preview/start-origin.sh');
+  assert.match(startOrigin, /up -d --build --no-deps beacon-stream/);
+  assert.doesNotMatch(startOrigin, /\blistener\b.*\bup\b|up[^\n]*listener/);
   const stop = await readRepository('scripts/early-birds-preview/stop.sh');
   assert.match(stop, /stop listener beacon-stream postgres/);
   assert.doesNotMatch(stop, /\bdown\b|-v\b|volume rm/);

--- a/scripts/early-birds-preview/rollback.sh
+++ b/scripts/early-birds-preview/rollback.sh
@@ -4,9 +4,11 @@ set -eu
 env_file=${1:?usage: scripts/early-birds-preview/rollback.sh /secure/preview.env}
 require_synthetic_env "$env_file"
 
-# Stop public-serving components only. PostgreSQL and its named volume remain
-# intact for inspection and an additive forward fix.
-preview_compose_command "$env_file" stop listener beacon-stream
-echo 'EarlyBirds Listener and stream origin stopped; preview PostgreSQL was retained.'
+# Stop only the application control plane. PostgreSQL and its named volume
+# remain intact for inspection, while the approved long-lived origin keeps
+# serving already issued short-lived media URLs. Use stop-stream.sh only for
+# a separately diagnosed origin incident.
+preview_compose_command "$env_file" stop listener
+echo 'EarlyBirds Listener stopped; preview PostgreSQL and Beacon origin were retained.'
 echo 'Set EARLY_BIRDS_ENABLED=0, EARLY_BIRDS_FREE_FOR_ALL=0 and EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=0 before the next start.'
 echo 'No live/event service or volume was targeted.'

--- a/scripts/early-birds-preview/start-origin.sh
+++ b/scripts/early-birds-preview/start-origin.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+. "$(dirname -- "$0")/lib.sh"
+env_file=${1:?usage: scripts/early-birds-preview/start-origin.sh /secure/preview.env}
+require_synthetic_env "$env_file"
+
+echo 'This command may recreate the isolated Beacon audio origin.'
+echo 'Run it only in an explicit origin maintenance window with a decoded-audio canary ready.'
+preview_compose_command "$env_file" up -d --build --no-deps beacon-stream
+echo 'Beacon stream origin updated. Run health-smoke.sh and decoded-audio acceptance immediately.'

--- a/scripts/early-birds-preview/start.sh
+++ b/scripts/early-birds-preview/start.sh
@@ -5,10 +5,13 @@ env_file=${1:?usage: scripts/early-birds-preview/start.sh /secure/preview.env}
 require_synthetic_env "$env_file"
 
 # Compose's completed-successfully dependency makes this order fail closed:
-# PostgreSQL health -> forward-only migration -> Listener readiness.
-preview_compose_command "$env_file" up -d --build listener beacon-stream
+# PostgreSQL health -> forward-only migration -> Listener readiness. The
+# long-lived audio origin is intentionally outside an ordinary app release;
+# use start-origin.sh only in its own reviewed maintenance window.
+preview_compose_command "$env_file" up -d --build listener
 kill_switch=$(preview_env_value EARLY_BIRDS_ENABLED "$env_file")
 free_for_all_switch=$(preview_env_value EARLY_BIRDS_FREE_FOR_ALL "$env_file")
 team_entry_switch=$(preview_env_value EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED "$env_file")
 echo "EarlyBirds synthetic preview started with EARLY_BIRDS_ENABLED=$kill_switch, EARLY_BIRDS_FREE_FOR_ALL=$free_for_all_switch and EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED=$team_entry_switch."
+echo 'The Beacon stream origin was not rebuilt, recreated or restarted.'
 echo 'Run health-smoke.sh; keep the public entry disabled until every gate passes.'

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -17,6 +17,12 @@ import {
     type HarmonicAnalysisFrame,
     type HarmonicAnalysisProvider,
 } from '@/lib/listener/analysis';
+import {
+    LISTENER_PLAYBACK_WATCHDOG_INTERVAL_MS,
+    ListenerPlaybackLivenessWatchdog,
+    listenerPlaybackObservation,
+    type ListenerPlaybackDiagnostic,
+} from '@/lib/listener/playback-liveness';
 
 import { deriveListenerPresentationPhase } from './listener-presentation';
 import { ListenerTabIdentityCoordinator } from './listener-tab-identity';
@@ -61,6 +67,13 @@ const TRANSPORT_FADE_OUT_MS = 650;
 const DEFAULT_LISTENER_VOLUME = 0.7;
 
 export const LISTENER_PLAYBACK_PRESENCE_EVENT = 'listener:playback-presence';
+export const LISTENER_PLAYBACK_DIAGNOSTIC_EVENT = 'listener:playback-diagnostic';
+
+function boundedDiagnosticToken(value: unknown): string | null {
+    return typeof value === 'string' && /^[A-Za-z0-9_.:-]{1,64}$/.test(value)
+        ? value
+        : null;
+}
 
 export function resolveListenerAnalysisFramesPerSecond({
     reducedMotion,
@@ -265,6 +278,13 @@ function ListenerPlayerController({
     const recoveryTimer = useRef<number | null>(null);
     const queuedRecoveryDelay = useRef<number | null>(null);
     const nativeSuspendObserved = useRef(false);
+    const playbackWatchdog = useRef(new ListenerPlaybackLivenessWatchdog());
+    const lastPlaybackAction = useRef('mount');
+    const lastHlsSignal = useRef<ListenerPlaybackDiagnostic['hls']>({
+        type: null,
+        details: null,
+        fatal: null,
+    });
     const listenerPresence = useRef<'idle' | 'listening'>('idle');
     const automaticRecovery = useRef<(initialDelayMs?: number) => void>(() => undefined);
     const deferLiveFadeForRecovery = useRef<() => void>(() => undefined);
@@ -437,6 +457,7 @@ function ListenerPlayerController({
         const audio = liveAudio.current;
         if (!audio) return;
         stopHls();
+        lastHlsSignal.current = { type: null, details: null, fatal: null };
         manifestUrl.current = url;
 
         const nativeHlsSupported = Boolean(audio.canPlayType('application/vnd.apple.mpegurl'));
@@ -461,6 +482,11 @@ function ListenerPlayerController({
         }
         const instance = new HlsConstructor(LISTENER_HLS_BUFFER_CONFIG);
         instance.on(HlsConstructor.Events.ERROR, (_event, data) => {
+            lastHlsSignal.current = {
+                type: boundedDiagnosticToken(data.type),
+                details: boundedDiagnosticToken(data.details),
+                fatal: Boolean(data.fatal),
+            };
             if (!data.fatal) return;
             deferLiveFadeForRecovery.current();
             liveAudio.current?.pause();
@@ -837,9 +863,12 @@ function ListenerPlayerController({
                     manifestExpiresAt.current = 0;
                 } else if (probe.kind === 'active') {
                     manifestExpiresAt.current = Date.parse(probe.grant.stream.expiresAt);
-                    if (probe.grant.stream.manifestUrl !== manifestUrl.current) {
+                    if (forceRefresh || probe.grant.stream.manifestUrl !== manifestUrl.current) {
                         await attachManifest(probe.grant.stream.manifestUrl);
                     }
+                    // A verified active lease has now been force-reattached or
+                    // was already fresh. Never mint a duplicate lease merely
+                    // to recover the media pipeline.
                     forceRefresh = false;
                 } else {
                     // A newer request/presence report won the race. Keep its
@@ -1053,6 +1082,8 @@ function ListenerPlayerController({
     const scheduleAutomaticRecovery = useCallback((initialDelayMs = 0) => {
         if (!wantsLivePlayback.current || liveStateRef.current === 'displaced') return;
 
+        lastPlaybackAction.current = 'automatic-recovery';
+
         if (playbackAttemptRunning.current) {
             queuedRecoveryDelay.current = queuedRecoveryDelay.current === null
                 ? Math.max(0, initialDelayMs)
@@ -1097,6 +1128,45 @@ function ListenerPlayerController({
     }, [attemptLivePlayback, reportPresence, updateLiveState]);
 
     useEffect(() => {
+        const interval = window.setInterval(() => {
+            const audio = liveAudio.current;
+            const eligible = Boolean(audio)
+                && wantsLivePlayback.current
+                && activeDrop.current === null
+                && liveStateRef.current === 'playing'
+                && document.visibilityState === 'visible';
+            if (!audio || !eligible) {
+                playbackWatchdog.current.reset();
+                return;
+            }
+
+            const diagnostic = playbackWatchdog.current.observe(listenerPlaybackObservation({
+                audio,
+                observedAtMs: performance.now(),
+                lastAction: lastPlaybackAction.current,
+                leaseGeneration: leaseGeneration.current,
+                presenceSequence: presenceSequence.current,
+                hlsSignal: lastHlsSignal.current,
+                visibility: document.visibilityState,
+            }));
+            if (!diagnostic) return;
+
+            playbackWatchdog.current.reset();
+            lastPlaybackAction.current = 'watchdog-recovery';
+            // The object is deliberately bounded and contains no account,
+            // lease ID, token, URL, cookie, IP or device fingerprint.
+            console.warn('[listener] media-clock recovery', diagnostic);
+            window.dispatchEvent(new CustomEvent(LISTENER_PLAYBACK_DIAGNOSTIC_EVENT, {
+                detail: diagnostic,
+            }));
+            reportPresence('idle');
+            deferLiveFade();
+            scheduleAutomaticRecovery(0);
+        }, LISTENER_PLAYBACK_WATCHDOG_INTERVAL_MS);
+        return () => window.clearInterval(interval);
+    }, [deferLiveFade, reportPresence, scheduleAutomaticRecovery]);
+
+    useEffect(() => {
         automaticRecovery.current = scheduleAutomaticRecovery;
         return () => {
             automaticRecovery.current = () => undefined;
@@ -1128,6 +1198,7 @@ function ListenerPlayerController({
     }, [armLiveFadeIn, attemptLivePlayback, cancelRecovery, pauseDropIns, reportPresence, scheduleAutomaticRecovery, updateLiveState]);
 
     function playBeaconOnly() {
+        lastPlaybackAction.current = 'listen-beacon';
         dropGeneration.current += 1;
         if (!livePreparedRef.current) return;
         startReactiveAnalysis('beacon');
@@ -1168,6 +1239,8 @@ function ListenerPlayerController({
     }
 
     function stopTransport() {
+        lastPlaybackAction.current = 'stop';
+        playbackWatchdog.current.reset();
         dropGeneration.current += 1;
         setTransportStopped(true);
         setTransportPaused(false);
@@ -1213,6 +1286,8 @@ function ListenerPlayerController({
 
     function handleNativePlaying() {
         if (!wantsLivePlayback.current) return;
+        lastPlaybackAction.current = 'media-playing';
+        playbackWatchdog.current.reset();
         nativeSuspendObserved.current = false;
         cancelRecovery(true);
         const introduction = activeDrop.current
@@ -1382,6 +1457,7 @@ function ListenerPlayerController({
     }
 
     async function playWithIntro(language: DropLanguage) {
+        lastPlaybackAction.current = `listen-intro-${language}`;
         const selected = dropAudio[language].current;
         if (!selected || !dropIns[language]) return;
         startReactiveAnalysis(`intro-${language}`);
@@ -1481,6 +1557,7 @@ function ListenerPlayerController({
             [language]: { current: 0, duration: current[language].duration },
         }));
         audio!.currentTime = 0;
+        lastPlaybackAction.current = 'intro-handoff';
         startReactiveAnalysis('beacon');
         if (liveAudio.current && !liveAudio.current.paused) {
             cancelRecovery(true);
@@ -1542,6 +1619,7 @@ function ListenerPlayerController({
     }
 
     function skipToBeacon() {
+        lastPlaybackAction.current = 'skip-to-beacon';
         dropGeneration.current += 1;
         setTransportPaused(false);
         startReactiveAnalysis('beacon');

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -121,6 +121,7 @@ import ListenerPlayer, {
     getOrCreateEarlyBirdDeviceId,
     hlsFragmentProgramTimeMs,
     LISTENER_HLS_BUFFER_CONFIG,
+    LISTENER_PLAYBACK_DIAGNOSTIC_EVENT,
     LISTENER_PLAYBACK_PRESENCE_EVENT,
     nativeHlsProgramTimeMs,
     nextPresenceSequence,
@@ -657,6 +658,81 @@ describe('EarlyBird Listener player', () => {
         expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
     });
 
+    it('detects a silent media-clock stall and rebuilds the same lease pipeline', async () => {
+        const intervals: Array<{ callback: () => void; delay: number }> = [];
+        vi.spyOn(window, 'setInterval').mockImplementation((callback, delay) => {
+            if (typeof callback === 'function') {
+                intervals.push({ callback: callback as () => void, delay: Number(delay) });
+            }
+            return intervals.length as unknown as ReturnType<typeof window.setInterval>;
+        });
+        vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+        vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+        vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockReturnValue('');
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        let monotonicNow = 0;
+        vi.spyOn(performance, 'now').mockImplementation(() => monotonicNow);
+        const manifestUrl = '/api/early-birds/stream/manifest?leaseId=00000000-0000-4000-8000-000000000003&leaseGeneration=1';
+        const grant = {
+            leaseId: '00000000-0000-4000-8000-000000000003',
+            leaseGeneration: 1,
+            presenceSequence: 0,
+            leaseExpiresAt: '2099-08-06T12:03:00.000Z',
+            stream: { manifestUrl, expiresAt: '2099-08-06T12:03:00.000Z' },
+        };
+        const fetchMock = vi.fn().mockImplementation((url, init) => {
+            if (url === '/api/early-birds/stream/lease') {
+                return Promise.resolve(new Response(JSON.stringify(grant), { status: 200 }));
+            }
+            const body = JSON.parse(String(init?.body ?? '{}')) as { presenceSequence?: number };
+            return Promise.resolve(new Response(JSON.stringify({
+                leaseGeneration: 1,
+                presenceSequence: body.presenceSequence ?? 0,
+                leaseExpiresAt: '2099-08-06T12:04:00.000Z',
+                stream: { manifestUrl, expiresAt: '2099-08-06T12:04:00.000Z' },
+            }), { status: 200 }));
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const diagnostics: unknown[] = [];
+        const onDiagnostic: EventListener = (event) => {
+            diagnostics.push((event as CustomEvent).detail);
+        };
+        window.addEventListener(LISTENER_PLAYBACK_DIAGNOSTIC_EVENT, onDiagnostic);
+
+        render(
+            <LocaleProvider initialLocale="en">
+                <ListenerPlayer dropIns={{ es: null, en: null }} />
+            </LocaleProvider>,
+        );
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Listen' })).toBeEnabled());
+        fireEvent.click(screen.getByRole('button', { name: 'Listen' }));
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument());
+        const live = screen.getByLabelText('Beacon');
+        Object.defineProperties(live, {
+            currentTime: { value: 120, writable: true, configurable: true },
+            paused: { value: false, configurable: true },
+        });
+        const watchdog = intervals.find(({ delay }) => delay === 5_000);
+        expect(watchdog).toBeDefined();
+
+        watchdog!.callback();
+        monotonicNow = 15_000;
+        watchdog!.callback();
+
+        await waitFor(() => expect(hlsHarness.instances).toHaveLength(2));
+        expect(hlsHarness.instances[0].destroy).toHaveBeenCalledOnce();
+        expect(hlsHarness.instances[1].loadedSources).toEqual([manifestUrl]);
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toMatchObject({
+            schemaVersion: 1,
+            reason: 'media-clock-stalled',
+            lease: { generation: 1 },
+        });
+        expect(JSON.stringify(diagnostics[0])).not.toMatch(/leaseId|account|email|cookie|token|url/i);
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument());
+        window.removeEventListener(LISTENER_PLAYBACK_DIAGNOSTIC_EVENT, onDiagnostic);
+    });
+
     it('keeps the pre-attached iOS source lease alive before the first play gesture', async () => {
         const intervalCallbacks: Array<() => void | Promise<void>> = [];
         vi.spyOn(window, 'setInterval').mockImplementation((callback) => {
@@ -1129,10 +1205,12 @@ describe('EarlyBird Listener player', () => {
         finishFirstPlay?.();
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3), { timeout: 3_000 });
-        // Presence promotion/refresh never replaces the prepared generation or
-        // creates a second audio pipeline.
-        expect(hlsHarness.instances).toHaveLength(1);
+        // Recovery preserves the prepared lease generation while rebuilding
+        // the one hls.js pipeline. A control-plane interruption must not leave
+        // the original non-progressing instance attached.
+        expect(hlsHarness.instances).toHaveLength(2);
+        expect(hlsHarness.instances[0].destroy).toHaveBeenCalledOnce();
         await waitFor(() => expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument());
-        expect(hlsHarness.instances[0].loadedSources).toEqual([initialGrant.stream.manifestUrl]);
+        expect(hlsHarness.instances[1].loadedSources).toEqual([initialGrant.stream.manifestUrl]);
     });
 });

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -5,13 +5,13 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const MEDIA_FILE_SHA256 = {
-    // Reviewed and re-pinned for the public server-side harmonic field. The
-    // browser no longer creates Web Audio nodes, adds crossOrigin or remounts
-    // media for analysis. This change only hides the tuning lab behind a
-    // server-side staging flag while leaving the accepted field enabled;
-    // HLS parameters, source URLs, media assets, element gain/fades and event
+    // Reviewed and re-pinned for the non-acoustic playback liveness recovery.
+    // A privacy-safe media-clock watchdog rebuilds the single hls.js instance
+    // after 15 seconds without progress and ordinary recovery now reattaches a
+    // verified lease even when its manifest URL is unchanged. HLS parameters,
+    // source URLs, media assets, element gain/fades, AudioContext and event
     // audio remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': 'fd80bb558317c78c983e1ae623b7697bb778b44def0bafe0d0b4ca4e421cd358',
+    'src/components/early-birds/ListenerPlayer.tsx': '8aa13c93b886ccf51aebead3b960fe7f6478933fed101dd6c296a524f0001234',
     'src/lib/early-birds/stream.ts': '96a2d9fe798591833327631b59a73a5b2fc5ca06be7081945a0b07450970da84',
     'src/lib/early-birds/drop-ins.ts': '3b0d18c2c8548aa3ee917ece726cbca4b6d253ea3b4941a8424f8bcbfb8922e2',
     'src/app/api/early-birds/stream/lease/route.ts': 'ec0e8780387bc1f493eb33d13a2d90e01cfdb6d899fc6232e04f51aaf2dfc508',

--- a/src/lib/listener/__tests__/playback-liveness.test.ts
+++ b/src/lib/listener/__tests__/playback-liveness.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import {
+    LISTENER_PLAYBACK_STALL_AFTER_MS,
+    ListenerPlaybackLivenessWatchdog,
+    listenerPlaybackObservation,
+} from '../playback-liveness';
+
+function observation(overrides: Partial<Parameters<ListenerPlaybackLivenessWatchdog['observe']>[0]> = {}) {
+    return {
+        transport: 'beacon' as const,
+        lastAction: 'listen',
+        observedAtMs: 0,
+        media: {
+            currentTimeSeconds: 42,
+            paused: false,
+            ended: false,
+            readyState: 4,
+            networkState: 1,
+            muted: false,
+            volume: 0.7,
+            playbackRate: 1,
+            errorCode: null,
+            bufferedRangeCount: 1,
+            bufferedEndSeconds: 72,
+            seekableRangeCount: 1,
+            seekableEndSeconds: 90,
+        },
+        lease: { generation: 3, presenceSequence: 7 },
+        hls: { type: null, details: null, fatal: null },
+        visibility: 'visible' as const,
+        ...overrides,
+    };
+}
+
+describe('ListenerPlaybackLivenessWatchdog', () => {
+    it('accepts slow progress and resets across a live-edge jump', () => {
+        const watchdog = new ListenerPlaybackLivenessWatchdog();
+        expect(watchdog.observe(observation())).toBeNull();
+        expect(watchdog.observe(observation({
+            observedAtMs: LISTENER_PLAYBACK_STALL_AFTER_MS,
+            media: { ...observation().media, currentTimeSeconds: 42.1 },
+        }))).toBeNull();
+        expect(watchdog.observe(observation({
+            observedAtMs: LISTENER_PLAYBACK_STALL_AFTER_MS * 2,
+            media: { ...observation().media, currentTimeSeconds: 8 },
+        }))).toBeNull();
+    });
+
+    it('reports a bounded privacy-safe snapshot after a silent media-clock stall', () => {
+        const watchdog = new ListenerPlaybackLivenessWatchdog();
+        expect(watchdog.observe(observation())).toBeNull();
+        const diagnostic = watchdog.observe(observation({
+            observedAtMs: LISTENER_PLAYBACK_STALL_AFTER_MS,
+        }));
+
+        expect(diagnostic).toMatchObject({
+            schemaVersion: 1,
+            reason: 'media-clock-stalled',
+            stalledForMs: LISTENER_PLAYBACK_STALL_AFTER_MS,
+            lease: { generation: 3, presenceSequence: 7 },
+        });
+        expect(JSON.stringify(diagnostic)).not.toMatch(/leaseId|account|email|cookie|token|url/i);
+    });
+
+    it('classifies paused, ended and media-error failures without changing thresholds', () => {
+        for (const [field, expected] of [
+            ['paused', 'paused-unexpectedly'],
+            ['ended', 'ended-unexpectedly'],
+        ] as const) {
+            const watchdog = new ListenerPlaybackLivenessWatchdog();
+            expect(watchdog.observe(observation())).toBeNull();
+            expect(watchdog.observe(observation({
+                observedAtMs: LISTENER_PLAYBACK_STALL_AFTER_MS,
+                media: { ...observation().media, [field]: true },
+            }))).toMatchObject({ reason: expected });
+        }
+
+        const watchdog = new ListenerPlaybackLivenessWatchdog();
+        expect(watchdog.observe(observation())).toBeNull();
+        expect(watchdog.observe(observation({
+            observedAtMs: 1,
+            media: { ...observation().media, errorCode: 2 },
+        }))).toMatchObject({ reason: 'media-error' });
+    });
+
+    it('extracts range summaries without throwing or retaining range contents', () => {
+        const audio = document.createElement('audio');
+        Object.defineProperties(audio, {
+            currentTime: { value: 12.5, configurable: true },
+            buffered: {
+                value: { length: 1, start: () => 3, end: () => 18 },
+                configurable: true,
+            },
+            seekable: {
+                value: { length: 1, start: () => 0, end: () => 24 },
+                configurable: true,
+            },
+        });
+        const snapshot = listenerPlaybackObservation({
+            audio,
+            observedAtMs: 100,
+            lastAction: 'listen',
+            leaseGeneration: 2,
+            presenceSequence: 4,
+            hlsSignal: { type: 'networkError', details: 'manifestLoadError', fatal: false },
+            visibility: 'visible',
+        });
+        expect(snapshot.media).toMatchObject({
+            currentTimeSeconds: 12.5,
+            bufferedRangeCount: 1,
+            bufferedEndSeconds: 18,
+            seekableRangeCount: 1,
+            seekableEndSeconds: 24,
+        });
+    });
+});

--- a/src/lib/listener/playback-liveness.ts
+++ b/src/lib/listener/playback-liveness.ts
@@ -1,0 +1,154 @@
+export const LISTENER_PLAYBACK_WATCHDOG_INTERVAL_MS = 5_000;
+export const LISTENER_PLAYBACK_STALL_AFTER_MS = 15_000;
+
+const MEDIA_PROGRESS_EPSILON_SECONDS = 0.05;
+
+export type ListenerPlaybackStallReason =
+    | 'media-error'
+    | 'paused-unexpectedly'
+    | 'ended-unexpectedly'
+    | 'media-clock-stalled';
+
+export type ListenerPlaybackDiagnostic = {
+    schemaVersion: 1;
+    reason: ListenerPlaybackStallReason;
+    transport: 'beacon';
+    lastAction: string;
+    observedAtMs: number;
+    stalledForMs: number;
+    media: {
+        currentTimeSeconds: number;
+        paused: boolean;
+        ended: boolean;
+        readyState: number;
+        networkState: number;
+        muted: boolean;
+        volume: number;
+        playbackRate: number;
+        errorCode: number | null;
+        bufferedRangeCount: number;
+        bufferedEndSeconds: number | null;
+        seekableRangeCount: number;
+        seekableEndSeconds: number | null;
+    };
+    lease: {
+        generation: number | null;
+        presenceSequence: number;
+    };
+    hls: {
+        type: string | null;
+        details: string | null;
+        fatal: boolean | null;
+    };
+    visibility: DocumentVisibilityState;
+};
+
+type LivenessObservation = Omit<ListenerPlaybackDiagnostic, 'schemaVersion' | 'reason' | 'stalledForMs'>;
+
+function finiteOr(value: number, fallback: number): number {
+    return Number.isFinite(value) ? value : fallback;
+}
+
+function lastRangeEnd(ranges: TimeRanges): number | null {
+    if (ranges.length < 1) return null;
+    try {
+        const value = ranges.end(ranges.length - 1);
+        return Number.isFinite(value) ? value : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Process-local media clock observer. It stores no identity, URL, token,
+ * account or raw browser metadata and never changes the audio graph.
+ */
+export class ListenerPlaybackLivenessWatchdog {
+    private lastMediaTimeSeconds: number | null = null;
+    private lastProgressAtMs: number | null = null;
+
+    reset(): void {
+        this.lastMediaTimeSeconds = null;
+        this.lastProgressAtMs = null;
+    }
+
+    observe(input: LivenessObservation): ListenerPlaybackDiagnostic | null {
+        const currentTimeSeconds = finiteOr(input.media.currentTimeSeconds, 0);
+        const observedAtMs = finiteOr(input.observedAtMs, 0);
+        const previousTime = this.lastMediaTimeSeconds;
+        const progressed = previousTime === null
+            || Math.abs(currentTimeSeconds - previousTime) >= MEDIA_PROGRESS_EPSILON_SECONDS;
+
+        if (progressed) {
+            this.lastMediaTimeSeconds = currentTimeSeconds;
+            this.lastProgressAtMs = observedAtMs;
+            return null;
+        }
+
+        if (this.lastProgressAtMs === null) this.lastProgressAtMs = observedAtMs;
+        const stalledForMs = Math.max(0, observedAtMs - this.lastProgressAtMs);
+        const reason: ListenerPlaybackStallReason | null = input.media.errorCode !== null
+            ? 'media-error'
+            : stalledForMs < LISTENER_PLAYBACK_STALL_AFTER_MS
+                ? null
+                : input.media.paused
+                    ? 'paused-unexpectedly'
+                    : input.media.ended
+                        ? 'ended-unexpectedly'
+                        : 'media-clock-stalled';
+
+        if (!reason) return null;
+        return {
+            schemaVersion: 1,
+            ...input,
+            reason,
+            stalledForMs,
+            media: { ...input.media, currentTimeSeconds },
+        };
+    }
+}
+
+export function listenerPlaybackObservation({
+    audio,
+    observedAtMs,
+    lastAction,
+    leaseGeneration,
+    presenceSequence,
+    hlsSignal,
+    visibility,
+}: {
+    audio: HTMLMediaElement;
+    observedAtMs: number;
+    lastAction: string;
+    leaseGeneration: number | null;
+    presenceSequence: number;
+    hlsSignal: { type: string | null; details: string | null; fatal: boolean | null };
+    visibility: DocumentVisibilityState;
+}): LivenessObservation {
+    return {
+        transport: 'beacon',
+        lastAction: lastAction.slice(0, 48),
+        observedAtMs,
+        media: {
+            currentTimeSeconds: finiteOr(audio.currentTime, 0),
+            paused: audio.paused,
+            ended: audio.ended,
+            readyState: audio.readyState,
+            networkState: audio.networkState,
+            muted: audio.muted,
+            volume: finiteOr(audio.volume, 0),
+            playbackRate: finiteOr(audio.playbackRate, 1),
+            errorCode: audio.error?.code ?? null,
+            bufferedRangeCount: audio.buffered.length,
+            bufferedEndSeconds: lastRangeEnd(audio.buffered),
+            seekableRangeCount: audio.seekable.length,
+            seekableEndSeconds: lastRangeEnd(audio.seekable),
+        },
+        lease: {
+            generation: leaseGeneration,
+            presenceSequence,
+        },
+        hls: { ...hlsSignal },
+        visibility,
+    };
+}


### PR DESCRIPTION
Addresses #304.

## Root cause
Mona evidence correlates the reported silence with a 21-second Listener/control-plane outage during a preview deployment that also recreated the isolated origin. hls.js stopped advancing without emitting a fatal/stalled event; remote analysis continued polling the frozen program time until it became stale.

## Fix
- sample only the direct Beacon media clock every 5s while visible and expected to play
- after 15s without progress, emit one bounded privacy-safe diagnostic and enter the existing bounded recovery path
- verify and preserve the current lease/generation, destroy the stalled hls.js instance and reattach even when the manifest URL is unchanged
- decouple ordinary Listener start/rollback from origin maintenance; origin changes now require the explicit `start-origin.sh` lane
- add incident/triage/physical-acceptance runbook

## Gates
- full pre-commit suite: 1,542 passed, 30 skipped
- focused liveness/player/media tests: 37 passed
- preview contract: 32 passed
- TypeScript, focused ESLint, shell syntax, diff-check and production build green

No codec, bitrate, sample rate, channels, gain, fade, buffer, routing, AudioContext, media asset or event/live surface changed. No deployment is included. The issue should stay open until staging fault injection plus physical 60-minute acceptance complete.