### PR TITLE
docs(listener): reconcile commercial launch checkpoint

### DIFF
--- a/docs/architecture/EARLY_BIRDS_MAGIC_LINK.md
+++ b/docs/architecture/EARLY_BIRDS_MAGIC_LINK.md
@@ -1,7 +1,7 @@
 # Founding Listener email magic-link boundary
 
-Status: Listener side implemented; private mail adapter pending in
-`SairaAsua/proyecciones-mito`.
+Status: Listener and private delivery implemented. The dedicated mail sidecar is
+being rolled out independently from the event runtime.
 
 This fallback reuses the deployed Google Workspace/Gmail delivery capability
 without copying its OAuth grant into the Listener container. It is additive to
@@ -56,7 +56,7 @@ Body (`listener-magic-link.v1`):
 The endpoint must:
 
 1. exist only on the private `earlybirds_authority_private` network under the
-   existing `pmp-myth-api` alias;
+   dedicated `listener-mail-api` alias;
 2. authenticate the dedicated Bearer token in constant time;
 3. accept only the schema above, ES/EN locale, an HTTPS
    `listen.harmonicbeacon.com` or staging verification URL and a future expiry
@@ -68,24 +68,24 @@ The endpoint must:
    its current ambiguous-outcome semantics;
 7. return a minimal `202 {"status":"accepted"}` for accepted or replayed work.
 
-The current deployed PMP service already owns the Gmail API OAuth grant for the
-Google Workspace sender and its worker/durable delivery machinery. It does not
-yet expose this purpose/endpoint. That small adapter belongs in
-`proyecciones-mito`; mounting the same grant in the Listener would create a
-second email authority and is explicitly rejected.
+The event PMP runtime owns the Gmail API OAuth grant for the Google Workspace
+sender. A dedicated Listener-only API, worker and PostgreSQL queue reuse that
+root-owned grant through a read-only worker mount. Listener and the sidecar API
+never receive it. The sidecar has no host ports and neither deploys nor restarts
+the event API or workers.
 
 ## Configuration and rollout
 
 The Listener feature remains absent unless all are set:
 
 ```dotenv
-EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL=http://pmp-myth-api:8765/api/internal/v1/listener-magic-links/deliver
+BEACON_LISTENER_MAGIC_LINK_DELIVERY_URL=http://listener-mail-api:8765/api/internal/v1/listener-magic-links/deliver
 EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN=<32-plus random characters>
 EARLY_BIRDS_MAGIC_LINK_RATE_SECRET=<32-plus independent random characters>
 ```
 
-Apply migration `20260807090000_early_bird_magic_link_throttles`, configure the
-mail adapter first, then install the three protected Listener values and
+Apply migration `20260807090000_early_bird_magic_link_throttles`, deploy the
+isolated mail sidecar first, then install the three protected Listener values and
 recreate only the isolated Listener. Rollback clears the three values and
 recreates only that container; existing Google sessions and email-only sessions
 remain valid until normal expiry, while no new email request route is exposed.

--- a/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+++ b/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
@@ -1,6 +1,19 @@
 # EarlyBirds isolated staging runtime
 
-## 2026-08-12 terminal-status checkpoint deployed with Live sales OFF
+## 2026-08-12 Listener silence-recovery checkpoint deployed with Live sales OFF
+
+The isolated Listener runs exact merge SHA
+`4ac408f4bc43cab85f058fc3d39aa2a2b4b4207a`, image
+`harmonic-beacon/earlybirds-preview-listener:4ac408f` and unchanged Prisma head
+`20260810223000_listener_founder_continuity`. It adds a bounded media-liveness
+watchdog and same-lease recovery for the reported silent-playback failure. It
+does not change origin, audio assets, codec, gain, fades, HLS timing or event
+services. Public health/readiness and fail-closed payment smokes are green.
+Immediate rollback is retained as container
+`earlybirds-preview-listener-1-pre-4ac408f-20260812T085101Z` and protected backup
+`/mnt/beacon-data/staging-backups/listener-release-20260812T084938Z`.
+
+## 2026-08-12 terminal-status checkpoint (superseded application image)
 
 The isolated Listener now runs merge SHA
 `fcdde37948e7f826641d5e4438f7666765aeda22`, image
@@ -621,16 +634,16 @@ Return both switches to `0` after the supervised team window.
 
 ### Optional email magic-link fallback
 
-The fallback remains absent until the existing PMP mail authority implements
-the exact private contract in
+The fallback remains absent until the dedicated PMP Listener mail sidecar is
+healthy with the exact private contract in
 `docs/architecture/EARLY_BIRDS_MAGIC_LINK.md`. Do not copy or mount its Gmail
-OAuth grant into the Listener. After that adapter is deployed on
+OAuth grant into the Listener or sidecar API. After the adapter is deployed on
 `earlybirds_authority_private`, apply the additive
 `20260807090000_early_bird_magic_link_throttles` migration and configure all
 three values together:
 
 ```dotenv
-EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL=http://pmp-myth-api:8765/api/internal/v1/listener-magic-links/deliver
+BEACON_LISTENER_MAGIC_LINK_DELIVERY_URL=http://listener-mail-api:8765/api/internal/v1/listener-magic-links/deliver
 EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN=<dedicated-32-plus-character-token>
 EARLY_BIRDS_MAGIC_LINK_RATE_SECRET=<independent-32-plus-character-secret>
 ```

--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -28,12 +28,12 @@ truthful launch baseline, not a substitute for counsel review. Human owner: Nico
   database backup was restored into an isolated rehearsal database and verified.
 - Production provider and new-sales flags remain OFF. No real payment was attempted.
 
-Backend magic-link delivery is merged at `c443a7ec9b387fa54ff16904e1a5d561613ec102` but remains
-inert until an event-safe PMP maintenance window. The other remaining gates are human/external:
+Backend magic-link delivery is merged at `c443a7ec9b387fa54ff16904e1a5d561613ec102` and its
+dedicated Listener-only sidecar is being deployed without an event maintenance window. The other
+remaining gates are human/external:
 final legal/copy acceptance, protected Live credentials, Google OAuth secret rotation (#328), one
 supervised low-value Live lifecycle per enabled provider and explicit approval to open public
-checkout. Production font builds must also be made hermetic under #327; retries against Google
-Fonts are evidence of a release defect, not a durable build strategy.
+checkout. Production fonts are now hermetic under #327/#329.
 
 ## Independent switches
 
@@ -106,6 +106,6 @@ converted back into a reversible action.
 - PayPal Live Business account/app/product/plan/webhook and root-only Live secrets.
 - Mercado Pago productive merchant credentials/webhook and root-only Live secrets.
 - Counsel/merchant review of public terms, privacy, refund and tax/invoicing obligations.
-- Hermetic production fonts (#327) and controlled Google OAuth secret rotation (#328).
+- Controlled Google OAuth secret rotation (#328); hermetic fonts are complete (#327/#329).
 - One supervised real purchase and cancellation per provider.
 - Explicit approval to turn on real sales. The checked-in defaults remain OFF.

--- a/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
+++ b/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
@@ -23,10 +23,10 @@ The weekly-Free candidate has advanced to a complete Founding Listener pre-relea
 - production provider adapters and public checkout present but fail-closed/default-off.
 
 The release is not yet authorized for real sales. Backend magic-link delivery is merged at
-`SairaAsua/proyecciones-mito@c443a7ec9b387fa54ff16904e1a5d561613ec102` but still needs an event-safe
-runtime rollout. Remaining gates also include final ES/EN legal/copy review, controlled rotation of the exposed Google OAuth
+`SairaAsua/proyecciones-mito@c443a7ec9b387fa54ff16904e1a5d561613ec102`; its dedicated sidecar rollout
+is isolated from the event runtime. Remaining gates include final ES/EN legal/copy review, controlled rotation of the exposed Google OAuth
 client secret, protected PayPal/MP Live credentials, one supervised low-value Live lifecycle per
-provider, a hermetic font build and explicit main/public-sales approval. See
+provider and explicit main/public-sales approval. Hermetic fonts are complete. See
 `docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and issue #315 for the current checklist.
 
 ## Status: weekly Free deployed for acceptance
@@ -188,12 +188,11 @@ worksheet.
    and support copy.
 2. Rotate the exposed Google OAuth client secret through the protected store and
    re-run callback/logout without printing it.
-3. Self-host the approved fonts so the release build has no Google Fonts network dependency (#327).
-4. Deploy backend #44 in an event-safe maintenance window and prove one controlled
+3. Prove one controlled
    magic-link request, email, callback and Free entry.
-5. Install protected PayPal and Mercado Pago Live credentials with all sales
+4. Install protected PayPal and Mercado Pago Live credentials with all sales
    flags still OFF, then run one explicitly approved low-value lifecycle per provider.
-6. Approve merge to `main` and public checkout separately; retain the immediate
+5. Approve merge to `main` and public checkout separately; retain the immediate
    new-sales kill switch throughout launch.
 
 Do not select a user's Google account, provision Apple, charge a provider,


### PR DESCRIPTION
Reconciles the commercial launch handoff with the deployed 4ac408f Listener release, completed hermetic fonts, verified payment lifecycles, and the event-isolated magic-link sidecar topology. Documentation only; no event, audio, runtime, payment flag, or secret changes.