### PR TITLE
docs(listener): reconcile payment processor truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The product makes public commitments in its policy corpus. They are documented, 
 - **[Trust & Safety](./docs/TRUST_AND_SAFETY.md)**: reports will be acknowledged within 24 hours and S1 incidents will get a public postmortem. Neither exists yet — there is no report model and no incidents page. **[Planned — Phase 1]**
 - **[Research ethics](./docs/RESEARCH_PROTOCOL.md)**: informed consent, revocable participation, preregistered protocols, de-identified public aggregates — the standard the research protocol will be held to once it starts enrolling. No research data is collected today. **[Planned — Phase 3]**
 - **[Content policy](./docs/CONTENT_POLICY.md)**: no therapeutic claims is a standing rule enforced today through moderation review; appeals of a moderation decision are not yet available. **[Planned — Phase 2]**
-- **[Monetization](./docs/MONETIZATION.md)**: patronage-not-paywall, core experience free forever. No payment processing or entitlement model exists yet, so every published meditation is free to everyone today by default rather than by an enforced floor. **[Planned — Phase 2]**
+- **[Monetization](./docs/MONETIZATION.md)**: the broader patronage/provider economy remains planned for Phase 2. Separately, the experimental Founding Listener lane now has a server-authoritative weekly Free allowance and USD 5/month PayPal/Mercado Pago membership authority. Sandbox/TEST are accepted; Live credentials, real charges and public checkout remain OFF pending [the release gates](./docs/operations/LISTENER_LAUNCH_NOW.md).
 
 What's live today:
 

--- a/docs/MONETIZATION.md
+++ b/docs/MONETIZATION.md
@@ -246,10 +246,15 @@ This is documented here only to note that monetization for the Seal is an open q
 
 ## Compliance scaffolding
 
-Whatever monetization we ship will run on these scaffolds. None of them is in place — Stripe is not integrated, no tax advisor has been engaged, and no ledger separates Harmonic Beacon within the parent org's accounts. **[Planned — Phase 2]**
+The broader patronage/provider economy below remains planned for Phase 2. It is not the current
+Founding Listener implementation. That pre-release uses a provider-neutral authority with PayPal
+and Mercado Pago, USD 5/month Founder continuity, weekly Free access and default-off Live gates;
+see `operations/LISTENER_LAUNCH_NOW.md`. No real charge or public checkout is enabled yet. A tax
+advisor and a dedicated Harmonic Beacon accounting ledger remain launch/operations work.
 
-- **Billing provider**: Stripe at launch (Stripe Billing for subscriptions, Stripe Connect for Provider payouts, Stripe Tax for VAT/sales tax, Stripe Checkout for one-time donations).
-- **Tax**: Stripe Tax computes and collects. We file where required. A tax advisor is engaged before the first payout-bearing month — it is an open thread in [README.md](./README.md#open-threads) and it gates the phase, because the currencies quoted above decide which registrations we need.
+- **Founding Listener billing**: PayPal and Mercado Pago through the canonical membership authority; Live remains OFF until supervised cutover.
+- **Future patron/provider economy**: provider, payout and tax tooling are a separate Phase 2 decision; Stripe is a candidate, not deployed fact.
+- **Tax**: the receiving merchant/entity and jurisdictional obligations must be accepted before public sales. A processor does not replace the tax/accounting decision.
 - **Receipts**: every charge generates a compliant receipt. Annual patrons receive a year-end summary of what they contributed.
 - **Legal entity**: payments flow through the designated AlterMundi entity; separate ledger for Harmonic Beacon within the parent org's accounts.
 - **Currency risk**: unhedged at launch; visible in the monthly financial review.

--- a/docs/RESEARCH_PROTOCOL.md
+++ b/docs/RESEARCH_PROTOCOL.md
@@ -180,19 +180,24 @@ Two things in that diagram are commitments rather than descriptions and should b
 
 ### 4.3 Processors
 
-An earlier draft of this document asserted that "no third-party processor touches identifiable data except Stripe (billing) and our email provider (transactional)". That sentence was wrong in both directions — neither Stripe nor an email provider is integrated, and the roadmap adds several processors the sentence excluded. An absolute claim about processors is falsified the day a dependency is added, so this section is a dated list instead. Maintaining it is also what GDPR Art. 28 and Art. 30 record-keeping will require.
+An earlier draft of this document asserted that "no third-party processor touches identifiable data except Stripe (billing) and our email provider (transactional)". That sentence was wrong in both directions: Stripe is not the current Listener billing authority, and an absolute list becomes false as soon as a dependency is added. This dated inventory separates services currently exercised in the Founding Listener pre-release from later research processors. Maintaining it is also what GDPR Art. 28 and Art. 30 record-keeping will require.
 
-**Processors with access to identifiable data, as of 2026-06-09:**
+**Processors with access to identifiable data, as of 2026-08-12:**
 
 | Processor | Data | Role |
 |---|---|---|
-| Zitadel (`auth.altermundi.net`, AlterMundi-operated) | Email, name, OIDC subject | Identity provider — see `src/lib/auth-config.ts` |
+| Google OAuth | Email and provider subject during sign-in | Configured Listener identity provider |
+| Gmail API / Google Workspace | Recipient and one-use sign-in URL | Transactional Listener magic-link delivery |
+| PayPal Sandbox and Mercado Pago TEST | Test buyer identity and synthetic payment instrument data | Accepted pre-release subscription testing only; no Live charges |
 | PostgreSQL and object storage on AlterMundi-operated hosts | All application data | First-party infrastructure |
 | LiveKit, self-hosted on AlterMundi infrastructure | Live audio, participant identities | Real-time transport |
 
-No payment processor, email provider, error-tracking, crash-reporting, analytics or push-notification service is integrated today.
+PayPal Live and Mercado Pago productive credentials are not installed, their provider and public
+checkout flags are OFF, and no real Founding Listener charge has occurred. The Listener stores
+opaque provider evidence and membership state; providers retain financial instrument data. No
+error-tracking, crash-reporting or push-notification service is integrated in this lane.
 
-**We update this list before adding a processor, not after.** The roadmap already names candidates that will belong here, each of which is a processor decision and not merely a dependency choice: Sentry with release tracking (Phase 1), a transactional email provider such as Resend or Postmark (Phase 2), Stripe including Connect KYC for provider payouts (Phase 2), Firebase Crashlytics (Phase 3 — Google as processor, with its own data-sharing posture, which is the one on this list most worth a second look before it is adopted), and a push-notification service (Phase 3). None is integrated; none may be added while this table still says it is not.
+**We update this list before adding a processor, not after.** The broader roadmap still names candidates such as Sentry, Stripe Connect for a future provider economy, Firebase Crashlytics and push notifications. None is implied by the Listener pre-release and each requires its own processor decision and inventory update before activation.
 
 ### 4.4 Retention
 

--- a/docs/operations/LISTENER_LAUNCH_NOW.md
+++ b/docs/operations/LISTENER_LAUNCH_NOW.md
@@ -19,6 +19,7 @@ and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
 - PayPal Live checkout: OFF
 - Mercado Pago Live checkout: OFF
 - Authority paid checkout/providers: OFF
+- Authority Sandbox/TEST new-sales gate: ON only inside isolated staging acceptance; Live metrics remain zero/OFF
 - Public sales and real charges: not authorized
 
 PayPal Sandbox has passed activation, pending cancellation, reactivation and
@@ -61,3 +62,12 @@ without explicit approval.
   authority.
 - Magic delivery incident: clear the three protected magic-link values and
   recreate only Listener; do not restart the event runtime.
+
+## Public-document truth
+
+The broad Phase 2 patronage/provider-economy documents are future strategy, not
+the implementation authority for Founding Listeners. Public and repository copy
+must not claim that Harmonic Beacon has no payment or email processing: the
+Sandbox/TEST subscription lanes and Gmail magic-link delivery are already real
+pre-release processors. Equally, copy must not claim Live billing is active;
+productive credentials, real charges and public checkout remain OFF.


### PR DESCRIPTION
## Outcome

Removes present-tense claims that no payment/email processor exists and separates the active Founding Listener pre-release lane from future Stripe patronage/provider strategy.

## Truth preserved

- PayPal Sandbox and Mercado Pago TEST are integrated/accepted
- Gmail magic-link delivery is deployed
- PayPal Live, Mercado Pago productive credentials, real charges and public checkout remain OFF
- broader Stripe/Connect economy remains future strategy

Documentation only. No runtime, provider flag, secret, event or audio change. `git diff --check` is green.