### PR TITLE
docs(listener): record Live preflight checkpoint

### DIFF
--- a/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+++ b/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
@@ -1,5 +1,19 @@
 # EarlyBirds isolated staging runtime
 
+## 2026-08-12 payment-authority Live-preflight checkpoint
+
+The isolated membership authority runs exact merge SHA
+`8e10f16fe3471a097021f7f1ee41eb8f88f4f154`, image
+`harmonic-beacon/earlybirds-authority:8e10f16fe3471a097021f7f1ee41eb8f88f4f154`
+and unchanged Alembic head `7b4c1e9a2d60`. API and worker are healthy with
+zero restarts and migration exit `0`. PayPal Sandbox and Mercado Pago TEST remain
+ready for staging acceptance; both Live providers and Live new sales remain OFF.
+The release adds only a read-only, redacted Live catalog/merchant/webhook
+preflight. Productive secrets are not installed and no checkout, subscription,
+payment, event service or audio surface changed. Rollback retains exact prior
+authority image `60584936603525027c9891e0865efc58055a3d5d` and protected backup
+`/mnt/beacon-data/staging-backups/authority-live-preflight-20260812T193128Z`.
+
 ## 2026-08-12 Listener silence-recovery checkpoint deployed with Live sales OFF
 
 The isolated Listener runs exact merge SHA
@@ -19,7 +33,7 @@ The isolated Listener now runs merge SHA
 `fcdde37948e7f826641d5e4438f7666765aeda22`, image
 `harmonic-beacon/earlybirds-preview-listener:fcdde37` and unchanged Prisma
 head `20260810223000_listener_founder_continuity`. The isolated membership
-authority runs merge SHA `60584936603525027c9891e0865efc58055a3d5d`
+authority then ran merge SHA `60584936603525027c9891e0865efc58055a3d5d`
 at unchanged Alembic head `7b4c1e9a2d60`.
 
 - PayPal Live, Mercado Pago Live and both public Listener checkout flags are

--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -42,6 +42,13 @@ The exact public Listener image is
 same-schema Listener image `fcdde379` remains available as the bounded application rollback target;
 the weekly-quota database policy itself is forward-only.
 
+The exact isolated payment-authority image is
+`8e10f16fe3471a097021f7f1ee41eb8f88f4f154`. Its read-only Live preflight is deployed, health is
+green and its migration completed with exit `0`. PayPal Live and Mercado Pago Live remain disabled
+and report zero provider-readiness/new-sales metrics because productive credentials are absent.
+The previous authority image `60584936603525027c9891e0865efc58055a3d5d` and protected backup
+`/mnt/beacon-data/staging-backups/authority-live-preflight-20260812T193128Z` are retained for rollback.
+
 ## Independent switches
 
 Listener app, all default OFF:
@@ -83,17 +90,24 @@ converted back into a reversible action.
 
 1. Back up the Listener database and record current Listener and authority image SHAs.
 2. Install root-only provider secrets; verify ownership/mode without printing values.
-3. Keep new-sales flags OFF. Enable one provider lifecycle and validate private readiness,
-   catalog/merchant identity, signed-webhook negative cases and reconciliation.
-4. Install the reviewed Listener nginx template and verify exact routes plus final 404. Do not
+3. Keep every Live provider and Listener checkout flag OFF. Temporarily set
+   `PMP_MYTH_EARLY_BIRDS_PAID_CHECKOUT_ENABLED=false` so the read-only preflight cannot coexist
+   with Sandbox/TEST new sales, then run inside the exact authority container:
+   `pmp-myth-listener-live-preflight --provider paypal`,
+   `pmp-myth-listener-live-preflight --provider mercado_pago`, or `--provider all`.
+   The command performs only provider reads and emits no IDs, secrets or PII. Require
+   `status=verified` and `new_sales=disabled`; on any failure, keep all Live flags OFF.
+4. Validate private readiness, exact signed-webhook negative cases and reconciliation. The
+   preflight does not replace webhook signature or lifecycle tests.
+5. Install the reviewed Listener nginx template and verify exact routes plus final 404. Do not
    reload nginx unless `nginx -t` is green.
-5. Enable the matching Listener checkout flag only after the authority reports that Live provider
+6. Enable the matching Listener checkout flag only after the authority reports that Live provider
    ready and the public copy/terms have human approval.
-6. Execute one supervised real USD 5 membership with an agreed account. Confirm provider event,
+7. Execute one supervised real USD 5 membership with an agreed account. Confirm provider event,
    canonical projection, profile badge, unlimited access, renewal boundary and no raw PII in logs.
-7. Request cancellation in the profile. Confirm provider cancellation, pending-end projection and
+8. Request cancellation in the profile. Confirm provider cancellation, pending-end projection and
    access through paid-through. Use a separate controlled account to rehearse failure/refund.
-8. Expand availability only after webhook/reconciliation lag and alerts remain healthy.
+9. Expand availability only after webhook/reconciliation lag and alerts remain healthy.
 
 ## Incident and rollback
 

--- a/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
+++ b/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
@@ -55,10 +55,16 @@ repair, never restoring daily/welcome authorization.
 | Previous same-schema application rollback | `fcdde379` |
 | Commercial checkpoint documentation | `78ede811161cf47104f3758e6703d06d2328ea6f` |
 | Listener database schema | `20260808160000_listener_weekly_quota` |
-| Canonical payment authority application | `60584936603525027c9891e0865efc58055a3d5d` |
+| Canonical payment authority application | `8e10f16fe3471a097021f7f1ee41eb8f88f4f154` |
 | Listener mail sidecar application | `456ece2b38e203a2d12c54864115e03ebaa1a89c` |
 | Public mode | Free for All OFF during coordinated registered-Free acceptance |
 | Recovery | Stop/kill-switch and roll forward; old policy images unsupported |
+
+The current authority adds a read-only Live provider preflight only. Live
+credentials are not installed, Live provider/new-sales metrics remain zero and
+no real charge is authorized. Authority rollback retains exact previous image
+`60584936603525027c9891e0865efc58055a3d5d` plus protected backup
+`/mnt/beacon-data/staging-backups/authority-live-preflight-20260812T193128Z`.
 
 Health must attest the deployed application SHA, not the later documentation or
 test-only branch head.

--- a/docs/operations/LISTENER_LAUNCH_NOW.md
+++ b/docs/operations/LISTENER_LAUNCH_NOW.md
@@ -11,7 +11,8 @@ and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
 - Public candidate: `https://listen.harmonicbeacon.com/`
 - Listener image/SHA: `4ac408f4bc43cab85f058fc3d39aa2a2b4b4207a`
 - Previous same-schema Listener rollback image: `fcdde379`
-- Canonical payment authority: `60584936603525027c9891e0865efc58055a3d5d`
+- Canonical payment authority: `8e10f16fe3471a097021f7f1ee41eb8f88f4f154`
+- Previous authority rollback image: `60584936603525027c9891e0865efc58055a3d5d`
 - Listener mail sidecar: `456ece2b38e203a2d12c54864115e03ebaa1a89c`
 - Weekly Free: three hours per server-owned seven-day cycle
 - Founding Listener: USD 5/month while service remains uninterrupted
@@ -21,6 +22,15 @@ and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
 - Authority paid checkout/providers: OFF
 - Authority Sandbox/TEST new-sales gate: ON only inside isolated staging acceptance; Live metrics remain zero/OFF
 - Public sales and real charges: not authorized
+
+The authority now includes a read-only Live-provider preflight. It validates the
+exact PayPal Live product, plan and webhook event set and the Mercado Pago Live
+merchant identity without creating checkouts, subscriptions or payments. The
+deployed authority is healthy with migration exit `0`; PayPal Live and Mercado
+Pago Live readiness/new-sales metrics are both `0`. Productive credentials are
+not installed, so the preflight cannot yet reach either Live provider. The
+global staging new-sales gate deliberately remains ON for Sandbox/TEST and makes
+the Live preflight fail closed until an operator explicitly disables it.
 
 PayPal Sandbox has passed activation, pending cancellation, reactivation and
 terminal refund. Mercado Pago TEST has passed checkout, activation, pause,
@@ -39,7 +49,8 @@ event runtime and have no host ports. A controlled Gmail delivery reached
 5. #328 — rotate the exposed Google OAuth client secret in the protected store,
    then prove canonical and staging login/logout/relogin without printing it.
 6. Install protected PayPal Live and Mercado Pago productive credentials while
-   every sales/provider flag remains OFF.
+   every Live sales/provider flag remains OFF; temporarily disable the global
+   staging new-sales gate and run the read-only provider preflight.
 7. With explicit approval, execute one supervised low-value activation,
    cancellation and refund per provider.
 8. Obtain separate explicit approvals for merge to `main` and public checkout.
@@ -56,6 +67,9 @@ without explicit approval.
 
 - Commerce incident: switch OFF Listener checkout flags and authority new-sales;
   keep webhooks, reconciliation, cancellation and existing access running.
+- Authority application regression: restore exact image `60584936603525027c9891e0865efc58055a3d5d`
+  with the protected pre-deploy configuration/database backup at
+  `/mnt/beacon-data/staging-backups/authority-live-preflight-20260812T193128Z`.
 - Listener application regression: roll back only the isolated Listener to
   `fcdde379` if contract-compatible; otherwise disable Listener and roll forward.
 - Weekly quota is forward-only. Never restore the retired daily-window/welcome

--- a/docs/plans/EARLY_BIRDS.md
+++ b/docs/plans/EARLY_BIRDS.md
@@ -9,7 +9,7 @@
 
 > **Current launch memory (2026-08-12):** the public Listener candidate runs exact
 > SHA `4ac408f4bc43cab85f058fc3d39aa2a2b4b4207a`; canonical payment authority runs
-> `60584936603525027c9891e0865efc58055a3d5d`; the isolated mail sidecar runs
+> `8e10f16fe3471a097021f7f1ee41eb8f88f4f154`; the isolated mail sidecar runs
 > `456ece2b38e203a2d12c54864115e03ebaa1a89c`. PayPal Sandbox and Mercado Pago
 > TEST lifecycles are accepted. Live providers, new sales and public checkout
 > remain OFF. See `docs/operations/LISTENER_LAUNCH_NOW.md` for the few remaining
@@ -493,10 +493,13 @@ The webapp vendors byte-exact copies of the canonical backend contracts under
   checkout command/result. It exposes no provider subscription ID, fixes
   `environment=live`, keeps payer email transient and uses a separate new-sales
   gate from provider lifecycle. The deployed authority runtime
-  `60584936603525027c9891e0865efc58055a3d5d` is CI-green and includes canonical
+  `8e10f16fe3471a097021f7f1ee41eb8f88f4f154` is CI-green and includes canonical
   cancellation/reactivation plus paid-lifecycle metrics. The Listener Live
   surface and exact webhook ingress remain disabled by default;
   see `docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md`.
+  This authority release also provides a read-only, redacted Live-provider
+  preflight for exact PayPal catalog/webhook and Mercado Pago merchant checks;
+  productive credentials remain absent and all Live flags remain OFF.
 
 ## 11. Fast Forward development lane
 


### PR DESCRIPTION
## Outcome

Reconciles the durable Listener launch memory with the exact authority release now deployed on Mona.

## Evidence

- authority image/revision: `8e10f16fe3471a097021f7f1ee41eb8f88f4f154`
- API + worker healthy, restart count 0; migration exit 0
- PayPal Sandbox and Mercado Pago TEST remain ready
- PayPal Live and Mercado Pago Live readiness/new-sales metrics remain 0/OFF
- read-only Live preflight fails closed while the global staging new-sales gate is ON
- previous authority image `60584936603525027c9891e0865efc58055a3d5d` and protected rollback backup retained
- event/runtime containers retained exact IDs with zero restarts

Docs only. No provider flag, secret, checkout, event, audio or runtime change.