### PR TITLE
docs(listener): close Google OAuth rotation gate

### DIFF
--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -33,9 +33,15 @@ SHA `456ece2b38e203a2d12c54864115e03ebaa1a89c`. The API, worker and PostgreSQL q
 ports, use separate storage and did not restart or modify any event service. A controlled message
 reached Gmail with terminal delivery state `SENT`; the human callback, Free-entry and logout check
 remain. The other remaining gates are human/external:
-final legal/copy acceptance, Google OAuth secret rotation (#328), one
+final legal/copy acceptance, one
 supervised low-value Live lifecycle per enabled provider and explicit approval to open public
 checkout. Production fonts are now hermetic under #327/#329.
+
+Google OAuth rotation #328 is complete. The persistent Listener and disposable staging workbench
+both use the replacement client and root-only secret. Canonical login, logout and re-login passed;
+the staging callback passed without `authError`. The previous client was revoked only after those
+checks and is recoverable in Google Cloud for 30 days for administrative recovery. Never restore
+the exposed secret from an environment backup.
 
 The exact public Listener image is
 `4ac408f4bc43cab85f058fc3d39aa2a2b4b4207a`. Health and readiness attest that SHA. The previous
@@ -129,7 +135,6 @@ converted back into a reversible action.
 ## Human release gates still required
 
 - Counsel/merchant review of public terms, privacy, refund and tax/invoicing obligations.
-- Controlled Google OAuth secret rotation (#328); hermetic fonts are complete (#327/#329).
 - One supervised real purchase and cancellation per provider.
 - Explicit approval to turn on real sales. The checked-in defaults remain OFF.
 

--- a/docs/operations/LISTENER_LAUNCH_NOW.md
+++ b/docs/operations/LISTENER_LAUNCH_NOW.md
@@ -40,19 +40,22 @@ The dedicated magic-link API, worker and PostgreSQL queue are isolated from the
 event runtime and have no host ports. A controlled Gmail delivery reached
 `SENT`; the human callback/Free/logout check remains.
 
+Google OAuth rotation #328 is complete. Canonical login → logout → re-login and
+the staging callback passed on the replacement client. The previous client was
+revoked after acceptance; its secret must never be restored from an old env
+backup. Only Listener and the disposable staging workbench were recreated.
+
 ## Remaining blockers to public sales
 
 1. #217 — open the delivered magic link and prove email-only session → Free → logout.
 2. #304 — complete a physical 60-minute listen and record any watchdog recovery.
 3. #317 — final mobile/account-menu billing acceptance.
 4. #318 — human ES/EN offer/legal/seller/refund/support acceptance.
-5. #328 — rotate the exposed Google OAuth client secret in the protected store,
-   then prove canonical and staging login/logout/relogin without printing it.
-6. With explicit approval, execute one supervised low-scope activation,
+5. With explicit approval, execute one supervised low-scope activation,
    cancellation and refund per provider.
-7. Confirm Founder activation, terminal Free fallback, metrics, alerts and the
+6. Confirm Founder activation, terminal Free fallback, metrics, alerts and the
    absence of PII/secret leakage against those Live transactions.
-8. Obtain separate explicit approvals for merge to `main` and public checkout.
+7. Obtain separate explicit approvals for merge to `main` and public checkout.
 
 ## Non-negotiable isolation
 
@@ -75,6 +78,9 @@ without explicit approval.
   authority.
 - Magic delivery incident: clear the three protected magic-link values and
   recreate only Listener; do not restart the event runtime.
+- Google OAuth incident: keep the replacement client and roll forward with a
+  new secret. The revoked client remains provider-restorable for 30 days only
+  for controlled recovery; never restore its exposed secret from backups.
 
 ## Public-document truth
 


### PR DESCRIPTION
## Outcome

Records completion of #328 after a controlled client/secret rotation.

## Evidence

- replacement Google client has exact canonical + staging origins/callbacks;
- canonical login → logout → re-login passed;
- staging callback passed without `authError`;
- only persistent Listener and disposable staging workbench were recreated;
- previous client was revoked after acceptance and is provider-restorable for 30 days;
- active secret was installed root-only and is absent from Git/logs/handoff;
- event services retained their existing uptime.

Docs only; no runtime or secret content in this PR.
