### PR TITLE
docs(listener): enforce post-Live rollback floor

### DIFF
--- a/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+++ b/docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
@@ -1,5 +1,21 @@
 # EarlyBirds isolated staging runtime
 
+## 2026-08-13 Live-lifecycle rollback floor
+
+The isolated payment authority runs exact SHA
+`b1038ddb579817e39add567c5b7b055e2f716095`. A supervised PayPal Live approval intent was created
+for the exact USD 5 offer; it awaits a buyer account different from the merchant and created no
+subscription or charge. New sales were returned to OFF immediately. PayPal Live lifecycle
+ingestion remains ON so signed webhooks, reconciliation and cancellation stay available; Mercado
+Pago Live remains OFF.
+
+From this first Live checkout attempt onward, `b1038ddb` is the minimum authority binary. Routine
+incident recovery keeps the current database, disables new sales, leaves the affected provider's
+lifecycle ingestion active, reconciles from the provider and rolls forward. The older `8e10f16`
+image and pre-`b1038` database backup must not be paired with current data or used as routine
+rollback targets. The Listener UI may still roll back independently to `fcdde379` while its
+contract remains compatible.
+
 ## 2026-08-12 payment-authority Live-preflight checkpoint
 
 The isolated membership authority runs exact merge SHA

--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -54,10 +54,14 @@ hardening from backend PR #80. API and worker are healthy, Alembic is at head `7
 the exact public webhook routes fail closed while Live is disabled. Productive PayPal and Mercado
 Pago credentials are installed only in the root-owned runtime store. Read-only preflights verified
 the PayPal Live catalog/webhook and Mercado Pago productive merchant/webhook configuration with
-new sales forced OFF. No checkout, subscription or payment was created. The previous authority
-image `8e10f16fe3471a097021f7f1ee41eb8f88f4f154` and protected pre-deploy backup
+new sales forced OFF. On 2026-08-13, a supervised PayPal Live approval intent was created for the
+USD 5 offer; it is awaiting approval by a buyer account different from the merchant, and created
+no subscription or charge. New sales were immediately returned to OFF while PayPal Live lifecycle
+ingestion remains ON. The former authority image
+`8e10f16fe3471a097021f7f1ee41eb8f88f4f154` and protected pre-deploy backup
 `/var/backups/harmonic-beacon/earlybirds-authority-pre-b1038ddb579817e39add567c5b7b055e2f716095.sql.gz`
-are retained for rollback.
+are retained only as pre-Live forensic/disaster-recovery artifacts; they are no longer routine
+rollback targets.
 
 ## Independent switches
 
@@ -123,7 +127,20 @@ converted back into a reversible action.
 
 - Checkout/provider incident: turn off both app checkout flags and the authority new-sales flag.
   Existing lifecycle workers and webhooks stay running.
+- Live authority floor: after the first Live checkout attempt, provider binding or event,
+  `b1038ddb579817e39add567c5b7b055e2f716095` is the minimum supported authority binary. Do not run
+  `8e10f16fe3471a097021f7f1ee41eb8f88f4f154` against the current database and do not routinely
+  restore the pre-`b1038` database backup. The older binary predates required Mercado Pago
+  adverse-event hardening and a database restore could discard canonical checkout/lifecycle
+  evidence.
+- Authority regression after Live cutover: keep the current database, turn new sales OFF, retain
+  the affected provider's Live lifecycle flag so signed webhooks, reconciliation, cancellation and
+  existing access continue, then deploy a repaired `b1038`-compatible-or-newer image and reconcile
+  from the provider. Recovery is roll-forward. A pre-cutover database restore is reserved for an
+  explicitly commanded disaster recovery with both providers frozen and a complete provider-led
+  reconciliation plan; it is not an ordinary rollback.
 - Listener regression: roll back only the Listener image while keeping a contract-compatible
+  authority. `fcdde379` remains the bounded contract-compatible UI rollback for the current
   authority. If compatibility is uncertain, keep Listener disabled and roll forward.
 - Provider-specific incident: disable only that app checkout flag. Do not route a pending checkout
   to the other provider or manufacture membership.

--- a/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
+++ b/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
@@ -22,13 +22,13 @@ The weekly-Free candidate has advanced to a complete Founding Listener pre-relea
 - private paid-operation metrics, alerts, backup/restore and sales kill switches;
 - production provider adapters and public checkout present but fail-closed/default-off.
 
-The release is not yet authorized for real sales. Passwordless email delivery is deployed in an
+The release is not yet authorized for public real sales. Passwordless email delivery is deployed in an
 event-isolated sidecar at exact backend SHA
 `SairaAsua/proyecciones-mito@456ece2b38e203a2d12c54864115e03ebaa1a89c`; a controlled email reached
-Gmail with terminal state `SENT`. The human callback/Free/logout check remains. Remaining gates
-include final ES/EN legal/copy review, controlled rotation of the exposed Google OAuth
-client secret, protected PayPal/MP Live credentials, one supervised low-value Live lifecycle per
-provider and explicit main/public-sales approval. Hermetic fonts are complete. See
+Gmail with terminal state `SENT`. The human callback/Free/logout check remains. Google OAuth
+rotation and real callback/logout/re-login acceptance are complete. Productive provider credentials
+are installed root-only. Remaining gates include final ES/EN legal/copy review, completion of one
+supervised low-value Live lifecycle per provider and explicit main/public-sales approval. Hermetic fonts are complete. See
 `docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and issue #315 for the current checklist.
 
 ## Status: weekly Free deployed for acceptance
@@ -55,16 +55,18 @@ repair, never restoring daily/welcome authorization.
 | Previous same-schema application rollback | `fcdde379` |
 | Commercial checkpoint documentation | `78ede811161cf47104f3758e6703d06d2328ea6f` |
 | Listener database schema | `20260808160000_listener_weekly_quota` |
-| Canonical payment authority application | `8e10f16fe3471a097021f7f1ee41eb8f88f4f154` |
+| Canonical payment authority application and post-Live rollback floor | `b1038ddb579817e39add567c5b7b055e2f716095` |
 | Listener mail sidecar application | `456ece2b38e203a2d12c54864115e03ebaa1a89c` |
 | Public mode | Free for All OFF during coordinated registered-Free acceptance |
 | Recovery | Stop/kill-switch and roll forward; old policy images unsupported |
 
-The current authority adds a read-only Live provider preflight only. Live
-credentials are not installed, Live provider/new-sales metrics remain zero and
-no real charge is authorized. Authority rollback retains exact previous image
-`60584936603525027c9891e0865efc58055a3d5d` plus protected backup
-`/mnt/beacon-data/staging-backups/authority-live-preflight-20260812T193128Z`.
+The current authority adds the reviewed Mercado Pago adverse-event hardening and a read-only Live
+provider preflight. Productive credentials are installed root-only. A supervised PayPal Live
+approval intent was created for USD 5 and is awaiting a non-merchant buyer; it created no
+subscription or charge. New sales and public checkout are OFF while PayPal Live lifecycle
+ingestion remains ON. Once any Live checkout attempt exists, `b1038ddb` is the authority binary
+floor: preserve the current database, reconcile provider state and roll forward. Older images and
+pre-cutover backups are forensic/disaster-recovery artifacts, not routine rollback targets.
 
 Health must attest the deployed application SHA, not the later documentation or
 test-only branch head.
@@ -152,6 +154,9 @@ deployed image; later documentation-only commits do not require rebuilding it.
 - Current image is `4ac408f`. Image `fcdde379` remains the same-schema application recovery
   target; earlier policy images are historical and
   are not valid rollback targets.
+- The authority has an independent post-Live floor: `b1038ddb` is the minimum binary. New sales
+  stop with flags while provider lifecycle ingestion and the current canonical database remain;
+  recovery reconciles and rolls forward.
 - The fixed public-disable command was exercised after deployment. Its first
   health probe observed the normal Next.js startup connection reset, retried,
   then proved liveness, readiness and anonymous lease denial before exiting 0.
@@ -186,9 +191,10 @@ deployed image; later documentation-only commits do not require rebuilding it.
   remains default-off and can be re-enabled only on staging for later variants.
 - #199/#200 have fresh provider evidence: PayPal Sandbox completed USD 5
   activation, cancel-pending-end, reversal and terminal refund; Mercado Pago TEST
-  completed checkout, pause, reactivation and reconciliation. Both adapters and
-  their production lanes remain default-off. No Live credential, public checkout
-  flag or real sale is active.
+  completed checkout, pause, reactivation and reconciliation. Productive credentials are installed
+  root-only. One PayPal Live approval intent exists without a subscription or charge; PayPal Live
+  lifecycle ingestion stays ON while global new sales, both public checkout flags and Mercado Pago
+  Live remain OFF.
 
 ## Remaining human sequence
 

--- a/docs/operations/LISTENER_LAUNCH_NOW.md
+++ b/docs/operations/LISTENER_LAUNCH_NOW.md
@@ -1,6 +1,6 @@
 # Listener launch — current state
 
-Last reconciled: 2026-08-12
+Last reconciled: 2026-08-13
 
 This is the compact operational memory for Founding Listeners. Detailed evidence
 and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
@@ -12,16 +12,17 @@ and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
 - Listener image/SHA: `4ac408f4bc43cab85f058fc3d39aa2a2b4b4207a`
 - Previous same-schema Listener rollback image: `fcdde379`
 - Canonical payment authority: `b1038ddb579817e39add567c5b7b055e2f716095`
-- Previous authority rollback image: `8e10f16fe3471a097021f7f1ee41eb8f88f4f154`
+- Minimum authority after any Live checkout attempt: `b1038ddb579817e39add567c5b7b055e2f716095`
 - Listener mail sidecar: `456ece2b38e203a2d12c54864115e03ebaa1a89c`
 - Weekly Free: three hours per server-owned seven-day cycle
 - Founding Listener: USD 5/month while service remains uninterrupted
 - Free For All: OFF
 - PayPal Live checkout: OFF
 - Mercado Pago Live checkout: OFF
-- Authority Live providers: OFF
-- Authority Sandbox/TEST new-sales gate: ON only inside isolated staging acceptance; Live metrics remain zero/OFF
-- Public sales and real charges: not authorized
+- PayPal Live lifecycle: ON with new sales OFF after creating one supervised approval intent
+- Mercado Pago Live provider: OFF
+- Mercado Pago TEST lifecycle: ready; global new sales OFF
+- Public sales: OFF; only the explicitly supervised Live lifecycle is authorized
 
 The authority now includes the reviewed adverse-event hardening and a read-only
 Live-provider preflight. The deployed API/worker are healthy at exact revision
@@ -29,8 +30,11 @@ Live-provider preflight. The deployed API/worker are healthy at exact revision
 root-only. With new sales forced OFF, PayPal verified its exact Live product,
 USD 5 plan and webhook event set; Mercado Pago verified its productive MLA
 merchant and webhook configuration. Neither preflight creates checkout,
-subscription, binding or payment. The normal runtime deliberately remains on
-Sandbox/TEST for acceptance, with both Live provider flags OFF.
+subscription, binding or payment. A supervised PayPal Live approval intent was subsequently
+created for the exact USD 5 offer and is awaiting a buyer account different from the merchant; it
+created no subscription or charge. Global new sales and both public Listener checkout flags are
+OFF. PayPal Live lifecycle ingestion remains ON so its callback, signed webhook, reconciliation
+and cancellation path stay available. Mercado Pago remains on TEST with Live OFF.
 
 PayPal Sandbox has passed activation, pending cancellation, reactivation and
 terminal refund. Mercado Pago TEST has passed checkout, activation, pause,
@@ -51,8 +55,9 @@ backup. Only Listener and the disposable staging workbench were recreated.
 2. #304 — complete a physical 60-minute listen and record any watchdog recovery.
 3. #317 — final mobile/account-menu billing acceptance.
 4. #318 — human ES/EN offer/legal/seller/refund/support acceptance.
-5. With explicit approval, execute one supervised low-scope activation,
-   cancellation and refund per provider.
+5. Complete the already-created PayPal approval intent with a non-merchant buyer, then execute its
+   supervised activation, cancellation and refund evidence. Execute the corresponding supervised
+   Mercado Pago lifecycle separately.
 6. Confirm Founder activation, terminal Free fallback, metrics, alerts and the
    absence of PII/secret leakage against those Live transactions.
 7. Obtain separate explicit approvals for merge to `main` and public checkout.
@@ -69,9 +74,12 @@ without explicit approval.
 
 - Commerce incident: switch OFF Listener checkout flags and authority new-sales;
   keep webhooks, reconciliation, cancellation and existing access running.
-- Authority application regression: restore exact image `8e10f16fe3471a097021f7f1ee41eb8f88f4f154`
-  with the protected pre-deploy configuration/database backup at
-  `/var/backups/harmonic-beacon/earlybirds-authority-pre-b1038ddb579817e39add567c5b7b055e2f716095.sql.gz`.
+- Authority application regression after any Live checkout attempt: keep the current database,
+  keep the affected provider's Live lifecycle flag ON, keep new sales OFF and roll forward with
+  `b1038ddb` or a newer contract-compatible authority. Never deploy `8e10f16` against the current
+  database. Never use the protected pre-`b1038` database backup as a routine rollback: it can lose
+  canonical checkout/lifecycle evidence and exists only for explicitly commanded disaster
+  recovery followed by complete provider reconciliation.
 - Listener application regression: roll back only the isolated Listener to
   `fcdde379` if contract-compatible; otherwise disable Listener and roll forward.
 - Weekly quota is forward-only. Never restore the retired daily-window/welcome

--- a/docs/plans/EARLY_BIRDS.md
+++ b/docs/plans/EARLY_BIRDS.md
@@ -7,12 +7,13 @@
 > real charges and every audio encoding/content/signature choice still require the
 > explicit release and audio gates in this document.
 
-> **Current launch memory (2026-08-12):** the public Listener candidate runs exact
+> **Current launch memory (2026-08-13):** the public Listener candidate runs exact
 > SHA `4ac408f4bc43cab85f058fc3d39aa2a2b4b4207a`; canonical payment authority runs
-> `8e10f16fe3471a097021f7f1ee41eb8f88f4f154`; the isolated mail sidecar runs
+> `b1038ddb579817e39add567c5b7b055e2f716095`; the isolated mail sidecar runs
 > `456ece2b38e203a2d12c54864115e03ebaa1a89c`. PayPal Sandbox and Mercado Pago
-> TEST lifecycles are accepted. Live providers, new sales and public checkout
-> remain OFF. See `docs/operations/LISTENER_LAUNCH_NOW.md` for the few remaining
+> TEST lifecycles are accepted. One PayPal Live approval intent exists without a
+> subscription or charge; new sales and public checkout remain OFF while its Live
+> lifecycle ingestion stays ON. See `docs/operations/LISTENER_LAUNCH_NOW.md` for the few remaining
 > human/external gates.
 
 Reviewed inputs: `.hermes/plans/2026-08-05_beacon-founders-mvp.md` and
@@ -493,8 +494,9 @@ The webapp vendors byte-exact copies of the canonical backend contracts under
   checkout command/result. It exposes no provider subscription ID, fixes
   `environment=live`, keeps payer email transient and uses a separate new-sales
   gate from provider lifecycle. The deployed authority runtime
-  `8e10f16fe3471a097021f7f1ee41eb8f88f4f154` is CI-green and includes canonical
-  cancellation/reactivation plus paid-lifecycle metrics. The Listener Live
+  `b1038ddb579817e39add567c5b7b055e2f716095` is CI-green, includes canonical
+  cancellation/reactivation, paid-lifecycle metrics and reviewed Mercado Pago adverse-event
+  hardening, and is the minimum authority binary after any Live checkout attempt. The Listener Live
   surface and exact webhook ingress remain disabled by default;
   see `docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md`.
   This authority release also provides a read-only, redacted Live-provider
@@ -744,6 +746,10 @@ its own explicit approval.
   incident response stops Listener/uses the kill switch and rolls forward a
   repair. It never restores the retired daily-schedule or welcome-access
   authorization rules.
+- After the first Live checkout attempt, payment-authority rollback is also forward-only:
+  `b1038ddb` is the minimum supported binary. Stop new sales with flags, keep provider lifecycle
+  ingestion and the current database, reconcile, and roll forward. Never use a pre-cutover database
+  restore as routine rollback.
 - No secret, provider token, raw webhook payload with PII or customer record is
   committed or logged publicly.
 - No synthetic test writes to real participant or payment data.


### PR DESCRIPTION
## Outcome

Closes the post-Live rollback safety gap found during the supervised commerce preflight.

- establishes `b1038ddb` as the minimum authority binary after any Live checkout attempt
- forbids routine restoration of the pre-cutover database once provider state may exist
- uses new-sales flags OFF + lifecycle/reconciliation + same database + roll-forward
- retains `fcdde379` only as the bounded contract-compatible Listener UI rollback
- records the current PayPal approval intent as pending with no subscription or charge

## Verification

- `npm run contract:early-birds:verify`
- `npm run contract:commerce:verify`
- `git diff --check`

No runtime, deploy, event, LiveKit, or audio surface changes.