### PR TITLE
feat(listener): identify initial merchant in terms

### DIFF
--- a/src/lib/early-birds/__tests__/copy.test.ts
+++ b/src/lib/early-birds/__tests__/copy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { earlyBirdCopy, earlyBirdHomeCopy } from '@/lib/early-birds/copy';
+import { earlyBirdCopy, earlyBirdHomeCopy, earlyBirdLegalCopy } from '@/lib/early-birds/copy';
 
 describe('EarlyBirds interface copy', () => {
     it.each([
@@ -14,5 +14,18 @@ describe('EarlyBirds interface copy', () => {
         expect(visibleCopy).not.toMatch(
             /record(?:ed|ing)?|grabaci[oó]n|grabad[oa]|live instrument|instrumento en vivo/i,
         );
+    });
+
+    it('identifies the initial merchant and billing contact in both public terms locales', () => {
+        const spanish = earlyBirdLegalCopy.es.sections.flatMap((section) => section.paragraphs).join(' ');
+        const english = earlyBirdLegalCopy.en.sections.flatMap((section) => section.paragraphs).join(' ');
+
+        for (const visibleCopy of [spanish, english]) {
+            expect(visibleCopy).toContain('Nicolás Echaniz');
+            expect(visibleCopy).toContain('nicoechaniz@harmonicbeacon.com');
+            expect(visibleCopy).toMatch(/merchant of record/i);
+            expect(visibleCopy).toMatch(/PayPal/);
+            expect(visibleCopy).toMatch(/Mercado Pago/);
+        }
     });
 });

--- a/src/lib/early-birds/copy.ts
+++ b/src/lib/early-birds/copy.ts
@@ -169,11 +169,12 @@ export const earlyBirdLegalCopy = {
         back: 'Volver a Listener',
         eyebrow: 'HARMONIC BEACON · FOUNDING LISTENER',
         title: 'Condiciones y privacidad del servicio Listener',
-        updated: 'Versión de lanzamiento · 12 de agosto de 2026',
+        updated: 'Versión de lanzamiento · 13 de agosto de 2026',
         sections: [
             {
                 title: 'Oferta',
                 paragraphs: [
+                    'El vendedor inicial y merchant of record es Nicolás Echaniz, operando Harmonic Beacon desde Argentina. PayPal o Mercado Pago muestran el descriptor aplicable antes de confirmar. Para soporte de facturación o solicitar el comprobante fiscal aplicable escribe a nicoechaniz@harmonicbeacon.com.',
                     'Founding Listener cuesta USD 5 por mes, con cobro recurrente y sin período de prueba. Mercado Pago puede cobrar el equivalente en ARS informado por el checkout. El acceso se activa únicamente después de la confirmación canónica del proveedor.',
                     'El precio Founder se conserva mientras el servicio permanezca ininterrumpido, incluyendo el período ya pagado o de gracia aprobado. Cuando el servicio termina, también terminan la categoría y el precio Founder.',
                 ],
@@ -205,11 +206,12 @@ export const earlyBirdLegalCopy = {
         back: 'Back to Listener',
         eyebrow: 'HARMONIC BEACON · FOUNDING LISTENER',
         title: 'Listener service terms and privacy',
-        updated: 'Launch version · August 12, 2026',
+        updated: 'Launch version · August 13, 2026',
         sections: [
             {
                 title: 'Offer',
                 paragraphs: [
+                    'The initial seller and merchant of record is Nicolás Echaniz, operating Harmonic Beacon from Argentina. PayPal or Mercado Pago shows the applicable descriptor before confirmation. For billing support or to request the applicable tax receipt, contact nicoechaniz@harmonicbeacon.com.',
                     'Founding Listener costs USD 5 per month, billed recurrently with no trial. Mercado Pago may charge the ARS equivalent shown at checkout. Access starts only after canonical provider confirmation.',
                     'Founder pricing continues while service remains uninterrupted, including an already-paid period or approved grace. When service ends, Founder status and pricing end as well.',
                 ],


### PR DESCRIPTION
## Outcome

Makes the public ES/EN terms identify the initial seller/merchant of record and billing/tax-receipt contact before any public checkout is enabled.

## Product truth

- initial merchant: Nicolás Echaniz, operating Harmonic Beacon from Argentina
- PayPal/Mercado Pago show their applicable descriptor before confirmation
- billing/tax-receipt support: nicoechaniz@harmonicbeacon.com
- no invented refund window, tax category, invoice type, or provider identifier

## Gates

- focused copy tests: 5/5
- focused ESLint
- TypeScript
- diff check

Listener-only copy; no provider flags, event/audio code or runtime change.