### PR TITLE
fix(listener): alert only on enabled test sales

### DIFF
--- a/ops/early-birds/prometheus/alerts.yml
+++ b/ops/early-birds/prometheus/alerts.yml
@@ -29,10 +29,10 @@ groups:
         labels: { severity: critical, service: listener-payments }
         annotations: { summary: "Listener membership authority is unreachable", runbook: "listener-paid-authority" }
       - alert: ListenerSandboxProviderUnavailable
-        expr: pmp_listener_provider_ready{environment=~"sandbox|test"} == 0
+        expr: pmp_listener_new_sales_enabled{environment=~"sandbox|test"} == 1 and on(provider, environment) pmp_listener_provider_ready{environment=~"sandbox|test"} == 0
         for: 5m
         labels: { severity: warning, service: listener-payments }
-        annotations: { summary: "A Listener sandbox/test provider is unavailable", runbook: "listener-paid-provider" }
+        annotations: { summary: "Sandbox/test sales are enabled while a Listener provider is unavailable", runbook: "listener-paid-provider" }
       - alert: ListenerLiveProviderUnavailableDuringSales
         expr: pmp_listener_new_sales_enabled{environment="live"} == 1 and on(provider, environment) pmp_listener_provider_ready{environment="live"} == 0
         for: 2m

--- a/ops/early-birds/test/config.test.mjs
+++ b/ops/early-birds/test/config.test.mjs
@@ -105,6 +105,17 @@ test('alerts on paid authority failures without account or provider identifiers'
   assert.doesNotMatch(alerts, /account_id|email|subscription_id|approval_url/);
 });
 
+test('alerts on unavailable payment providers only while their sales lane is enabled', async () => {
+  const alerts = await read('prometheus/alerts.yml');
+  const sandboxRule = alerts.slice(
+    alerts.indexOf('- alert: ListenerSandboxProviderUnavailable'),
+    alerts.indexOf('- alert: ListenerLiveProviderUnavailableDuringSales'),
+  );
+  assert.match(sandboxRule, /pmp_listener_new_sales_enabled\{environment=~"sandbox\|test"\} == 1/);
+  assert.match(sandboxRule, /pmp_listener_provider_ready\{environment=~"sandbox\|test"\} == 0/);
+  assert.match(sandboxRule, /on\(provider, environment\)/);
+});
+
 test('routes warnings hourly and critical alerts immediately every fifteen minutes', async () => {
   const alertmanager = await read('alertmanager/alertmanager.yml.tmpl');
   assert.match(alertmanager, /group_wait: 5m[\s\S]*repeat_interval: 1h/);


### PR DESCRIPTION
## Summary
- alert on Sandbox/TEST provider readiness only while its sales lane is enabled
- keep Live fail-closed readiness alert unchanged
- add a regression contract for the PromQL join

This removes false FIRING notifications when a test provider is intentionally disabled. No Listener runtime, event, audio, provider credentials, or sales flags change.

## Verification
- `node --test ops/early-birds/test/config.test.mjs`
- `promtool check rules` (34 rules)
- `git diff --check`