### PR TITLE
fix(deps): update nanoid advisory floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8108,9 +8108,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Outcome

Restore the aggregate Listener PR dependency gate after GHSA-2v37-7h3g-55p8 raised the safe nanoid floor from 3.3.17 to 3.3.18.

## Change

- update only the transitive `nanoid` lockfile entry to 3.3.18;
- no source, runtime, event, audio, payment, schema, or provider flag change.

## Evidence

- `npm ci --ignore-scripts`
- all three production `npm audit --omit=dev --audit-level=high` gates
- full ESLint
- production Next build + TypeScript
- `git diff --check`
