### PR TITLE
docs(listener): reconcile Live launch checkpoint

### DIFF
--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -58,19 +58,20 @@ rules at 20h/24h; the runtime smoke accepted and resolved one synthetic request 
 returned the open queue and alerts to zero without exporting PII.
 
 The exact isolated payment-authority image is
-`b1038ddb579817e39add567c5b7b055e2f716095`. It includes the reviewed Mercado Pago adverse-event
-hardening from backend PR #80. API and worker are healthy, Alembic is at head `7b4c1e9a2d60`, and
+`4e5b208e902969285c8f68067f7fd13b7e2eb68d`. It includes the reviewed Mercado Pago adverse-event
+hardening from backend PR #80 and missing-PayPal-approval recovery from backend PR #82. API and
+worker are healthy, Alembic is at head `7b4c1e9a2d60`, and
 the exact public webhook routes fail closed while Live is disabled. Productive PayPal and Mercado
 Pago credentials are installed only in the root-owned runtime store. Read-only preflights verified
 the PayPal Live catalog/webhook and Mercado Pago productive merchant/webhook configuration with
-new sales forced OFF. On 2026-08-13, a supervised PayPal Live approval intent was created for the
-USD 5 offer; it is awaiting approval by a buyer account different from the merchant, and created
-no subscription or charge. New sales were immediately returned to OFF while PayPal Live lifecycle
-ingestion remains ON. The former authority image
-`8e10f16fe3471a097021f7f1ee41eb8f88f4f154` and protected pre-deploy backup
-`/var/backups/harmonic-beacon/earlybirds-authority-pre-b1038ddb579817e39add567c5b7b055e2f716095.sql.gz`
-are retained only as pre-Live forensic/disaster-recovery artifacts; they are no longer routine
-rollback targets.
+new sales forced OFF. On 2026-08-15 the abandoned supervised PayPal approval was verified missing
+through the official provider API and retired with the application operator. The repair produced no
+subscription, charge, Founder continuity, Purchase or direct SQL mutation; the request is
+tombstoned and outstanding PayPal Live bindings are zero. New sales remain OFF while PayPal Live
+lifecycle/reconciliation stays ready. The exact pre-deploy backup
+`/var/backups/harmonic-beacon/earlybirds-authority-pre-4e5b208-20260815T090209Z.dump`
+and older images are retained only as forensic/disaster-recovery artifacts; they are not routine
+post-transaction rollback targets.
 
 ## Independent switches
 
@@ -136,15 +137,16 @@ converted back into a reversible action.
 
 - Checkout/provider incident: turn off both app checkout flags and the authority new-sales flag.
   Existing lifecycle workers and webhooks stay running.
-- Live authority floor: after the first Live checkout attempt, provider binding or event,
-  `b1038ddb579817e39add567c5b7b055e2f716095` is the minimum supported authority binary. Do not run
-  `8e10f16fe3471a097021f7f1ee41eb8f88f4f154` against the current database and do not routinely
-  restore the pre-`b1038` database backup. The older binary predates required Mercado Pago
-  adverse-event hardening and a database restore could discard canonical checkout/lifecycle
-  evidence.
+- Live authority floor: after any new Live checkout attempt, provider binding or event,
+  `4e5b208e902969285c8f68067f7fd13b7e2eb68d` is the minimum supported authority binary. Do not run
+  `b1038ddb579817e39add567c5b7b055e2f716095` or
+  `8e10f16fe3471a097021f7f1ee41eb8f88f4f154` after a new approval exists: the first predates
+  safe provider-404 retirement and the second also predates required Mercado Pago adverse-event
+  hardening. Do not routinely restore a pre-cutover database backup; it could discard canonical
+  checkout/lifecycle evidence.
 - Authority regression after Live cutover: keep the current database, turn new sales OFF, retain
   the affected provider's Live lifecycle flag so signed webhooks, reconciliation, cancellation and
-  existing access continue, then deploy a repaired `b1038`-compatible-or-newer image and reconcile
+  existing access continue, then deploy a repaired `4e5b208`-compatible-or-newer image and reconcile
   from the provider. Recovery is roll-forward. A pre-cutover database restore is reserved for an
   explicitly commanded disaster recovery with both providers frozen and a complete provider-led
   reconciliation plan; it is not an ordinary rollback.

--- a/docs/operations/LISTENER_LAUNCH_NOW.md
+++ b/docs/operations/LISTENER_LAUNCH_NOW.md
@@ -1,6 +1,6 @@
 # Listener launch — current state
 
-Last reconciled: 2026-08-13
+Last reconciled: 2026-08-15
 
 This is the compact operational memory for Founding Listeners. Detailed evidence
 and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
@@ -12,31 +12,35 @@ and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
 - Listener image/SHA: `acc90ba35fea52f63ef18337e3a555ef637c552f`
 - Previous contract-compatible Listener application image: `0a475717d45d32cec38afdb8fc35fb772a994017`
 - Withdrawal operator sidecar image/SHA: `0a475717d45d32cec38afdb8fc35fb772a994017`
-- Canonical payment authority: `b1038ddb579817e39add567c5b7b055e2f716095`
-- Minimum authority after any Live checkout attempt: `b1038ddb579817e39add567c5b7b055e2f716095`
+- Canonical payment authority: `4e5b208e902969285c8f68067f7fd13b7e2eb68d`
+- Minimum authority after any new Live checkout attempt: `4e5b208e902969285c8f68067f7fd13b7e2eb68d`
 - Listener mail sidecar: `456ece2b38e203a2d12c54864115e03ebaa1a89c`
 - Weekly Free: three hours per server-owned seven-day cycle
 - Founding Listener: USD 5/month while service remains uninterrupted
 - Free For All: OFF
 - PayPal Live checkout: OFF
 - Mercado Pago Live checkout: OFF
-- PayPal Live lifecycle: ON with new sales OFF after creating one supervised approval intent
+- PayPal Live lifecycle/read-only reconciliation: ready with new sales OFF and no outstanding intent
 - Mercado Pago Live provider: OFF
 - Mercado Pago TEST lifecycle: ready; global new sales OFF
 - Public consumer withdrawal/service cancellation: ON; no login, immediate opaque receipt
 - Public sales: OFF; only the explicitly supervised Live lifecycle is authorized
 
-The authority now includes the reviewed adverse-event hardening and a read-only
-Live-provider preflight. The deployed API/worker are healthy at exact revision
-`b1038ddb`; Alembic is at `7b4c1e9a2d60`. Productive credentials are installed
+The authority now includes the reviewed adverse-event hardening, typed recovery
+for missing PayPal approvals and a read-only Live-provider preflight. The
+deployed API/worker are healthy at exact revision `4e5b208`; Alembic is at
+`7b4c1e9a2d60`. Productive credentials are installed
 root-only. With new sales forced OFF, PayPal verified its exact Live product,
 USD 5 plan and webhook event set; Mercado Pago verified its productive MLA
 merchant and webhook configuration. Neither preflight creates checkout,
-subscription, binding or payment. A supervised PayPal Live approval intent was subsequently
-created for the exact USD 5 offer and is awaiting a buyer account different from the merchant; it
-created no subscription or charge. Global new sales and both public Listener checkout flags are
-OFF. PayPal Live lifecycle ingestion remains ON so its callback, signed webhook, reconciliation
-and cancellation path stay available. Mercado Pago remains on TEST with Live OFF.
+subscription, binding or payment. The one abandoned PayPal Live approval later
+returned canonical provider 404 and was retired with the bounded application
+operator: no charge, provider subscription, Founder continuity or Purchase was
+created, the old approval cannot replay and no outstanding PayPal binding
+remains. Global new sales and both public Listener checkout flags are OFF.
+PayPal Live lifecycle ingestion remains ready so signed webhooks,
+reconciliation and cancellation stay available. Mercado Pago remains on TEST
+with Live OFF.
 
 PayPal Sandbox has passed activation, pending cancellation, reactivation and
 terminal refund. Mercado Pago TEST has passed checkout, activation, pause,
@@ -59,9 +63,10 @@ backup. Only Listener and the disposable staging workbench were recreated.
    acceptance. The public no-login withdrawal and service-cancellation paths,
    dedicated secret, migration, private operator, metrics and 20h/24h alerts
    are deployed and smoke-tested.
-4. Complete the already-created PayPal approval intent with a non-merchant buyer, then execute its
-   supervised activation, cancellation and refund evidence. Execute the corresponding supervised
-   Mercado Pago lifecycle separately.
+4. With a new explicit approval, create a fresh PayPal checkout for a
+   non-merchant buyer and execute supervised activation, cancellation and
+   refund evidence. Execute the corresponding supervised Mercado Pago Live
+   lifecycle separately.
 5. Confirm Founder activation, terminal Free fallback, metrics, alerts and the
    absence of PII/secret leakage against those Live transactions.
 6. Obtain separate explicit approvals for merge to `main` and public checkout.
@@ -78,10 +83,11 @@ without explicit approval.
 
 - Commerce incident: switch OFF Listener checkout flags and authority new-sales;
   keep webhooks, reconciliation, cancellation and existing access running.
-- Authority application regression after any Live checkout attempt: keep the current database,
+- Authority application regression after any new Live checkout attempt: keep the current database,
   keep the affected provider's Live lifecycle flag ON, keep new sales OFF and roll forward with
-  `b1038ddb` or a newer contract-compatible authority. Never deploy `8e10f16` against the current
-  database. Never use the protected pre-`b1038` database backup as a routine rollback: it can lose
+  `4e5b208` or a newer contract-compatible authority. Never deploy `b1038ddb` or `8e10f16` after a
+  new approval has been created: `b1038ddb` predates safe provider-404 retirement and `8e10f16`
+  predates adverse-webhook hardening. Never use a protected pre-cutover backup as a routine rollback: it can lose
   canonical checkout/lifecycle evidence and exists only for explicitly commanded disaster
   recovery followed by complete provider reconciliation.
 - Listener application regression: roll back only the isolated Listener to
@@ -105,5 +111,5 @@ must not claim that Harmonic Beacon has no payment or email processing: the
 Sandbox/TEST subscription lanes and Gmail magic-link delivery are already real
 pre-release processors. Equally, copy must not claim public Live billing is
 active: productive credentials are installed and verified, PayPal Live
-lifecycle ingestion is ON only for the supervised pending intent, and authority
-new sales, real charges and both public checkout flags remain OFF.
+lifecycle/reconciliation is ready with no outstanding intent, and authority new
+sales, real charges and both public checkout flags remain OFF.

--- a/docs/plans/EARLY_BIRDS.md
+++ b/docs/plans/EARLY_BIRDS.md
@@ -7,14 +7,15 @@
 > real charges and every audio encoding/content/signature choice still require the
 > explicit release and audio gates in this document.
 
-> **Current launch memory (2026-08-13):** the public Listener candidate runs exact
+> **Current launch memory (2026-08-15):** the public Listener candidate runs exact
 > SHA `acc90ba35fea52f63ef18337e3a555ef637c552f`; the private withdrawal operator remains pinned at
 > `0a475717d45d32cec38afdb8fc35fb772a994017`; canonical payment authority runs
-> `b1038ddb579817e39add567c5b7b055e2f716095`; the isolated mail sidecar runs
+> `4e5b208e902969285c8f68067f7fd13b7e2eb68d`; the isolated mail sidecar runs
 > `456ece2b38e203a2d12c54864115e03ebaa1a89c`. PayPal Sandbox and Mercado Pago
-> TEST lifecycles are accepted. One PayPal Live approval intent exists without a
-> subscription or charge; new sales and public checkout remain OFF while its Live
-> lifecycle ingestion stays ON. The public no-login withdrawal and service-cancellation paths,
+> TEST lifecycles are accepted. The abandoned PayPal Live approval was retired
+> after canonical provider 404 evidence without a charge, subscription or
+> Founder state; no outstanding binding remains. New sales and public checkout
+> remain OFF while Live lifecycle/reconciliation stays ready. The public no-login withdrawal and service-cancellation paths,
 > private queue and 20h/24h alerts are deployed and smoke-tested. See
 > `docs/operations/LISTENER_LAUNCH_NOW.md` for the few remaining human/external gates.
 
@@ -496,14 +497,16 @@ The webapp vendors byte-exact copies of the canonical backend contracts under
   checkout command/result. It exposes no provider subscription ID, fixes
   `environment=live`, keeps payer email transient and uses a separate new-sales
   gate from provider lifecycle. The deployed authority runtime
-  `b1038ddb579817e39add567c5b7b055e2f716095` is CI-green, includes canonical
-  cancellation/reactivation, paid-lifecycle metrics and reviewed Mercado Pago adverse-event
-  hardening, and is the minimum authority binary after any Live checkout attempt. The Listener Live
+  `4e5b208e902969285c8f68067f7fd13b7e2eb68d` is CI-green, includes canonical
+  cancellation/reactivation, paid-lifecycle metrics, reviewed Mercado Pago adverse-event
+  hardening and bounded missing-PayPal-approval recovery, and is the minimum authority binary after
+  any new Live checkout attempt. The Listener Live
   surface and exact webhook ingress remain disabled by default;
   see `docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md`.
   This authority release also provides a read-only, redacted Live-provider
   preflight for exact PayPal catalog/webhook and Mercado Pago merchant checks;
-  productive credentials remain absent and all Live flags remain OFF.
+  productive credentials are installed root-only and verified read-only; public
+  checkout and global new sales remain OFF.
 
 ## 11. Fast Forward development lane
 
@@ -752,8 +755,8 @@ its own explicit approval.
   incident response stops Listener/uses the kill switch and rolls forward a
   repair. It never restores the retired daily-schedule or welcome-access
   authorization rules.
-- After the first Live checkout attempt, payment-authority rollback is also forward-only:
-  `b1038ddb` is the minimum supported binary. Stop new sales with flags, keep provider lifecycle
+- After any new Live checkout attempt, payment-authority rollback is also forward-only:
+  `4e5b208` is the minimum supported binary. Stop new sales with flags, keep provider lifecycle
   ingestion and the current database, reconcile, and roll forward. Never use a pre-cutover database
   restore as routine rollback.
 - No secret, provider token, raw webhook payload with PII or customer record is


### PR DESCRIPTION
## Outcome

Reconcile the canonical Listener launch memory after retiring the abandoned PayPal Live approval and deploying the repaired authority.

## Current truth

- Listener remains exact `acc90ba35fea52f63ef18337e3a555ef637c552f`.
- Authority is exact `4e5b208e902969285c8f68067f7fd13b7e2eb68d`.
- The abandoned approval produced no charge, subscription, Founder or Purchase and no outstanding binding remains.
- New sales and both public Live checkout flags remain OFF.
- Future Live recovery uses the current database and `4e5b208`-or-newer roll-forward.
- No event, LiveKit, Ticket Tailor, audio or `live.harmonicbeacon.com` surface changed.

## Evidence

- EarlyBird contracts byte-exact: 33 files.
- Commerce contract fixtures green.
- `git diff --check`.
