### PR TITLE
fix(listener): keep legal actions clear on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2139,9 +2139,15 @@ body {
 
 @media (max-width: 640px) {
   .listener-consumer-request-links {
-    left: 0.75rem;
-    right: 0.75rem;
-    bottom: max(0.75rem, env(safe-area-inset-bottom));
+    position: static;
+    width: auto;
+    max-width: none;
+    margin: 0 0.75rem;
+    padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+  }
+
+  .listener-consumer-request-links .listener-withdrawal-link {
+    width: 100%;
     max-width: none;
   }
 }

--- a/src/app/listener/layout.tsx
+++ b/src/app/listener/layout.tsx
@@ -6,11 +6,11 @@ export default function ListenerLayout({ children }: { children: React.ReactNode
     const withdrawalAvailable = listenerWithdrawalPublicConfiguration() !== null;
     return (
         <EarlyBirdLayout>
+            {children}
             {withdrawalAvailable ? <div className="listener-consumer-request-links" aria-label="Consumer service actions">
                 <ConsumerWithdrawalLink />
                 <ConsumerWithdrawalLink kind="SERVICE_CANCELLATION" />
             </div> : null}
-            {children}
         </EarlyBirdLayout>
     );
 }

--- a/src/components/early-birds/__tests__/ConsumerWithdrawalLink.test.tsx
+++ b/src/components/early-birds/__tests__/ConsumerWithdrawalLink.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LocaleProvider } from '@/context/LocaleContext';
@@ -31,5 +33,19 @@ describe('prominent consumer-withdrawal entry', () => {
         usePathname.mockReturnValue('/listener/withdrawal');
         render(<LocaleProvider initialLocale="es"><ConsumerWithdrawalLink /></LocaleProvider>);
         expect(screen.queryByRole('link')).toBeNull();
+    });
+
+    it('keeps mobile consumer actions in document flow after Listener content', () => {
+        const root = process.cwd();
+        const layout = readFileSync(join(root, 'src/app/listener/layout.tsx'), 'utf8');
+        const css = readFileSync(join(root, 'src/app/globals.css'), 'utf8');
+
+        expect(layout.indexOf('{children}')).toBeGreaterThan(-1);
+        expect(layout.indexOf('{children}')).toBeLessThan(
+            layout.indexOf('className="listener-consumer-request-links"'),
+        );
+        expect(css).toMatch(
+            /@media \(max-width: 640px\)[\s\S]*?\.listener-consumer-request-links\s*\{[\s\S]*?position:\s*static;/,
+        );
     });
 });


### PR DESCRIPTION
## Outcome

Keeps the two mandatory consumer-action links prominent without obscuring the Listener hero or primary CTA on narrow screens. Desktop remains fixed; mobile places the actions in normal document flow after Listener content.

## Evidence

- focused component regression: 5/5
- TypeScript: green
- focused ESLint: green
- production build: green
- `git diff --check`: green

## Isolation

No checkout, provider, membership, event, LiveKit, media, audio, or deployment behavior changes.