### PR TITLE
fix(listener): accept pinned withdrawal operator in release lane

### DIFF
--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -44,12 +44,19 @@ checks and is recoverable in Google Cloud for 30 days for administrative recover
 the exposed secret from an environment backup.
 
 The exact public Listener image is
-`acc90ba35fea52f63ef18337e3a555ef637c552f`. Health and readiness attest that SHA. The same exact
-image runs the staging-only Live workbench. The no-port withdrawal operator remains independently
-pinned at `0a475717d45d32cec38afdb8fc35fb772a994017`. That previous contract-compatible Listener image remains available as
-an application-only rollback target; the operator and current database must remain running so legal
+`5d1073f598272d81a14a64d55a4220c2c13e9a74`. Health attests that SHA. The dormant staging-only
+Live workbench remains on `acc90ba35fea52f63ef18337e3a555ef637c552f`. The no-port withdrawal
+operator remains independently pinned at `0a475717d45d32cec38afdb8fc35fb772a994017`.
+`acc90ba35fea52f63ef18337e3a555ef637c552f` remains available as the previous
+contract-compatible application-only rollback target; the operator and current database must remain running so legal
 requests already received can still be processed. The weekly-quota database policy itself is
 forward-only.
+
+The `5d1073f` release keeps the mandatory consumer actions fixed on desktop but places them after
+Listener content on screens up to 640 px, so they remain prominent without obscuring the hero or
+primary entry action. Real-browser ES/EN checks at 390x844 confirmed the actions in document flow;
+the desktop check retained the fixed bottom-right placement. No checkout, membership, provider,
+event, LiveKit, media or audio behavior changed.
 
 The public no-login `BOTÓN DE ARREPENTIMIENTO` and `BOTÓN DE BAJA DE SERVICIO` are deployed with an
 immediate opaque receipt, bounded durable queue and no automatic provider action. Root-only timers

--- a/docs/operations/LISTENER_LAUNCH_NOW.md
+++ b/docs/operations/LISTENER_LAUNCH_NOW.md
@@ -9,8 +9,8 @@ and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
 ## Exact deployed state
 
 - Public candidate: `https://listen.harmonicbeacon.com/`
-- Listener image/SHA: `acc90ba35fea52f63ef18337e3a555ef637c552f`
-- Previous contract-compatible Listener application image: `0a475717d45d32cec38afdb8fc35fb772a994017`
+- Listener image/SHA: `5d1073f598272d81a14a64d55a4220c2c13e9a74`
+- Previous contract-compatible Listener application image: `acc90ba35fea52f63ef18337e3a555ef637c552f`
 - Withdrawal operator sidecar image/SHA: `0a475717d45d32cec38afdb8fc35fb772a994017`
 - Canonical payment authority: `4e5b208e902969285c8f68067f7fd13b7e2eb68d`
 - Minimum authority after any new Live checkout attempt: `4e5b208e902969285c8f68067f7fd13b7e2eb68d`
@@ -25,6 +25,7 @@ and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
 - Mercado Pago Live provider: OFF
 - Mercado Pago TEST lifecycle: ready; global new sales OFF
 - Public consumer withdrawal/service cancellation: ON; no login, immediate opaque receipt
+- Mobile consumer actions: in document flow after Listener content; desktop remains fixed
 - Public sales: OFF; only the explicitly supervised Live lifecycle is authorized
 
 The authority now includes the reviewed adverse-event hardening, typed recovery

--- a/docs/plans/EARLY_BIRDS.md
+++ b/docs/plans/EARLY_BIRDS.md
@@ -8,7 +8,9 @@
 > explicit release and audio gates in this document.
 
 > **Current launch memory (2026-08-15):** the public Listener candidate runs exact
-> SHA `acc90ba35fea52f63ef18337e3a555ef637c552f`; the private withdrawal operator remains pinned at
+> SHA `5d1073f598272d81a14a64d55a4220c2c13e9a74`; the previous contract-compatible Listener
+> image and dormant private Live workbench remain on `acc90ba35fea52f63ef18337e3a555ef637c552f`;
+> the private withdrawal operator remains pinned at
 > `0a475717d45d32cec38afdb8fc35fb772a994017`; canonical payment authority runs
 > `4e5b208e902969285c8f68067f7fd13b7e2eb68d`; the isolated mail sidecar runs
 > `456ece2b38e203a2d12c54864115e03ebaa1a89c`. PayPal Sandbox and Mercado Pago

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -206,9 +206,29 @@ test('preview lifecycle pins and preserves the private withdrawal operator', asy
     '-c', '. "$1"; require_withdrawal_operator_image "$2"', 'sh',
     path.join(repositoryRoot, 'scripts/early-birds-preview/lib.sh'), missingTagEnv,
   ], { encoding: 'utf8' });
-  await fs.rm(temporary, { recursive: true, force: true });
   assert.equal(missingTag.status, 2);
   assert.match(missingTag.stderr, /EARLYBIRDS_WITHDRAWAL_OPERATOR_IMAGE_TAG is required/);
+
+  const exactSha = 'cccccccccccccccccccccccccccccccccccccccc';
+  const exactRuntimeEnv = path.join(temporary, 'exact-runtime.env');
+  const fakeBin = path.join(temporary, 'bin');
+  await fs.mkdir(fakeBin);
+  await fs.writeFile(exactRuntimeEnv, [
+    'EARLYBIRDS_PREVIEW_ENV=synthetic',
+    `EARLYBIRDS_WITHDRAWAL_OPERATOR_IMAGE_TAG=${exactSha}`,
+    `EARLYBIRDS_WITHDRAWAL_OPERATOR_GIT_SHA=${exactSha}`,
+    '',
+  ].join('\n'));
+  await fs.writeFile(path.join(fakeBin, 'docker'), `#!/bin/sh\nprintf '%s\\n' 'BEACON_GIT_SHA=${exactSha}'\n`, { mode: 0o755 });
+  const exactRuntime = spawnSync('sh', [
+    '-c', '. "$1"; require_withdrawal_operator_image "$2"', 'sh',
+    path.join(repositoryRoot, 'scripts/early-birds-preview/lib.sh'), exactRuntimeEnv,
+  ], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
+  });
+  await fs.rm(temporary, { recursive: true, force: true });
+  assert.equal(exactRuntime.status, 0, exactRuntime.stderr);
 });
 
 test('withdrawal edge is exact, private-by-default and isolated from non-Listener vhosts', async () => {

--- a/scripts/early-birds-preview/lib.sh
+++ b/scripts/early-birds-preview/lib.sh
@@ -44,9 +44,10 @@ require_withdrawal_operator_image() {
   operator_tag=$(preview_env_value EARLYBIRDS_WITHDRAWAL_OPERATOR_IMAGE_TAG "$operator_env_file")
   operator_expected_sha=$(preview_env_value EARLYBIRDS_WITHDRAWAL_OPERATOR_GIT_SHA "$operator_env_file")
   operator_environment=$(preview_env_value EARLYBIRDS_PREVIEW_ENV "$operator_env_file")
-  if test "$operator_environment" = synthetic; then
-    test "$operator_tag" = synthetic || preview_fail 'synthetic withdrawal operator image tag must be synthetic'
-    test "$operator_expected_sha" = synthetic-preview || preview_fail 'synthetic withdrawal operator provenance must be synthetic-preview'
+  if test "$operator_environment" = synthetic && \
+     test "$operator_tag" = synthetic && \
+     test "$operator_expected_sha" = synthetic-preview; then
+    :
   else
     test -n "$operator_tag" || preview_fail 'EARLYBIRDS_WITHDRAWAL_OPERATOR_IMAGE_TAG is required'
     test -n "$operator_expected_sha" || preview_fail 'EARLYBIRDS_WITHDRAWAL_OPERATOR_GIT_SHA is required'


### PR DESCRIPTION
## Outcome

Repairs the ordinary Listener release helper discovered during the `5d1073f` rollout: an experimental preview environment may use either the explicit synthetic operator pair or an exact sha40 operator image/provenance pair. Mismatches remain fail-closed.

Also records the exact deployed Listener, rollback, independent operator and dormant workbench state plus ES/EN mobile legal-action acceptance.

## Evidence

- preview contract suite: 37/37
- shell syntax: green
- diff check: green
- deployed Listener `5d1073f`: health/readiness/HTTPS green
- 390x844 ES/EN real-browser checks: green
- desktop fixed placement: green

## Isolation

No provider, checkout, membership, event, LiveKit, media or audio behavior changes.