### PR TITLE
feat(listener): observe container continuity for external smoke

### DIFF
--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -96,9 +96,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 22 }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.13' }
       - run: npm test
       - run: npm run check
       - run: npm run validate
+      - run: npm --prefix ../../tools/early-birds-hls-load test
+      - run: npm --prefix ../../tools/early-birds-hls-load run check
 
   staging-preview:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 /e2e/.auth/
 /artifacts/load-test/
 /artifacts/early-birds-hls-load/
+__pycache__/
+*.py[cod]
 
 # next.js
 /.next/

--- a/docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
+++ b/docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
@@ -1,10 +1,11 @@
 # First external Listener HLS smoke
 
-**Status: code-complete but runtime-blocked. This smoke is not ready to
-execute.** The fail-closed harness, monitor, canary and policy are complete and
-tested, but the restart/OOM preflight blocker below is unresolved on `mona`:
-no supported per-container restart/OOM observer exists yet. No monitored smoke
-may run until one is implemented and verified (see "Runtime blocker" below).
+**Status: observer implementation prepared but not deployed; this smoke is not
+ready to execute.** The fail-closed harness, monitor, canary, policy and a
+reviewable fixed-target observer are complete and tested. The observer has not
+been installed or verified on `mona`, so its metrics remain absent and every
+network run still fails closed. Installation is a separate operational change
+requiring explicit review because the root-owned process reads Docker state.
 
 This is the only approved first network step for Listener capacity evidence. It
 drives exactly ten media-plane clients from one external host for a sixty-second
@@ -75,7 +76,8 @@ firing rules, evaluates the immediate stop thresholds from direct instant
 queries (host CPU, memory, root disk, egress, TCP retransmits, interface
 errors/drops, origin up and the deployed decoded canary) and maintains an
 in-process restart/OOM baseline for the exact isolated Listener and origin
-containers:
+roles. Its private Prometheus input comes from the reviewed root-owned observer,
+not cAdvisor:
 
 ```bash
 node tools/early-birds-hls-load/external-target-monitor.mjs \
@@ -92,22 +94,23 @@ monitor never infers Alertmanager health from Prometheus.
 
 ### Restart/OOM preflight blocker
 
-The restart/OOM baseline requires per-container `container_start_time_seconds`
-and `container_oom_events_total` series (currently expected from cAdvisor) for
-exactly
-`earlybirds-preview-listener-1` and `earlybirds-preview-beacon-stream-1`, each
-resolving to exactly one finite series. Before scheduling load, run the monitor
+The restart/OOM baseline requires the fixed
+`beacon_listener_container_*` observer series for roles `listener` and
+`origin`, plus one fresh observer health and epoch series. Every query must
+resolve to exactly one finite sample. Before scheduling load, run the monitor
 with `--once` (it probes twice: baseline plus verification) and confirm a
 `PASS` status with `restartBaselineEstablished: true`,
-`containerRestartsObserved: 0` and `oomEventsDelta: 0`. If those container
-metrics are absent or ambiguous, the monitor keeps reporting `FAIL` — that is
-the exact preflight blocker, and it is currently unresolved on `mona` (see
-"Runtime blocker" below). The monitor never silently claims zero restarts.
+`containerObserverFresh: true`, `containerRestartsObserved: 0` and
+`oomEventsDelta: 0`. If any observer metric is absent, stale, ambiguous,
+non-finite or reports failure, the monitor keeps reporting `FAIL`. The monitor
+never silently claims zero restarts.
 Because the baseline is
 in-process, a restarted monitor reports `FAIL` again until it has re-established
-and verified a fresh baseline, and the wrapper rejects such a status.
+and verified a fresh baseline. An observer epoch change or counter regression
+is latched as lost continuity and cannot pass until the monitor itself is
+restarted for a new operator-observed five-minute baseline.
 
-### Runtime blocker: no supported per-container restart/OOM observer
+### Root-owned fixed-target observer
 
 Verified on `mona` (read-only inspection): Prometheus currently exposes **only
 the root cgroup** for `container_start_time_seconds` and
@@ -132,34 +135,91 @@ reverted. **Recreating or restarting cAdvisor is not a fix and must never be
 treated as one** — with any mount propagation flag it keeps exposing only the
 root cgroup for these series.
 
-Therefore the ten-client smoke **cannot start** and stays blocked: the
-monitor's exact container queries return empty vectors, every probe reports
-`FAIL`, and the wrapper refuses the network run. There is no fallback — no
-Docker CLI/API read, no inferred zero, no weakened restart/OOM evidence. No
-monitored smoke may run until a supported, read-only per-container
-restart/OOM observer is implemented and verified on `mona`. Candidate options
-are listed in `ops/early-birds/runbook/README.md` ("Per-container restart/OOM
-observability blocker"); none may be implemented, restarted or deployed
-without explicit operational approval.
+The selected implementation is `scripts/listener_container_observer.py` plus
+the `harmonic-beacon-listener-container-observer` oneshot/timer units. It is
+not a cAdvisor replacement and changes no container. Every five seconds a
+root-owned, network-isolated host process performs one fixed `docker inspect`
+for exactly the isolated Listener and origin names, verifies their exact
+Compose project/service labels, maintains a root-only durable epoch/counter
+file and atomically exports fixed-role textfile metrics for node-exporter.
 
-Only after such an observer is deployed and verified, the operator confirms —
-through the loopback SSH tunnel — that each of the four exact queries returns
-exactly one finite series, not an empty vector:
+Threat boundary:
+
+- access to the Docker socket is root-equivalent, so the observer runs only as
+  a reviewed root-owned host unit; the socket is never mounted into Listener,
+  the load generator or another application container;
+- the program accepts no arguments, paths, names or labels from callers and
+  invokes only `/usr/bin/docker inspect` for two compiled-in container names;
+- the unit has private networking, `AF_UNIX` only, strict filesystem
+  protection and write access only to its metrics and state directories;
+- exported labels are the fixed allowlist `role="listener|origin"`; container
+  IDs, hostnames, image names, account data and Docker payloads never enter
+  Prometheus;
+- missing/stopped/wrong-label/duplicated targets, corrupt state, a backwards
+  counter or any inspect error best-effort exports observer failure and removes
+  the role series. If the output path itself is unavailable, the last success
+  becomes stale within fifteen seconds. Freshness and exact-cardinality queries
+  therefore fail closed;
+- start time, a cumulative replacement/restart counter and a cumulative OOM
+  counter are all observed. A fast OOM restart is still detected by start time
+  and restart count even if the terminal `OOMKilled` flag is no longer set.
+
+The code being merged does **not** authorize installation. Before any load, a
+host operator must review the exact release and explicitly install the script
+and units:
+
+```bash
+install -d -o root -g root -m 0755 /usr/local/libexec/harmonic-beacon
+install -d -o root -g root -m 0755 /var/lib/harmonic-beacon/metrics
+install -d -o root -g root -m 0700 \
+  /var/lib/harmonic-beacon/listener-container-observer
+install -o root -g root -m 0755 scripts/listener_container_observer.py \
+  /usr/local/libexec/harmonic-beacon/listener_container_observer.py
+install -o root -g root -m 0644 \
+  ops/early-birds/systemd/harmonic-beacon-listener-container-observer.{service,timer} \
+  /etc/systemd/system/
+systemd-analyze verify \
+  /etc/systemd/system/harmonic-beacon-listener-container-observer.{service,timer}
+systemctl daemon-reload
+systemctl start harmonic-beacon-listener-container-observer.service
+systemctl enable --now harmonic-beacon-listener-container-observer.timer
+```
+
+This operation must not restart Docker, cAdvisor, Listener, origin or any event
+service. Back up any pre-existing destination files first. Revocation is:
+
+```bash
+systemctl disable --now harmonic-beacon-listener-container-observer.timer
+rm -f /var/lib/harmonic-beacon/metrics/listener-container-observer.prom
+```
+
+Keep the root-only state file for audit unless its removal is separately
+approved. Removing it starts a new observer epoch and invalidates any active
+monitor baseline.
+
+Only after the observer is deployed and verified, the operator confirms through
+the loopback SSH tunnel that every exact query returns one finite series:
 
 ```bash
 for query in \
-  'container_start_time_seconds{name="earlybirds-preview-listener-1"}' \
-  'container_start_time_seconds{name="earlybirds-preview-beacon-stream-1"}' \
-  'container_oom_events_total{name="earlybirds-preview-listener-1"}' \
-  'container_oom_events_total{name="earlybirds-preview-beacon-stream-1"}'
+  'beacon_listener_container_observer_up' \
+  'time() - beacon_listener_container_observer_last_success_timestamp_seconds' \
+  'beacon_listener_container_observer_epoch_start_time_seconds' \
+  'beacon_listener_container_start_time_seconds{role="listener"}' \
+  'beacon_listener_container_start_time_seconds{role="origin"}' \
+  'beacon_listener_container_restart_events_total{role="listener"}' \
+  'beacon_listener_container_restart_events_total{role="origin"}' \
+  'beacon_listener_container_oom_events_total{role="listener"}' \
+  'beacon_listener_container_oom_events_total{role="origin"}'
 do
   curl -fsS 'http://127.0.0.1:19090/api/v1/query' --get --data-urlencode "query=$query"
 done
 ```
 
-Only then run the monitor `--once` preflight above. An empty vector at any
-step is a hard blocker: stop and resolve observability first; never treat
-missing series as zero restarts or zero OOM events.
+Require observer `up=1`, age between zero and fifteen seconds, then run the
+monitor `--once` preflight above. An empty or duplicate vector, changed epoch,
+negative age or counter regression is a hard blocker; never treat missing
+series as zero restarts or zero OOM events.
 
 ## Five-minute baseline
 

--- a/ops/early-birds/runbook/README.md
+++ b/ops/early-birds/runbook/README.md
@@ -97,12 +97,12 @@ projection is verified before the drill is considered complete.
 
 ## Per-container restart/OOM observability blocker
 
-Per-container `container_start_time_seconds` and `container_oom_events_total`
-series for the isolated Listener and origin containers are a hard prerequisite
-for the Listener external smoke (see
-`docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md`). On `mona`, Prometheus
-currently exposes only the root cgroup for these series and the exact
-per-container queries return empty vectors; cAdvisor logs that it cannot find
+Per-container start, restart and OOM continuity for the isolated Listener and
+origin is a hard prerequisite for the Listener external smoke (see
+`docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md`). The original cAdvisor-backed
+`container_start_time_seconds` and `container_oom_events_total` design remains
+unusable on `mona`: Prometheus exposes only the root cgroup and cAdvisor logs
+that it cannot find
 `/rootfs/var/lib/docker/image/overlayfs/layerdb/mounts/.../mount-id`.
 
 An earlier change blamed missing recursive slave propagation on the cAdvisor
@@ -116,34 +116,27 @@ cAdvisor is incompatible with Docker's containerd image store for these
 per-container series.
 
 **Recreating or restarting cAdvisor is not a fix and must never be proposed or
-treated as one** — no mount propagation flag changes this. No monitored smoke
-may run until a supported, read-only per-container restart/OOM observer is
-implemented and verified on `mona`. Until then the smoke stays
-runtime-blocked (its harness is code-complete and fails closed on the missing
-series).
+treated as one** — no mount propagation flag changes this.
 
-Candidate future options, for evaluation only — none may be implemented,
-restarted or deployed without explicit operational approval:
+The reviewed code path is now a root-owned host observer:
+`scripts/listener_container_observer.py` and the
+`harmonic-beacon-listener-container-observer` systemd timer. It accepts no
+caller-controlled target/path, performs only one fixed `docker inspect` for the
+isolated Listener and origin, verifies exact Compose labels, stores a durable
+root-only epoch/counter state and exports fixed-role metrics through the
+existing node-exporter textfile directory. Private networking, AF_UNIX-only and
+strict filesystem controls bound the unit; no Docker socket is mounted into an
+application container.
 
-1. A minimal read-only Docker Engine observer that watches the Engine event
-   stream and container state (restart counts, OOM-killed status) for exactly
-   the isolated Listener and origin containers and exports the required
-   Prometheus series. This needs read-only access to the Docker socket, which
-   is root-equivalent on the host, so it is acceptable only with an explicit
-   threat model: dedicated least-privilege observer, read-only socket mount,
-   no write API calls.
-2. A proven containerd-compatible per-container collector — for example a
-   cAdvisor release verified against the containerd image store, or a
-   containerd-native metrics source — validated read-only in a throwaway
-   container on `mona` before any change to the checked-in observability
-   stack.
-3. Any other observer only if it keeps the same fail-closed contract: exactly
-   one finite series per exact container query, no inferred zeros, no
-   weakened restart/OOM evidence.
-
-Whatever is chosen, verification is unchanged: the four exact per-container
-queries must each return exactly one finite series before any load, and empty
-vectors remain a hard blocker, never a reason to proceed.
+This implementation remains **not installed by code merge**. Installation on
+`mona` requires a separate operational review because Docker read access is
+root-equivalent. It must not restart Docker, cAdvisor, Listener, origin or any
+event service. Until the unit is explicitly installed and all observer
+health/freshness/epoch/start/restart/OOM queries return exactly one finite
+series, the ten-client smoke remains runtime-blocked. Empty, duplicated, stale
+or reset series are a hard blocker, never a reason to proceed. Exact install,
+verification and revocation commands live in
+`docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md`.
 
 The bounded ten-client wrapper also requires its fixed local lock at
 `/tmp/harmonic-beacon-listener-smoke-10-network-run.lock`. The path has no CLI

--- a/ops/early-birds/systemd/harmonic-beacon-listener-container-observer.service
+++ b/ops/early-birds/systemd/harmonic-beacon-listener-container-observer.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Export fixed Listener container restart and OOM metrics
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/bin/python3 /usr/local/libexec/harmonic-beacon/listener_container_observer.py
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateNetwork=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadOnlyPaths=/var/run/docker.sock
+ReadWritePaths=/var/lib/harmonic-beacon/metrics /var/lib/harmonic-beacon/listener-container-observer
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+UMask=0077

--- a/ops/early-birds/systemd/harmonic-beacon-listener-container-observer.timer
+++ b/ops/early-birds/systemd/harmonic-beacon-listener-container-observer.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Refresh fixed Listener container restart and OOM metrics
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=5s
+AccuracySec=1s
+Persistent=false
+Unit=harmonic-beacon-listener-container-observer.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/early-birds/test/config.test.mjs
+++ b/ops/early-birds/test/config.test.mjs
@@ -56,6 +56,32 @@ test('scrapes node-exporter by the internal Docker DNS name', async () => {
   assert.doesNotMatch(prometheus, /host\.docker\.internal/);
 });
 
+test('exports fixed Listener container safety metrics from a hardened host timer', async () => {
+  const observer = await fs.readFile(
+    path.join(root, '../../scripts/listener_container_observer.py'),
+    'utf8',
+  );
+  const service = await read('systemd/harmonic-beacon-listener-container-observer.service');
+  const timer = await read('systemd/harmonic-beacon-listener-container-observer.timer');
+  assert.match(observer, /earlybirds-preview-listener-1/);
+  assert.match(observer, /earlybirds-preview-beacon-stream-1/);
+  assert.match(observer, /com\.docker\.compose\.project.*earlybirds-preview/s);
+  assert.match(observer, /subprocess\.run\([\s\S]*DOCKER_BINARY,[\s\S]*--host=unix:\/\/\/var\/run\/docker\.sock[\s\S]*"inspect"/);
+  assert.match(observer, /"DOCKER_CONFIG": "\/nonexistent"/);
+  assert.doesNotMatch(observer, /docker exec|docker events|curl|https?:\/\//);
+  assert.match(observer, /beacon_listener_container_observer_up 0/);
+  assert.match(observer, /beacon_listener_container_observer_epoch_start_time_seconds/);
+  assert.match(observer, /role="\{role\}"/);
+  assert.doesNotMatch(observer, /name="\{target\['name'\]\}"/);
+  assert.match(service, /User=root/);
+  assert.match(service, /PrivateNetwork=yes/);
+  assert.match(service, /RestrictAddressFamilies=AF_UNIX/);
+  assert.match(service, /ReadOnlyPaths=\/var\/run\/docker\.sock/);
+  assert.match(service, /ReadWritePaths=\/var\/lib\/harmonic-beacon\/metrics \/var\/lib\/harmonic-beacon\/listener-container-observer/);
+  assert.match(timer, /OnUnitActiveSec=5s/);
+  assert.match(timer, /Persistent=false/);
+});
+
 test('alerts on the private consumer request age metric without PII', async () => {
   const alerts = await read('prometheus/alerts.yml');
   assert.match(alerts, /ListenerConsumerRequestQueueWarning[\s\S]*> 72000/);

--- a/scripts/listener_container_observer.py
+++ b/scripts/listener_container_observer.py
@@ -1,0 +1,361 @@
+#!/usr/bin/python3
+"""Export fixed Listener container restart/OOM continuity as textfile metrics."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+import stat
+import subprocess
+import sys
+import time
+from typing import Any
+
+OBSERVER_SCHEMA_VERSION = 1
+DOCKER_BINARY = "/usr/bin/docker"
+METRICS_FILE = Path("/var/lib/harmonic-beacon/metrics/listener-container-observer.prom")
+STATE_FILE = Path("/var/lib/harmonic-beacon/listener-container-observer/state.json")
+MAX_INSPECT_BYTES = 256 * 1024
+MAX_STATE_BYTES = 64 * 1024
+MAX_SAFE_COUNTER = (2**53) - 1
+
+TARGETS = (
+    {"role": "listener", "name": "earlybirds-preview-listener-1", "service": "listener"},
+    {"role": "origin", "name": "earlybirds-preview-beacon-stream-1", "service": "beacon-stream"},
+)
+
+
+def _bounded_counter(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0 or value > MAX_SAFE_COUNTER:
+        raise ValueError(f"{label} is invalid")
+    return value
+
+
+def _timestamp(value: Any, label: str) -> float:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} is invalid")
+    try:
+        # Docker emits RFC3339 with nanoseconds and Z; fromisoformat accepts a
+        # bounded microsecond form, so truncate only the fractional precision.
+        normalized = value.replace("Z", "+00:00")
+        if "." in normalized:
+            prefix, suffix = normalized.split(".", 1)
+            digits, zone = suffix.split("+", 1) if "+" in suffix else suffix.split("-", 1)
+            sign = "+" if "+" in suffix else "-"
+            normalized = f"{prefix}.{digits[:6]}{sign}{zone}"
+        from datetime import datetime
+
+        result = datetime.fromisoformat(normalized).timestamp()
+    except (TypeError, ValueError):
+        raise ValueError(f"{label} is invalid") from None
+    if not result > 0:
+        raise ValueError(f"{label} is invalid")
+    return result
+
+
+def _identity_digest(value: Any) -> str:
+    if not isinstance(value, str) or len(value) != 64 or any(ch not in "0123456789abcdef" for ch in value):
+        raise ValueError("container identity is invalid")
+    return hashlib.sha256(value.encode("ascii")).hexdigest()
+
+
+def parse_docker_inspect(raw: str) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw, str) or len(raw.encode("utf-8")) > MAX_INSPECT_BYTES:
+        raise ValueError("Docker inspect output is invalid")
+    try:
+        rows = json.loads(raw)
+    except json.JSONDecodeError:
+        raise ValueError("Docker inspect output is malformed") from None
+    if not isinstance(rows, list) or len(rows) != len(TARGETS):
+        raise ValueError("Docker inspect target set is incomplete or ambiguous")
+
+    by_name: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        name = row.get("Name", "") if isinstance(row, dict) else ""
+        name = name.removeprefix("/") if isinstance(name, str) else ""
+        if not name or name in by_name:
+            raise ValueError("Docker inspect target is duplicated")
+        by_name[name] = row
+
+    result: dict[str, dict[str, Any]] = {}
+    for target in TARGETS:
+        row = by_name.get(target["name"])
+        labels = row.get("Config", {}).get("Labels", {}) if isinstance(row, dict) else {}
+        if (
+            not row
+            or labels.get("com.docker.compose.project") != "earlybirds-preview"
+            or labels.get("com.docker.compose.service") != target["service"]
+        ):
+            raise ValueError(f"Docker inspect {target['role']} target does not match its fixed boundary")
+        state = row.get("State", {})
+        if state.get("Status") != "running":
+            raise ValueError(f"Docker inspect {target['role']} target is not running")
+        result[target["role"]] = {
+            "identity": _identity_digest(row.get("Id")),
+            "startTimeSeconds": _timestamp(state.get("StartedAt"), f"{target['role']} start time"),
+            "dockerRestartCount": _bounded_counter(
+                row.get("RestartCount"), f"{target['role']} restart count"
+            ),
+            "oomKilled": state.get("OOMKilled") is True,
+        }
+    return result
+
+
+def _validate_previous_target(value: Any, role: str) -> dict[str, Any]:
+    if (
+        not isinstance(value, dict)
+        or not isinstance(value.get("identity"), str)
+        or len(value["identity"]) != 64
+        or any(ch not in "0123456789abcdef" for ch in value["identity"])
+        or isinstance(value.get("startTimeSeconds"), bool)
+        or not isinstance(value.get("startTimeSeconds"), (int, float))
+        or not isinstance(value.get("oomKilled"), bool)
+    ):
+        raise ValueError(f"observer {role} state is invalid")
+    _bounded_counter(value.get("dockerRestartCount"), f"{role} stored Docker restart count")
+    _bounded_counter(value.get("restartEventsTotal"), f"{role} stored restart total")
+    _bounded_counter(value.get("oomEventsTotal"), f"{role} stored OOM total")
+    return value
+
+
+def _add_counter(left: int, right: int, label: str) -> int:
+    return _bounded_counter(left + right, label)
+
+
+def advance_observer_state(
+    previous: dict[str, Any] | None,
+    observations: dict[str, dict[str, Any]],
+    observed_at_seconds: int,
+) -> dict[str, Any]:
+    if isinstance(observed_at_seconds, bool) or not isinstance(observed_at_seconds, int) or observed_at_seconds <= 0:
+        raise ValueError("observer timestamp is invalid")
+    first = previous is None
+    if not first and (
+        not isinstance(previous, dict)
+        or previous.get("schemaVersion") != OBSERVER_SCHEMA_VERSION
+        or isinstance(previous.get("epochStartedAtSeconds"), bool)
+        or not isinstance(previous.get("epochStartedAtSeconds"), int)
+        or previous["epochStartedAtSeconds"] <= 0
+        or not isinstance(previous.get("targets"), dict)
+    ):
+        raise ValueError("observer state is invalid")
+
+    next_targets: dict[str, dict[str, Any]] = {}
+    for target in TARGETS:
+        role = target["role"]
+        observation = observations.get(role)
+        if not isinstance(observation, dict):
+            raise ValueError(f"observer {role} observation is missing")
+        identity = observation.get("identity")
+        if not isinstance(identity, str) or len(identity) != 64:
+            raise ValueError(f"observer {role} observation is invalid")
+        restart_count = _bounded_counter(observation.get("dockerRestartCount"), f"{role} restart count")
+        start_time = observation.get("startTimeSeconds")
+        if isinstance(start_time, bool) or not isinstance(start_time, (int, float)) or not start_time > 0:
+            raise ValueError(f"observer {role} start time is invalid")
+        oom_killed = observation.get("oomKilled") is True
+        old = None if first else _validate_previous_target(previous["targets"].get(role), role)
+
+        if old is None:
+            restart_total = restart_count
+            oom_total = 1 if oom_killed else 0
+        elif old["identity"] != identity:
+            restart_total = _add_counter(
+                old["restartEventsTotal"], 1 + restart_count, f"{role} restart total"
+            )
+            oom_total = _add_counter(old["oomEventsTotal"], 1 if oom_killed else 0, f"{role} OOM total")
+        else:
+            if restart_count < old["dockerRestartCount"]:
+                raise ValueError(f"observer {role} Docker restart counter moved backwards")
+            restart_total = _add_counter(
+                old["restartEventsTotal"], restart_count - old["dockerRestartCount"], f"{role} restart total"
+            )
+            oom_total = _add_counter(
+                old["oomEventsTotal"], 1 if oom_killed and not old["oomKilled"] else 0, f"{role} OOM total"
+            )
+
+        next_targets[role] = {
+            "identity": identity,
+            "startTimeSeconds": start_time,
+            "dockerRestartCount": restart_count,
+            "restartEventsTotal": restart_total,
+            "oomEventsTotal": oom_total,
+            "oomKilled": oom_killed,
+        }
+
+    return {
+        "schemaVersion": OBSERVER_SCHEMA_VERSION,
+        "epochStartedAtSeconds": observed_at_seconds if first else previous["epochStartedAtSeconds"],
+        "lastSuccessAtSeconds": observed_at_seconds,
+        "targets": next_targets,
+    }
+
+
+def render_observer_metrics(state: dict[str, Any]) -> str:
+    if not isinstance(state, dict) or state.get("schemaVersion") != OBSERVER_SCHEMA_VERSION:
+        raise ValueError("observer metrics state is invalid")
+    epoch = _bounded_counter(state.get("epochStartedAtSeconds"), "observer epoch")
+    success = _bounded_counter(state.get("lastSuccessAtSeconds"), "observer success timestamp")
+    lines = [
+        "# HELP beacon_listener_container_observer_up Whether the fixed Listener container observer completed its latest sample.",
+        "# TYPE beacon_listener_container_observer_up gauge",
+        "beacon_listener_container_observer_up 1",
+        "# HELP beacon_listener_container_observer_last_success_timestamp_seconds Unix time of the latest complete fixed-target sample.",
+        "# TYPE beacon_listener_container_observer_last_success_timestamp_seconds gauge",
+        f"beacon_listener_container_observer_last_success_timestamp_seconds {success}",
+        "# HELP beacon_listener_container_observer_epoch_start_time_seconds Unix time at which the durable observer epoch began.",
+        "# TYPE beacon_listener_container_observer_epoch_start_time_seconds gauge",
+        f"beacon_listener_container_observer_epoch_start_time_seconds {epoch}",
+        "# HELP beacon_listener_container_start_time_seconds Start time of the currently observed fixed container role.",
+        "# TYPE beacon_listener_container_start_time_seconds gauge",
+        "# HELP beacon_listener_container_restart_events_total Restarts or replacements observed for the fixed container role.",
+        "# TYPE beacon_listener_container_restart_events_total counter",
+        "# HELP beacon_listener_container_oom_events_total OOM-killed terminal states observed for the fixed container role.",
+        "# TYPE beacon_listener_container_oom_events_total counter",
+    ]
+    for target in TARGETS:
+        role = target["role"]
+        value = _validate_previous_target(state.get("targets", {}).get(role), role)
+        lines.extend(
+            [
+                f'beacon_listener_container_start_time_seconds{{role="{role}"}} {value["startTimeSeconds"]}',
+                f'beacon_listener_container_restart_events_total{{role="{role}"}} {value["restartEventsTotal"]}',
+                f'beacon_listener_container_oom_events_total{{role="{role}"}} {value["oomEventsTotal"]}',
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_observer_failure_metrics(observed_at_seconds: int) -> str:
+    failure = _bounded_counter(observed_at_seconds, "observer failure timestamp")
+    return "\n".join(
+        [
+            "# HELP beacon_listener_container_observer_up Whether the fixed Listener container observer completed its latest sample.",
+            "# TYPE beacon_listener_container_observer_up gauge",
+            "beacon_listener_container_observer_up 0",
+            "# HELP beacon_listener_container_observer_last_failure_timestamp_seconds Unix time of the latest failed sample.",
+            "# TYPE beacon_listener_container_observer_last_failure_timestamp_seconds gauge",
+            f"beacon_listener_container_observer_last_failure_timestamp_seconds {failure}",
+            "",
+        ]
+    )
+
+
+def _ensure_root_directory(path: Path, mode: int) -> None:
+    path.mkdir(parents=True, exist_ok=True, mode=mode)
+    details = path.lstat()
+    if not stat.S_ISDIR(details.st_mode) or details.st_uid != 0 or details.st_mode & 0o022:
+        raise RuntimeError("observer output directory is unsafe")
+    path.chmod(mode)
+
+
+def _atomic_write(path: Path, contents: str, mode: int) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(6)}.tmp")
+    descriptor = None
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, mode)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            descriptor = None
+            output.write(contents)
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(temporary, mode, follow_symlinks=False)
+        os.replace(temporary, path)
+        directory_descriptor = os.open(
+            path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        )
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _read_state() -> dict[str, Any] | None:
+    try:
+        details = STATE_FILE.lstat()
+    except FileNotFoundError:
+        return None
+    if (
+        not stat.S_ISREG(details.st_mode)
+        or details.st_uid != 0
+        or stat.S_IMODE(details.st_mode) != 0o600
+        or details.st_size > MAX_STATE_BYTES
+    ):
+        raise RuntimeError("observer state cannot be read safely")
+    descriptor = os.open(STATE_FILE, os.O_RDONLY | os.O_NOFOLLOW)
+    try:
+        with os.fdopen(descriptor, "r", encoding="utf-8") as source:
+            descriptor = -1
+            value = json.load(source)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise RuntimeError("observer state cannot be read safely") from None
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return value
+
+
+def _write_failure_best_effort(observed_at_seconds: int) -> None:
+    try:
+        _ensure_root_directory(METRICS_FILE.parent, 0o755)
+        _atomic_write(METRICS_FILE, render_observer_failure_metrics(observed_at_seconds), 0o644)
+    except Exception:
+        pass
+
+
+def run_observer() -> None:
+    if len(sys.argv) != 1:
+        raise RuntimeError("observer accepts no arguments")
+    if os.geteuid() != 0:
+        raise RuntimeError("observer requires root")
+    observed_at_seconds = int(time.time())
+    _ensure_root_directory(METRICS_FILE.parent, 0o755)
+    _ensure_root_directory(STATE_FILE.parent, 0o700)
+    try:
+        completed = subprocess.run(
+            [
+                DOCKER_BINARY,
+                "--host=unix:///var/run/docker.sock",
+                "inspect",
+                *(target["name"] for target in TARGETS),
+            ],
+            check=True,
+            capture_output=True,
+            env={
+                "DOCKER_CONFIG": "/nonexistent",
+                "HOME": "/nonexistent",
+                "LANG": "C",
+                "LC_ALL": "C",
+                "PATH": "/usr/bin:/bin",
+            },
+            text=True,
+            timeout=5,
+        )
+        if len(completed.stdout.encode("utf-8")) > MAX_INSPECT_BYTES:
+            raise RuntimeError("Docker inspect output is oversized")
+        state = advance_observer_state(
+            _read_state(), parse_docker_inspect(completed.stdout), observed_at_seconds
+        )
+        _atomic_write(STATE_FILE, json.dumps(state, separators=(",", ":")) + "\n", 0o600)
+        _atomic_write(METRICS_FILE, render_observer_metrics(state), 0o644)
+    except Exception:
+        _write_failure_best_effort(observed_at_seconds)
+        raise
+
+
+if __name__ == "__main__":
+    try:
+        run_observer()
+    except Exception as error:
+        print(f"Listener container observer failed closed: {error}", file=sys.stderr)
+        raise SystemExit(1) from None

--- a/tools/early-birds-hls-load/README.md
+++ b/tools/early-birds-hls-load/README.md
@@ -115,7 +115,9 @@ same external host as the wrapper. The target monitor queries Alertmanager
 (`--prometheus-url`, default `http://127.0.0.1:19090`) through separate
 uncredentialed loopback SSH tunnels, evaluates the immediate host thresholds
 directly and maintains an in-process restart/OOM baseline for the isolated
-Listener and origin containers. The wrapper polls both status files every two
+Listener and origin roles. A passing sample additionally requires the private
+fixed-target observer to be up, fresh, in the same durable epoch and to expose
+exactly one finite start/restart/OOM series per role. The wrapper polls both status files every two
 seconds and aborts the load child exactly once on the first failing or stale
 check. See
 [`LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md`](../../docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md).

--- a/tools/early-birds-hls-load/package.json
+++ b/tools/early-birds-hls-load/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "External, bounded, format-neutral HLS load and soak evidence harness",
   "scripts": {
-    "check": "node --check run.mjs && node --check run-staging-smoke.mjs && node --check external-decoded-canary.mjs && node --check external-target-monitor.mjs && node --check aggregate.mjs && node --check verify-planned.mjs && node --check src/contracts.mjs && node --check src/runner.mjs && node --check src/smoke-safety.mjs && node --check src/target-probe.mjs && node --check src/smoke-guard.mjs && node --check src/network-run-lock.mjs",
-    "test": "node --test test/*.test.mjs"
+    "check": "python3 -m py_compile ../../scripts/listener_container_observer.py && node --check run.mjs && node --check run-staging-smoke.mjs && node --check external-decoded-canary.mjs && node --check external-target-monitor.mjs && node --check aggregate.mjs && node --check verify-planned.mjs && node --check src/contracts.mjs && node --check src/runner.mjs && node --check src/smoke-safety.mjs && node --check src/target-probe.mjs && node --check src/smoke-guard.mjs && node --check src/network-run-lock.mjs",
+    "test": "node --test test/*.test.mjs && python3 -m unittest discover -s test -p 'test_*.py'"
   },
   "engines": {
     "node": ">=22"

--- a/tools/early-birds-hls-load/src/smoke-safety.mjs
+++ b/tools/early-birds-hls-load/src/smoke-safety.mjs
@@ -174,6 +174,8 @@ export function validateTargetMonitorStatus(status, nowMs = Date.now()) {
   boundedCount(status.interfaceErrorsDrops, 'target monitor interface errors/drops', 1e9);
   assert(status.interfaceErrorsDrops === MONITOR_THRESHOLDS.maxInterfaceErrorsDrops,
     'target monitor reports interface errors or drops');
+  assert(status.containerObserverFresh === true,
+    'target monitor container observer is missing, failed or stale');
   // A status that has not established and verified a restart/OOM baseline can
   // never be accepted; nor can one that observed a restart or OOM kill.
   assert(status.restartBaselineEstablished === true,

--- a/tools/early-birds-hls-load/src/target-probe.mjs
+++ b/tools/early-birds-hls-load/src/target-probe.mjs
@@ -15,6 +15,7 @@ export const STAGING_ATTESTATION = 'early-birds-staging';
 // earlybirds-preview Compose project. Never participant or event containers.
 export const LISTENER_CONTAINER = 'earlybirds-preview-listener-1';
 export const ORIGIN_CONTAINER = 'earlybirds-preview-beacon-stream-1';
+export const CONTAINER_OBSERVER_MAX_AGE_SECONDS = 15;
 
 // Instant Prometheus queries. Every query must yield exactly one vector
 // element; an empty, duplicated or non-finite result fails the probe. Host
@@ -36,10 +37,16 @@ export const MONITOR_QUERIES = Object.freeze({
     + ' + sum(node_network_receive_drop_total{device!~"lo|docker.*|veth.*"})',
   originUp: 'up{job="beacon-stream"}',
   canaryOk: 'beacon_stream_canary_ok',
-  listenerStartSeconds: `container_start_time_seconds{name="${LISTENER_CONTAINER}"}`,
-  originStartSeconds: `container_start_time_seconds{name="${ORIGIN_CONTAINER}"}`,
-  listenerOomEvents: `container_oom_events_total{name="${LISTENER_CONTAINER}"}`,
-  originOomEvents: `container_oom_events_total{name="${ORIGIN_CONTAINER}"}`,
+  containerObserverUp: 'beacon_listener_container_observer_up',
+  containerObserverAgeSeconds:
+    'time() - beacon_listener_container_observer_last_success_timestamp_seconds',
+  containerObserverEpochSeconds: 'beacon_listener_container_observer_epoch_start_time_seconds',
+  listenerStartSeconds: 'beacon_listener_container_start_time_seconds{role="listener"}',
+  originStartSeconds: 'beacon_listener_container_start_time_seconds{role="origin"}',
+  listenerRestartEvents: 'beacon_listener_container_restart_events_total{role="listener"}',
+  originRestartEvents: 'beacon_listener_container_restart_events_total{role="origin"}',
+  listenerOomEvents: 'beacon_listener_container_oom_events_total{role="listener"}',
+  originOomEvents: 'beacon_listener_container_oom_events_total{role="origin"}',
 });
 
 export function loopbackTunnelOrigin(value, label) {
@@ -147,7 +154,10 @@ export function createContainerBaseline() {
     established: false,
     verified: false,
     startSeconds: null,
+    restartEvents: null,
     oomEvents: null,
+    observerEpochSeconds: null,
+    continuityLost: false,
     restartsObserved: 0,
     oomEventsDelta: 0,
   };
@@ -155,19 +165,36 @@ export function createContainerBaseline() {
 
 export function observeContainerBaseline(baseline, sample) {
   const starts = [sample.listenerStartSeconds, sample.originStartSeconds];
+  const restarts = [sample.listenerRestartEvents, sample.originRestartEvents];
   const ooms = [sample.listenerOomEvents, sample.originOomEvents];
   if (!baseline.established) {
     baseline.established = true;
     baseline.startSeconds = starts;
+    baseline.restartEvents = restarts;
     baseline.oomEvents = ooms;
+    baseline.observerEpochSeconds = sample.containerObserverEpochSeconds;
     return;
   }
+  if (sample.containerObserverEpochSeconds !== baseline.observerEpochSeconds) {
+    baseline.continuityLost = true;
+    baseline.verified = false;
+  }
   starts.forEach((value, index) => {
-    if (value !== baseline.startSeconds[index]) {
+    const restartDelta = restarts[index] - baseline.restartEvents[index];
+    if (restartDelta < 0) {
+      baseline.continuityLost = true;
+      baseline.verified = false;
+    } else if (restartDelta > 0) {
+      baseline.restartsObserved += restartDelta;
+      baseline.verified = false;
+    } else if (value !== baseline.startSeconds[index]) {
+      // A changed start time with no matching monotonic counter movement is
+      // still a restart and must never become a clean sample.
       baseline.restartsObserved += 1;
-      baseline.startSeconds[index] = value;
       baseline.verified = false;
     }
+    baseline.restartEvents[index] = restarts[index];
+    baseline.startSeconds[index] = value;
   });
   ooms.forEach((value, index) => {
     const delta = value - baseline.oomEvents[index];
@@ -175,10 +202,38 @@ export function observeContainerBaseline(baseline, sample) {
       baseline.oomEventsDelta += delta;
       baseline.verified = false;
     }
+    if (delta < 0) {
+      baseline.continuityLost = true;
+      baseline.verified = false;
+    }
     if (delta !== 0) baseline.oomEvents[index] = value;
   });
-  if (baseline.restartsObserved === 0 && baseline.oomEventsDelta === 0) {
+  if (!baseline.continuityLost
+    && baseline.restartsObserved === 0 && baseline.oomEventsDelta === 0) {
     baseline.verified = true;
+  }
+}
+
+function validateContainerObserverScalars(scalars) {
+  if (scalars.containerObserverUp !== 1
+    || scalars.containerObserverAgeSeconds < 0
+    || scalars.containerObserverAgeSeconds > CONTAINER_OBSERVER_MAX_AGE_SECONDS
+    || !Number.isSafeInteger(scalars.containerObserverEpochSeconds)
+    || scalars.containerObserverEpochSeconds <= 0) {
+    throw new Error('container observer is missing, failed or stale');
+  }
+  for (const name of ['listenerStartSeconds', 'originStartSeconds']) {
+    if (!(scalars[name] > 0)) throw new Error('container start time is invalid');
+  }
+  for (const name of [
+    'listenerRestartEvents',
+    'originRestartEvents',
+    'listenerOomEvents',
+    'originOomEvents',
+  ]) {
+    if (!Number.isSafeInteger(scalars[name]) || scalars[name] < 0) {
+      throw new Error('container continuity counter is invalid');
+    }
   }
 }
 
@@ -232,6 +287,7 @@ export async function probeMonitor({
     egressBitsPerSecond: null,
     tcpRetransmitRatio: null,
     interfaceErrorsDrops: null,
+    containerObserverFresh: false,
     restartBaselineEstablished: baseline.verified,
     containerRestartsObserved: baseline.restartsObserved,
     oomEventsDelta: baseline.oomEventsDelta,
@@ -254,15 +310,21 @@ export async function probeMonitor({
       ])
     );
     const scalars = Object.fromEntries(scalarNames.map((name, index) => [name, scalarValues[index]]));
+    validateContainerObserverScalars(scalars);
     observeContainerBaseline(baseline, {
+      containerObserverEpochSeconds: scalars.containerObserverEpochSeconds,
       listenerStartSeconds: scalars.listenerStartSeconds,
       originStartSeconds: scalars.originStartSeconds,
+      listenerRestartEvents: scalars.listenerRestartEvents,
+      originRestartEvents: scalars.originRestartEvents,
       listenerOomEvents: scalars.listenerOomEvents,
       originOomEvents: scalars.originOomEvents,
     });
+    const containerObserverFresh = true;
     const passed = listenerReady && streamHealthy && liveReady
       && alertmanager.ready && alertmanager.activeAlerts === 0 && firingAlerts === 0
       && withinImmediateThresholds(scalars)
+      && containerObserverFresh
       && baseline.verified
       && baseline.restartsObserved === 0 && baseline.oomEventsDelta === 0;
     return {
@@ -283,6 +345,7 @@ export async function probeMonitor({
       egressBitsPerSecond: scalars.egressBitsPerSecond,
       tcpRetransmitRatio: scalars.tcpRetransmitRatio,
       interfaceErrorsDrops: scalars.interfaceErrorsDrops,
+      containerObserverFresh,
       restartBaselineEstablished: baseline.verified,
       containerRestartsObserved: baseline.restartsObserved,
       oomEventsDelta: baseline.oomEventsDelta,

--- a/tools/early-birds-hls-load/test/smoke-safety.test.mjs
+++ b/tools/early-birds-hls-load/test/smoke-safety.test.mjs
@@ -82,6 +82,7 @@ function fixture(nowMs = Date.now()) {
       egressBitsPerSecond: 500_000_000,
       tcpRetransmitRatio: 0.001,
       interfaceErrorsDrops: 0,
+      containerObserverFresh: true,
       restartBaselineEstablished: true,
       containerRestartsObserved: 0,
       oomEventsDelta: 0,

--- a/tools/early-birds-hls-load/test/target-monitor.test.mjs
+++ b/tools/early-birds-hls-load/test/target-monitor.test.mjs
@@ -26,8 +26,13 @@ const DEFAULT_SCALARS = {
   interfaceErrorsDrops: 0,
   originUp: 1,
   canaryOk: 1,
+  containerObserverUp: 1,
+  containerObserverAgeSeconds: 2,
+  containerObserverEpochSeconds: 1_700_000_050,
   listenerStartSeconds: 1_700_000_000,
   originStartSeconds: 1_700_000_100,
+  listenerRestartEvents: 0,
+  originRestartEvents: 0,
   listenerOomEvents: 0,
   originOomEvents: 0,
 };
@@ -240,6 +245,87 @@ test('a changed container start timestamp is latched as a restart', async () => 
   const latched = await probeMonitor(options);
   assert.equal(latched.status, 'FAIL');
   assert.equal(latched.containerRestartsObserved, 1);
+});
+
+test('a monotonic restart counter increase is counted once even when start time also changes', async () => {
+  const state = { scalars: {} };
+  const baseline = createContainerBaseline();
+  const options = {
+    fetchImpl: makeFetch(state),
+    prometheusOrigin: PROMETHEUS,
+    alertmanagerOrigin: ALERTMANAGER,
+    hostHash: TEST_HOST_HASH,
+    baseline,
+  };
+  await probeMonitor(options);
+  assert.equal((await probeMonitor(options)).status, 'PASS');
+  state.scalars.listenerRestartEvents = 1;
+  state.scalars.listenerStartSeconds = DEFAULT_SCALARS.listenerStartSeconds + 60;
+  const restarted = await probeMonitor(options);
+  assert.equal(restarted.status, 'FAIL');
+  assert.equal(restarted.containerRestartsObserved, 1);
+});
+
+test('observer failure, staleness or epoch/counter reset fails closed and stays latched', async () => {
+  const down = await probeTwice({ scalars: { containerObserverUp: 0 } });
+  assert.equal(down.second.status, 'FAIL');
+  assert.equal(down.second.containerObserverFresh, false);
+
+  const stale = await probeTwice({ scalars: { containerObserverAgeSeconds: 16 } });
+  assert.equal(stale.second.status, 'FAIL');
+  assert.equal(stale.second.containerObserverFresh, false);
+
+  const state = { scalars: {} };
+  const baseline = createContainerBaseline();
+  const options = {
+    fetchImpl: makeFetch(state),
+    prometheusOrigin: PROMETHEUS,
+    alertmanagerOrigin: ALERTMANAGER,
+    hostHash: TEST_HOST_HASH,
+    baseline,
+  };
+  await probeMonitor(options);
+  assert.equal((await probeMonitor(options)).status, 'PASS');
+  state.scalars.containerObserverEpochSeconds = DEFAULT_SCALARS.containerObserverEpochSeconds + 1;
+  assert.equal((await probeMonitor(options)).status, 'FAIL');
+  state.scalars.containerObserverEpochSeconds = DEFAULT_SCALARS.containerObserverEpochSeconds;
+  assert.equal((await probeMonitor(options)).status, 'FAIL');
+
+  const counterState = { scalars: { listenerRestartEvents: 3 } };
+  const counterBaseline = createContainerBaseline();
+  const counterOptions = {
+    ...options,
+    fetchImpl: makeFetch(counterState),
+    baseline: counterBaseline,
+  };
+  await probeMonitor(counterOptions);
+  assert.equal((await probeMonitor(counterOptions)).status, 'PASS');
+  counterState.scalars.listenerRestartEvents = 2;
+  assert.equal((await probeMonitor(counterOptions)).status, 'FAIL');
+  counterState.scalars.listenerRestartEvents = 3;
+  assert.equal((await probeMonitor(counterOptions)).status, 'FAIL');
+});
+
+test('invalid observer timestamps and counters fail before establishing a baseline', async () => {
+  for (const scalars of [
+    { containerObserverAgeSeconds: -1 },
+    { containerObserverEpochSeconds: 1.5 },
+    { listenerStartSeconds: 0 },
+    { listenerRestartEvents: -1 },
+    { originOomEvents: 0.5 },
+  ]) {
+    const baseline = createContainerBaseline();
+    const result = await probeMonitor({
+      fetchImpl: makeFetch({ scalars }),
+      prometheusOrigin: PROMETHEUS,
+      alertmanagerOrigin: ALERTMANAGER,
+      hostHash: TEST_HOST_HASH,
+      baseline,
+    });
+    assert.equal(result.status, 'FAIL');
+    assert.equal(result.containerObserverFresh, false);
+    assert.equal(baseline.established, false);
+  }
 });
 
 test('an increased container OOM counter fails closed with a bounded delta', async () => {

--- a/tools/early-birds-hls-load/test/test_listener_container_observer.py
+++ b/tools/early-birds-hls-load/test/test_listener_container_observer.py
@@ -1,0 +1,159 @@
+import copy
+from datetime import datetime
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SPEC = importlib.util.spec_from_file_location(
+    "listener_container_observer", ROOT / "scripts/listener_container_observer.py"
+)
+OBSERVER = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(OBSERVER)
+
+IDS = {
+    "listener": "a" * 64,
+    "origin": "b" * 64,
+    "listener_replacement": "c" * 64,
+}
+
+
+def inspect_rows():
+    rows = []
+    for index, target in enumerate(OBSERVER.TARGETS):
+        rows.append(
+            {
+                "Id": IDS[target["role"]],
+                "Name": f"/{target['name']}",
+                "Config": {
+                    "Labels": {
+                        "com.docker.compose.project": "earlybirds-preview",
+                        "com.docker.compose.service": target["service"],
+                    }
+                },
+                "State": {
+                    "Status": "running",
+                    "StartedAt": f"2026-08-15T10:00:0{index}.000000000Z",
+                    "OOMKilled": False,
+                },
+                "RestartCount": 0,
+            }
+        )
+    return rows
+
+
+def observations():
+    return OBSERVER.parse_docker_inspect(json.dumps(inspect_rows()))
+
+
+class ListenerContainerObserverTest(unittest.TestCase):
+    def test_parses_only_exact_running_compose_targets(self):
+        result = observations()
+        self.assertEqual(list(result), ["listener", "origin"])
+        self.assertEqual(
+            result["listener"]["startTimeSeconds"],
+            datetime.fromisoformat("2026-08-15T10:00:00+00:00").timestamp(),
+        )
+        self.assertEqual(
+            result["origin"]["startTimeSeconds"],
+            datetime.fromisoformat("2026-08-15T10:00:01+00:00").timestamp(),
+        )
+        self.assertRegex(result["listener"]["identity"], r"^[a-f0-9]{64}$")
+        self.assertNotEqual(result["listener"]["identity"], IDS["listener"])
+
+    def test_rejects_missing_duplicate_wrong_boundary_and_stopped_targets(self):
+        with self.assertRaisesRegex(ValueError, "incomplete or ambiguous"):
+            OBSERVER.parse_docker_inspect("[]")
+
+        duplicate = inspect_rows()
+        duplicate[1]["Name"] = duplicate[0]["Name"]
+        with self.assertRaisesRegex(ValueError, "duplicated"):
+            OBSERVER.parse_docker_inspect(json.dumps(duplicate))
+
+        wrong_project = inspect_rows()
+        wrong_project[0]["Config"]["Labels"]["com.docker.compose.project"] = "pmp-myth"
+        with self.assertRaisesRegex(ValueError, "fixed boundary"):
+            OBSERVER.parse_docker_inspect(json.dumps(wrong_project))
+
+        wrong_service = inspect_rows()
+        wrong_service[1]["Config"]["Labels"]["com.docker.compose.service"] = "listener"
+        with self.assertRaisesRegex(ValueError, "fixed boundary"):
+            OBSERVER.parse_docker_inspect(json.dumps(wrong_service))
+
+        stopped = inspect_rows()
+        stopped[0]["State"]["Status"] = "exited"
+        with self.assertRaisesRegex(ValueError, "not running"):
+            OBSERVER.parse_docker_inspect(json.dumps(stopped))
+
+    def test_durable_epoch_and_monotonic_restart_oom_totals(self):
+        first = OBSERVER.advance_observer_state(None, observations(), 1_700_000_000)
+        self.assertEqual(first["schemaVersion"], OBSERVER.OBSERVER_SCHEMA_VERSION)
+        self.assertEqual(first["targets"]["listener"]["restartEventsTotal"], 0)
+
+        changed = observations()
+        changed["listener"].update(
+            {
+                "startTimeSeconds": changed["listener"]["startTimeSeconds"] + 20,
+                "dockerRestartCount": 1,
+                "oomKilled": True,
+            }
+        )
+        second = OBSERVER.advance_observer_state(first, changed, 1_700_000_005)
+        self.assertEqual(second["epochStartedAtSeconds"], first["epochStartedAtSeconds"])
+        self.assertEqual(second["targets"]["listener"]["restartEventsTotal"], 1)
+        self.assertEqual(second["targets"]["listener"]["oomEventsTotal"], 1)
+
+        still_oomed = OBSERVER.advance_observer_state(second, changed, 1_700_000_010)
+        self.assertEqual(still_oomed["targets"]["listener"]["oomEventsTotal"], 1)
+        recovered_observation = copy.deepcopy(changed)
+        recovered_observation["listener"]["oomKilled"] = False
+        recovered = OBSERVER.advance_observer_state(still_oomed, recovered_observation, 1_700_000_015)
+        oomed_again = OBSERVER.advance_observer_state(recovered, changed, 1_700_000_020)
+        self.assertEqual(oomed_again["targets"]["listener"]["oomEventsTotal"], 2)
+
+    def test_replacement_preserves_cumulative_totals(self):
+        initial = observations()
+        initial["listener"]["dockerRestartCount"] = 2
+        first = OBSERVER.advance_observer_state(None, initial, 1_700_000_000)
+        replacement = observations()
+        replacement["listener"].update(
+            {
+                "identity": IDS["listener_replacement"],
+                "startTimeSeconds": replacement["listener"]["startTimeSeconds"] + 60,
+                "dockerRestartCount": 1,
+            }
+        )
+        next_state = OBSERVER.advance_observer_state(first, replacement, 1_700_000_005)
+        self.assertEqual(next_state["targets"]["listener"]["restartEventsTotal"], 4)
+
+    def test_refuses_corrupt_state_and_backwards_docker_counter(self):
+        initial = observations()
+        initial["listener"]["dockerRestartCount"] = 2
+        first = OBSERVER.advance_observer_state(None, initial, 1_700_000_000)
+        corrupt = {**first, "schemaVersion": 99}
+        with self.assertRaisesRegex(ValueError, "state is invalid"):
+            OBSERVER.advance_observer_state(corrupt, observations(), 1_700_000_005)
+        with self.assertRaisesRegex(ValueError, "moved backwards"):
+            OBSERVER.advance_observer_state(first, observations(), 1_700_000_005)
+
+    def test_metrics_use_fixed_roles_without_identity_or_container_name(self):
+        state = OBSERVER.advance_observer_state(None, observations(), 1_700_000_000)
+        metrics = OBSERVER.render_observer_metrics(state)
+        self.assertIn("beacon_listener_container_observer_up 1", metrics)
+        self.assertEqual(metrics.count('beacon_listener_container_start_time_seconds{role='), 2)
+        self.assertEqual(metrics.count('beacon_listener_container_restart_events_total{role='), 2)
+        self.assertEqual(metrics.count('beacon_listener_container_oom_events_total{role='), 2)
+        self.assertNotIn("earlybirds-preview", metrics)
+        self.assertNotIn("beacon-stream", metrics)
+        self.assertNotRegex(metrics, r"[a-f0-9]{64}")
+
+        failure = OBSERVER.render_observer_failure_metrics(1_700_000_005)
+        self.assertIn("beacon_listener_container_observer_up 0", failure)
+        self.assertNotIn("role=", failure)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the code gap tracked in #195 for a fail-closed first external Listener smoke.

- adds a fixed-target, root-owned host observer for the isolated Listener and origin containers
- exports only low-cardinality start/restart/OOM continuity metrics through node-exporter textfiles
- hardens Docker inspection to the local socket and exact Compose identities
- makes the external monitor require fresh observer epoch/counters and latch resets/restarts/OOMs
- wires Python and harness tests into the observability CI job
- documents installation, verification and revocation without authorizing deployment

Local evidence:
- HLS harness: 54 Node tests + 6 Python tests, syntax checks green
- observability: 14 tests + config validation green
- preview boundary: 37 tests green
- systemd-analyze verify green
- parser validated read-only against the real Listener/origin docker inspect shape on Mona with payload redacted

No load was generated. Nothing was installed or restarted. No event, LiveKit, audio, Listener playback, origin configuration, payment or public checkout surface changed.