### PR TITLE
fix(listener): align observer freshness with scraping

### DIFF
--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -19,6 +19,9 @@ on:
       - ops/early-birds/**
       - ops/early-birds-preview/**
       - scripts/early-birds-preview/**
+      - scripts/listener_container_observer.py
+      - tools/early-birds-hls-load/**
+      - docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
       - docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
       - .github/workflows/early-birds-fast-forward.yml
   push:
@@ -40,6 +43,9 @@ on:
       - ops/early-birds/**
       - ops/early-birds-preview/**
       - scripts/early-birds-preview/**
+      - scripts/listener_container_observer.py
+      - tools/early-birds-hls-load/**
+      - docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
       - docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
       - .github/workflows/early-birds-fast-forward.yml
 

--- a/docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
+++ b/docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
@@ -158,7 +158,7 @@ Threat boundary:
 - missing/stopped/wrong-label/duplicated targets, corrupt state, a backwards
   counter or any inspect error best-effort exports observer failure and removes
   the role series. If the output path itself is unavailable, the last success
-  becomes stale within fifteen seconds. Freshness and exact-cardinality queries
+  becomes stale within thirty seconds. Freshness and exact-cardinality queries
   therefore fail closed;
 - start time, a cumulative replacement/restart counter and a cumulative OOM
   counter are all observed. A fast OOM restart is still detected by start time
@@ -216,10 +216,12 @@ do
 done
 ```
 
-Require observer `up=1`, age between zero and fifteen seconds, then run the
-monitor `--once` preflight above. An empty or duplicate vector, changed epoch,
-negative age or counter regression is a hard blocker; never treat missing
-series as zero restarts or zero OOM events.
+Require observer `up=1` and age between zero and thirty seconds, then run the
+monitor `--once` preflight above. The bound covers the five-second observer
+timer plus the configured fifteen-second node-exporter scrape alignment; one
+missed scrape fails the continuously polled monitor. An empty or duplicate
+vector, changed epoch, negative age or counter regression is a hard blocker;
+never treat missing series as zero restarts or zero OOM events.
 
 ## Five-minute baseline
 

--- a/tools/early-birds-hls-load/src/target-probe.mjs
+++ b/tools/early-birds-hls-load/src/target-probe.mjs
@@ -15,7 +15,10 @@ export const STAGING_ATTESTATION = 'early-birds-staging';
 // earlybirds-preview Compose project. Never participant or event containers.
 export const LISTENER_CONTAINER = 'earlybirds-preview-listener-1';
 export const ORIGIN_CONTAINER = 'earlybirds-preview-beacon-stream-1';
-export const CONTAINER_OBSERVER_MAX_AGE_SECONDS = 15;
+// The host timer runs every 5s and Prometheus scrapes node-exporter every 15s.
+// Thirty seconds tolerates one normal scrape interval plus timer alignment,
+// while a missed scrape still fails the continuously polled monitor.
+export const CONTAINER_OBSERVER_MAX_AGE_SECONDS = 30;
 
 // Instant Prometheus queries. Every query must yield exactly one vector
 // element; an empty, duplicated or non-finite result fails the probe. Host

--- a/tools/early-birds-hls-load/test/target-monitor.test.mjs
+++ b/tools/early-birds-hls-load/test/target-monitor.test.mjs
@@ -271,7 +271,11 @@ test('observer failure, staleness or epoch/counter reset fails closed and stays 
   assert.equal(down.second.status, 'FAIL');
   assert.equal(down.second.containerObserverFresh, false);
 
-  const stale = await probeTwice({ scalars: { containerObserverAgeSeconds: 16 } });
+  const boundary = await probeTwice({ scalars: { containerObserverAgeSeconds: 30 } });
+  assert.equal(boundary.second.status, 'PASS');
+  assert.equal(boundary.second.containerObserverFresh, true);
+
+  const stale = await probeTwice({ scalars: { containerObserverAgeSeconds: 31 } });
   assert.equal(stale.second.status, 'FAIL');
   assert.equal(stale.second.containerObserverFresh, false);
 


### PR DESCRIPTION
Follow-up to #350 after real runtime verification on Mona.

Prometheus scrapes node-exporter every 15 seconds while the host observer runs every 5 seconds. The previous 15-second freshness ceiling could therefore reject a healthy observer between scrapes. This changes the ceiling to 30 seconds: enough for normal timer/scrape alignment, while one missed scrape still fails the continuously polled monitor.

Evidence:
- observed healthy production-isolated sample age of 11.4 seconds under normal alignment
- boundary test: 30 seconds passes, 31 seconds fails
- HLS harness 54 Node + 6 Python tests green
- syntax checks green

No load, checkout, payment, event, audio, container restart or runtime configuration change.