### PR TITLE
docs(listener): clarify productive rehearsal boundary

### DIFF
--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -23,6 +23,9 @@ on:
       - tools/early-birds-hls-load/**
       - docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
       - docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+      - docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+      - docs/operations/LISTENER_LAUNCH_NOW.md
+      - docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
       - .github/workflows/early-birds-fast-forward.yml
   push:
     branches: [early-birds, "feat/early-birds-*"]
@@ -47,6 +50,9 @@ on:
       - tools/early-birds-hls-load/**
       - docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
       - docs/operations/EARLY_BIRDS_STAGING_PREVIEW.md
+      - docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+      - docs/operations/LISTENER_LAUNCH_NOW.md
+      - docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
       - .github/workflows/early-birds-fast-forward.yml
 
 permissions:

--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -28,6 +28,11 @@ truthful launch baseline, not a substitute for counsel review. Human owner: Nico
   database backup was restored into an isolated rehearsal database and verified.
 - Production provider and new-sales flags remain OFF. No real payment was attempted.
 
+These accepted browser lifecycles are explicitly non-production: PayPal used
+Sandbox and Mercado Pago used TEST. The productive lanes have passed only
+read-only provider preflight so far; neither provider has completed a Live
+activation/cancel/refund rehearsal and no real charge has been created.
+
 Passwordless email delivery is deployed in the dedicated Listener-only sidecar at exact backend
 SHA `456ece2b38e203a2d12c54864115e03ebaa1a89c`. The API, worker and PostgreSQL queue have no host
 ports, use separate storage and did not restart or modify any event service. A controlled message
@@ -164,9 +169,10 @@ converted back into a reversible action.
   explicitly commanded disaster recovery with both providers frozen and a complete provider-led
   reconciliation plan; it is not an ordinary rollback.
 - Listener regression: roll back only the Listener image while keeping a contract-compatible
-  authority. `0a475717` remains the bounded contract-compatible application rollback for the current
-  authority. Preserve the `0a475717` withdrawal operator and database so already-received legal
-  requests remain processable; hide new legal submissions with their feature switch if necessary.
+  authority. `acc90ba3` remains the bounded contract-compatible application rollback for the current
+  authority. Preserve the independently pinned `0a475717` withdrawal operator
+  and database so already-received legal requests remain processable; hide new
+  legal submissions with their feature switch if necessary.
   If compatibility is uncertain, keep Listener disabled and roll forward.
 - Provider-specific incident: disable only that app checkout flag. Do not route a pending checkout
   to the other provider or manufacture membership.

--- a/docs/operations/LISTENER_LAUNCH_NOW.md
+++ b/docs/operations/LISTENER_LAUNCH_NOW.md
@@ -50,6 +50,14 @@ PayPal Sandbox has passed activation, pending cancellation, reactivation and
 terminal refund. Mercado Pago TEST has passed checkout, activation, pause,
 reactivation and reconciliation. Browser redirects never grant membership.
 
+| Provider | Non-production lifecycle | Productive state |
+| --- | --- | --- |
+| PayPal | Sandbox activation, pending cancellation, reactivation and terminal refund accepted | Live catalog/webhook read-only preflight verified; lifecycle and real charge not yet rehearsed |
+| Mercado Pago | TEST checkout, activation, pause, reactivation and reconciliation accepted | Live merchant/webhook read-only preflight verified; lifecycle and real charge not yet rehearsed |
+
+“Private rehearsal completed” currently means Sandbox/TEST only. A productive
+Live rehearsal remains a separate, explicitly approved real-money operation.
+
 The first bounded external media-plane smoke passed on 2026-08-15: ten clients
 from `daimonmatrix`, 348/348 successful requests, no fetch/window/scheduling
 misses, no Listener/origin restart or OOM, no alert and clean five-minute

--- a/docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
+++ b/docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
@@ -23,6 +23,19 @@ not touch event, LiveKit, playlist-bot, tapestry or audio services.
 - Recreating this disposable port-13001 container did not restart the
   persistent Listener, event app, LiveKit, event workers or audio origin.
 
+The dormant preflight was reconfirmed after the first external media smoke:
+
+- `pmp-myth-listener-live-preflight --provider all` returned `verified` for
+  the PayPal catalog/webhook and Mercado Pago merchant/webhook with
+  `new_sales=disabled`;
+- authority API/worker, public Listener and the staging workbench were healthy
+  with restart count `0` at their exact documented images;
+- same-origin, correctly shaped public PayPal and Mercado Pago checkout
+  requests returned `404`; canonical and staging Live-workbench requests also
+  returned `404`;
+- Prometheus and Alertmanager had zero active alerts. This read-only evidence
+  created no checkout, approval, subscription or charge.
+
 This dormant state is the required baseline before selecting either provider.
 Do not turn the gate or authority new sales on merely to test route reachability.
 


### PR DESCRIPTION
Clarifies that accepted private browser lifecycles were PayPal Sandbox and Mercado Pago TEST, while productive Live lanes have only passed read-only preflight.

Records a fresh dormant-state verification with new sales OFF and all checkout/workbench paths closed. Corrects the commercial rollback runbook to use the prior Listener app SHA (`acc90ba3`) instead of the independently pinned withdrawal-operator SHA.

No runtime, payment, event or audio changes; no checkout, subscription or charge created.