### PR TITLE
feat(listener): verify dormant Live commerce boundary

### DIFF
--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -139,8 +139,10 @@ converted back into a reversible action.
    `pmp-myth-listener-live-preflight --provider mercado_pago`, or `--provider all`.
    The command performs only provider reads and emits no IDs, secrets or PII. Require
    `status=verified` and `new_sales=disabled`; on any failure, keep all Live flags OFF.
-4. Validate private readiness, exact signed-webhook negative cases and reconciliation. The
-   preflight does not replace webhook signature or lifecycle tests.
+4. Validate private readiness, exact signed-webhook negative cases and reconciliation. From an
+   external operator host, run
+   `node scripts/early-birds-preview/listener-live-dormant-check.mjs` and require `PASS` while
+   sales are dormant. The provider preflight does not replace webhook signature or lifecycle tests.
 5. Install the reviewed Listener nginx template and verify exact routes plus final 404. Do not
    reload nginx unless `nginx -t` is green.
 6. Enable the matching Listener checkout flag only after the authority reports that Live provider

--- a/docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
+++ b/docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
@@ -39,6 +39,20 @@ The dormant preflight was reconfirmed after the first external media smoke:
 This dormant state is the required baseline before selecting either provider.
 Do not turn the gate or authority new sales on merely to test route reachability.
 
+Recheck the public/staging/event HTTP boundary from an external operator host:
+
+```bash
+node scripts/early-birds-preview/listener-live-dormant-check.mjs
+```
+
+Require `status=PASS`. The fixed verifier uses no cookie, authorization header,
+account or provider secret. It checks health/legal surfaces and sends only
+anonymous, correctly shaped requests that can never pass session validation;
+both productive provider routes and both Live-workbench hosts must return
+`404`, and the event vhost must expose neither route. Pair this external check
+with the authority's read-only `pmp-myth-listener-live-preflight --provider all`;
+neither command creates checkout state.
+
 ## Boundary
 
 - Exact browser endpoint: `POST /api/listener/checkout/live-workbench` on the staging host only.

--- a/ops/early-birds-preview/package.json
+++ b/ops/early-birds-preview/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "node --check ../../scripts/early-birds-preview/validate.mjs && sh -n ../../scripts/early-birds-preview/lib.sh ../../scripts/early-birds-preview/start.sh ../../scripts/early-birds-preview/stop.sh ../../scripts/early-birds-preview/rollback.sh ../../scripts/early-birds-preview/disable-public.sh ../../scripts/early-birds-preview/rehearse-migration.sh ../../scripts/early-birds-preview/health-smoke.sh ../../scripts/early-birds-preview/canonical-free-smoke.sh ../../scripts/early-birds-preview/registered-free-smoke.sh",
+    "check": "node --check ../../scripts/early-birds-preview/validate.mjs ../../scripts/early-birds-preview/listener-live-dormant-check.mjs && sh -n ../../scripts/early-birds-preview/lib.sh ../../scripts/early-birds-preview/start.sh ../../scripts/early-birds-preview/stop.sh ../../scripts/early-birds-preview/rollback.sh ../../scripts/early-birds-preview/disable-public.sh ../../scripts/early-birds-preview/rehearse-migration.sh ../../scripts/early-birds-preview/health-smoke.sh ../../scripts/early-birds-preview/canonical-free-smoke.sh ../../scripts/early-birds-preview/registered-free-smoke.sh",
     "validate": "node ../../scripts/early-birds-preview/validate.mjs",
     "validate:build": "node ../../scripts/early-birds-preview/validate.mjs --build",
     "test": "node --test test/*.test.mjs"

--- a/ops/early-birds-preview/test/listener-live-dormant-check.test.mjs
+++ b/ops/early-birds-preview/test/listener-live-dormant-check.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  verifyDormantListenerLiveState,
+} from '../../../scripts/early-birds-preview/listener-live-dormant-check.mjs';
+
+function responseFor(url, init, overrides = {}) {
+  const path = new URL(url).pathname;
+  if (init.method === 'POST') return new Response('', { status: overrides[path] ?? 404 });
+  if (path.startsWith('/api/health')) {
+    return Response.json({ status: 'ok' }, { status: overrides[path] ?? 200 });
+  }
+  return new Response('<!doctype html><title>Listener</title>', {
+    status: overrides[path] ?? 200,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  });
+}
+
+test('passes only with healthy fixed hosts, legal pages and every Live checkout path closed', async () => {
+  const calls = [];
+  const result = await verifyDormantListenerLiveState({
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return responseFor(url, init);
+    },
+  });
+
+  assert.equal(result.status, 'PASS');
+  assert.equal(result.checks.length, 14);
+  assert.ok(result.checks.every((check) => check.passed));
+  const posts = calls.filter((call) => call.init.method === 'POST');
+  assert.equal(posts.length, 6);
+  for (const { url, init } of posts) {
+    const origin = new URL(url).origin;
+    assert.equal(init.credentials, 'omit');
+    assert.equal(init.redirect, 'manual');
+    assert.equal(init.headers.origin, origin);
+    assert.equal(init.headers['sec-fetch-site'], 'same-origin');
+    assert.equal(init.headers.authorization, undefined);
+    assert.equal(init.headers.cookie, undefined);
+    assert.doesNotMatch(init.body, /email|token|subscription|account/i);
+  }
+});
+
+test('fails closed if either productive provider becomes reachable', async () => {
+  let checkoutCount = 0;
+  const result = await verifyDormantListenerLiveState({
+    fetchImpl: async (url, init) => {
+      if (init.method === 'POST' && new URL(url).hostname === 'listen.harmonicbeacon.com' &&
+          new URL(url).pathname === '/api/listener/checkout') {
+        checkoutCount += 1;
+        return new Response('', { status: checkoutCount === 2 ? 401 : 404 });
+      }
+      return responseFor(url, init);
+    },
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.deepEqual(
+    result.checks.find((check) => check.name === 'listener-mercado-pago-live-checkout-off'),
+    { name: 'listener-mercado-pago-live-checkout-off', passed: false, status: 401 },
+  );
+});
+
+test('fails closed on redirects, malformed health, oversized bodies and network errors', async () => {
+  const result = await verifyDormantListenerLiveState({
+    fetchImpl: async (url, init) => {
+      const path = new URL(url).pathname;
+      if (path === '/api/health') return new Response('not-json', { headers: { 'content-type': 'application/json' } });
+      if (path === '/api/health/ready' && new URL(url).hostname === 'earlybirds-staging.harmonicbeacon.com') {
+        return new Response('', { status: 302, headers: { location: 'https://example.invalid/' } });
+      }
+      if (path === '/listener/privacy') {
+        return new Response('x', { headers: { 'content-type': 'text/html', 'content-length': '70000' } });
+      }
+      if (path === '/listener/withdrawal') throw new Error('network details must not escape');
+      return responseFor(url, init);
+    },
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.deepEqual(Object.keys(result).sort(), ['checks', 'schemaVersion', 'status']);
+  assert.doesNotMatch(JSON.stringify(result), /network details|example\.invalid|not-json/);
+  assert.equal(result.checks.filter((check) => !check.passed).length, 4);
+});

--- a/scripts/early-birds-preview/listener-live-dormant-check.mjs
+++ b/scripts/early-birds-preview/listener-live-dormant-check.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const ATTEMPT_ID = '00000000-0000-4000-8000-000000000000';
+
+const hosts = Object.freeze({
+  listener: 'https://listen.harmonicbeacon.com',
+  staging: 'https://earlybirds-staging.harmonicbeacon.com',
+  event: 'https://live.harmonicbeacon.com',
+});
+
+const checks = Object.freeze([
+  { name: 'listener-health', kind: 'health', url: `${hosts.listener}/api/health` },
+  { name: 'listener-readiness', kind: 'health', url: `${hosts.listener}/api/health/ready` },
+  { name: 'staging-readiness', kind: 'health', url: `${hosts.staging}/api/health/ready` },
+  { name: 'event-readiness', kind: 'health', url: `${hosts.event}/api/health/ready` },
+  { name: 'listener-terms', kind: 'html', url: `${hosts.listener}/listener/terms` },
+  { name: 'listener-privacy', kind: 'html', url: `${hosts.listener}/listener/privacy` },
+  { name: 'listener-withdrawal', kind: 'html', url: `${hosts.listener}/listener/withdrawal` },
+  {
+    name: 'listener-service-cancellation',
+    kind: 'html',
+    url: `${hosts.listener}/listener/cancel-service`,
+  },
+  {
+    name: 'listener-paypal-live-checkout-off',
+    kind: 'closed',
+    url: `${hosts.listener}/api/listener/checkout`,
+    origin: hosts.listener,
+    body: { provider: 'paypal', attemptId: ATTEMPT_ID },
+  },
+  {
+    name: 'listener-mercado-pago-live-checkout-off',
+    kind: 'closed',
+    url: `${hosts.listener}/api/listener/checkout`,
+    origin: hosts.listener,
+    body: { provider: 'mercado_pago', attemptId: ATTEMPT_ID },
+  },
+  {
+    name: 'listener-live-workbench-absent',
+    kind: 'closed',
+    url: `${hosts.listener}/api/listener/checkout/live-workbench`,
+    origin: hosts.listener,
+    body: { attemptId: ATTEMPT_ID },
+  },
+  {
+    name: 'staging-live-workbench-off',
+    kind: 'closed',
+    url: `${hosts.staging}/api/listener/checkout/live-workbench`,
+    origin: hosts.staging,
+    body: { attemptId: ATTEMPT_ID },
+  },
+  {
+    name: 'event-checkout-absent',
+    kind: 'closed',
+    url: `${hosts.event}/api/listener/checkout`,
+    origin: hosts.event,
+    body: { provider: 'paypal', attemptId: ATTEMPT_ID },
+  },
+  {
+    name: 'event-live-workbench-absent',
+    kind: 'closed',
+    url: `${hosts.event}/api/listener/checkout/live-workbench`,
+    origin: hosts.event,
+    body: { attemptId: ATTEMPT_ID },
+  },
+]);
+
+async function boundedBody(response) {
+  const declared = response.headers.get('content-length');
+  if (declared !== null && (!/^\d+$/.test(declared) || Number(declared) > MAX_RESPONSE_BYTES)) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error('invalid_response');
+  }
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const chunks = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error('invalid_response');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const joined = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder('utf-8', { fatal: true }).decode(joined);
+}
+
+async function runCheck(check, fetchImpl) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const isPost = check.kind === 'closed';
+    const response = await fetchImpl(check.url, {
+      method: isPost ? 'POST' : 'GET',
+      redirect: 'manual',
+      cache: 'no-store',
+      credentials: 'omit',
+      signal: controller.signal,
+      headers: isPost ? {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        origin: check.origin,
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+      } : { accept: check.kind === 'html' ? 'text/html' : 'application/json' },
+      body: isPost ? JSON.stringify(check.body) : undefined,
+    });
+    if (check.kind === 'closed') {
+      await response.body?.cancel().catch(() => undefined);
+      return { name: check.name, passed: response.status === 404, status: response.status };
+    }
+    if (response.status !== 200) {
+      await response.body?.cancel().catch(() => undefined);
+      return { name: check.name, passed: false, status: response.status };
+    }
+    const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim();
+    const body = await boundedBody(response);
+    if (check.kind === 'html') {
+      return { name: check.name, passed: contentType === 'text/html' && body.length > 0, status: 200 };
+    }
+    let value;
+    try {
+      value = JSON.parse(body);
+    } catch {
+      value = null;
+    }
+    return {
+      name: check.name,
+      passed: contentType === 'application/json' && value?.status === 'ok',
+      status: 200,
+    };
+  } catch {
+    return { name: check.name, passed: false, status: null };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function verifyDormantListenerLiveState({ fetchImpl = fetch } = {}) {
+  const results = await Promise.all(checks.map((check) => runCheck(check, fetchImpl)));
+  return {
+    schemaVersion: 'listener-live-dormant-check.v1',
+    status: results.every((result) => result.passed) ? 'PASS' : 'FAIL',
+    checks: results,
+  };
+}
+
+async function main() {
+  if (process.argv.length !== 2) {
+    process.stderr.write('Usage: node scripts/early-birds-preview/listener-live-dormant-check.mjs\n');
+    process.exitCode = 2;
+    return;
+  }
+  const result = await verifyDormantListenerLiveState();
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  if (result.status !== 'PASS') process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}


### PR DESCRIPTION
Adds a fixed, credential-free external gate for the required dormant commercial state. It validates Listener/staging/event health, public legal actions, both productive checkout providers OFF, both Live workbench hosts OFF and no payment routes on the event vhost.

The verifier has no configurable target, sends no cookie/auth/account/PII and cannot create checkout state. Unexpected reachability, redirects, malformed/oversized responses or network errors fail closed without echoing response/error content.

Evidence: 46 preview tests green; focused negative tests green; exact public runtime PASS; contracts byte-exact. No provider mutation, real checkout, event deployment or audio change.