### PR TITLE
feat(listener): decouple authorized audio delivery

### DIFF
--- a/docs/architecture/EARLY_BIRDS_LISTENER.md
+++ b/docs/architecture/EARLY_BIRDS_LISTENER.md
@@ -196,15 +196,18 @@ test window and rotate the temporary code after the window.
 
 ## Stream and device leases
 
-An entitled account may hold two active device leases. A third device evicts the oldest lease. The
-browser plays a stable same-origin URL under `/api/early-birds/stream/manifest`; the route rechecks
-the authenticated account, current membership and non-evicted lease before proxying a short-lived
-origin manifest with `private, no-store` behavior.
+An entitled account may hold two active device leases. A third device evicts the oldest lease. After
+the account, quota and lease decision, Listener registers one opaque media grant over a private
+container network. The browser then fetches the manifest and segments directly from
+`stream.harmonicbeacon.com`; playback no longer polls Listener, Better Auth or PostgreSQL.
 
-The origin signature is HMAC-SHA-256 base64url over the exact bytes
-`GET\n/v1/hls/{artifactId}/live.m3u8\n{unix_expiry}`. Expiry never exceeds the lease or ten minutes.
-The origin manifest must contain individually signed, same-origin segment URLs. Signing material and
-signed URLs are never returned in API JSON or logged.
+The grant ID and bearer are deterministic per opaque lease generation, so a heartbeat extends its
+expiry without replacing the media URL. The origin retains only a token hash and expiry—never the
+account, device, lease ID or PII—and rejects grants beyond the three-minute lease horizon. A Listener
+or database outage therefore cannot interrupt already-buffered audio immediately: origin requests
+continue until the last registered lease expiry, then fail closed. Media-query credentials are not
+written to nginx or application logs. Legacy `exp`/`sig` HMAC URLs remain an operator canary and
+origin-first rollback protocol, not an alternate public authorization model.
 
 Reviewed intro artifacts are configured as immutable, server-selected private files. Listener UI does not
 encode or alter them and their progress is local to the browser. Before either intro can be selected, the

--- a/docs/decisions/0003-deterministic-hls-and-audio-guardrail.md
+++ b/docs/decisions/0003-deterministic-hls-and-audio-guardrail.md
@@ -10,13 +10,18 @@ small origin derives the current media sequence from wall-clock time. Restarting
 the origin does not restart or duplicate the Beacon timeline.
 
 Safari uses native HLS and other supported browsers use `hls.js`. Membership
-authorizes a stable, same-origin lease-manifest route. That route rechecks the
-session, current membership and device lease on every manifest refresh, then
-proxies a very short-lived origin manifest whose segment URLs are individually
-signed. Native players therefore never need an `audio.src` replacement merely
-to refresh authorization. Signatures cover method, canonical path and expiry,
-use constant-time comparison and are never logged. Public health is minimal;
-metrics bind privately.
+authorizes an opaque, three-minute media grant registered on the origin over a
+private network. The browser receives one stable direct-origin URL; heartbeats
+extend the same grant without replacing `audio.src`. Manifest and segment
+fetches therefore do not depend on the Listener process, auth service or
+database. The origin stores only a token hash and expiry, compares credentials
+in constant time and fails closed at the lease horizon. Bearer query strings
+are never logged. Public health is minimal; metrics bind privately.
+
+The current immutable loop is a temporary source adapter for development. The
+delivery and grant boundary is source-agnostic: a future continuously played
+Beacon is packaged into the same advancing HLS timeline without changing
+browser authorization or the audio controls.
 
 ## Audio boundary
 

--- a/docs/operations/LISTENER_AUDIO_CONTINUITY.md
+++ b/docs/operations/LISTENER_AUDIO_CONTINUITY.md
@@ -85,12 +85,22 @@ Firefox, Android Chrome and iPhone Safari. Include foreground, one
 background/foreground cycle and speakers/headphones when available. Perform a
 60-minute physical listen on at least one representative mobile device.
 
-For deterministic recovery evidence in staging, interrupt only the Listener
-control plane for less than 30 seconds while the independent origin remains
-healthy. The same client must reconnect at the configured buffered live
-position with one audible source and one quota presence interval. Do not
-perform this exercise while an event is active and do not restart the origin
-to simulate it.
+For deterministic recovery evidence in staging, acquire a media grant and then
+interrupt only the Listener control plane while the independent origin remains
+healthy. Manifest and segment requests using the already-issued URL must keep
+returning 200 without any Listener/database callback until the exact registered
+lease expiry; the next request must return 403. Restore Listener before expiry
+for a physical playback drill. The stable URL must survive heartbeat renewal,
+with one audible source and one quota presence interval. Do not restart the
+origin to simulate a control-plane failure.
+
+This is bounded continuity, not unrestricted media access. Heartbeats renew
+once per minute; each successful renewal grants at most three further minutes,
+also capped by remaining quota. With the approximately two-minute playback
+buffer, a failure immediately after renewal can preserve roughly five minutes
+of user-perceived audio. Stop/revoke may likewise take at most the outstanding
+grant horizon to drain at origin; quota settlement remains capped by the same
+lease expiry.
 
 ## Reliability tiers still required
 
@@ -98,16 +108,11 @@ The five-minute origin window protects against ordinary last-mile jitter; it
 does not make a single host highly available. Public-release reliability also
 requires independently reviewable delivery work:
 
-1. cache immutable media segments at a CDN/edge and keep manifests private and
-   short-lived;
-2. remove the Listener application/database from the segment hot path after a
-   bounded authorization decision, so control-plane latency cannot interrupt
-   already-authorized audio;
-3. publish the identical encoded timeline from at least two failure domains
+1. publish the identical encoded timeline from at least two failure domains
    and provide tested client/playlist failover without overlapping audio;
-4. run synthetic audio canaries from North America, Europe and Latin America,
+2. run synthetic audio canaries from North America, Europe and Latin America,
    and retain low-cardinality, non-PII browser recovery causes;
-5. define and gate on interruption-free session rate, rebuffer ratio, join
+3. define and gate on interruption-free session rate, rebuffer ratio, join
    success and recovery time, including multi-hour network and origin-failure
    drills.
 

--- a/docs/plans/EARLY_BIRDS.md
+++ b/docs/plans/EARLY_BIRDS.md
@@ -289,12 +289,12 @@ promotion, never an accidental restart side effect.
 - The public page does not expose a durable unrestricted media URL.
 - The private player obtains a short-lived signed stream authorization after a
   current membership check.
-- The browser keeps one stable same-origin lease-manifest URL. Each refresh
-  rechecks session, membership and device lease before proxying a fresh signed
-  origin manifest, so authorization refresh never replaces the media source.
-- The manifest embeds individually signed segment URLs; signatures cover HTTP
-  method, canonical path and expiry, are compared in constant time and are
-  never logged.
+- The browser keeps one stable direct-origin media-grant URL. Listener checks
+  session, membership, quota and device lease only at acquisition/heartbeat,
+  then renews the opaque grant privately without replacing the media source.
+- Manifest and segment fetches never consult Listener or PostgreSQL. The origin
+  stores only a token hash and lease-bounded expiry; bearer URLs are never
+  logged and fail closed after the last successful renewal.
 - Expiry and refresh do not interrupt healthy playback unnecessarily.
 - The UI says "continuous Beacon stream" and does not claim whether the source
   is an instrument, a file or another origin.

--- a/ops/early-birds-preview/compose.yml
+++ b/ops/early-birds-preview/compose.yml
@@ -82,6 +82,7 @@ services:
       EARLY_BIRDS_BEACON_SERVICE_KEY_CURRENT_ID: ${EARLY_BIRDS_BEACON_SERVICE_KEY_CURRENT_ID:?set_in_preview.env}
       EARLY_BIRDS_BEACON_SERVICE_KEY_CURRENT: ${EARLY_BIRDS_BEACON_SERVICE_KEY_CURRENT:?set_in_preview.env}
       EARLY_BIRDS_STREAM_ORIGIN: ${EARLY_BIRDS_STREAM_ORIGIN:?set_in_preview.env}
+      EARLY_BIRDS_STREAM_CONTROL_ORIGIN: ${EARLY_BIRDS_STREAM_CONTROL_ORIGIN:?set_in_preview.env}
       EARLY_BIRDS_STREAM_ARTIFACT_ID: ${EARLY_BIRDS_STREAM_ARTIFACT_ID:?set_in_preview.env}
       EARLY_BIRDS_STREAM_SIGNING_SECRET: ${EARLY_BIRDS_STREAM_SIGNING_SECRET:?set_in_preview.env}
       EARLY_BIRDS_DEVICE_PEPPER: ${EARLY_BIRDS_DEVICE_PEPPER:?set_in_preview.env}
@@ -119,6 +120,7 @@ services:
     networks:
       - preview_db
       - listener_egress
+      - stream_control
     depends_on:
       postgres: { condition: service_healthy }
       migration: { condition: service_completed_successfully }
@@ -175,6 +177,11 @@ networks:
   # HTTPS stream origin without giving PostgreSQL or migrations internet egress.
   listener_egress:
     name: earlybirds_preview_listener_egress
+  # Private control-plane link: Listener renews opaque media grants here while
+  # browsers fetch audio directly from the public stream origin.
+  stream_control:
+    name: earlybirds_stream_control_internal
+    internal: true
 
 volumes:
   earlybirds-preview-postgres:

--- a/ops/early-birds-preview/nginx/stream.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/stream.harmonicbeacon.com.conf.template
@@ -38,6 +38,10 @@ server {
     }
 
     location ^~ /v1/hls/ {
+        # Signed/granted media URLs are bearer credentials. Never persist the
+        # query string in edge access logs.
+        access_log off;
+        error_log /dev/null crit;
         proxy_pass http://127.0.0.1:18080;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/ops/early-birds-preview/preview.env.synthetic.example
+++ b/ops/early-birds-preview/preview.env.synthetic.example
@@ -71,6 +71,7 @@ EARLY_BIRDS_BEACON_SERVICE_KEY_CURRENT=synthetic-preview-inbound-token-at-least-
 # The Listener is production-mode and therefore accepts only HTTPS here. The
 # shared secret and artifact identifier must match beacon-stream below.
 EARLY_BIRDS_STREAM_ORIGIN=https://stream.harmonicbeacon.com
+EARLY_BIRDS_STREAM_CONTROL_ORIGIN=http://beacon-stream:8080
 EARLY_BIRDS_STREAM_ARTIFACT_ID=synthetic-preview-artifact
 EARLY_BIRDS_STREAM_SIGNING_SECRET=synthetic-preview-stream-signing-secret-at-least-32-characters
 EARLY_BIRDS_DEVICE_PEPPER=synthetic-preview-device-pepper-at-least-32-characters

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -287,6 +287,18 @@ test('stream publishes only through a dedicated edge network', async () => {
   assert.match(source, /- stream_observability\s+[^]*- stream_edge/);
   assert.match(source, /stream_observability:\s+name: earlybirds_stream_observability\s+internal: true/);
   assert.match(source, /stream_edge:\s+name: earlybirds_stream_edge/);
+  assert.match(source, /stream_control:\s+name: earlybirds_stream_control_internal\s+internal: true/);
+});
+
+test('Listener renews media grants only over the shared private control network', async () => {
+  const listener = await readPreview('compose.yml');
+  const origin = await readRepository('services/beacon-stream/docker-compose.yml');
+  const nginx = await readPreview('nginx/stream.harmonicbeacon.com.conf.template');
+  assert.match(listener, /EARLY_BIRDS_STREAM_CONTROL_ORIGIN:.*EARLY_BIRDS_STREAM_CONTROL_ORIGIN/);
+  assert.match(listener, /- stream_control/);
+  assert.match(origin, /- stream_control/);
+  assert.match(nginx, /location \^~ \/v1\/hls\/ \{\s+[^}]*access_log off;[^}]*error_log \/dev\/null crit;/);
+  assert.doesNotMatch(nginx, /internal\/v1\/listener\/media-grants/);
 });
 
 test('nginx templates isolate staging, stream and the constrained public Listener host', async () => {

--- a/scripts/early-birds-preview/lib.sh
+++ b/scripts/early-birds-preview/lib.sh
@@ -116,6 +116,7 @@ require_synthetic_env() {
     require_exact_preview_value EARLY_BIRDS_TRUSTED_ORIGINS https://earlybirds-staging.harmonicbeacon.com "$env_file"
   fi
   require_exact_preview_value EARLY_BIRDS_STREAM_ORIGIN https://stream.harmonicbeacon.com "$env_file"
+  require_exact_preview_value EARLY_BIRDS_STREAM_CONTROL_ORIGIN http://beacon-stream:8080 "$env_file"
   require_exact_preview_value BEACON_STREAM_PUBLIC_ORIGIN https://stream.harmonicbeacon.com "$env_file"
   stream_allowed_origins=$(preview_env_value BEACON_STREAM_ALLOWED_ORIGINS "$env_file")
   case "$stream_allowed_origins" in
@@ -197,6 +198,7 @@ require_synthetic_env() {
       EARLY_BIRDS_TRUSTED_ORIGINS=https://listen.harmonicbeacon.com,https://earlybirds-staging.harmonicbeacon.com|\
       EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS=earlybirds-staging.harmonicbeacon.com|\
       EARLY_BIRDS_STREAM_ORIGIN=https://stream.harmonicbeacon.com|\
+      EARLY_BIRDS_STREAM_CONTROL_ORIGIN=http://beacon-stream:8080|\
       BEACON_STREAM_PUBLIC_ORIGIN=https://stream.harmonicbeacon.com|\
       BEACON_STREAM_ALLOWED_ORIGINS=https://earlybirds-staging.harmonicbeacon.com|\
       BEACON_STREAM_ALLOWED_ORIGINS=https://earlybirds-staging.harmonicbeacon.com,https://listen.harmonicbeacon.com) ;;

--- a/scripts/early-birds-preview/validate.mjs
+++ b/scripts/early-birds-preview/validate.mjs
@@ -45,6 +45,7 @@ const syntheticEnv = [
   'EARLY_BIRDS_BEACON_SERVICE_KEY_CURRENT_ID=synthetic-v1',
   'EARLY_BIRDS_BEACON_SERVICE_KEY_CURRENT=synthetic-preview-inbound-token-at-least-43-characters-long',
   'EARLY_BIRDS_STREAM_ORIGIN=https://stream.harmonicbeacon.com',
+  'EARLY_BIRDS_STREAM_CONTROL_ORIGIN=http://beacon-stream:8080',
   'EARLY_BIRDS_STREAM_ARTIFACT_ID=synthetic-preview-artifact',
   `EARLY_BIRDS_STREAM_SIGNING_SECRET=${syntheticSecret}`,
   'EARLY_BIRDS_DEVICE_PEPPER=synthetic-preview-device-pepper-at-least-32-characters',
@@ -128,7 +129,8 @@ try {
   assert.equal(listener.volumes[1].read_only, true);
   assert.equal(listener.depends_on.postgres.condition, 'service_healthy');
   assert.equal(listener.depends_on.migration.condition, 'service_completed_successfully');
-  assert.deepEqual(Object.keys(listener.networks).sort(), ['listener_egress', 'preview_db']);
+  assert.deepEqual(Object.keys(listener.networks).sort(), ['listener_egress', 'preview_db', 'stream_control']);
+  assert.equal(listener.environment.EARLY_BIRDS_STREAM_CONTROL_ORIGIN, 'http://beacon-stream:8080');
   const appPort = publishedPort(listener, 3000);
   assert.equal(appPort.host_ip, '127.0.0.1');
   assert.equal(Number(appPort.published), 13000);
@@ -145,7 +147,9 @@ try {
 
   assert.equal(stream.build.context, path.join(root, 'services/beacon-stream'));
   assert.equal(stream.build.dockerfile, 'Dockerfile');
-  assert.deepEqual(Object.keys(stream.networks).sort(), ['stream_edge', 'stream_observability']);
+  assert.deepEqual(Object.keys(stream.networks).sort(), ['stream_control', 'stream_edge', 'stream_observability']);
+  assert.equal(resolved.networks.stream_control.internal, true);
+  assert.equal(resolved.networks.stream_control.name, 'earlybirds_stream_control_internal');
   assert.equal(resolved.networks.stream_observability.internal, true);
   assert.equal(resolved.networks.stream_observability.name, 'earlybirds_stream_observability');
   assert.notEqual(resolved.networks.stream_edge.internal, true);
@@ -175,7 +179,7 @@ try {
   assert.equal(authorityResolved.networks.authority_private.external, true);
   assert.equal(authorityResolved.networks.authority_private.name, 'earlybirds_authority_private');
   assert.deepEqual(Object.keys(authorityResolved.services.listener.networks).sort(), [
-    'authority_private', 'listener_egress', 'preview_db',
+    'authority_private', 'listener_egress', 'preview_db', 'stream_control',
   ]);
   assert.deepEqual(
     authorityResolved.services.listener.networks.authority_private.aliases,

--- a/services/beacon-stream/docker-compose.yml
+++ b/services/beacon-stream/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       # `internal` network. This separate edge bridge permits the explicit
       # loopback binding above without exposing private readiness/metrics.
       - stream_edge
+      - stream_control
     deploy:
       resources:
         limits:
@@ -46,3 +47,6 @@ networks:
     internal: true
   stream_edge:
     name: earlybirds_stream_edge
+  stream_control:
+    name: earlybirds_stream_control_internal
+    internal: true

--- a/services/beacon-stream/src/control-auth.mjs
+++ b/services/beacon-stream/src/control-auth.mjs
@@ -1,0 +1,23 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+export const CONTROL_CLOCK_SKEW_SECONDS = 30;
+
+export function controlBodyHash(body) {
+  return createHash('sha256').update(body).digest('hex');
+}
+
+export function signControlRequest({ secret, method = 'PUT', pathname, timestamp, body }) {
+  const canonical = `${method}\n${pathname}\n${controlBodyHash(body)}\n${timestamp}`;
+  return createHmac('sha256', secret).update(canonical).digest('base64url');
+}
+
+export function verifyControlRequest({ secret, method, pathname, timestamp, body, signature, nowMs = Date.now() }) {
+  if (!/^\d{10}$/.test(String(timestamp)) || !/^[A-Za-z0-9_-]{43}$/.test(String(signature))) return false;
+  const timestampSeconds = Number(timestamp);
+  if (Math.abs(Math.floor(nowMs / 1000) - timestampSeconds) > CONTROL_CLOCK_SKEW_SECONDS) return false;
+  const expected = signControlRequest({ secret, method, pathname, timestamp: timestampSeconds, body });
+  const suppliedBuffer = Buffer.from(signature, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  return suppliedBuffer.length === expectedBuffer.length && timingSafeEqual(suppliedBuffer, expectedBuffer);
+}
+

--- a/services/beacon-stream/src/manifest.mjs
+++ b/services/beacon-stream/src/manifest.mjs
@@ -39,6 +39,7 @@ export function renderManifest({
   tokenTtlSeconds = 120,
   authorizationExpiresAtSeconds = Number.POSITIVE_INFINITY,
   windowSegments = WINDOW_SEGMENTS,
+  mediaAuthorizationQuery = null,
 }) {
   if (!Number.isSafeInteger(windowSegments) || windowSegments < 6 || windowSegments > 150) {
     throw new Error('windowSegments must be an integer between 6 and 150');
@@ -62,9 +63,19 @@ export function renderManifest({
     '#EXT-X-INDEPENDENT-SEGMENTS',
   ];
 
+  const mediaUrl = (pathname) => {
+    if (mediaAuthorizationQuery) {
+      const url = new URL(pathname, origin);
+      url.searchParams.set('grantId', mediaAuthorizationQuery.grantId);
+      url.searchParams.set('grant', mediaAuthorizationQuery.grant);
+      return url.toString();
+    }
+    return signedUrl({ origin, secret, pathname, expiresAt });
+  };
+
   if (metadata.initialization) {
     const pathname = `/v1/hls/${metadata.artifactId}/segments/${encodeURIComponent(metadata.initialization.file)}`;
-    lines.push(`#EXT-X-MAP:URI="${signedUrl({ origin, secret, pathname, expiresAt })}"`);
+    lines.push(`#EXT-X-MAP:URI="${mediaUrl(pathname)}"`);
   }
 
   for (let sequence = firstSequence; sequence <= edgeSequence; sequence += 1) {
@@ -74,7 +85,7 @@ export function renderManifest({
     lines.push(`#EXTINF:${segment.durationSeconds.toFixed(6)},`);
     const pathname = `/v1/hls/${metadata.artifactId}/segments/${encodeURIComponent(segment.file)}`;
     // Native HLS does not inherit the manifest query string. Every URI is signed.
-    lines.push(signedUrl({ origin, secret, pathname, expiresAt }));
+    lines.push(mediaUrl(pathname));
   }
   return `${lines.join('\n')}\n`;
 }

--- a/services/beacon-stream/src/media-grants.mjs
+++ b/services/beacon-stream/src/media-grants.mjs
@@ -1,0 +1,71 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+export const MEDIA_GRANT_ID_PATTERN = /^[a-f0-9]{64}$/;
+export const MEDIA_GRANT_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+export const MEDIA_GRANT_MAX_TTL_MS = 4 * 60 * 1000;
+export const MEDIA_GRANT_MAX_ENTRIES = 20_000;
+
+function tokenHash(token) {
+  return createHash('sha256').update(token, 'utf8').digest();
+}
+
+export class MediaGrantRegistry {
+  #entries = new Map();
+  #now;
+  #maxEntries;
+
+  constructor({ now = () => Date.now(), maxEntries = MEDIA_GRANT_MAX_ENTRIES } = {}) {
+    this.#now = now;
+    this.#maxEntries = maxEntries;
+  }
+
+  pruneExpired(nowMs = this.#now()) {
+    for (const [id, entry] of this.#entries) {
+      if (entry.expiresAtMs <= nowMs) this.#entries.delete(id);
+    }
+  }
+
+  upsert({ id, tokenSha256, expiresAtMs }) {
+    const nowMs = this.#now();
+    this.pruneExpired(nowMs);
+    if (!MEDIA_GRANT_ID_PATTERN.test(id)
+      || !/^[a-f0-9]{64}$/.test(tokenSha256)
+      || !Number.isSafeInteger(expiresAtMs)
+      || expiresAtMs <= nowMs
+      || expiresAtMs > nowMs + MEDIA_GRANT_MAX_TTL_MS) {
+      return { ok: false, reason: 'invalid' };
+    }
+    const existing = this.#entries.get(id);
+    if (existing && existing.tokenSha256 !== tokenSha256) {
+      return { ok: false, reason: 'conflict' };
+    }
+    if (!existing && this.#entries.size >= this.#maxEntries) {
+      return { ok: false, reason: 'capacity' };
+    }
+    this.#entries.set(id, {
+      tokenSha256,
+      expiresAtMs: Math.max(existing?.expiresAtMs ?? 0, expiresAtMs),
+    });
+    return { ok: true };
+  }
+
+  authorize({ id, token }) {
+    if (!MEDIA_GRANT_ID_PATTERN.test(id) || !MEDIA_GRANT_TOKEN_PATTERN.test(token)) return false;
+    const entry = this.#entries.get(id);
+    if (!entry) return false;
+    const nowMs = this.#now();
+    if (entry.expiresAtMs <= nowMs) {
+      this.#entries.delete(id);
+      return false;
+    }
+    const supplied = tokenHash(token);
+    const expected = Buffer.from(entry.tokenSha256, 'hex');
+    return supplied.length === expected.length && timingSafeEqual(supplied, expected);
+  }
+
+  get size() {
+    this.pruneExpired();
+    return this.#entries.size;
+  }
+}
+

--- a/services/beacon-stream/src/server.mjs
+++ b/services/beacon-stream/src/server.mjs
@@ -3,7 +3,9 @@ import http from 'node:http';
 import path from 'node:path';
 import { loadArtifact, verifyArtifactFiles } from './artifact.mjs';
 import { verifySignedPath } from './auth.mjs';
+import { verifyControlRequest } from './control-auth.mjs';
 import { renderManifest } from './manifest.mjs';
+import { MediaGrantRegistry, MEDIA_GRANT_ID_PATTERN } from './media-grants.mjs';
 import { Metrics } from './metrics.mjs';
 
 function send(response, status, body = '', headers = {}) {
@@ -62,8 +64,33 @@ function authorized({ request, url, secret }) {
   });
 }
 
+function mediaGrantFrom(url) {
+  return {
+    id: url.searchParams.get('grantId') ?? '',
+    token: url.searchParams.get('grant') ?? '',
+  };
+}
+
+function authorizedMedia({ request, url, secret, mediaGrants }) {
+  const grant = mediaGrantFrom(url);
+  if (grant.id || grant.token) return mediaGrants.authorize(grant);
+  return authorized({ request, url, secret });
+}
+
+async function readBoundedBody(request, maximumBytes = 1024) {
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of request) {
+    bytes += chunk.length;
+    if (bytes > maximumBytes) throw new Error('body_too_large');
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
 function routeName(pathname) {
   if (pathname === '/healthz') return 'health';
+  if (pathname.startsWith('/internal/v1/listener/media-grants/')) return 'grant_control';
   if (pathname.endsWith('/live.m3u8')) return 'manifest';
   if (pathname.includes('/segments/')) return 'segment';
   return 'unknown';
@@ -75,7 +102,7 @@ function mediaContentType(file) {
   return 'application/octet-stream';
 }
 
-export function createPublicHandler({ artifactRoot, metadata, publicOrigin, signingSecret, allowedOrigins = new Set(), metrics = new Metrics(), now = () => Date.now() }) {
+export function createPublicHandler({ artifactRoot, metadata, publicOrigin, signingSecret, allowedOrigins = new Set(), metrics = new Metrics(), now = () => Date.now(), mediaGrants = new MediaGrantRegistry({ now }) }) {
   const manifestPath = `/v1/hls/${metadata.artifactId}/live.m3u8`;
   const segmentPrefix = `/v1/hls/${metadata.artifactId}/segments/`;
 
@@ -90,6 +117,40 @@ export function createPublicHandler({ artifactRoot, metadata, publicOrigin, sign
       send(response, responseStatus, body, { ...cors, ...headers })
     );
     try {
+      const controlPrefix = '/internal/v1/listener/media-grants/';
+      if (request.method === 'PUT' && url.pathname.startsWith(controlPrefix)) {
+        const grantId = url.pathname.slice(controlPrefix.length);
+        const body = await readBoundedBody(request);
+        if (!MEDIA_GRANT_ID_PATTERN.test(grantId)
+          || !verifyControlRequest({
+            secret: signingSecret,
+            method: 'PUT',
+            pathname: url.pathname,
+            timestamp: request.headers['x-beacon-control-timestamp'],
+            signature: request.headers['x-beacon-control-signature'],
+            body,
+            nowMs: now(),
+          })) {
+          status = 403;
+          respond(status, 'forbidden\n', { 'Cache-Control': 'no-store' });
+          return;
+        }
+        let payload;
+        try { payload = JSON.parse(body.toString('utf8')); } catch { payload = null; }
+        const result = payload && mediaGrants.upsert({
+          id: grantId,
+          tokenSha256: payload.tokenSha256,
+          expiresAtMs: payload.expiresAtMs,
+        });
+        if (!result?.ok) {
+          status = result?.reason === 'capacity' ? 503 : result?.reason === 'conflict' ? 409 : 400;
+          respond(status, status === 503 ? 'unavailable\n' : 'invalid grant\n', { 'Cache-Control': 'no-store' });
+          return;
+        }
+        status = 204;
+        respond(status, '', { 'Cache-Control': 'no-store' });
+        return;
+      }
       if (request.method !== 'GET' && request.method !== 'HEAD') {
         status = 405;
         respond(status, 'method not allowed\n', { Allow: 'GET, HEAD' });
@@ -101,11 +162,12 @@ export function createPublicHandler({ artifactRoot, metadata, publicOrigin, sign
         return;
       }
       if (url.pathname === manifestPath) {
-        if (!authorized({ request, url, secret: signingSecret })) {
+        if (!authorizedMedia({ request, url, secret: signingSecret, mediaGrants })) {
           status = 403;
           respond(status, 'forbidden\n', { 'Cache-Control': 'no-store' });
           return;
         }
+        const grant = mediaGrantFrom(url);
         const manifest = renderManifest({
           metadata,
           origin: publicOrigin,
@@ -114,6 +176,7 @@ export function createPublicHandler({ artifactRoot, metadata, publicOrigin, sign
           // A segment grant is derived from this manifest grant and must never
           // remain usable after the upstream Listener lease horizon.
           authorizationExpiresAtSeconds: tokenFrom(url).expiresAt,
+          mediaAuthorizationQuery: grant.id ? { grantId: grant.id, grant: grant.token } : null,
         });
         status = 200;
         bytes = request.method === 'HEAD' ? 0 : Buffer.byteLength(manifest);
@@ -124,7 +187,7 @@ export function createPublicHandler({ artifactRoot, metadata, publicOrigin, sign
         return;
       }
       if (url.pathname.startsWith(segmentPrefix)) {
-        if (!authorized({ request, url, secret: signingSecret })) {
+        if (!authorizedMedia({ request, url, secret: signingSecret, mediaGrants })) {
           status = 403;
           respond(status, 'forbidden\n', { 'Cache-Control': 'no-store' });
           return;
@@ -154,10 +217,10 @@ export function createPublicHandler({ artifactRoot, metadata, publicOrigin, sign
       }
       status = 404;
       respond(status, 'not found\n', { 'Cache-Control': 'no-store' });
-    } catch {
+    } catch (error) {
       // Do not expose filesystem paths, credentials or signed URLs.
-      status = 500;
-      if (!response.headersSent) respond(status, 'internal server error\n', { 'Cache-Control': 'no-store' });
+      status = error instanceof Error && error.message === 'body_too_large' ? 413 : 500;
+      if (!response.headersSent) respond(status, status === 413 ? 'payload too large\n' : 'internal server error\n', { 'Cache-Control': 'no-store' });
     } finally {
       metrics.observe({ route, status, bytes, durationMs: Math.max(0, now() - startedAt) });
     }

--- a/services/beacon-stream/test/manifest.test.mjs
+++ b/services/beacon-stream/test/manifest.test.mjs
@@ -54,6 +54,31 @@ test('never signs a segment beyond the inbound manifest authorization horizon', 
   }
 });
 
+test('carries one stable opaque media grant across every map and segment URL', () => {
+  const item = variableMetadata();
+  const grantId = 'a'.repeat(64);
+  const grant = 'b'.repeat(43);
+  const manifest = renderManifest({
+    metadata: item,
+    origin: 'https://stream.example.test',
+    secret,
+    nowMs: item.epochMs + 50_000,
+    mediaAuthorizationQuery: { grantId, grant },
+  });
+  const urls = [
+    ...manifest.split('\n').filter((line) => line.startsWith('https://')),
+    manifest.match(/#EXT-X-MAP:URI="([^"]+)"/)?.[1],
+  ].filter(Boolean);
+  assert.ok(urls.length > 1);
+  for (const value of urls) {
+    const url = new URL(value);
+    assert.equal(url.searchParams.get('grantId'), grantId);
+    assert.equal(url.searchParams.get('grant'), grant);
+    assert.equal(url.searchParams.has('exp'), false);
+    assert.equal(url.searchParams.has('sig'), false);
+  }
+});
+
 test('renders a signed fMP4 map and preserves a short final segment across loops', () => {
   const item = variableMetadata();
   const epoch = item.epochMs;

--- a/services/beacon-stream/test/media-grants.test.mjs
+++ b/services/beacon-stream/test/media-grants.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHash } from 'node:crypto';
+import { MediaGrantRegistry, MEDIA_GRANT_MAX_TTL_MS } from '../src/media-grants.mjs';
+
+const id = 'a'.repeat(64);
+const token = 'b'.repeat(43);
+const hash = createHash('sha256').update(token).digest('hex');
+
+test('media grants are bounded, monotonic, opaque and expire fail-closed', () => {
+  let now = 1_800_000_000_000;
+  const registry = new MediaGrantRegistry({ now: () => now, maxEntries: 1 });
+  assert.deepEqual(registry.upsert({ id, tokenSha256: hash, expiresAtMs: now + 60_000 }), { ok: true });
+  assert.equal(registry.authorize({ id, token }), true);
+  assert.equal(registry.authorize({ id, token: 'c'.repeat(43) }), false);
+  assert.deepEqual(registry.upsert({ id, tokenSha256: hash, expiresAtMs: now + 30_000 }), { ok: true });
+  assert.deepEqual(registry.upsert({ id, tokenSha256: 'd'.repeat(64), expiresAtMs: now + 60_000 }), { ok: false, reason: 'conflict' });
+  assert.deepEqual(registry.upsert({ id: 'e'.repeat(64), tokenSha256: hash, expiresAtMs: now + 60_000 }), { ok: false, reason: 'capacity' });
+  assert.deepEqual(registry.upsert({ id: 'f'.repeat(64), tokenSha256: hash, expiresAtMs: now + MEDIA_GRANT_MAX_TTL_MS + 1 }), { ok: false, reason: 'invalid' });
+  now += 60_001;
+  assert.equal(registry.authorize({ id, token }), false);
+  assert.equal(registry.size, 0);
+});
+

--- a/services/beacon-stream/test/server.test.mjs
+++ b/services/beacon-stream/test/server.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { createPublicHandler, createInternalHandler, parseAllowedOrigins } from '../src/server.mjs';
 import { signedUrl, signPath } from '../src/auth.mjs';
 import { Metrics } from '../src/metrics.mjs';
+import { signControlRequest } from '../src/control-auth.mjs';
 import { metadata, temporaryArtifact, temporaryVariableArtifact, variableMetadata } from './helpers.mjs';
 
 const secret = 'z'.repeat(32);
@@ -110,4 +111,76 @@ test('publishes readiness and Prometheus metrics only on the internal listener',
   assert.equal((await fetch(`${origin}/readyz`)).status, 200);
   const body = await (await fetch(`${origin}/metrics`)).text();
   assert.match(body, /beacon_stream_http_requests_total/);
+});
+
+test('serves a registered media grant without consulting Listener and expires it locally', async (t) => {
+  const { artifactRoot } = await temporaryArtifact();
+  const item = metadata();
+  let now = item.epochMs + 42_000;
+  const { server, origin } = await listen(createPublicHandler({
+    artifactRoot,
+    metadata: item,
+    publicOrigin: 'https://stream.example.test',
+    signingSecret: secret,
+    allowedOrigins: new Set(['https://listen.example.test']),
+    now: () => now,
+  }));
+  t.after(() => server.close());
+  const grantId = 'a'.repeat(64);
+  const grant = 'b'.repeat(43);
+  const pathname = `/internal/v1/listener/media-grants/${grantId}`;
+  const body = JSON.stringify({
+    tokenSha256: (await import('node:crypto')).createHash('sha256').update(grant).digest('hex'),
+    expiresAtMs: now + 180_000,
+  });
+  const timestamp = Math.floor(now / 1000);
+  const signature = signControlRequest({ secret, pathname, timestamp, body });
+  const registered = await fetch(`${origin}${pathname}`, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+      'x-beacon-control-timestamp': String(timestamp),
+      'x-beacon-control-signature': signature,
+    },
+    body,
+  });
+  assert.equal(registered.status, 204);
+
+  const manifestUrl = `${origin}/v1/hls/${item.artifactId}/live.m3u8?grantId=${grantId}&grant=${grant}`;
+  const response = await fetch(manifestUrl);
+  assert.equal(response.status, 200);
+  const manifest = await response.text();
+  const publicSegment = new URL(manifest.split('\n').find((line) => line.startsWith('https://')));
+  const segmentUrl = new URL(`${origin}${publicSegment.pathname}${publicSegment.search}`);
+  assert.equal((await fetch(segmentUrl)).status, 200);
+
+  // No callback to Listener occurs on either media request. The origin keeps
+  // serving solely from the local grant until its exact lease horizon.
+  now += 179_999;
+  assert.equal((await fetch(manifestUrl)).status, 200);
+  now += 1;
+  assert.equal((await fetch(manifestUrl)).status, 403);
+  assert.equal((await fetch(segmentUrl)).status, 403);
+});
+
+test('rejects mutated, stale and oversized grant-control requests', async (t) => {
+  const { artifactRoot } = await temporaryArtifact();
+  const item = metadata();
+  const now = item.epochMs + 42_000;
+  const { server, origin } = await listen(createPublicHandler({
+    artifactRoot, metadata: item, publicOrigin: 'https://stream.example.test', signingSecret: secret, now: () => now,
+  }));
+  t.after(() => server.close());
+  const pathname = `/internal/v1/listener/media-grants/${'c'.repeat(64)}`;
+  const body = JSON.stringify({ tokenSha256: 'd'.repeat(64), expiresAtMs: now + 60_000 });
+  const timestamp = Math.floor(now / 1000);
+  const headers = {
+    'x-beacon-control-timestamp': String(timestamp),
+    'x-beacon-control-signature': signControlRequest({ secret, pathname, timestamp, body }),
+  };
+  assert.equal((await fetch(`${origin}${pathname}`, { method: 'PUT', headers, body: `${body} ` })).status, 403);
+  assert.equal((await fetch(`${origin}${pathname}`, {
+    method: 'PUT', headers: { ...headers, 'x-beacon-control-timestamp': String(timestamp - 31) }, body,
+  })).status, 403);
+  assert.equal((await fetch(`${origin}${pathname}`, { method: 'PUT', headers, body: 'x'.repeat(1025) })).status, 413);
 });

--- a/src/app/api/early-birds/stream/heartbeat/__tests__/route.test.ts
+++ b/src/app/api/early-birds/stream/heartbeat/__tests__/route.test.ts
@@ -77,7 +77,8 @@ describe('EarlyBird stream heartbeat route', () => {
         });
     });
 
-    it('returns a renewed same-origin grant for an active lease', async () => {
+    it('returns the stable direct-origin grant for an active lease renewal', async () => {
+        const directGrant = `https://stream.harmonicbeacon.com/v1/hls/approved/live.m3u8?grantId=${'a'.repeat(64)}&grant=${'b'.repeat(43)}`;
         mocks.heartbeatEarlyBirdStreamLease.mockResolvedValue({
             serverNow: new Date('2026-08-06T12:00:00.000Z'),
             accessKind: 'free-quota',
@@ -86,14 +87,14 @@ describe('EarlyBird stream heartbeat route', () => {
             presenceSequence: 3,
             leaseExpiresAt: new Date('2026-08-06T12:03:00.000Z'),
             stream: {
-                manifestUrl: `/api/early-birds/stream/manifest?leaseId=${LEASE_ID}`,
+                manifestUrl: directGrant,
                 expiresAt: new Date('2026-08-06T12:03:00.000Z'),
             },
         });
         const response = await POST(request());
         expect(response.status).toBe(200);
         await expect(response.json()).resolves.toMatchObject({
-            stream: { manifestUrl: `/api/early-birds/stream/manifest?leaseId=${LEASE_ID}` },
+            stream: { manifestUrl: directGrant },
         });
         expect(mocks.heartbeatEarlyBirdStreamLease).toHaveBeenCalledWith(
             'listener-1', LEASE_ID, 2, 3, undefined, undefined, true,

--- a/src/app/api/early-birds/stream/lease/__tests__/route.test.ts
+++ b/src/app/api/early-birds/stream/lease/__tests__/route.test.ts
@@ -69,7 +69,7 @@ describe('EarlyBird stream lease route', () => {
         expect(acquireEarlyBirdStreamLease).not.toHaveBeenCalled();
     });
 
-    it('returns only the stable same-origin manifest grant', async () => {
+    it('returns only the stable direct-origin media grant', async () => {
         currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
         acquireEarlyBirdStreamLease.mockResolvedValue({
             serverNow: new Date('2026-08-06T12:00:00.000Z'),
@@ -81,7 +81,7 @@ describe('EarlyBird stream lease route', () => {
             leaseExpiresAt: new Date('2026-08-06T12:03:00.000Z'),
             evictedLeaseId: '00000000-0000-4000-8000-000000000001',
             stream: {
-                manifestUrl: '/api/early-birds/stream/manifest?leaseId=00000000-0000-4000-8000-000000000003',
+                manifestUrl: `https://stream.harmonicbeacon.com/v1/hls/approved/live.m3u8?grantId=${'a'.repeat(64)}&grant=${'b'.repeat(43)}`,
                 expiresAt: new Date('2026-08-06T12:03:00.000Z'),
             },
         });
@@ -89,7 +89,8 @@ describe('EarlyBird stream lease route', () => {
         expect(response.status).toBe(200);
         const body = await response.json();
         expect(body.evictedAnotherDevice).toBe(true);
-        expect(body.stream.manifestUrl).toMatch(/^\/api\/early-birds\/stream\/manifest/);
+        expect(body.stream.manifestUrl).toMatch(/^https:\/\/stream\.harmonicbeacon\.com\/v1\/hls\/[^?]+\/live\.m3u8\?grantId=/);
+        expect(body.stream.manifestUrl).not.toContain(body.leaseId);
         expect(JSON.stringify(body)).not.toContain('sig=');
     });
 

--- a/src/app/api/health/__tests__/ready-route.test.ts
+++ b/src/app/api/health/__tests__/ready-route.test.ts
@@ -51,6 +51,26 @@ describe('GET /api/health/ready', () => {
         }
     });
 
+    it('requires the private media-grant control origin when Listener is enabled', async () => {
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_AUTH_BASE_URL', 'https://listen.example.test');
+        vi.stubEnv('EARLY_BIRDS_AUTH_SECRET', 'a'.repeat(32));
+        vi.stubEnv('EARLY_BIRDS_STREAM_ORIGIN', 'https://stream.example.test');
+        vi.stubEnv('EARLY_BIRDS_STREAM_ARTIFACT_ID', 'approved-v1');
+        vi.stubEnv('EARLY_BIRDS_STREAM_SIGNING_SECRET', 's'.repeat(32));
+        vi.stubEnv('EARLY_BIRDS_STREAM_CONTROL_ORIGIN', '');
+        const mockPrisma = { $queryRaw: vi.fn() };
+        vi.doMock('@/lib/db', () => ({ prisma: mockPrisma, default: mockPrisma }));
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            const { GET } = await import('../ready/route');
+            expect((await GET()).status).toBe(503);
+            expect(mockPrisma.$queryRaw).not.toHaveBeenCalled();
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
     it('fails readiness before the database on a partial private Live workbench', async () => {
         vi.stubEnv('BEACON_LISTENER_STAGING_LIVE_WORKBENCH_ENABLED', '1');
         const mockPrisma = { $queryRaw: vi.fn() };

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db';
 import { redactError } from '@/lib/redact';
 import {
     ListenerRuntimeEnvironmentError,
+    listenerRuntimeFlag,
     validateListenerRuntimeEnvironment,
 } from '@/lib/listener/runtime-env';
 import {
@@ -14,6 +15,11 @@ import {
     ListenerWithdrawalConfigurationError,
     listenerWithdrawalConfiguration,
 } from '@/lib/listener/consumer-withdrawal';
+import {
+    earlyBirdOriginConfig,
+    earlyBirdStreamControlOrigin,
+    EarlyBirdStreamIssuerUnavailableError,
+} from '@/lib/early-birds/stream';
 
 export const dynamic = 'force-dynamic';
 
@@ -33,12 +39,17 @@ export async function GET() {
     let listenerWithdrawalConfigured = false;
     try {
         listenerRuntimeConfigured = validateListenerRuntimeEnvironment();
+        if (listenerRuntimeFlag('ENABLED')) {
+            earlyBirdOriginConfig();
+            earlyBirdStreamControlOrigin();
+        }
         validateListenerLiveWorkbenchEnvironment();
         listenerWithdrawalConfigured = listenerWithdrawalConfiguration().enabled;
     } catch (error) {
         const diagnostic = error instanceof ListenerRuntimeEnvironmentError ||
             error instanceof ListenerLiveWorkbenchConfigurationError ||
             error instanceof ListenerWithdrawalConfigurationError
+            || error instanceof EarlyBirdStreamIssuerUnavailableError
             ? error.message
             : 'unexpected validation failure';
         console.error('Listener runtime configuration invalid:', diagnostic);

--- a/src/lib/early-birds/__tests__/stream-contract.test.ts
+++ b/src/lib/early-birds/__tests__/stream-contract.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
-    EARLY_BIRD_LEASE_MANIFEST_PATH,
+    EnvironmentManifestIssuer,
     earlyBirdOriginConfig,
     earlyBirdOriginManifestPath,
-    earlyBirdStreamUrlIssuer,
+    earlyBirdStreamControlOrigin,
+    signEarlyBirdStreamControlRequest,
     EarlyBirdStreamIssuerUnavailableError,
     setEarlyBirdStreamUrlIssuerForTests,
     signEarlyBirdOriginPath,
@@ -32,6 +33,17 @@ describe('Beacon origin signing contract', () => {
         expect(beaconSignature).toBe(signPath(input));
     });
 
+    it('matches the origin grant-control request signer byte for byte', async () => {
+        const { signControlRequest } = await import('../../../../services/beacon-stream/src/control-auth.mjs');
+        const input = {
+            secret: SECRET,
+            pathname: `/internal/v1/listener/media-grants/${'a'.repeat(64)}`,
+            timestamp: 1_800_000_000,
+            body: '{"tokenSha256":"abc","expiresAtMs":1800000180000}',
+        };
+        expect(signEarlyBirdStreamControlRequest(input)).toBe(signControlRequest(input));
+    });
+
     it('caps origin authorization at the lease horizon and emits exp/sig only server-side', () => {
         const config = {
             origin: 'https://stream.example.test',
@@ -56,6 +68,14 @@ describe('Beacon origin signing contract', () => {
             EARLY_BIRDS_STREAM_ARTIFACT_ID: '../escape',
             EARLY_BIRDS_STREAM_SIGNING_SECRET: SECRET,
         } as NodeJS.ProcessEnv)).toThrow(EarlyBirdStreamIssuerUnavailableError);
+        expect(() => earlyBirdStreamControlOrigin({
+            NODE_ENV: 'production',
+            EARLY_BIRDS_STREAM_CONTROL_ORIGIN: 'https://external.example.test',
+        } as NodeJS.ProcessEnv)).toThrow(EarlyBirdStreamIssuerUnavailableError);
+        expect(earlyBirdStreamControlOrigin({
+            NODE_ENV: 'production',
+            EARLY_BIRDS_STREAM_CONTROL_ORIGIN: 'http://beacon-stream:8080',
+        } as NodeJS.ProcessEnv)).toBe('http://beacon-stream:8080');
         expect(() => earlyBirdOriginConfig({
             NODE_ENV: 'production',
             EARLY_BIRDS_STREAM_ORIGIN: 'http://stream.example.test',
@@ -84,19 +104,52 @@ describe('Beacon origin signing contract', () => {
         expect(validSignedOriginManifest(manifest.replace('&sig=map-signature', ''), config)).toBe(false);
     });
 
-    it('gives browsers only the stable same-origin lease manifest URL', async () => {
-        vi.stubEnv('EARLY_BIRDS_STREAM_ORIGIN', 'https://stream.example.test');
-        vi.stubEnv('EARLY_BIRDS_STREAM_ARTIFACT_ID', 'approved-v1');
-        vi.stubEnv('EARLY_BIRDS_STREAM_SIGNING_SECRET', SECRET);
-        const grant = await earlyBirdStreamUrlIssuer().issue({
+    it('registers a stable opaque grant privately and gives the browser a direct origin URL', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+        const issuer = new EnvironmentManifestIssuer({
+            NODE_ENV: 'production',
+            EARLY_BIRDS_STREAM_ORIGIN: 'https://stream.example.test',
+            EARLY_BIRDS_STREAM_CONTROL_ORIGIN: 'http://beacon-stream:8080',
+            EARLY_BIRDS_STREAM_ARTIFACT_ID: 'approved-v1',
+            EARLY_BIRDS_STREAM_SIGNING_SECRET: SECRET,
+        } as NodeJS.ProcessEnv, fetchMock);
+        const issuedAt = new Date('2027-01-15T08:00:00.000Z');
+        const request = {
             accountId: 'listener-1',
             leaseId: '00000000-0000-4000-8000-000000000111',
             leaseGeneration: 7,
-            issuedAt: new Date(),
-            leaseExpiresAt: new Date(Date.now() + 60_000),
-        });
-        expect(grant.manifestUrl).toBe(`${EARLY_BIRD_LEASE_MANIFEST_PATH}?leaseId=00000000-0000-4000-8000-000000000111&leaseGeneration=7`);
+            issuedAt,
+            leaseExpiresAt: new Date(issuedAt.getTime() + 180_000),
+        };
+        const grant = await issuer.issue(request);
+        const renewed = await issuer.issue({ ...request, issuedAt: new Date(issuedAt.getTime() + 60_000) });
+        expect(grant.manifestUrl).toBe(renewed.manifestUrl);
+        const browserUrl = new URL(grant.manifestUrl);
+        expect(browserUrl.origin).toBe('https://stream.example.test');
+        expect(browserUrl.pathname).toBe('/v1/hls/approved-v1/live.m3u8');
+        expect(browserUrl.searchParams.get('grantId')).toMatch(/^[a-f0-9]{64}$/);
+        expect(browserUrl.searchParams.get('grant')).toMatch(/^[A-Za-z0-9_-]{43}$/);
         expect(grant.manifestUrl).not.toContain('sig=');
-        expect(grant.manifestUrl).not.toContain('stream.example.test');
+        expect(grant.manifestUrl).not.toContain(request.leaseId);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        const [controlUrl, init] = fetchMock.mock.calls[0];
+        expect(String(controlUrl)).toMatch(/^http:\/\/beacon-stream:8080\/internal\/v1\/listener\/media-grants\/[a-f0-9]{64}$/);
+        expect(init.body).not.toContain('listener-1');
+        expect(init.body).not.toContain(request.leaseId);
+        expect(init.headers['x-beacon-control-signature']).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    });
+
+    it('fails closed when the private grant registry is unavailable', async () => {
+        const issuer = new EnvironmentManifestIssuer({
+            NODE_ENV: 'test',
+            EARLY_BIRDS_STREAM_ORIGIN: 'https://stream.example.test',
+            EARLY_BIRDS_STREAM_CONTROL_ORIGIN: 'http://control.example.test',
+            EARLY_BIRDS_STREAM_ARTIFACT_ID: 'approved-v1',
+            EARLY_BIRDS_STREAM_SIGNING_SECRET: SECRET,
+        } as NodeJS.ProcessEnv, vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+        await expect(issuer.issue({
+            accountId: 'listener-1', leaseId: crypto.randomUUID(), leaseGeneration: 1,
+            issuedAt: new Date(), leaseExpiresAt: new Date(Date.now() + 60_000),
+        })).rejects.toBeInstanceOf(EarlyBirdStreamIssuerUnavailableError);
     });
 });

--- a/src/lib/early-birds/__tests__/stream-lease.test.ts
+++ b/src/lib/early-birds/__tests__/stream-lease.test.ts
@@ -159,7 +159,7 @@ describe('quota-aware two-connection leases', () => {
         expect(tx.earlyBirdStreamLease.updateMany).not.toHaveBeenCalled();
     });
 
-    it('rolls back play+anchor when deterministic manifest issuance fails in-transaction', async () => {
+    it('revokes the exact committed lease generation if private grant issuance fails', async () => {
         quotaMocks.settleLockedEarlyBirdQuota
             .mockResolvedValueOnce(unstarted)
             .mockResolvedValueOnce(listening);
@@ -167,7 +167,15 @@ describe('quota-aware two-connection leases', () => {
         await expect(acquireEarlyBirdStreamLease(
             'listener-1', 'device_abcdefghijklmnopqrstuvwxyz', NOW, failingIssuer,
         )).rejects.toThrow('config');
-        expect(prisma.earlyBirdStreamLease.updateMany).not.toHaveBeenCalled();
+        expect(prisma.earlyBirdStreamLease.updateMany).toHaveBeenCalledWith({
+            where: { id: LEASE_ID, accountId: 'listener-1', generation: 1 },
+            data: {
+                evictedAt: NOW,
+                presence: 'IDLE',
+                presenceUpdatedAt: NOW,
+                expiresAt: NOW,
+            },
+        });
     });
 
     it('commits exhausted settlement before denying manifest authorization', async () => {

--- a/src/lib/early-birds/stream.ts
+++ b/src/lib/early-birds/stream.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 
 import type { Prisma } from '@prisma/client';
 
@@ -20,8 +20,8 @@ export const EARLY_BIRD_MAX_STREAM_DEVICES = 2;
 export const EARLY_BIRD_LEASE_TTL_MS = 3 * 60 * 1000;
 export const EARLY_BIRD_ORIGIN_MAX_SIGNATURE_TTL_SECONDS = 10 * 60;
 export const EARLY_BIRD_ORIGIN_MANIFEST_TTL_SECONDS = 60;
-export const EARLY_BIRD_LEASE_MANIFEST_PATH = '/api/early-birds/stream/manifest';
 export const EARLY_BIRD_FREE_FOR_ALL_ACCOUNT_ID = 'early-birds-free-for-all';
+export const EARLY_BIRD_STREAM_CONTROL_TIMEOUT_MS = 3_000;
 
 export type ListenerLeasePresence = {
     state: 'IDLE' | 'LISTENING';
@@ -60,18 +60,61 @@ export class EarlyBirdStreamIssuerUnavailableError extends Error {
     }
 }
 
-class EnvironmentManifestIssuer implements EarlyBirdStreamUrlIssuer {
+export class EnvironmentManifestIssuer implements EarlyBirdStreamUrlIssuer {
+    constructor(
+        private readonly environment: NodeJS.ProcessEnv = process.env,
+        private readonly fetchImpl: typeof fetch = fetch,
+    ) {}
+
     async issue(request: StreamUrlIssueRequest): Promise<StreamUrlGrant> {
-        // Validate the origin integration at lease issuance, but expose only a
-        // stable same-origin URL to the browser. The route signs and refreshes
-        // the upstream manifest on every HLS poll.
-        earlyBirdOriginConfig();
+        const config = earlyBirdOriginConfig(this.environment);
+        const controlOrigin = earlyBirdStreamControlOrigin(this.environment);
+        const identity = `${request.leaseId}:${request.leaseGeneration}`;
+        const grantId = createHmac('sha256', config.signingSecret)
+            .update(`listener-media-grant-id:v1:${identity}`, 'utf8')
+            .digest('hex');
+        const grantToken = createHmac('sha256', config.signingSecret)
+            .update(`listener-media-grant-token:v1:${identity}`, 'utf8')
+            .digest('base64url');
+        const pathname = `/internal/v1/listener/media-grants/${grantId}`;
+        const body = JSON.stringify({
+            tokenSha256: createHash('sha256').update(grantToken, 'utf8').digest('hex'),
+            expiresAtMs: request.leaseExpiresAt.getTime(),
+        });
+        const timestamp = Math.floor(request.issuedAt.getTime() / 1000);
+        const signature = signEarlyBirdStreamControlRequest({
+            secret: config.signingSecret,
+            pathname,
+            timestamp,
+            body,
+        });
+        let response: Response;
+        try {
+            response = await this.fetchImpl(new URL(pathname, controlOrigin), {
+                method: 'PUT',
+                headers: {
+                    'content-type': 'application/json',
+                    'x-beacon-control-timestamp': String(timestamp),
+                    'x-beacon-control-signature': signature,
+                },
+                body,
+                cache: 'no-store',
+                signal: AbortSignal.timeout(EARLY_BIRD_STREAM_CONTROL_TIMEOUT_MS),
+            });
+        } catch {
+            throw new EarlyBirdStreamIssuerUnavailableError();
+        }
+        if (response.status !== 204) throw new EarlyBirdStreamIssuerUnavailableError();
+
+        const manifestUrl = new URL(earlyBirdOriginManifestPath(config.artifactId), config.origin);
+        manifestUrl.searchParams.set('grantId', grantId);
+        manifestUrl.searchParams.set('grant', grantToken);
         const query = new URLSearchParams({
-            leaseId: request.leaseId,
-            leaseGeneration: String(request.leaseGeneration),
+            grantId,
+            grant: grantToken,
         });
         return {
-            manifestUrl: `${EARLY_BIRD_LEASE_MANIFEST_PATH}?${query}`,
+            manifestUrl: `${manifestUrl.origin}${manifestUrl.pathname}?${query}`,
             expiresAt: request.leaseExpiresAt,
         };
     }
@@ -175,6 +218,36 @@ export type EarlyBirdOriginConfig = {
     artifactId: string;
     signingSecret: string;
 };
+
+export function earlyBirdStreamControlOrigin(
+    environment: NodeJS.ProcessEnv = process.env,
+): string {
+    const value = environment.EARLY_BIRDS_STREAM_CONTROL_ORIGIN?.trim();
+    if (!value) throw new EarlyBirdStreamIssuerUnavailableError();
+    let parsed: URL;
+    try { parsed = new URL(value); } catch { throw new EarlyBirdStreamIssuerUnavailableError(); }
+    if (!['http:', 'https:'].includes(parsed.protocol)
+        || parsed.username || parsed.password || parsed.pathname !== '/'
+        || parsed.search || parsed.hash) {
+        throw new EarlyBirdStreamIssuerUnavailableError();
+    }
+    if (environment.NODE_ENV === 'production'
+        && !(parsed.protocol === 'http:' && parsed.hostname === 'beacon-stream')) {
+        throw new EarlyBirdStreamIssuerUnavailableError();
+    }
+    return parsed.origin;
+}
+
+export function signEarlyBirdStreamControlRequest(input: {
+    secret: string;
+    pathname: string;
+    timestamp: number;
+    body: string;
+}): string {
+    const bodyHash = createHash('sha256').update(input.body).digest('hex');
+    const canonical = `PUT\n${input.pathname}\n${bodyHash}\n${input.timestamp}`;
+    return createHmac('sha256', input.secret).update(canonical).digest('base64url');
+}
 
 export function earlyBirdOriginConfig(
     environment: NodeJS.ProcessEnv = process.env,
@@ -398,13 +471,6 @@ async function acquireEarlyBirdStreamLeaseWithMode(
                 data: { expiresAt: leaseExpiresAt },
             });
         }
-        const stream = await issuer.issue({
-            accountId,
-            leaseId: current.id,
-            leaseGeneration: current.generation,
-            issuedAt: now,
-            leaseExpiresAt,
-        });
         return {
             kind: 'ok' as const,
             current,
@@ -412,12 +478,37 @@ async function acquireEarlyBirdStreamLeaseWithMode(
             leaseExpiresAt,
             serverNow: now,
             access: accessAfter,
-            stream,
         };
     });
 
     if (lease.kind === 'denied') throw new EarlyBirdAccessDeniedError();
     if (lease.kind === 'capacity') throw new EarlyBirdDeviceCapacityError();
+
+    let stream: StreamUrlGrant;
+    try {
+        stream = await issuer.issue({
+            accountId,
+            leaseId: lease.current.id,
+            leaseGeneration: lease.current.generation,
+            issuedAt: lease.serverNow,
+            leaseExpiresAt: lease.leaseExpiresAt,
+        });
+    } catch (error) {
+        await prisma.earlyBirdStreamLease.updateMany({
+            where: {
+                id: lease.current.id,
+                accountId,
+                generation: lease.current.generation,
+            },
+            data: {
+                evictedAt: lease.serverNow,
+                presence: 'IDLE',
+                presenceUpdatedAt: lease.serverNow,
+                expiresAt: lease.serverNow,
+            },
+        });
+        throw error;
+    }
 
     return {
         leaseId: lease.current.id,
@@ -425,7 +516,7 @@ async function acquireEarlyBirdStreamLeaseWithMode(
         presenceSequence: lease.current.presenceSequence,
         leaseExpiresAt: lease.leaseExpiresAt,
         evictedLeaseId: lease.evictedLeaseId,
-        stream: lease.stream,
+        stream,
         serverNow: lease.serverNow,
         accessKind: lease.access.kind,
         quota: lease.access.quota ? serializeEarlyBirdQuotaSnapshot(lease.access.quota) : null,

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -9,11 +9,13 @@ const MEDIA_FILE_SHA256 = {
     // Listener-only HLS window/target changes from 60/90 seconds to a two-minute
     // start target and three-minute maximum, native HLS uses the same margin,
     // advisory stalls no longer rebuild a healthy buffer, and hidden documents
-    // explicitly pause before same-lease foreground recovery. Source URLs,
-    // media assets, codec, element gain/fades, AudioContext and event audio are
-    // unchanged.
+    // explicitly pause before same-lease foreground recovery. The stream core
+    // was re-reviewed again for the bounded direct-origin grant: it moves only
+    // authorization/network issuance out of the DB transaction and leaves all
+    // player, signal, codec, buffer, gain/fade, AudioContext, asset and event
+    // audio behavior unchanged.
     'src/components/early-birds/ListenerPlayer.tsx': '70a0bf3b72acf37f69974f97feed2bbd53499ad9e62b4eab18b2c7e0a7a96bc5',
-    'src/lib/early-birds/stream.ts': '96a2d9fe798591833327631b59a73a5b2fc5ca06be7081945a0b07450970da84',
+    'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',
     'src/lib/early-birds/drop-ins.ts': '3b0d18c2c8548aa3ee917ece726cbca4b6d253ea3b4941a8424f8bcbfb8922e2',
     'src/app/api/early-birds/stream/lease/route.ts': 'ec0e8780387bc1f493eb33d13a2d90e01cfdb6d899fc6232e04f51aaf2dfc508',
     'src/app/api/early-birds/stream/manifest/route.ts': '56d8266fd8144c1e3ee13b168115f0a814a1da9f0a9f2db8b33e33facbba094e',


### PR DESCRIPTION
## Outcome

Moves Listener/DB authorization out of the already-authorized HLS media hot path without changing codec, buffers, gain, fades, assets, player graph, event services, or external origins.

- Listener validates account/quota/two-device lease, then registers one opaque grant over a private container network.
- Browser fetches manifest and segments directly from the existing `stream.harmonicbeacon.com` origin.
- Heartbeats renew the same URL; origin stores only token hash + lease-bounded expiry.
- A Listener/DB outage cannot interrupt an existing grant before its exact expiry; origin then fails closed.
- HLS bearer query strings are disabled in nginx access/error logging.
- Current file loop remains only a temporary source adapter; the contract is compatible with future live Beacon ingest.

## Evidence

- 1,605 tests passed / 35 environment-gated skips.
- Origin Node suite: 21/21.
- Focused Listener/route/readiness suite: 43/43.
- Preview contracts: 38/38; Compose config validation green.
- TypeScript, full ESLint and production Next build green.
- Adversarial origin test: registered URL serves manifest+segment with no control-plane callback until exact lease expiry, then both return 403.
- Media boundary re-reviewed and pinned; no ListenerPlayer, event, LiveKit, playlist, tapestry or audio asset/config files changed.

Tracks #355 and defect #304.

## Rollout

Origin first (new code accepts old signed canary + new grants), then Listener. Roll back Listener before origin if necessary. No schema migration.
