### PR TITLE
fix(listener): keep kelp ribbons present at rest

### DIFF
--- a/docs/design/LISTENER_REACTIVE_CAMPFIRE.md
+++ b/docs/design/LISTENER_REACTIVE_CAMPFIRE.md
@@ -77,6 +77,10 @@ The laboratory offers one low-cost and four full renderers over the same frame:
   controls. Center field scale and width are independent from the outer-ribbon
   width. A signed camera-rotation control selects speed and direction around
   the same fixed center; neither the camera nor the center follows audio energy.
+  Every selected kelp leaf remains faintly present with gentle ambient motion;
+  activation changes its impulse and glow rather than creating or removing it.
+  Its inner tip is fully transparent and gains opacity along the body so the
+  outer field does not visually pile up over the center field.
 - **Horizon flow** pours broad harmonic ribbons from fixed horizon positions.
 
 Changing renderer, cut, zoom, activation TTL, width, palette or other visual

--- a/src/components/listener/reactive/ReactiveCampfireTuningPanel.tsx
+++ b/src/components/listener/reactive/ReactiveCampfireTuningPanel.tsx
@@ -70,7 +70,15 @@ const NUMBER_FIELDS: Array<{
     },
     { key: 'radialSpacingGrowthPercent', label: 'Outer spacing growth', min: 0, max: 250, step: 1, suffix: '%' },
     { key: 'zoomPercent', label: 'Zoom', min: 50, max: 220, step: 1, suffix: '%' },
-    { key: 'activationTtlSeconds', label: 'Activation TTL', min: 0, max: 30, step: 0.5, suffix: ' s' },
+    {
+        key: 'activationTtlSeconds',
+        label: 'Ribbon visibility TTL',
+        min: 0,
+        max: 30,
+        step: 0.5,
+        suffix: ' s',
+        modes: ['harmonic-radial-series', 'radial-ribbons'],
+    },
     { key: 'ribbonWidth', label: 'Outer ribbon width', min: 0.6, max: 3, step: 0.05 },
     {
         key: 'kelpPropagationSpeed',

--- a/src/components/listener/reactive/__tests__/components.test.tsx
+++ b/src/components/listener/reactive/__tests__/components.test.tsx
@@ -153,7 +153,7 @@ describe('reactive campfire components', () => {
         }));
         expect(screen.getByText(/4% center · 96% outer/)).toBeInTheDocument();
         expect(screen.getByLabelText(/Zoom/i)).toHaveValue('220');
-        expect(screen.getByLabelText(/Activation TTL/i)).toHaveValue('13.5');
+        expect(screen.queryByLabelText(/Ribbon visibility TTL/i)).not.toBeInTheDocument();
     });
 
     it('exposes inner-anchor propagation controls only for the kelp laboratory mode', () => {
@@ -168,6 +168,7 @@ describe('reactive campfire components', () => {
             />,
         );
         expect(screen.queryByLabelText(/Kelp propagation speed/i)).not.toBeInTheDocument();
+        expect(screen.getByLabelText(/Ribbon visibility TTL/i)).toHaveValue('13.5');
 
         rerender(
             <ReactiveCampfireTuningPanel
@@ -179,6 +180,7 @@ describe('reactive campfire components', () => {
                 onChange={vi.fn()}
             />,
         );
+        expect(screen.queryByLabelText(/Ribbon visibility TTL/i)).not.toBeInTheDocument();
         expect(screen.getByLabelText(/Center field scale/i)).toHaveValue('28');
         expect(screen.getByLabelText(/Center ribbon width/i)).toHaveValue('0.8');
         expect(screen.getByLabelText(/Camera rotation/i)).toHaveValue('-59.5');

--- a/src/components/listener/reactive/__tests__/draw.test.ts
+++ b/src/components/listener/reactive/__tests__/draw.test.ts
@@ -7,6 +7,7 @@ import {
     buildInnerDrivenRibbonPoints,
     centerFieldStrokeWidth,
     drawMinimalReactivePulse,
+    innerRibbonOpacityStops,
     innerKelpRotationAt,
     scaledCenterFieldRadius,
 } from '../draw';
@@ -113,6 +114,16 @@ describe('inner-anchor kelp', () => {
         expect(scaledCenterFieldRadius(200, { centerFieldScalePercent: 100 })).toBe(200);
         expect(centerFieldStrokeWidth(1, { centerRibbonWidth: 0.5 })).toBe(2.25);
         expect(centerFieldStrokeWidth(1, { centerRibbonWidth: 2 })).toBe(9);
+    });
+
+    it('fades every kelp ribbon completely out at its inner anchor', () => {
+        const stops = innerRibbonOpacityStops(0.8, 0.4);
+
+        expect(stops[0]).toEqual([0, 0]);
+        expect(stops[1][1]).toBeGreaterThan(0);
+        expect(stops[2][1]).toBeGreaterThan(stops[1][1]);
+        expect(stops[3]).toEqual([0.52, 0.8]);
+        expect(stops.at(-1)).toEqual([1, 0.4]);
     });
 });
 

--- a/src/components/listener/reactive/__tests__/scene.test.ts
+++ b/src/components/listener/reactive/__tests__/scene.test.ts
@@ -324,7 +324,7 @@ describe('reactive campfire scene', () => {
         expect(allCenter.veils.every((veil) => veil.opacity === 0)).toBe(true);
     });
 
-    it('glows on activation, then dims and disappears according to TTL', () => {
+    it('keeps the older radial ribbons activation-gated according to TTL', () => {
         const activeFrame = frameWith(
             Array.from({ length: 64 }, (_, index) => index === 50 ? -20 : -82),
             Array.from({ length: 64 }, () => 0),
@@ -337,18 +337,30 @@ describe('reactive campfire scene', () => {
         );
         const active = buildReactiveCampfireScene(
             activeFrame,
-            { centerCutPercent: 4, activationTtlSeconds: 8 },
+            {
+                centerCutPercent: 4,
+                activationTtlSeconds: 8,
+                visualizationMode: 'radial-ribbons',
+            },
         );
         const recentlyActive = buildReactiveCampfireScene(
             frame,
-            { centerCutPercent: 4, activationTtlSeconds: 8 },
+            {
+                centerCutPercent: 4,
+                activationTtlSeconds: 8,
+                visualizationMode: 'radial-ribbons',
+            },
             new Map(),
             1,
             new Map([[50, 6_000]]),
         );
         const expired = buildReactiveCampfireScene(
             frame,
-            { centerCutPercent: 4, activationTtlSeconds: 8 },
+            {
+                centerCutPercent: 4,
+                activationTtlSeconds: 8,
+                visualizationMode: 'radial-ribbons',
+            },
             new Map(),
             1,
             new Map([[50, 1_000]]),
@@ -362,5 +374,41 @@ describe('reactive campfire scene', () => {
         expect(recentRibbon?.activation).toBeLessThan(HARMONIC_ACTIVATION_THRESHOLD);
         expect(recentRibbon?.visibility).toBeCloseTo(0.5);
         expect(expiredRibbon?.visibility).toBe(0);
+    });
+
+    it('keeps every selected kelp ribbon visible before and after activation', () => {
+        const quietFrame = frameWith(
+            Array.from({ length: 64 }, () => -120),
+            Array.from({ length: 64 }, () => 0),
+            { capturedAtMs: 20_000 },
+        );
+        const neverActivated = buildReactiveCampfireScene(
+            quietFrame,
+            {
+                centerCutPercent: 4,
+                activationTtlSeconds: 0,
+                visualizationMode: 'inner-anchor-kelp',
+            },
+        );
+        const longAfterActivation = buildReactiveCampfireScene(
+            quietFrame,
+            {
+                centerCutPercent: 4,
+                activationTtlSeconds: 1,
+                visualizationMode: 'inner-anchor-kelp',
+            },
+            new Map(),
+            1,
+            new Map([[50, 1_000]]),
+            new Map([[50, 1_000]]),
+            20_000,
+        );
+
+        expect(neverActivated.filaments.length).toBeGreaterThan(0);
+        expect(neverActivated.filaments.every(({ visibility }) => visibility === 1)).toBe(true);
+        expect(neverActivated.rings.every(({ visibility }) => visibility === 1)).toBe(true);
+        expect(longAfterActivation.filaments.every(({ visibility }) => visibility === 1)).toBe(true);
+        expect(longAfterActivation.filaments.find(({ harmonicIndex }) => harmonicIndex === 50))
+            .toMatchObject({ activation: 0, visibility: 1, impulseAgeSeconds: 19 });
     });
 });

--- a/src/components/listener/reactive/draw.ts
+++ b/src/components/listener/reactive/draw.ts
@@ -122,6 +122,32 @@ function smoothstep(value: number): number {
     return bounded * bounded * (3 - 2 * bounded);
 }
 
+export function innerRibbonOpacityStops(
+    bodyAlpha: number,
+    endAlpha: number,
+): ReadonlyArray<readonly [offset: number, alpha: number]> {
+    const body = Math.max(0, Math.min(1, bodyAlpha));
+    const end = Math.max(0, Math.min(1, endAlpha));
+    return [
+        [0, 0],
+        [0.16, body * 0.12],
+        [0.36, body * 0.72],
+        [0.52, body],
+        [1, end],
+    ];
+}
+
+function applyInnerRibbonOpacityRamp(
+    gradient: CanvasGradient,
+    color: readonly number[],
+    bodyAlpha: number,
+    endAlpha: number,
+) {
+    for (const [offset, alpha] of innerRibbonOpacityStops(bodyAlpha, endAlpha)) {
+        gradient.addColorStop(offset, rgba(color, alpha));
+    }
+}
+
 /**
  * A small deterministic cloth model: the inner edge is pinned and two slow
  * waves travel toward the free edge. Absolute energy and measured variation
@@ -433,8 +459,20 @@ function drawRadialRibbon(
             ghost.angle + ghost.bend,
         );
         const ghostWidth = (1.4 + ghost.weight * 2.6) * ribbonScale;
-        context.fillStyle = rgba(color, ghost.opacity * filament.visibility);
         if (innerDriven) {
+            const ghostGradient = context.createLinearGradient(
+                ghostStart[0],
+                ghostStart[1],
+                ghostEnd[0],
+                ghostEnd[1],
+            );
+            applyInnerRibbonOpacityRamp(
+                ghostGradient,
+                color,
+                ghost.opacity * filament.visibility,
+                ghost.opacity * 0.62 * filament.visibility,
+            );
+            context.fillStyle = ghostGradient;
             const ghostAge = filament.impulseAgeSeconds === null
                 ? null
                 : Math.max(0, filament.impulseAgeSeconds - (
@@ -455,6 +493,7 @@ function drawRadialRibbon(
                 ghost.wiggle,
             );
         } else {
+            context.fillStyle = rgba(color, ghost.opacity * filament.visibility);
             fillClothRibbon(
                 context,
                 ghostStart,
@@ -473,19 +512,13 @@ function drawRadialRibbon(
     const width = (1.8 + filament.weight * 3.2) * ribbonScale;
     const leafGradient = context.createLinearGradient(start[0], start[1], end[0], end[1]);
     if (innerDriven) {
-        leafGradient.addColorStop(0, rgba(
+        applyInnerRibbonOpacityRamp(
+            leafGradient,
             color,
-            (0.035 + filament.opacity * 0.78 + filament.activation * 0.18)
+            (0.025 + filament.opacity * 0.68 + filament.activation * 0.12)
                 * filament.visibility,
-        ));
-        leafGradient.addColorStop(0.42, rgba(
-            color,
-            (0.025 + filament.opacity * 0.68) * filament.visibility,
-        ));
-        leafGradient.addColorStop(1, rgba(
-            color,
             (0.012 + filament.opacity * 0.44) * filament.visibility,
-        ));
+        );
     } else {
         leafGradient.addColorStop(0, rgba(
             color,

--- a/src/components/listener/reactive/scene.ts
+++ b/src/components/listener/reactive/scene.ts
@@ -298,13 +298,15 @@ export function buildReactiveCampfireScene(
             opacity: absolute * 0.78,
             weight: 0.6 + absolute * 2.4,
             activation,
-            visibility: harmonicVisibility(
-                index,
-                activation,
-                capturedAtMs,
-                settings.activationTtlSeconds,
-                lastActivatedAtMs,
-            ),
+            visibility: innerDrivenMode
+                ? 1
+                : harmonicVisibility(
+                    index,
+                    activation,
+                    capturedAtMs,
+                    settings.activationTtlSeconds,
+                    lastActivatedAtMs,
+                ),
             tier: progress < 0.16 ? 'low' : progress < 0.58 ? 'mid' : 'high',
         };
     });
@@ -332,13 +334,18 @@ export function buildReactiveCampfireScene(
             deltas[index] ?? 0,
             settings.absoluteFloorDb,
         ) * confidence;
-        const visibility = harmonicVisibility(
-            index,
-            activation,
-            capturedAtMs,
-            settings.activationTtlSeconds,
-            lastActivatedAtMs,
-        );
+        // Kelp is a persistent representation of the selected harmonic bank.
+        // Measured activation drives its impulse and glow, never its existence.
+        // The older radial modes retain TTL visibility for comparison in the lab.
+        const visibility = innerDrivenMode
+            ? 1
+            : harmonicVisibility(
+                index,
+                activation,
+                capturedAtMs,
+                settings.activationTtlSeconds,
+                lastActivatedAtMs,
+            );
         const activationStartedAt = activationStartedAtMs.get(index);
         const impulseAgeSeconds = activationStartedAt === undefined
             ? null


### PR DESCRIPTION
## Outcome\n\nRefines the accepted Inner-anchor kelp renderer so harmonic leaves are a persistent visual bank rather than TTL-gated objects.\n\n- every selected kelp leaf remains visible with gentle ambient motion while playback is active\n- measured activation still launches the causal inner-anchor impulse and glow\n- each main ribbon and whole-ribbon ghost trail is exactly transparent at its inner endpoint and ramps into the body\n- the TTL control remains available only for the older radial comparison modes\n- Stop still decays and clears the whole decorative field\n\n## Evidence\n\n- 39 focused reactive tests green\n- TypeScript green\n- focused ESLint green\n- production build green\n- staging: https://earlybirds-staging.harmonicbeacon.com/\n\n## Isolation\n\nRenderer/UI/docs/tests only. No Web Audio, media graph, HLS, stream, codec, gain, event, LiveKit, authority or payment change.