### PR TITLE
fix(listener): keep BeaconField loops spatially continuous

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1123,12 +1123,18 @@ body {
    ============================================ */
 
 @keyframes listener-orbit {
-  to { transform: rotate(360deg); }
+  from { transform: translate(-50%, -50%) rotate(0deg); }
+  to { transform: translate(-50%, -50%) rotate(360deg); }
 }
 
 @keyframes listener-breathe {
   0%, 100% { opacity: 0.58; transform: scale(0.96); }
   50% { opacity: 1; transform: scale(1.035); }
+}
+
+@keyframes listener-core-breathe {
+  0%, 100% { opacity: 0.58; transform: translate(-50%, -50%) scale(0.96); }
+  50% { opacity: 1; transform: translate(-50%, -50%) scale(1.035); }
 }
 
 @keyframes listener-point {
@@ -1425,7 +1431,7 @@ body {
   background: radial-gradient(circle, rgba(255, 249, 233, 0.09), transparent 70%);
   box-shadow: 0 0 3rem color-mix(in srgb, var(--field-color) 25%, transparent);
   transform: translate(-50%, -50%);
-  animation: listener-breathe 5.5s ease-in-out infinite;
+  animation: listener-core-breathe 5.5s ease-in-out infinite;
 }
 
 .listener-field__mark {

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -72,6 +72,20 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
         }
     });
 
+    it('keeps every BeaconField loop spatially continuous at its cycle boundary', () => {
+        const css = readFileSync('src/app/globals.css', 'utf8');
+        expect(css).toContain(
+            'from { transform: translate(-50%, -50%) rotate(0deg); }',
+        );
+        expect(css).toContain(
+            'to { transform: translate(-50%, -50%) rotate(360deg); }',
+        );
+        expect(css).toContain(
+            '0%, 100% { opacity: 0.58; transform: translate(-50%, -50%) scale(0.96); }',
+        );
+        expect(css).toContain('animation: listener-core-breathe 5.5s ease-in-out infinite;');
+    });
+
     it('standalone Listener pages render the listener page shell, never the event shell', () => {
         const unavailable = render(
             <LocaleProvider initialLocale="es"><EarlyBirdUnavailable /></LocaleProvider>,


### PR DESCRIPTION
## Outcome

Removes the visible reset jump from the CSS-only BeaconField.

- orbit keyframes retain centering throughout the full 0°→360° loop
- core breathing uses a dedicated transform that retains centering
- all cycle boundaries now render the same spatial state
- no audio, media, stream, reactive analyzer or event file changes

## Evidence

- focused visual tests 14/14
- TypeScript and ESLint green
- production build green
- explicit CSS boundary regression included

This can ride with the next Listener release rather than requiring a standalone cutover.