### PR TITLE
fix(ci): remove auth fixture time bomb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8245,9 +8245,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -170,7 +170,7 @@ async function attendeeRow(entitlement: Record<string, unknown> = {}) {
     return {
         id: 'web-session-1',
         tokenDigest: await digestOf(ATTENDEE_COOKIE),
-        expiresAt: new Date('2026-08-09T00:00:00.000Z'),
+        expiresAt: new Date('2036-08-09T00:00:00.000Z'),
         revokedAt: null,
         staffUser: null,
         ticketEntitlement: {
@@ -190,7 +190,7 @@ async function staffRow(role: string, disabledAt: Date | null = null) {
     return {
         id: 'web-session-2',
         tokenDigest: await digestOf(ATTENDEE_COOKIE),
-        expiresAt: new Date('2026-08-09T00:00:00.000Z'),
+        expiresAt: new Date('2036-08-09T00:00:00.000Z'),
         revokedAt: null,
         staffUser: { id: 'user-1', role, disabledAt },
         ticketEntitlement: null,


### PR DESCRIPTION
Restores the existing main gates without changing runtime behavior.

- moves synthetic web-session expiry beyond the current date so auth tests do not fail merely because wall time passed August 9
- raises the transitive nanoid lockfile entry to 3.3.18, matching the already-integrated early-birds advisory floor

Evidence: auth 29/29; npm audit has no high-severity production finding; diff-check clean.