### PR TITLE
fix(e2e): keep synthetic ticket login current

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -32,7 +32,10 @@ they never weaken their assertions to pass.
    ```
 
    The dump predates pending migrations by design; `migrate deploy` brings
-   it current without regenerating anything.
+   it current without regenerating anything. The guarded loader refreshes
+   only non-revoked ticket expirations in the throwaway database, so fixed
+   historical event timestamps remain deterministic while attendee login
+   does not expire merely because wall-clock time advances.
 
 2. **LiveKit** (only for the media-continuity suite):
 

--- a/scripts/load-test-fixture.mjs
+++ b/scripts/load-test-fixture.mjs
@@ -19,7 +19,17 @@ const root = dirname(dirname(fileURLToPath(import.meta.url)));
 // loader idempotent (safe here: the guard above pins throwaway databases).
 const sql = `DROP SCHEMA public CASCADE;
 CREATE SCHEMA public;
-${readFileSync(join(root, 'db', 'test-fixture.sql'), 'utf8')}`;
+${readFileSync(join(root, 'db', 'test-fixture.sql'), 'utf8')}
+
+-- The committed fixture keeps stable historical event timestamps so visual
+-- and lifecycle assertions remain deterministic. Authentication, however,
+-- must not start failing merely because wall-clock time moved past that
+-- historical weekend. Refresh only non-revoked test entitlements in this
+-- throwaway database; production data can never reach this guarded loader.
+UPDATE public.ticket_entitlements
+SET expires_at = GREATEST(expires_at, CURRENT_TIMESTAMP + INTERVAL '24 hours')
+WHERE state <> 'REVOKED' AND revoked_at IS NULL;
+`;
 const connectionString = process.env.E2E_DATABASE_URL ?? process.env.DATABASE_URL;
 
 if (!connectionString) {


### PR DESCRIPTION
Fixes the E2E quality gate after the fixed 2026 weekend fixture crossed its ticket support window.

- preserves deterministic event timestamps and fixture identities
- refreshes only non-revoked ticket expiry inside the localhost-only throwaway loader
- leaves revoked negative fixtures expired
- does not touch production/runtime/event behavior

Evidence:
- guarded loader against disposable PostgreSQL
- 10 active tickets refreshed beyond 23h59m
- 2 revoked tickets remained expired
- Node syntax and diff-check green

Root cause evidence: run 31964234650 logged repeated `ticket login rejected: reason=expired` before all 8 timeouts.