### PR TITLE
fix(listener): reveal BeaconField through interaction panels

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1387,9 +1387,10 @@ html[data-hb-surface='listener'] body {
   padding: clamp(0.85rem, 2.2vw, 1.2rem);
   border: 1px solid var(--hb-hair-soft);
   border-radius: var(--hb-radius-card);
-  background: linear-gradient(145deg, rgba(36, 29, 21, 0.84), rgba(22, 18, 13, 0.68));
-  box-shadow: var(--hb-shadow-card);
-  backdrop-filter: blur(18px);
+  background: linear-gradient(145deg, rgba(36, 29, 21, 0.055), rgba(22, 18, 13, 0.025));
+  box-shadow: var(--hb-shadow-card), inset 0 1px rgba(244, 238, 226, 0.025);
+  -webkit-backdrop-filter: blur(2.5px) saturate(108%);
+  backdrop-filter: blur(2.5px) saturate(108%);
 }
 
 .listener-stage__copy {
@@ -1830,9 +1831,10 @@ html[data-hb-surface='listener'] body {
   padding: clamp(1.25rem, 3vw, 2rem);
   border: 1px solid var(--border-subtle);
   border-radius: var(--hb-radius-card);
-  background: rgba(27, 21, 15, 0.82);
-  box-shadow: var(--hb-shadow-card);
-  backdrop-filter: blur(18px);
+  background: linear-gradient(145deg, rgba(36, 29, 21, 0.055), rgba(22, 18, 13, 0.025));
+  box-shadow: var(--hb-shadow-card), inset 0 1px rgba(244, 238, 226, 0.025);
+  -webkit-backdrop-filter: blur(2.5px) saturate(108%);
+  backdrop-filter: blur(2.5px) saturate(108%);
 }
 
 .listener-quota {

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -82,6 +82,22 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
         expect(listenerCss).not.toContain('rgba(255, 143, 200');
     });
 
+    it('keeps the real BeaconField visible through both large interaction panels', () => {
+        const css = readFileSync('src/app/globals.css', 'utf8');
+
+        for (const selector of ['.listener-control-panel', '.listener-access__card']) {
+            const start = css.indexOf(`${selector} {`);
+            const end = css.indexOf('\n}', start);
+            const rule = css.slice(start, end);
+
+            expect(start, `${selector} must exist`).toBeGreaterThanOrEqual(0);
+            expect(rule).toContain('rgba(36, 29, 21, 0.055)');
+            expect(rule).toContain('rgba(22, 18, 13, 0.025)');
+            expect(rule).toContain('backdrop-filter: blur(2.5px) saturate(108%);');
+            expect(rule).not.toContain('blur(18px)');
+        }
+    });
+
     it('keeps every BeaconField loop spatially continuous at its cycle boundary', () => {
         const css = readFileSync('src/app/globals.css', 'utf8');
         expect(css).toContain(


### PR DESCRIPTION
Correct surface: Listener only. Makes the real Listener BeaconField visible through both the access form and audio control panel by reducing warm overlay opacity and using a light 2.5px backdrop blur. No Live, event, player, audio, auth or commerce behavior files changed. Verified on the disposable earlybirds-staging runtime at 634x574 in both anonymous and Free For All states. Gates: 55 focused tests, TypeScript, focused ESLint and production build.