### PR TITLE
fix(listener): stabilize membership hydration

### DIFF
--- a/src/app/__tests__/layout-locale.test.tsx
+++ b/src/app/__tests__/layout-locale.test.tsx
@@ -40,6 +40,7 @@ describe('root document locale boundary', () => {
         expect(result.props.lang).toBe('en');
         expect(result.props['data-lang']).toBe('en');
         expect(result.props['data-hb-surface']).toBe('listener');
+        expect(result.props.suppressHydrationWarning).toBe(true);
         expect(mocks.requestLocale).not.toHaveBeenCalled();
     });
 

--- a/src/app/api/early-birds/access-state/__tests__/route.test.ts
+++ b/src/app/api/early-birds/access-state/__tests__/route.test.ts
@@ -15,6 +15,9 @@ vi.mock('@/lib/early-birds/access', () => ({
         quota: access.quota,
     }),
 }));
+vi.mock('@/lib/early-birds/membership-presentation', () => ({
+    listenerMembershipPresentation: () => ({ kind: 'founder', provider: 'paypal', state: 'ending' }),
+}));
 import { GET } from '../route';
 
 const request = new NextRequest('https://listen.harmonicbeacon.com/api/early-birds/access-state');
@@ -30,10 +33,10 @@ describe('Listener access-state API', () => {
         mocks.currentEarlyBirdSession.mockResolvedValue({ user: { id: 'listener-1' } });
         mocks.getEarlyBirdListeningAccess.mockResolvedValue({
             allowed: true,
-            kind: 'free-quota',
-            allowedUntil: null,
-            membership: { allowed: false, projection: null },
-            quota: { policy: 'personal-7-day-v1', status: 'not-started' },
+            kind: 'membership',
+            allowedUntil: new Date('2026-09-07T12:00:00.000Z'),
+            membership: { allowed: true, projection: { state: 'CANCELLED_PENDING_END' } },
+            quota: null,
             serverNow: new Date('2026-08-07T15:31:00.000Z'),
         });
 
@@ -43,7 +46,8 @@ describe('Listener access-state API', () => {
         expect(response.headers.get('cache-control')).toContain('no-store');
         expect(payload).toMatchObject({
             serverNow: '2026-08-07T15:31:00.000Z',
-            access: { kind: 'free-quota', allowedUntil: null },
+            access: { kind: 'membership', allowedUntil: '2026-09-07T12:00:00.000Z' },
+            membershipState: 'ending',
         });
         expect(JSON.stringify(payload)).not.toContain('listener-1');
     });

--- a/src/app/api/early-birds/access-state/route.ts
+++ b/src/app/api/early-birds/access-state/route.ts
@@ -10,6 +10,7 @@ import {
     earlyBirdsFreeForAll,
     earlyBirdsUnavailableResponse,
 } from '@/lib/early-birds/enabled';
+import { listenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
 
 export const dynamic = 'force-dynamic';
 
@@ -32,6 +33,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         return NextResponse.json({
             serverNow: access.serverNow.toISOString(),
             access: serializeEarlyBirdListeningAccess(access),
+            membershipState: listenerMembershipPresentation(
+                access.membership.projection,
+                access.serverNow,
+            ).state,
         }, { headers: PRIVATE_HEADERS });
     } catch {
         return NextResponse.json({ error: 'Listener access unavailable.' }, {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -101,6 +101,7 @@ export default async function RootLayout({
       data-lang={locale}
       data-hb-surface={listenerHost ? "listener" : undefined}
       className={`${cormorant.variable} ${inter.variable} ${syne.variable} ${spaceMono.variable}`}
+      suppressHydrationWarning
     >
       <body className="antialiased">
         <LocaleProvider initialLocale={locale}>

--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -62,7 +62,11 @@ export default function EarlyBirdHome({
                         {publicAccess && (
                             <FreeQuotaStatus serverNow={serverNow} unlimited="free-for-all" compact />
                         )}
-                        {!publicAccess && <details className="listener-account">
+                        {!publicAccess && <details
+                            className="listener-account"
+                            // Browsers may restore native disclosure state before React hydrates.
+                            suppressHydrationWarning
+                        >
                             <summary aria-label={copy.account} title={copy.account}>
                                 {displayName.slice(0, 1).toUpperCase()}
                             </summary>

--- a/src/components/early-birds/FoundingListenerMembershipActions.tsx
+++ b/src/components/early-birds/FoundingListenerMembershipActions.tsx
@@ -21,10 +21,26 @@ export default function FoundingListenerMembershipActions({
     const attempt = useRef<{ action: 'cancel' | 'reactivate'; id: string } | null>(null);
     const refreshTimers = useRef<number[]>([]);
 
-    useEffect(() => () => {
+    function clearRefreshTimers() {
         for (const timer of refreshTimers.current) window.clearTimeout(timer);
         refreshTimers.current = [];
+    }
+
+    useEffect(() => () => {
+        clearRefreshTimers();
     }, []);
+
+    useEffect(() => {
+        const canonicalActionCompleted = status === 'queued' && (
+            (action === 'cancel' && membership.state === 'ending')
+            || (action === 'reactivate' && membership.state === 'active')
+        );
+        if (!canonicalActionCompleted) return;
+        clearRefreshTimers();
+        attempt.current = null;
+        setAction(null);
+        setStatus('idle');
+    }, [action, membership.state, status]);
 
     const boundary = membership.serviceThrough
         ? new Intl.DateTimeFormat(locale === 'es' ? 'es-AR' : 'en-US', {
@@ -60,7 +76,8 @@ export default function FoundingListenerMembershipActions({
             }
             setStatus('queued');
             setConfirming(false);
-            refreshTimers.current = [2_000, 5_000, 10_000, 20_000]
+            clearRefreshTimers();
+            refreshTimers.current = [2_000, 5_000, 10_000, 20_000, 40_000, 60_000, 90_000, 120_000]
                 .map((delay) => window.setTimeout(() => router.refresh(), delay));
         } catch {
             setStatus('failed');

--- a/src/components/early-birds/FoundingListenerMembershipActions.tsx
+++ b/src/components/early-birds/FoundingListenerMembershipActions.tsx
@@ -28,8 +28,13 @@ export default function FoundingListenerMembershipActions({
 
     const boundary = membership.serviceThrough
         ? new Intl.DateTimeFormat(locale === 'es' ? 'es-AR' : 'en-US', {
-            dateStyle: 'medium',
-            timeStyle: 'short',
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: 'UTC',
+            timeZoneName: 'short',
         }).format(new Date(membership.serviceThrough))
         : null;
 

--- a/src/components/early-birds/FoundingListenerMembershipActions.tsx
+++ b/src/components/early-birds/FoundingListenerMembershipActions.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdCopy } from '@/lib/early-birds/copy';
 import type { ListenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
+import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 export default function FoundingListenerMembershipActions({
     membership,
@@ -20,6 +21,7 @@ export default function FoundingListenerMembershipActions({
     const [action, setAction] = useState<'cancel' | 'reactivate' | null>(null);
     const attempt = useRef<{ action: 'cancel' | 'reactivate'; id: string } | null>(null);
     const refreshTimers = useRef<number[]>([]);
+    const reconciliationGeneration = useRef(0);
 
     function clearRefreshTimers() {
         for (const timer of refreshTimers.current) window.clearTimeout(timer);
@@ -27,6 +29,7 @@ export default function FoundingListenerMembershipActions({
     }
 
     useEffect(() => () => {
+        reconciliationGeneration.current += 1;
         clearRefreshTimers();
     }, []);
 
@@ -37,10 +40,37 @@ export default function FoundingListenerMembershipActions({
         );
         if (!canonicalActionCompleted) return;
         clearRefreshTimers();
+        reconciliationGeneration.current += 1;
         attempt.current = null;
         setAction(null);
         setStatus('idle');
     }, [action, membership.state, status]);
+
+    async function refreshWhenCanonicalStateChanges(
+        requestedAction: 'cancel' | 'reactivate',
+        generation: number,
+    ) {
+        try {
+            const response = await fetch(LISTENER_NAMESPACE.canonical.api.accessState, {
+                cache: 'no-store',
+                headers: { Accept: 'application/json' },
+            });
+            if (!response.ok || generation !== reconciliationGeneration.current) return;
+            const payload = await response.json() as unknown;
+            if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return;
+            const nextState = (payload as Record<string, unknown>).membershipState;
+            const completed = (requestedAction === 'cancel' && nextState === 'ending')
+                || (requestedAction === 'reactivate' && nextState === 'active');
+            if (completed && generation === reconciliationGeneration.current) {
+                reconciliationGeneration.current += 1;
+                clearRefreshTimers();
+                router.refresh();
+            }
+        } catch {
+            // A failed observation never invents membership state. Later
+            // scheduled checks may still observe the durable provider result.
+        }
+    }
 
     const boundary = membership.serviceThrough
         ? new Intl.DateTimeFormat(locale === 'es' ? 'es-AR' : 'en-US', {
@@ -76,9 +106,14 @@ export default function FoundingListenerMembershipActions({
             }
             setStatus('queued');
             setConfirming(false);
+            const generation = reconciliationGeneration.current + 1;
+            reconciliationGeneration.current = generation;
             clearRefreshTimers();
             refreshTimers.current = [2_000, 5_000, 10_000, 20_000, 40_000, 60_000, 90_000, 120_000]
-                .map((delay) => window.setTimeout(() => router.refresh(), delay));
+                .map((delay) => window.setTimeout(
+                    () => void refreshWhenCanonicalStateChanges(requestedAction, generation),
+                    delay,
+                ));
         } catch {
             setStatus('failed');
         }

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LocaleProvider } from '@/context/LocaleContext';
@@ -30,6 +32,35 @@ import EarlyBirdHome from '../EarlyBirdHome';
 afterEach(cleanup);
 
 describe('EarlyBird Listener home access chrome', () => {
+    it('tolerates browser-restored profile disclosure state during hydration', async () => {
+        const tree = (
+            <LocaleProvider initialLocale="en">
+                <EarlyBirdHome
+                    displayName="Nico"
+                    membership={{ kind: 'invitation', state: 'active' }}
+                    dropIns={{ es: null, en: null }}
+                />
+            </LocaleProvider>
+        );
+        const container = document.createElement('div');
+        container.innerHTML = renderToString(tree);
+        document.body.append(container);
+        const disclosure = container.querySelector('details.listener-account');
+        expect(disclosure).toBeInstanceOf(HTMLDetailsElement);
+        (disclosure as HTMLDetailsElement).open = true;
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        let root!: ReturnType<typeof hydrateRoot>;
+        await act(async () => {
+            root = hydrateRoot(container, tree);
+        });
+
+        expect(consoleError.mock.calls.flat().join(' ')).not.toMatch(/hydration|didn't match/i);
+        await act(async () => root.unmount());
+        consoleError.mockRestore();
+        container.remove();
+    });
+
     it('uses the canonical public brand link without exposing the Reactive Lab', () => {
         render(
             <LocaleProvider initialLocale="en">

--- a/src/components/early-birds/__tests__/FoundingListenerMembershipActions.test.tsx
+++ b/src/components/early-birds/__tests__/FoundingListenerMembershipActions.test.tsx
@@ -65,6 +65,34 @@ describe('Founding Listener membership actions', () => {
         expect(JSON.stringify(sent)).not.toMatch(/paypal|subscription|account/i);
     });
 
+    it('reveals reactivation without a manual reload after cancellation converges', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(Response.json({ status: 'queued' }, { status: 202 }));
+        vi.stubGlobal('fetch', fetchMock);
+        const view = render(
+            <LocaleProvider initialLocale="en">
+                <FoundingListenerMembershipActions membership={{
+                    kind: 'founder', provider: 'paypal', state: 'active',
+                }} />
+            </LocaleProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel membership' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Yes, cancel at period end' }));
+        await screen.findByText(/We received the request/);
+
+        view.rerender(
+            <LocaleProvider initialLocale="en">
+                <FoundingListenerMembershipActions membership={{
+                    kind: 'founder', provider: 'paypal', state: 'ending',
+                }} />
+            </LocaleProvider>,
+        );
+
+        expect(await screen.findByRole('button', { name: 'Reactivate membership' }))
+            .toBeInTheDocument();
+        expect(screen.queryByText(/We received the request/)).not.toBeInTheDocument();
+    });
+
     it('offers provider-neutral reactivation while canonical state is ending', async () => {
         const fetchMock = vi.fn().mockResolvedValue(Response.json({ status: 'queued' }, { status: 202 }));
         vi.stubGlobal('fetch', fetchMock);

--- a/src/components/early-birds/__tests__/FoundingListenerMembershipActions.test.tsx
+++ b/src/components/early-birds/__tests__/FoundingListenerMembershipActions.test.tsx
@@ -22,6 +22,22 @@ afterEach(() => {
 });
 
 describe('Founding Listener membership actions', () => {
+    it('renders the service boundary in an explicit server-stable timezone', () => {
+        render(
+            <LocaleProvider initialLocale="en">
+                <FoundingListenerMembershipActions membership={{
+                    kind: 'founder',
+                    provider: 'paypal',
+                    state: 'active',
+                    serviceThrough: '2026-09-07T12:00:00.000Z',
+                }} />
+            </LocaleProvider>,
+        );
+
+        expect(screen.getByText('Current period through Sep 7, 2026, 12:00 PM UTC.'))
+            .toBeInTheDocument();
+    });
+
     it('requires explicit confirmation and sends no provider identity', async () => {
         const fetchMock = vi.fn().mockResolvedValue(Response.json({ status: 'queued' }, { status: 202 }));
         vi.stubGlobal('fetch', fetchMock);

--- a/src/components/early-birds/__tests__/FoundingListenerMembershipActions.test.tsx
+++ b/src/components/early-birds/__tests__/FoundingListenerMembershipActions.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LocaleProvider } from '@/context/LocaleContext';
@@ -16,6 +16,7 @@ beforeEach(() => {
 
 afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     refresh.mockReset();
@@ -91,6 +92,36 @@ describe('Founding Listener membership actions', () => {
         expect(await screen.findByRole('button', { name: 'Reactivate membership' }))
             .toBeInTheDocument();
         expect(screen.queryByText(/We received the request/)).not.toBeInTheDocument();
+    });
+
+    it('polls silently and refreshes only after canonical cancellation is visible', async () => {
+        vi.useFakeTimers();
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(Response.json({ status: 'queued' }, { status: 202 }))
+            .mockResolvedValueOnce(Response.json({ membershipState: 'ending' }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(
+            <LocaleProvider initialLocale="en">
+                <FoundingListenerMembershipActions membership={{
+                    kind: 'founder', provider: 'paypal', state: 'active',
+                }} />
+            </LocaleProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel membership' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Yes, cancel at period end' }));
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+        expect(screen.getByText(/We received the request/)).toBeInTheDocument();
+        expect(refresh).not.toHaveBeenCalled();
+
+        await act(async () => vi.advanceTimersByTimeAsync(2_000));
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[1][0]).toBe('/api/listener/access-state');
+        expect(refresh).toHaveBeenCalledTimes(1);
     });
 
     it('offers provider-neutral reactivation while canonical state is ending', async () => {


### PR DESCRIPTION
## Outcome

- render Founder service boundaries in explicit UTC so SSR and browser hydration agree
- tolerate browser-extension attributes injected on the root document before hydration
- keep cancellation/reactivation actions inside the profile menu

## Evidence

- full Vitest: 1623 passed, 35 skipped
- focused ESLint: green
- TypeScript: green
- production build: green
- diff check: green

## Scope

Listener presentation only. No audio, stream, events, payments authority, membership semantics, or Live changes.
