### PR TITLE
docs(listener): make cancellation prospective

### DIFF
--- a/docs/MONETIZATION.md
+++ b/docs/MONETIZATION.md
@@ -137,14 +137,15 @@ When a card fails:
 
 ### Refunds
 
-- Within 14 days of a new patronage or annual renewal: no-questions-refund via a self-serve flow.
-- Beyond 14 days: pro-rated by request. No automated pro-ration for monthly patrons beyond that window.
+- Cancellation stops future renewals and preserves the period already paid; it never initiates a refund.
+- Refunds, if exceptionally required by law, provider process or an individually reviewed support case,
+  are performed manually. There is no automatic or self-service refund actuator.
 
 ### Gifts
 
 - Annual patronage will be giftable at any tier. Gifts are a separate flow; the recipient can opt to continue as a patron or let the gift elapse without billing.
 
-The cancellation, dunning, refund and gift rules above are the contract each flow will be built to. None of the flows exists — there is nothing to cancel, no card to fail, and no charge to refund. **[Planned — Phase 2]**
+The cancellation, dunning, exceptional-refund and gift rules above are the contract each flow will be built to. None of the patronage flows exists yet. **[Planned — Phase 2]**
 
 ## Provider revenue share
 

--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -12,6 +12,9 @@ LiveKit, Ticket Tailor, playlist-bot, tapestry, event audio or `live.harmonicbea
 - Founder status and price exist only while service is uninterrupted. Cancellation retains access
   through the paid boundary. A real lapse, refund, reversal, dispute, chargeback, fraud or admin
   termination ends Founder continuity.
+- Cancellation is prospective and automatic: it disables future renewals, does not refund the
+  current paid period and does not require a human queue. Refunds are exceptional, manual provider
+  operations only; the authority still ingests their signed events as terminal evidence.
 - Browser redirects, Free, invitations and Free For All never grant membership or emit Purchase.
 
 Public terms and privacy are published at `/listener/terms` and `/listener/privacy`. They are a
@@ -29,9 +32,10 @@ truthful launch baseline, not a substitute for counsel review. Human owner: Nico
 - Production provider and new-sales flags remain OFF. No real payment was attempted.
 
 These accepted browser lifecycles are explicitly non-production: PayPal used
-Sandbox and Mercado Pago used TEST. The productive lanes have passed only
-read-only provider preflight so far; neither provider has completed a Live
-activation/cancel/refund rehearsal and no real charge has been created.
+Sandbox and Mercado Pago used TEST. PayPal Live has since completed activation,
+cancellation and reactivation with a non-merchant buyer. Mercado Pago Live
+still requires its supervised lifecycle. A real refund is intentionally not
+part of launch acceptance.
 
 Passwordless email delivery is deployed in the dedicated Listener-only sidecar at exact backend
 SHA `456ece2b38e203a2d12c54864115e03ebaa1a89c`. The API, worker and PostgreSQL queue have no host
@@ -149,8 +153,9 @@ converted back into a reversible action.
    ready and the public copy/terms have human approval.
 7. Execute one supervised real USD 5 membership with an agreed account. Confirm provider event,
    canonical projection, profile badge, unlimited access, renewal boundary and no raw PII in logs.
-8. Request cancellation in the profile. Confirm provider cancellation, pending-end projection and
-   access through paid-through. Use a separate controlled account to rehearse failure/refund.
+8. Request cancellation in the profile. Confirm future renewals stop, the projection becomes
+   pending-end and access continues through paid-through. Reactivate before the boundary and verify
+   continuity. Never issue a real refund merely as a rehearsal.
 9. Expand availability only after webhook/reconciliation lag and alerts remain healthy.
 
 ## Incident and rollback
@@ -180,8 +185,11 @@ converted back into a reversible action.
   to the other provider or manufacture membership.
 - Webhook/reconciliation lag: stop new sales, keep ingestion active, reconcile from provider APIs,
   and do not infer access from return URLs.
-- Refund/dispute: follow the canonical provider event. Support records the provider operation and
-  opaque account in the private ledger; no card/bank data enters GitHub or application logs.
+- Exceptional refund/dispute: a human explicitly performs or validates the provider operation,
+  then the authority follows the canonical signed provider event. This is not the normal
+  cancellation path and is never triggered automatically. Support records only the provider
+  operation and opaque account in the private ledger; no card/bank data enters GitHub or
+  application logs.
 
 ## Human release gates still required
 

--- a/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
+++ b/docs/operations/FOUNDING_LISTENER_RELEASE_CANDIDATE.md
@@ -18,7 +18,7 @@ The weekly-Free candidate has advanced to a complete Founding Listener pre-relea
 
 - canonical uninterrupted Founder continuity and USD 5/month offer;
 - PayPal Sandbox and Mercado Pago TEST browser acceptance;
-- self-service cancel/reactivate and terminal Free fallback;
+- self-service cancel/reactivate at the paid boundary and terminal Free fallback;
 - private paid-operation metrics, alerts, backup/restore and sales kill switches;
 - production provider adapters and public checkout present but fail-closed/default-off.
 
@@ -190,7 +190,7 @@ deployed image; later documentation-only commits do not require rebuilding it.
 - #211 is deployed. #212's accepted field is public; its technical laboratory
   remains default-off and can be re-enabled only on staging for later variants.
 - #199/#200 have fresh provider evidence: PayPal Sandbox completed USD 5
-  activation, cancel-pending-end, reversal and terminal refund; Mercado Pago TEST
+  activation, cancel-pending-end, reversal and terminal-event handling; Mercado Pago TEST
   completed checkout, pause, reactivation and reconciliation. Productive credentials are installed
   root-only. One PayPal Live approval intent exists without a subscription or charge; PayPal Live
   lifecycle ingestion stays ON while global new sales, both public checkout flags and Mercado Pago
@@ -201,8 +201,8 @@ deployed image; later documentation-only commits do not require rebuilding it.
 Use `docs/operations/EARLY_BIRDS_FREE_ACCEPTANCE.md` as the authoritative
 worksheet.
 
-1. Review and accept the final ES/EN offer, seller, cancellation/refund, privacy
-   and support copy.
+1. Review and accept the final ES/EN offer, seller, prospective cancellation,
+   manual-exception refund, privacy and support copy.
 2. Rotate the exposed Google OAuth client secret through the protected store and
    re-run callback/logout without printing it.
 3. Prove one controlled

--- a/docs/operations/LISTENER_LAUNCH_NOW.md
+++ b/docs/operations/LISTENER_LAUNCH_NOW.md
@@ -1,6 +1,6 @@
 # Listener launch — current state
 
-Last reconciled: 2026-08-15
+Last reconciled: 2026-08-16
 
 This is the compact operational memory for Founding Listeners. Detailed evidence
 and rollback procedures live in `FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md` and
@@ -47,12 +47,15 @@ reconciliation and cancellation stay available. Mercado Pago remains on TEST
 with Live OFF.
 
 PayPal Sandbox has passed activation, pending cancellation, reactivation and
-terminal refund. Mercado Pago TEST has passed checkout, activation, pause,
-reactivation and reconciliation. Browser redirects never grant membership.
+terminal-event handling. Mercado Pago TEST has passed checkout, activation,
+pause, reactivation and reconciliation. Browser redirects never grant
+membership. Normal cancellation only disables future renewals: it preserves
+the already-paid service period and never issues a refund. Refunds are manual,
+exceptional provider operations, not a launch rehearsal or self-service flow.
 
 | Provider | Non-production lifecycle | Productive state |
 | --- | --- | --- |
-| PayPal | Sandbox activation, pending cancellation, reactivation and terminal refund accepted | Live catalog/webhook read-only preflight verified; lifecycle and real charge not yet rehearsed |
+| PayPal | Sandbox activation, pending cancellation, reactivation and terminal-event ingestion accepted | Live activation, cancellation and reactivation accepted; cancellation pending end preserves the paid period and no refund was issued |
 | Mercado Pago | TEST checkout, activation, pause, reactivation and reconciliation accepted | Live merchant/webhook read-only preflight verified; lifecycle and real charge not yet rehearsed |
 
 “Private rehearsal completed” currently means Sandbox/TEST only. A productive
@@ -77,16 +80,18 @@ backup. Only Listener and the disposable staging workbench were recreated.
 
 1. #304 — complete a physical 60-minute listen and record any watchdog recovery.
 2. #317 — final mobile/account-menu billing acceptance.
-3. #318 — record human ES/EN offer/legal/seller/refund/support and invoicing
+3. #318 — record human ES/EN offer/legal/seller/manual-exception refund/support and invoicing
    acceptance. The public no-login withdrawal and service-cancellation paths,
    dedicated secret, migration, private operator, metrics and 20h/24h alerts
    are deployed and smoke-tested.
-4. With a new explicit approval, create a fresh PayPal checkout for a
-   non-merchant buyer and execute supervised activation, cancellation and
-   refund evidence. Execute the corresponding supervised Mercado Pago Live
-   lifecycle separately.
-5. Confirm Founder activation, terminal Free fallback, metrics, alerts and the
-   absence of PII/secret leakage against those Live transactions.
+4. Execute the corresponding supervised Mercado Pago Live activation,
+   cancellation and reactivation lifecycle with a non-merchant buyer. Do not
+   create a real refund as an acceptance test.
+5. Confirm Founder activation, paid-through cancellation, metrics, alerts and
+   the absence of PII/secret leakage against those Live transactions. Terminal
+   refund/dispute handling remains covered synthetically and by provider-event
+   reconciliation; an exceptional real refund is handled manually if one ever
+   occurs.
 6. Obtain separate explicit approvals for merge to `main` and public checkout.
 
 ## Non-negotiable isolation

--- a/docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
+++ b/docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
@@ -121,7 +121,8 @@ canonical authority runtime; they are never copied into Listener configuration.
    human confirms payment.
 7. As soon as the provider approval URL has been created, turn authority new sales OFF. Keep the
    selected provider lifecycle/webhook/reconciliation flag ON until activation, cancellation and
-   any supervised refund/terminal path are canonical and reconciled.
+   reactivation are canonical and reconciled. Do not issue a refund as part of rehearsal;
+   exceptional refunds remain manual provider operations whose signed events are still ingested.
 8. Verify canonical Founder projection, profile badge, unlimited access, provider event, metrics,
    alerts and logs without copying approval URLs, provider IDs, PII or secrets into public records.
 9. Set the workbench gate back to `0`, recreate only staging Listener, and verify its exact route is

--- a/docs/operations/LISTENER_WITHDRAWAL_REQUESTS.md
+++ b/docs/operations/LISTENER_WITHDRAWAL_REQUESTS.md
@@ -3,7 +3,9 @@
 This is the bounded operator flow for the public **BOTÓN DE
 ARREPENTIMIENTO** and **BOTÓN DE BAJA DE SERVICIO**. It receives and tracks a request; it never calls PayPal,
 Mercado Pago or the membership authority and it never cancels or refunds by
-itself.
+itself. The ordinary signed-in membership action is separate: it automatically
+stops future renewals, preserves the already-paid period and never refunds it.
+Refund requests are exceptional cases that require manual provider review.
 
 ## Runtime boundary
 
@@ -53,8 +55,8 @@ Then, outside this application:
 1. inspect `requestKind`, then correlate the email/provider/date against the canonical provider and
    membership authority;
 2. contact the requester when evidence is insufficient;
-3. perform the authorized provider cancellation/refund, if applicable, using
-   its normal audited procedure;
+3. perform the authorized provider cancellation, or an exceptional manual
+   refund when independently justified, using the provider's audited procedure;
 4. confirm canonical membership convergence;
 5. record only the bounded result in this queue:
 

--- a/docs/phases/PHASE_2_PARTICIPATION.md
+++ b/docs/phases/PHASE_2_PARTICIPATION.md
@@ -38,7 +38,7 @@ Five workstreams.
   - Early access: a separate `earlyAccess` flag on meditations, visible only to patrons
 - [ ] Cancellation flow: one-click, no retention offers, acknowledgement email in brand voice
 - [ ] Dunning: retry at day 1/3/7, pause on third failure, no account lockout
-- [ ] Refund flow: 14-day no-questions-refund endpoint, exposed in the patron's account page
+- [ ] Exceptional refund procedure: manual provider operation after an individually reviewed legal/support case; no automatic or self-service refund endpoint
 - [ ] Hearth page at `/hearth`: patrons at Hearth tier can opt to display name; rendered server-side, static-cached with 1h TTL; alphabetical or chronological, patron's choice
 - [ ] Annual year-end summary email with total patronage contribution (for tax-deductibility where applicable)
 - [ ] Gift flow: purchase annual patronage for another email address; recipient redeems with one click

--- a/src/lib/early-birds/__tests__/copy.test.ts
+++ b/src/lib/early-birds/__tests__/copy.test.ts
@@ -28,4 +28,14 @@ describe('EarlyBirds interface copy', () => {
             expect(visibleCopy).toMatch(/Mercado Pago/);
         }
     });
+
+    it('keeps cancellation prospective and refunds manual-only in both locales', () => {
+        const spanishTerms = earlyBirdLegalCopy.es.sections.flatMap((section) => section.paragraphs).join(' ');
+        const englishTerms = earlyBirdLegalCopy.en.sections.flatMap((section) => section.paragraphs).join(' ');
+
+        expect(earlyBirdCopy.es.membershipCancelConfirmDetail).toMatch(/próximos cobros.*No se reembolsa/i);
+        expect(earlyBirdCopy.en.membershipCancelConfirmDetail).toMatch(/Future charges.*not refunded/i);
+        expect(spanishTerms).toMatch(/reembolsos.*no.*automáticos.*manualmente/i);
+        expect(englishTerms).toMatch(/Refunds.*never automatic.*manually/i);
+    });
 });

--- a/src/lib/early-birds/copy.ts
+++ b/src/lib/early-birds/copy.ts
@@ -60,7 +60,7 @@ export const earlyBirdCopy = {
         membershipAccessThrough: 'Acceso Founder hasta {date}.',
         membershipCancel: 'Cancelar membresía',
         membershipCancelConfirmTitle: 'Confirmar cancelación',
-        membershipCancelConfirmDetail: 'Conservarás acceso hasta el fin del período ya pagado. Después perderás el precio Founder.',
+        membershipCancelConfirmDetail: 'Se detendrán los próximos cobros. No se reembolsa el período actual: conservarás acceso hasta que termine. Después perderás el precio Founder.',
         membershipCancelConfirm: 'Sí, cancelar al fin del período',
         membershipCancelWorking: 'Solicitando cancelación…',
         membershipKeep: 'Conservar membresía',
@@ -136,7 +136,7 @@ export const earlyBirdCopy = {
         membershipAccessThrough: 'Founder access through {date}.',
         membershipCancel: 'Cancel membership',
         membershipCancelConfirmTitle: 'Confirm cancellation',
-        membershipCancelConfirmDetail: 'You will keep access through the paid period. After that, Founder pricing ends.',
+        membershipCancelConfirmDetail: 'Future charges will stop. The current period is not refunded: you will keep access until it ends. After that, Founder pricing ends.',
         membershipCancelConfirm: 'Yes, cancel at period end',
         membershipCancelWorking: 'Requesting cancellation…',
         membershipKeep: 'Keep membership',
@@ -161,7 +161,7 @@ export const earlyBirdLegalCopy = {
         back: 'Volver a Listener',
         eyebrow: 'HARMONIC BEACON · FOUNDING LISTENER',
         title: 'Condiciones y privacidad del servicio Listener',
-        updated: 'Versión de lanzamiento · 13 de agosto de 2026',
+        updated: 'Versión de lanzamiento · 16 de agosto de 2026',
         sections: [
             {
                 title: 'Oferta',
@@ -174,8 +174,8 @@ export const earlyBirdLegalCopy = {
             {
                 title: 'Cancelación, fallos y reembolsos',
                 paragraphs: [
-                    'Puedes solicitar la cancelación desde tu perfil. Conservas acceso hasta el final del período ya pagado; el proveedor confirma el cambio y la app actualiza el estado canónico. Una nueva alta posterior usa la oferta pública vigente.',
-                    'Un reembolso, contracargo, disputa, fraude o terminación administrativa puede finalizar inmediatamente el acceso. Para pedir ayuda o revisar un cobro escribe a nicoechaniz@harmonicbeacon.com. La política legal aplicable y los derechos irrenunciables del consumidor prevalecen.',
+                    'Puedes cancelar desde tu perfil. La cancelación detiene cobros futuros, no reembolsa el período actual y conservas acceso hasta que termine ese período ya pagado. Una nueva alta posterior usa la oferta pública vigente.',
+                    'Los reembolsos no forman parte de la cancelación normal ni son automáticos. Si un caso legal o de soporte excepcional requiere uno, se procesa manualmente con el proveedor; su confirmación, un contracargo, una disputa, fraude o terminación administrativa puede finalizar inmediatamente el acceso. Para pedir ayuda o revisar un cobro escribe a nicoechaniz@harmonicbeacon.com. La política legal aplicable y los derechos irrenunciables del consumidor prevalecen.',
                 ],
             },
             {
@@ -198,7 +198,7 @@ export const earlyBirdLegalCopy = {
         back: 'Back to Listener',
         eyebrow: 'HARMONIC BEACON · FOUNDING LISTENER',
         title: 'Listener service terms and privacy',
-        updated: 'Launch version · August 13, 2026',
+        updated: 'Launch version · August 16, 2026',
         sections: [
             {
                 title: 'Offer',
@@ -211,8 +211,8 @@ export const earlyBirdLegalCopy = {
             {
                 title: 'Cancellation, failures and refunds',
                 paragraphs: [
-                    'You can request cancellation from your profile. Access continues through the paid period; the provider confirms the change and the app updates canonical status. A later signup uses the public offer available then.',
-                    'A refund, chargeback, dispute, fraud finding or administrative termination may end access immediately. For billing help or review, contact nicoechaniz@harmonicbeacon.com. Applicable law and non-waivable consumer rights prevail.',
+                    'You can cancel from your profile. Cancellation stops future charges, does not refund the current period, and access continues until that already-paid period ends. A later signup uses the public offer available then.',
+                    'Refunds are not part of normal cancellation and are never automatic. If an exceptional legal or support case requires one, it is processed manually with the provider; its confirmation, a chargeback, dispute, fraud finding or administrative termination may end access immediately. For billing help or review, contact nicoechaniz@harmonicbeacon.com. Applicable law and non-waivable consumer rights prevail.',
                 ],
             },
             {


### PR DESCRIPTION
## Outcome

Makes the product policy unambiguous across Listener copy, launch runbooks and future monetization plans:

- cancellation stops future renewals;
- the already-paid period remains active and is not refunded;
- no automatic or self-service refund actuator;
- exceptional refunds are manual provider operations;
- signed refund/chargeback/dispute events remain terminal authority evidence.

Also removes real refunds from PayPal/Mercado Pago Live acceptance. PayPal Live is recorded as activation → cancellation → reactivation → final paid-through cancellation; Mercado Pago Live must prove the same lifecycle.

## Verification

- 16 focused tests pass (copy, membership actions, membership route)
- TypeScript passes
- focused ESLint passes
- `git diff --check` passes

No provider, runtime, membership authority, payment, audio or event behavior changed.
