### PR TITLE
fix(listener): remove persistent withdrawal buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1156,8 +1156,7 @@ html[data-hb-surface='listener'] body {
 }
 
 .listener-shell,
-.listener-page-shell,
-.listener-consumer-request-links {
+.listener-page-shell {
   --night: var(--hb-bg-0);
   --forest: var(--hb-bg-1);
   --forest-2: var(--hb-bg-2);
@@ -2119,15 +2118,6 @@ html[data-hb-surface='listener'] body {
   line-height: 1.65;
 }
 
-.listener-consumer-request-links {
-  position: fixed;
-  right: max(0.8rem, env(safe-area-inset-right));
-  bottom: max(0.8rem, env(safe-area-inset-bottom));
-  z-index: 90;
-  display: grid;
-  gap: 0.5rem;
-}
-
 .listener-withdrawal-link {
   display: grid;
   gap: 0.12rem;
@@ -2212,21 +2202,6 @@ html[data-hb-surface='listener'] body {
   background: var(--hb-gold-2);
   font-family: var(--font-space-mono), ui-monospace, monospace;
   font-size: clamp(0.72rem, 2.5vw, 0.95rem);
-}
-
-@media (max-width: 640px) {
-  .listener-consumer-request-links {
-    position: static;
-    width: auto;
-    max-width: none;
-    margin: 0 0.75rem;
-    padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
-  }
-
-  .listener-consumer-request-links .listener-withdrawal-link {
-    width: 100%;
-    max-width: none;
-  }
 }
 
 /* --------------------------------------------

--- a/src/app/listener/layout.tsx
+++ b/src/app/listener/layout.tsx
@@ -1,16 +1,5 @@
-import ConsumerWithdrawalLink from '@/components/early-birds/ConsumerWithdrawalLink';
-import { listenerWithdrawalPublicConfiguration } from '@/lib/listener/consumer-withdrawal';
 import EarlyBirdLayout from '../early-birds/layout';
 
 export default function ListenerLayout({ children }: { children: React.ReactNode }) {
-    const withdrawalAvailable = listenerWithdrawalPublicConfiguration() !== null;
-    return (
-        <EarlyBirdLayout>
-            {children}
-            {withdrawalAvailable ? <div className="listener-consumer-request-links" aria-label="Consumer service actions">
-                <ConsumerWithdrawalLink />
-                <ConsumerWithdrawalLink kind="SERVICE_CANCELLATION" />
-            </div> : null}
-        </EarlyBirdLayout>
-    );
+    return <EarlyBirdLayout>{children}</EarlyBirdLayout>;
 }

--- a/src/components/early-birds/__tests__/ConsumerWithdrawalLink.test.tsx
+++ b/src/components/early-birds/__tests__/ConsumerWithdrawalLink.test.tsx
@@ -35,17 +35,11 @@ describe('prominent consumer-withdrawal entry', () => {
         expect(screen.queryByRole('link')).toBeNull();
     });
 
-    it('keeps mobile consumer actions in document flow after Listener content', () => {
+    it('does not inject consumer-request links into every Listener screen', () => {
         const root = process.cwd();
         const layout = readFileSync(join(root, 'src/app/listener/layout.tsx'), 'utf8');
-        const css = readFileSync(join(root, 'src/app/globals.css'), 'utf8');
 
-        expect(layout.indexOf('{children}')).toBeGreaterThan(-1);
-        expect(layout.indexOf('{children}')).toBeLessThan(
-            layout.indexOf('className="listener-consumer-request-links"'),
-        );
-        expect(css).toMatch(
-            /@media \(max-width: 640px\)[\s\S]*?\.listener-consumer-request-links\s*\{[\s\S]*?position:\s*static;/,
-        );
+        expect(layout).not.toContain('ConsumerWithdrawalLink');
+        expect(layout).not.toContain('listener-consumer-request-links');
     });
 });


### PR DESCRIPTION
## Outcome

Removes the two persistent fixed/mobile cards for `BOTÓN DE ARREPENTIMIENTO` and `BOTÓN DE BAJA DE SERVICIO` from the Listener interface.

The existing request pages, API, durable queue, operator and links within Terms remain intact and reversible; no received request or backend surface is deleted. Live never rendered these controls and remains unchanged.

## Gates

- 9 focused component tests pass
- TypeScript passes
- focused ESLint passes
- diff-check passes

No payment, membership, event, audio or provider behavior changed.
