### PR TITLE
fix(listener): decouple Mercado Pago payer identity

### DIFF
--- a/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
+++ b/docs/operations/FOUNDING_LISTENER_COMMERCIAL_LAUNCH.md
@@ -124,9 +124,13 @@ deleting bindings, events, jobs or projections.
 - PayPal Live webhook: `POST /v1/webhooks/listener/paypal`.
 - Mercado Pago Live webhook: `POST /v1/webhooks/listener/mercado-pago`.
 - Every other authority route stays loopback/private. Event vhosts expose none of these routes.
-- The browser supplies only provider plus a random attempt ID for checkout, and only a random
-  attempt ID plus canonical action for membership management. Account, email, current provider and provider subscription ID are
-  server-derived. Provider IDs never enter the browser response.
+- The browser supplies provider plus a random attempt ID for checkout. Mercado Pago additionally
+  requires the payer email entered specifically for that provider; it may differ from the Listener
+  sign-in email, is forwarded without becoming profile identity and is retained only as keyed
+  evidence rather than readable PII. PayPal receives no payer email from Listener. Account,
+  current membership provider and provider subscription ID remain server-derived. Membership
+  management supplies only a random attempt ID plus canonical action. Provider IDs never enter the
+  browser response.
 
 For reversible cancellation before the service boundary, PayPal uses suspend/activate and Mercado
 Pago uses pause/reactivate. A terminal provider cancellation, lapse or adverse event is never

--- a/docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
+++ b/docs/operations/LISTENER_PRIVATE_LIVE_WORKBENCH.md
@@ -58,8 +58,10 @@ neither command creates checkout state.
 - Exact browser endpoint: `POST /api/listener/checkout/live-workbench` on the staging host only.
 - The endpoint is absent from the public Listener nginx vhost. A direct application request with
   the public or event Host returns `404` before authentication or authority access.
-- The browser sends only a random attempt UUID and a short-lived session-bound CSRF proof. Account,
-  email, provider, price, environment and callbacks are server-derived.
+- The browser sends a random attempt UUID and a short-lived session-bound CSRF proof. For Mercado
+  Pago only, it also sends the payer email explicitly entered for that provider; this may differ
+  from the Listener sign-in email. Account, provider, price, environment and callbacks remain
+  server-derived. PayPal receives no Listener or client-supplied payer email.
 - One root-owned configuration selects exactly one opaque Listener account and one provider.
 - Enabling either public Listener Live flag makes the workbench fail readiness and disappear.
 - Normal `POST /api/listener/checkout` on staging continues using only PayPal Sandbox or Mercado

--- a/src/app/api/listener/checkout/__tests__/route.test.ts
+++ b/src/app/api/listener/checkout/__tests__/route.test.ts
@@ -60,7 +60,7 @@ afterEach(() => {
 });
 
 describe('Listener sandbox checkout route', () => {
-    it('derives account, email and callbacks from the session and exact staging origin', async () => {
+    it('derives account and callbacks from the session without sending its email to PayPal', async () => {
         const response = await POST(request());
 
         expect(response.status).toBe(200);
@@ -71,13 +71,31 @@ describe('Listener sandbox checkout route', () => {
         });
         expect(createCheckout).toHaveBeenCalledWith({
             accountId: 'opaqueBetterAuthId',
-            email: 'listener@example.com',
+            payerEmail: undefined,
             provider: 'paypal',
             attemptId: ATTEMPT,
             returnUrl: `https://${HOST}/?checkout=returned`,
             cancelUrl: `https://${HOST}/?checkout=cancelled`,
             environment: 'staging',
         });
+    });
+
+    it('accepts a distinct normalized Mercado Pago payer email without changing Listener identity', async () => {
+        createCheckout.mockResolvedValue({
+            provider: 'mercado_pago',
+            approvalUrl: 'https://www.mercadopago.com.ar/subscriptions/checkout?preapproval_id=test',
+        });
+        const response = await POST(request({
+            provider: 'mercado_pago',
+            attemptId: ATTEMPT,
+            payerEmail: 'Ani.Billing@Example.com ',
+        }));
+        expect(response.status).toBe(200);
+        expect(createCheckout).toHaveBeenCalledWith(expect.objectContaining({
+            accountId: 'opaqueBetterAuthId',
+            provider: 'mercado_pago',
+            payerEmail: 'ani.billing@example.com',
+        }));
     });
 
     it('allows an explicitly enabled Live checkout only on the canonical Listener origin', async () => {
@@ -128,7 +146,9 @@ describe('Listener sandbox checkout route', () => {
         ['mercado_pago', 'BEACON_LISTENER_MERCADO_PAGO_TEST_CHECKOUT_ENABLED'],
     ] as const)('fails closed when %s is disabled', async (provider, variable) => {
         vi.stubEnv(variable, '0');
-        const response = await POST(request({ provider, attemptId: ATTEMPT }));
+        const response = await POST(request(provider === 'mercado_pago'
+            ? { provider, attemptId: ATTEMPT, payerEmail: 'buyer@example.com' }
+            : { provider, attemptId: ATTEMPT }));
         expect(response.status).toBe(404);
         expect(currentEarlyBirdSession).not.toHaveBeenCalled();
         expect(createCheckout).not.toHaveBeenCalled();
@@ -138,6 +158,9 @@ describe('Listener sandbox checkout route', () => {
         [{ provider: 'paypal', attemptId: 'not-a-uuid' }, 400],
         [{ provider: 'stripe', attemptId: ATTEMPT }, 400],
         [{ provider: 'paypal', attemptId: ATTEMPT, email: 'attacker@example.com' }, 400],
+        [{ provider: 'paypal', attemptId: ATTEMPT, payerEmail: 'attacker@example.com' }, 400],
+        [{ provider: 'mercado_pago', attemptId: ATTEMPT }, 400],
+        [{ provider: 'mercado_pago', attemptId: ATTEMPT, payerEmail: 'not-an-email' }, 400],
     ])('rejects malformed or client-supplied identity input', async (body, status) => {
         const response = await POST(request(body));
         expect(response.status).toBe(status);

--- a/src/app/api/listener/checkout/live-workbench/__tests__/route.test.ts
+++ b/src/app/api/listener/checkout/live-workbench/__tests__/route.test.ts
@@ -91,7 +91,7 @@ afterEach(() => {
 });
 
 describe('private staging-only Listener Live workbench', () => {
-    it('derives account, email and the single provider from server state', async () => {
+    it('derives account and the single PayPal provider without coupling the session email', async () => {
         const response = await POST(request());
         expect(response.status).toBe(200);
         await expect(response.json()).resolves.toEqual({
@@ -100,13 +100,31 @@ describe('private staging-only Listener Live workbench', () => {
         });
         expect(createCheckout).toHaveBeenCalledWith({
             accountId: ACCOUNT_ID,
-            email: 'listener@example.com',
+            payerEmail: undefined,
             provider: 'paypal',
             attemptId: ATTEMPT,
             returnUrl: `${ORIGIN}/?checkout=returned`,
             cancelUrl: `${ORIGIN}/?checkout=cancelled`,
             environment: 'live',
         });
+    });
+
+    it('accepts an explicit Mercado Pago payer email for the allowlisted Listener account', async () => {
+        vi.stubEnv('BEACON_LISTENER_STAGING_LIVE_WORKBENCH_PROVIDER', 'mercado_pago');
+        createCheckout.mockResolvedValue({
+            provider: 'mercado_pago',
+            approvalUrl: 'https://www.mercadopago.com.ar/subscriptions/checkout?preapproval_id=live',
+        });
+        const response = await POST(request({ body: {
+            attemptId: ATTEMPT,
+            payerEmail: 'Ani.Billing@Example.com ',
+        } }));
+        expect(response.status).toBe(200);
+        expect(createCheckout).toHaveBeenCalledWith(expect.objectContaining({
+            accountId: ACCOUNT_ID,
+            provider: 'mercado_pago',
+            payerEmail: 'ani.billing@example.com',
+        }));
     });
 
     it('is absent by default and whenever public Live checkout is enabled', async () => {
@@ -150,6 +168,7 @@ describe('private staging-only Listener Live workbench', () => {
         { attemptId: ATTEMPT, provider: 'mercado_pago' },
         { attemptId: ATTEMPT, accountId: ACCOUNT_ID },
         { attemptId: 'not-a-uuid' },
+        { attemptId: ATTEMPT, payerEmail: 'unexpected@example.com' },
     ])('rejects client attempts to choose authority fields', async (body) => {
         const response = await POST(request({ body }));
         expect(response.status).toBe(400);

--- a/src/app/api/listener/checkout/live-workbench/route.ts
+++ b/src/app/api/listener/checkout/live-workbench/route.ts
@@ -6,6 +6,7 @@ import {
     ListenerCheckoutUnavailableError,
 } from '@/lib/early-birds/checkout';
 import { earlyBirdsEnabled } from '@/lib/early-birds/enabled';
+import { normalizeMercadoPagoPayerEmail } from '@/lib/early-birds/payer-email';
 import {
     LISTENER_LIVE_WORKBENCH_CSRF_HEADER,
     listenerLiveWorkbenchConfig,
@@ -19,7 +20,7 @@ import {
 export const dynamic = 'force-dynamic';
 
 const STAGING_ORIGIN = `https://${LISTENER_STAGING_HOST}`;
-const MAX_REQUEST_BYTES = 256;
+const MAX_REQUEST_BYTES = 512;
 const ATTEMPT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function json(body: Record<string, unknown>, status: number): NextResponse {
@@ -65,12 +66,24 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     } catch {
         return json({ error: 'Invalid request.' }, 400);
     }
-    if (!input || typeof input !== 'object' || Array.isArray(input) ||
-        Object.keys(input).join('\0') !== 'attemptId') {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
         return json({ error: 'Invalid request.' }, 400);
     }
-    const attemptId = (input as Record<string, unknown>).attemptId;
+    const body = input as Record<string, unknown>;
+    const expectedKeys = config.provider === 'mercado_pago'
+        ? ['attemptId', 'payerEmail']
+        : ['attemptId'];
+    if (Object.keys(body).sort().join('\0') !== expectedKeys.join('\0')) {
+        return json({ error: 'Invalid request.' }, 400);
+    }
+    const attemptId = body.attemptId;
+    const payerEmail = config.provider === 'mercado_pago'
+        ? normalizeMercadoPagoPayerEmail(body.payerEmail)
+        : null;
     if (typeof attemptId !== 'string' || !ATTEMPT_ID.test(attemptId)) {
+        return json({ error: 'Invalid request.' }, 400);
+    }
+    if (config.provider === 'mercado_pago' && !payerEmail) {
         return json({ error: 'Invalid request.' }, 400);
     }
 
@@ -87,7 +100,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
         const result = await new HttpListenerCheckoutGateway().create({
             accountId: session.user.id,
-            email: session.user.email,
+            payerEmail: payerEmail ?? undefined,
             provider: config.provider,
             attemptId,
             returnUrl: `${STAGING_ORIGIN}/?checkout=returned`,

--- a/src/app/api/listener/checkout/route.ts
+++ b/src/app/api/listener/checkout/route.ts
@@ -9,6 +9,7 @@ import {
     type ListenerCheckoutEnvironment,
 } from '@/lib/early-birds/checkout';
 import { earlyBirdsEnabled } from '@/lib/early-birds/enabled';
+import { normalizeMercadoPagoPayerEmail } from '@/lib/early-birds/payer-email';
 import { isCanonicalListenerHost, isListenerStagingHost } from '@/lib/listener/public-discovery';
 
 export const dynamic = 'force-dynamic';
@@ -59,14 +60,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     } catch {
         return json({ error: 'Invalid request.' }, 400);
     }
-    if (!input || typeof input !== 'object' || Array.isArray(input) ||
-        Object.keys(input).sort().join('\0') !== ['attemptId', 'provider'].join('\0')) {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
         return json({ error: 'Invalid request.' }, 400);
     }
     const body = input as Record<string, unknown>;
     const provider = providerFrom(body.provider);
+    const expectedKeys = provider === 'mercado_pago'
+        ? ['attemptId', 'payerEmail', 'provider']
+        : ['attemptId', 'provider'];
+    if (Object.keys(body).sort().join('\0') !== expectedKeys.join('\0')) {
+        return json({ error: 'Invalid request.' }, 400);
+    }
     const attemptId = typeof body.attemptId === 'string' ? body.attemptId : '';
+    const payerEmail = provider === 'mercado_pago'
+        ? normalizeMercadoPagoPayerEmail(body.payerEmail)
+        : null;
     if (!provider || !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(attemptId)) {
+        return json({ error: 'Invalid request.' }, 400);
+    }
+    if (provider === 'mercado_pago' && !payerEmail) {
         return json({ error: 'Invalid request.' }, 400);
     }
 
@@ -81,7 +93,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
         const result = await new HttpListenerCheckoutGateway().create({
             accountId: session.user.id,
-            email: session.user.email,
+            payerEmail: payerEmail ?? undefined,
             provider,
             attemptId,
             returnUrl: `${context.origin}/?checkout=returned`,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1934,6 +1934,27 @@ html[data-hb-surface='listener'] body {
 .listener-checkout__options p { line-height: 1.45; }
 .listener-checkout__options [role="alert"] { color: #fecaca; }
 
+.listener-checkout__payer-email {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text-secondary);
+  text-align: left;
+}
+
+.listener-checkout__payer-email > label {
+  color: var(--hb-bone);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.listener-checkout__payer-email > small {
+  color: var(--text-muted);
+  font-size: 0.66rem;
+  line-height: 1.4;
+}
+
+.listener-checkout__payer-email > small[role="alert"] { color: #fecaca; }
+
 .listener-checkout__legal {
   color: var(--text-muted);
   font-size: 0.68rem;

--- a/src/components/early-birds/FoundingListenerCheckout.tsx
+++ b/src/components/early-birds/FoundingListenerCheckout.tsx
@@ -5,6 +5,9 @@ import { useRef, useState } from 'react';
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdCopy } from '@/lib/early-birds/copy';
 import type { ListenerCheckoutProvider } from '@/lib/early-birds/checkout';
+import { normalizeMercadoPagoPayerEmail } from '@/lib/early-birds/payer-email';
+
+import MercadoPagoPayerEmailField from './MercadoPagoPayerEmailField';
 
 type Availability = { paypal: boolean; mercadoPago: boolean };
 
@@ -19,12 +22,21 @@ export default function FoundingListenerCheckout({
     const copy = earlyBirdCopy[locale];
     const [busy, setBusy] = useState<ListenerCheckoutProvider | null>(null);
     const [failed, setFailed] = useState(false);
+    const [payerEmail, setPayerEmail] = useState('');
+    const [payerEmailInvalid, setPayerEmailInvalid] = useState(false);
     const attempts = useRef<Partial<Record<ListenerCheckoutProvider, string>>>({});
 
     if (!available.paypal && !available.mercadoPago) return null;
 
     async function start(provider: ListenerCheckoutProvider) {
         if (busy) return;
+        const normalizedPayerEmail = provider === 'mercado_pago'
+            ? normalizeMercadoPagoPayerEmail(payerEmail)
+            : null;
+        if (provider === 'mercado_pago' && !normalizedPayerEmail) {
+            setPayerEmailInvalid(true);
+            return;
+        }
         setBusy(provider);
         setFailed(false);
         const attemptId = attempts.current[provider] ?? crypto.randomUUID();
@@ -34,7 +46,9 @@ export default function FoundingListenerCheckout({
                 method: 'POST',
                 cache: 'no-store',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-                body: JSON.stringify({ provider, attemptId }),
+                body: JSON.stringify(provider === 'mercado_pago'
+                    ? { provider, attemptId, payerEmail: normalizedPayerEmail }
+                    : { provider, attemptId }),
             });
             const result = await response.json() as unknown;
             if (!response.ok || !result || typeof result !== 'object' || Array.isArray(result)) throw new Error();
@@ -74,14 +88,26 @@ export default function FoundingListenerCheckout({
                     </button>
                 )}
                 {available.mercadoPago && (
-                    <button
-                        type="button"
-                        className="listener-button listener-button--secondary w-full"
-                        disabled={busy !== null}
-                        onClick={() => void start('mercado_pago')}
-                    >
-                        {busy === 'mercado_pago' ? copy.checkoutOpening : copy.checkoutMercadoPago}
-                    </button>
+                    <>
+                        <MercadoPagoPayerEmailField
+                            value={payerEmail}
+                            disabled={busy !== null}
+                            invalid={payerEmailInvalid}
+                            onChange={(value) => {
+                                setPayerEmail(value);
+                                setPayerEmailInvalid(false);
+                                attempts.current.mercado_pago = undefined;
+                            }}
+                        />
+                        <button
+                            type="button"
+                            className="listener-button listener-button--secondary w-full"
+                            disabled={busy !== null}
+                            onClick={() => void start('mercado_pago')}
+                        >
+                            {busy === 'mercado_pago' ? copy.checkoutOpening : copy.checkoutMercadoPago}
+                        </button>
+                    </>
                 )}
                 {failed && <p role="alert">{environment === 'live'
                     ? copy.checkoutLiveUnavailable

--- a/src/components/early-birds/FoundingListenerLiveWorkbench.tsx
+++ b/src/components/early-birds/FoundingListenerLiveWorkbench.tsx
@@ -5,6 +5,9 @@ import { useRef, useState } from 'react';
 import { useLocale } from '@/context/LocaleContext';
 import type { ListenerCheckoutProvider } from '@/lib/early-birds/checkout';
 import { earlyBirdCopy } from '@/lib/early-birds/copy';
+import { normalizeMercadoPagoPayerEmail } from '@/lib/early-birds/payer-email';
+
+import MercadoPagoPayerEmailField from './MercadoPagoPayerEmailField';
 
 const CSRF_HEADER = 'x-hb-listener-live-csrf';
 
@@ -22,12 +25,21 @@ export default function FoundingListenerLiveWorkbench({
     const copy = earlyBirdCopy[locale];
     const [busy, setBusy] = useState(false);
     const [failed, setFailed] = useState(false);
+    const [payerEmail, setPayerEmail] = useState('');
+    const [payerEmailInvalid, setPayerEmailInvalid] = useState(false);
     const attemptId = useRef<string | null>(null);
 
     if (!config) return null;
 
     async function start() {
         if (busy || !config) return;
+        const normalizedPayerEmail = config.provider === 'mercado_pago'
+            ? normalizeMercadoPagoPayerEmail(payerEmail)
+            : null;
+        if (config.provider === 'mercado_pago' && !normalizedPayerEmail) {
+            setPayerEmailInvalid(true);
+            return;
+        }
         setBusy(true);
         setFailed(false);
         attemptId.current ??= crypto.randomUUID();
@@ -40,7 +52,9 @@ export default function FoundingListenerLiveWorkbench({
                     'Content-Type': 'application/json',
                     [CSRF_HEADER]: config.csrfToken,
                 },
-                body: JSON.stringify({ attemptId: attemptId.current }),
+                body: JSON.stringify(config.provider === 'mercado_pago'
+                    ? { attemptId: attemptId.current, payerEmail: normalizedPayerEmail }
+                    : { attemptId: attemptId.current }),
             });
             const result = await response.json() as unknown;
             if (!response.ok || !result || typeof result !== 'object' || Array.isArray(result)) {
@@ -71,6 +85,18 @@ export default function FoundingListenerLiveWorkbench({
                     <a href="/listener/terms">{copy.checkoutTerms}</a>{' · '}
                     <a href="/listener/privacy">{copy.checkoutPrivacy}</a>
                 </p>
+                {config.provider === 'mercado_pago' && (
+                    <MercadoPagoPayerEmailField
+                        value={payerEmail}
+                        disabled={busy}
+                        invalid={payerEmailInvalid}
+                        onChange={(value) => {
+                            setPayerEmail(value);
+                            setPayerEmailInvalid(false);
+                            attemptId.current = null;
+                        }}
+                    />
+                )}
                 <button
                     type="button"
                     className="listener-button listener-button--secondary w-full"

--- a/src/components/early-birds/MercadoPagoPayerEmailField.tsx
+++ b/src/components/early-birds/MercadoPagoPayerEmailField.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useId } from 'react';
+
+import { useLocale } from '@/context/LocaleContext';
+import { earlyBirdCopy } from '@/lib/early-birds/copy';
+
+export default function MercadoPagoPayerEmailField({
+    value,
+    disabled,
+    invalid,
+    onChange,
+}: {
+    value: string;
+    disabled: boolean;
+    invalid: boolean;
+    onChange: (value: string) => void;
+}) {
+    const { locale } = useLocale();
+    const copy = earlyBirdCopy[locale];
+    const inputId = useId();
+    const hintId = `${inputId}-hint`;
+    const errorId = `${inputId}-error`;
+
+    return (
+        <div className="listener-checkout__payer-email">
+            <label htmlFor={inputId}>{copy.checkoutMercadoPagoEmail}</label>
+            <input
+                id={inputId}
+                className="listener-input"
+                type="email"
+                inputMode="email"
+                autoComplete="email"
+                spellCheck={false}
+                maxLength={320}
+                required
+                disabled={disabled}
+                value={value}
+                aria-invalid={invalid || undefined}
+                aria-describedby={invalid ? `${hintId} ${errorId}` : hintId}
+                onChange={(event) => onChange(event.target.value)}
+            />
+            <small id={hintId}>{copy.checkoutMercadoPagoEmailHint}</small>
+            {invalid && <small id={errorId} role="alert">{copy.checkoutMercadoPagoEmailInvalid}</small>}
+        </div>
+    );
+}

--- a/src/components/early-birds/__tests__/FoundingListenerCheckout.test.tsx
+++ b/src/components/early-birds/__tests__/FoundingListenerCheckout.test.tsx
@@ -52,4 +52,38 @@ describe('Founding Listener sandbox checkout', () => {
         expect(second).toEqual(first);
         expect(JSON.stringify(first)).not.toMatch(/email|account|price|currency/i);
     });
+
+    it('asks separately for the Mercado Pago payer email and never derives it from Listener identity', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ error: 'Checkout unavailable.' }),
+            { status: 503, headers: { 'Content-Type': 'application/json' } },
+        ));
+        vi.stubGlobal('fetch', fetchMock);
+        render(
+            <LocaleProvider initialLocale="en">
+                <FoundingListenerCheckout available={{ paypal: true, mercadoPago: true }} />
+            </LocaleProvider>,
+        );
+
+        fireEvent.click(screen.getByText('Become a member for full access'));
+        expect(screen.getByLabelText('Email for your Mercado Pago account')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Continue with Mercado Pago' }));
+        expect(await screen.findByRole('alert')).toHaveTextContent('Enter the email you use for Mercado Pago.');
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        fireEvent.change(screen.getByLabelText('Email for your Mercado Pago account'), {
+            target: { value: 'Ani.Billing@Example.com ' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Continue with Mercado Pago' }));
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+            provider: 'mercado_pago',
+            attemptId,
+            payerEmail: 'ani.billing@example.com',
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Continue with PayPal' }));
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ provider: 'paypal', attemptId });
+    });
 });

--- a/src/components/early-birds/__tests__/FoundingListenerLiveWorkbench.test.tsx
+++ b/src/components/early-birds/__tests__/FoundingListenerLiveWorkbench.test.tsx
@@ -28,7 +28,7 @@ describe('Founding Listener private Live workbench', () => {
         expect(container).toBeEmptyDOMElement();
     });
 
-    it('sends only an attempt and CSRF proof to the separate endpoint', async () => {
+    it('sends the explicit Mercado Pago payer email with the attempt and CSRF proof', async () => {
         const fetchMock = vi.fn().mockResolvedValue(new Response(
             JSON.stringify({ error: 'Checkout unavailable.' }),
             { status: 503, headers: { 'Content-Type': 'application/json' } },
@@ -44,18 +44,42 @@ describe('Founding Listener private Live workbench', () => {
         );
 
         fireEvent.click(screen.getByText('Become a member for full access'));
+        fireEvent.change(screen.getByLabelText('Email for your Mercado Pago account'), {
+            target: { value: 'Billing@Example.com' },
+        });
         fireEvent.click(screen.getByRole('button', { name: 'Continue with Mercado Pago' }));
         await screen.findByRole('alert');
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         const [, init] = fetchMock.mock.calls[0];
         expect(fetchMock.mock.calls[0][0]).toBe('/api/listener/checkout/live-workbench');
-        expect(JSON.parse(init.body)).toEqual({ attemptId });
+        expect(JSON.parse(init.body)).toEqual({ attemptId, payerEmail: 'billing@example.com' });
         expect(init.headers).toEqual(expect.objectContaining({
             'x-hb-listener-live-csrf': 'browser-csrf-proof',
         }));
-        expect(JSON.stringify({ url: fetchMock.mock.calls[0][0], init })).not.toMatch(
-            /opaque-account|listener@example|provider.*mercado_pago/i,
+        expect(JSON.stringify({ url: fetchMock.mock.calls[0][0], init }))
+            .not.toMatch(/opaque-account|listener@example|provider.*mercado_pago/i);
+    });
+
+    it('does not render or send a payer email for PayPal', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ error: 'Checkout unavailable.' }),
+            { status: 503, headers: { 'Content-Type': 'application/json' } },
+        ));
+        vi.stubGlobal('fetch', fetchMock);
+        render(
+            <LocaleProvider initialLocale="en">
+                <FoundingListenerLiveWorkbench config={{
+                    provider: 'paypal',
+                    csrfToken: 'browser-csrf-proof',
+                }} />
+            </LocaleProvider>,
         );
+
+        fireEvent.click(screen.getByText('Become a member for full access'));
+        expect(screen.queryByLabelText('Email for your Mercado Pago account')).not.toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Continue with PayPal' }));
+        await screen.findByRole('alert');
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ attemptId });
     });
 });

--- a/src/lib/early-birds/__tests__/checkout.test.ts
+++ b/src/lib/early-birds/__tests__/checkout.test.ts
@@ -13,7 +13,6 @@ const config = {
 };
 const base = {
     accountId: 'betterAuthOpaqueId_123',
-    email: 'Listener@Example.COM ',
     attemptId: '123e4567-e89b-42d3-a456-426614174000',
     returnUrl: 'https://earlybirds-staging.harmonicbeacon.com/?checkout=returned',
     cancelUrl: 'https://earlybirds-staging.harmonicbeacon.com/?checkout=cancelled',
@@ -79,14 +78,18 @@ describe('Listener sandbox checkout gateway', () => {
             .toBe(requests[1].headers.get('idempotency-key'));
     });
 
-    it('creates Mercado Pago through v2 with only the normalized session email', async () => {
+    it('creates Mercado Pago through v2 with the normalized checkout-specific payer email', async () => {
         let captured: Request | null = null;
         const request = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
             captured = new Request(input, init);
             return Response.json(result('mercado_pago'));
         });
         const gateway = new HttpListenerCheckoutGateway(config, request as typeof fetch);
-        const created = await gateway.create({ ...base, provider: 'mercado_pago' });
+        const created = await gateway.create({
+            ...base,
+            provider: 'mercado_pago',
+            payerEmail: 'Billing@Example.COM ',
+        });
 
         expect(created).toEqual({
             provider: 'mercado_pago',
@@ -97,8 +100,26 @@ describe('Listener sandbox checkout gateway', () => {
             schema_version: 'early-bird-checkout.checkout-create.v2',
             account_id: base.accountId,
             provider: 'mercado_pago',
-            payer_email: 'listener@example.com',
+            payer_email: 'billing@example.com',
         }));
+    });
+
+    it('requires a payer email for Mercado Pago but never permits one to affect PayPal', async () => {
+        const request = vi.fn(async () => Response.json(result('mercado_pago')));
+        const gateway = new HttpListenerCheckoutGateway(config, request as typeof fetch);
+
+        await expect(gateway.create({ ...base, provider: 'mercado_pago' }))
+            .rejects.toBeInstanceOf(ListenerCheckoutUnavailableError);
+        expect(request).not.toHaveBeenCalled();
+
+        const paypalRequests: Request[] = [];
+        const paypalRequest = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+            paypalRequests.push(new Request(input, init));
+            return Response.json(result('paypal'));
+        });
+        const paypalGateway = new HttpListenerCheckoutGateway(config, paypalRequest as typeof fetch);
+        await paypalGateway.create({ ...base, provider: 'paypal', payerEmail: 'ignored@example.com' });
+        expect(JSON.stringify(await paypalRequests[0].json())).not.toMatch(/payer|email/i);
     });
 
     it.each([

--- a/src/lib/early-birds/checkout.ts
+++ b/src/lib/early-birds/checkout.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import { isEarlyBirdAccountId } from './account-id';
+import { normalizeMercadoPagoPayerEmail } from './payer-email';
 
 export type ListenerCheckoutProvider = 'paypal' | 'mercado_pago';
 export type ListenerCheckoutEnvironment = 'staging' | 'live';
@@ -34,15 +35,6 @@ export function listenerCheckoutAvailability(
         paypal: environment.BEACON_LISTENER_PAYPAL_SANDBOX_CHECKOUT_ENABLED === '1',
         mercadoPago: environment.BEACON_LISTENER_MERCADO_PAGO_TEST_CHECKOUT_ENABLED === '1',
     } as const;
-}
-
-function normalizedEmail(value: string): string {
-    const normalized = value.trim().toLowerCase();
-    if (normalized.length < 3 || normalized.length > 320 ||
-        normalized.split('@').length !== 2 || /[\s\x00-\x20\x7f]/.test(normalized)) {
-        throw new ListenerCheckoutUnavailableError();
-    }
-    return normalized;
 }
 
 export function listenerAuthorityConfig(environment: NodeJS.ProcessEnv = process.env) {
@@ -198,7 +190,7 @@ export class HttpListenerCheckoutGateway {
 
     async create(input: {
         accountId: string;
-        email: string;
+        payerEmail?: string;
         provider: ListenerCheckoutProvider;
         attemptId: string;
         returnUrl: string;
@@ -215,11 +207,17 @@ export class HttpListenerCheckoutGateway {
             : input.provider === 'paypal'
                 ? '/api/internal/v1/early-bird-checkouts'
                 : '/api/internal/v2/early-bird-checkouts';
+        const payerEmail = input.provider === 'mercado_pago'
+            ? normalizeMercadoPagoPayerEmail(input.payerEmail)
+            : null;
+        if (input.provider === 'mercado_pago' && !payerEmail) {
+            throw new ListenerCheckoutUnavailableError();
+        }
         const payload = environment === 'live' ? {
             schema_version: 'listener-checkout.checkout-create.v1',
             account_id: input.accountId,
             provider: input.provider,
-            payer_email: input.provider === 'mercado_pago' ? normalizedEmail(input.email) : null,
+            payer_email: payerEmail,
             return_url: input.returnUrl,
             cancel_url: input.cancelUrl,
         } : input.provider === 'paypal' ? {
@@ -232,7 +230,7 @@ export class HttpListenerCheckoutGateway {
             schema_version: 'early-bird-checkout.checkout-create.v2',
             account_id: input.accountId,
             provider: input.provider,
-            payer_email: normalizedEmail(input.email),
+            payer_email: payerEmail,
             return_url: input.returnUrl,
             cancel_url: input.cancelUrl,
         };

--- a/src/lib/early-birds/copy.ts
+++ b/src/lib/early-birds/copy.ts
@@ -37,6 +37,9 @@ export const earlyBirdCopy = {
         checkoutLiveDetail: 'USD 5 por mes, cobro recurrente. Sin período de prueba. Puedes cancelar cuando quieras; si el servicio se interrumpe, termina el precio Founder.',
         checkoutPayPal: 'Continuar con PayPal',
         checkoutMercadoPago: 'Continuar con Mercado Pago',
+        checkoutMercadoPagoEmail: 'Correo de tu cuenta de Mercado Pago',
+        checkoutMercadoPagoEmailHint: 'Puede ser distinto del correo de tu cuenta Listener. Sólo se usa para abrir esta suscripción.',
+        checkoutMercadoPagoEmailInvalid: 'Ingresa el correo que usas en Mercado Pago.',
         checkoutOpening: 'Abriendo checkout…',
         checkoutUnavailable: 'El checkout de prueba no está disponible ahora.',
         checkoutLiveUnavailable: 'La membresía no está disponible para compra en este momento.',
@@ -113,6 +116,9 @@ export const earlyBirdCopy = {
         checkoutLiveDetail: 'USD 5 per month, billed recurrently. No trial. Cancel anytime; if service lapses, Founder pricing ends.',
         checkoutPayPal: 'Continue with PayPal',
         checkoutMercadoPago: 'Continue with Mercado Pago',
+        checkoutMercadoPagoEmail: 'Email for your Mercado Pago account',
+        checkoutMercadoPagoEmailHint: 'It can differ from your Listener email. It is used only to open this subscription.',
+        checkoutMercadoPagoEmailInvalid: 'Enter the email you use for Mercado Pago.',
         checkoutOpening: 'Opening checkout…',
         checkoutUnavailable: 'Test checkout is unavailable right now.',
         checkoutLiveUnavailable: 'Membership is not available for purchase right now.',
@@ -188,7 +194,7 @@ export const earlyBirdLegalCopy = {
             {
                 title: 'Datos y privacidad',
                 paragraphs: [
-                    'Guardamos un identificador opaco de cuenta, identidad de acceso, sesión, estado de membresía, cuota y leases de reproducción. Los proveedores de pago procesan los datos financieros; Harmonic Beacon no recibe ni almacena números completos de tarjeta.',
+                    'Guardamos un identificador opaco de cuenta, identidad de acceso, sesión, estado de membresía, cuota y leases de reproducción. Los proveedores de pago procesan los datos financieros; Harmonic Beacon no recibe ni almacena números completos de tarjeta. Para Mercado Pago, el correo de pago que ingresas se transmite al proveedor para abrir la suscripción y no se conserva en texto legible como parte de tu perfil Listener.',
                     'Conservamos evidencia de pago y eventos de membresía necesaria para seguridad, soporte, contabilidad e idempotencia. No enviamos información personal a la visualización pública ni vendemos datos personales. Puedes solicitar acceso, corrección o eliminación escribiendo a nicoechaniz@harmonicbeacon.com, sujeto a obligaciones legales de conservación.',
                 ],
             },
@@ -225,7 +231,7 @@ export const earlyBirdLegalCopy = {
             {
                 title: 'Data and privacy',
                 paragraphs: [
-                    'We keep an opaque account identifier, sign-in identity, session, membership state, allowance and playback leases. Payment providers process financial details; Harmonic Beacon does not receive or store full card numbers.',
+                    'We keep an opaque account identifier, sign-in identity, session, membership state, allowance and playback leases. Payment providers process financial details; Harmonic Beacon does not receive or store full card numbers. For Mercado Pago, the payer email you enter is sent to the provider to open the subscription and is not retained in readable form as part of your Listener profile.',
                     'We retain payment evidence and membership events needed for security, support, accounting and idempotency. We do not send personal data to the public visualization or sell personal data. You may request access, correction or deletion at nicoechaniz@harmonicbeacon.com, subject to legal retention duties.',
                 ],
             },

--- a/src/lib/early-birds/payer-email.ts
+++ b/src/lib/early-birds/payer-email.ts
@@ -1,0 +1,10 @@
+export function normalizeMercadoPagoPayerEmail(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim().toLowerCase();
+    if (normalized.length < 3 || normalized.length > 320 ||
+        normalized.split('@').length !== 2 || normalized.startsWith('@') ||
+        normalized.endsWith('@') || /[\s\x00-\x20\x7f]/.test(normalized)) {
+        return null;
+    }
+    return normalized;
+}


### PR DESCRIPTION
Separates Listener sign-in identity from Mercado Pago billing identity. Mercado Pago now asks for the provider-specific payer email at checkout; PayPal never asks for or derives it. The billing email is forwarded only to the authority/provider and remains keyed evidence rather than readable Listener profile data. Covers public and private Live workbench routes, strict request shapes, ES/EN UI, privacy truth, and retry behavior.\n\nGates: 185 focused tests, TypeScript, focused ESLint, production build, diff-check. No event, LiveKit, audio, stream, quota, membership-authority, or provider-adapter changes.