### PR TITLE
fix(listener): keep staging auth on staging

### DIFF
--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -103,6 +103,18 @@ test('payment workbench keeps OAuth state and callback on the staging origin', a
   assert.match(source, /PREVIEW_ORIGIN="https:\/\/earlybirds-staging\.harmonicbeacon\.com"/);
   assert.match(source, /set_env_file_value BEACON_LISTENER_AUTH_BASE_URL "\$PREVIEW_ORIGIN"/);
   assert.match(source, /set_env_file_value EARLY_BIRDS_AUTH_BASE_URL "\$PREVIEW_ORIGIN"/);
+  const authBaseIndex = source.indexOf('set_env_file_value BEACON_LISTENER_AUTH_BASE_URL "$PREVIEW_ORIGIN"');
+  const paymentModeIndex = source.indexOf('if [ "$PREVIEW_PAYPAL_CHECKOUT" = 1 ]');
+  assert.ok(authBaseIndex > 0 && authBaseIndex < paymentModeIndex,
+    'staging auth base must be fixed before selecting ordinary or payment runtime mode');
+  assert.equal(
+    source.match(/set_env_file_value BEACON_LISTENER_AUTH_BASE_URL "\$PREVIEW_ORIGIN"/g)?.length,
+    1,
+  );
+  assert.equal(
+    source.match(/set_env_file_value EARLY_BIRDS_AUTH_BASE_URL "\$PREVIEW_ORIGIN"/g)?.length,
+    1,
+  );
   assert.match(source, /PREVIEW_LIVE_WORKBENCH="\$\{LISTENER_UI_PREVIEW_LIVE_WORKBENCH_ENABLED:-0\}"/);
   assert.match(source, /LIVE_WORKBENCH_ENV_FILE="\/etc\/harmonic-beacon\/listener-live-workbench\.env"/);
   assert.match(source, /harmonic-beacon\/earlybirds-preview-listener:\$\{PREVIEW_EXPECTED_SHA\}/);

--- a/scripts/listener-ui-preview.sh
+++ b/scripts/listener-ui-preview.sh
@@ -126,17 +126,17 @@ if docker container inspect "$DEV_CONTAINER" >/dev/null 2>&1; then
     docker rm -f "$DEV_CONTAINER" >/dev/null
 fi
 
+# Every disposable staging mode must initiate and receive authentication on
+# its own host. Inheriting the persistent Listener base URL sends OAuth back
+# to listen.harmonicbeacon.com, where the staging state cookie is absent.
+set_env_file_value BEACON_LISTENER_AUTH_BASE_URL "$PREVIEW_ORIGIN"
+set_env_file_value EARLY_BIRDS_AUTH_BASE_URL "$PREVIEW_ORIGIN"
+
 runtime_args=()
 command_args=()
 if [ "$PREVIEW_PAYPAL_CHECKOUT" = 1 ] || [ "$PREVIEW_MERCADO_PAGO_CHECKOUT" = 1 ] || [ "$PREVIEW_LIVE_WORKBENCH" = 1 ]; then
     # Synthetic team entry is deliberately unavailable under NODE_ENV=development.
     # Payment rehearsal therefore runs the exact built release artifact.
-    # OAuth state and session cookies are host-only. The workbench must initiate
-    # and receive the callback on its own origin; inheriting the persistent
-    # Listener base URL sends Google back to listen.harmonicbeacon.com, where
-    # the staging state cookie is absent and Better Auth correctly rejects it.
-    set_env_file_value BEACON_LISTENER_AUTH_BASE_URL "$PREVIEW_ORIGIN"
-    set_env_file_value EARLY_BIRDS_AUTH_BASE_URL "$PREVIEW_ORIGIN"
     runtime_args=(-e NODE_ENV=production)
     command_args=(node server.js)
 else
@@ -184,8 +184,6 @@ if [ "$PREVIEW_LIVE_WORKBENCH" = 1 ]; then
     set_env_file_value BEACON_LISTENER_MERCADO_PAGO_TEST_CHECKOUT_ENABLED 0
     set_env_file_value BEACON_LISTENER_PAYPAL_LIVE_CHECKOUT_ENABLED 0
     set_env_file_value BEACON_LISTENER_MERCADO_PAGO_LIVE_CHECKOUT_ENABLED 0
-    set_env_file_value BEACON_LISTENER_AUTH_BASE_URL "$PREVIEW_ORIGIN"
-    set_env_file_value EARLY_BIRDS_AUTH_BASE_URL "$PREVIEW_ORIGIN"
     # The inherited release env would otherwise override the selected image's
     # baked provenance with the persistent 13000 release SHA.
     set_env_file_value BEACON_GIT_SHA "$PREVIEW_EXPECTED_SHA"


### PR DESCRIPTION
Fixes the disposable staging launcher so every mode—ordinary UI, sandbox/test, and private Live workbench—sets both Listener auth-base aliases to earlybirds-staging.harmonicbeacon.com before the container starts. This prevents Google OAuth from returning to the canonical Listen host with an incompatible staging state cookie.\n\nGates: bash syntax, 38 preview contract tests, diff-check. Listener staging launcher only; no public Listener, event, audio, provider, or authority changes.