### PR TITLE
fix(listener): deduplicate private workbench environment

### DIFF
--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -123,6 +123,8 @@ test('payment workbench keeps OAuth state and callback on the staging origin', a
   assert.match(source, /set_env_file_value EARLY_BIRDS_FREE_FOR_ALL 0/);
   assert.match(source, /set_env_file_value BEACON_LISTENER_FREE_FOR_ALL 0/);
   assert.match(source, /set_env_file_value BEACON_GIT_SHA "\$PREVIEW_EXPECTED_SHA"/);
+  assert.match(source, /while IFS='=' read -r workbench_key workbench_value; do[\s\S]*set_env_file_value "\$workbench_key" "\$workbench_value"[\s\S]*done < <\(sudo cat "\$LIVE_WORKBENCH_ENV_FILE"\)/);
+  assert.doesNotMatch(source, /sudo cat "\$LIVE_WORKBENCH_ENV_FILE" >> "\$env_file"/);
   assert.match(source, /sudo stat -c '%u:%g:%a'/);
   assert.match(source, /workbench_container_started=1/);
   assert.match(source, /workbench_validated=1/);

--- a/scripts/listener-ui-preview.sh
+++ b/scripts/listener-ui-preview.sh
@@ -177,7 +177,12 @@ if [ "$PREVIEW_LIVE_WORKBENCH" = 1 ]; then
             exit good ? 0 : 1
         }
     ' "$LIVE_WORKBENCH_ENV_FILE"
-    sudo cat "$LIVE_WORKBENCH_ENV_FILE" >> "$env_file"
+    # The persistent Listener env already contains the dormant workbench keys.
+    # Replace each value instead of appending duplicates: OCI env arrays may
+    # preserve both entries and runtimes are not required to select the last.
+    while IFS='=' read -r workbench_key workbench_value; do
+        set_env_file_value "$workbench_key" "$workbench_value"
+    done < <(sudo cat "$LIVE_WORKBENCH_ENV_FILE")
     set_env_file_value EARLY_BIRDS_FREE_FOR_ALL 0
     set_env_file_value BEACON_LISTENER_FREE_FOR_ALL 0
     set_env_file_value BEACON_LISTENER_PAYPAL_SANDBOX_CHECKOUT_ENABLED 0


### PR DESCRIPTION
Fixes the staging-only Live workbench launcher so root-owned values replace dormant inherited variables instead of creating duplicate OCI env entries.

Evidence:
- bash -n scripts/listener-ui-preview.sh
- node --test ops/early-birds-preview/test/preview-contract.test.mjs (38/38)
- runtime staging: one effective workbench key each; Mercado Pago card visible only to the allowlisted account

Scope: isolated Listener staging launcher/tests only; no public Listener, event, LiveKit or audio changes.