### PR TITLE
fix(listener): prefer configured membership checkout

### DIFF
--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -104,7 +104,11 @@ export default function EarlyBirdHome({
                             snapshot={quota}
                             serverNow={serverNow}
                             compact
-                            showMembershipLink={!checkoutAvailability.paypal && !checkoutAvailability.mercadoPago}
+                            showMembershipLink={
+                                !checkoutAvailability.paypal
+                                && !checkoutAvailability.mercadoPago
+                                && !liveWorkbench
+                            }
                         />
                         <FoundingListenerCheckout
                             available={checkoutAvailability}

--- a/src/components/early-birds/EarlyBirdLanding.tsx
+++ b/src/components/early-birds/EarlyBirdLanding.tsx
@@ -164,6 +164,7 @@ export default function EarlyBirdLanding(props: Props) {
                                             showMembershipLink={
                                                 !props.checkoutAvailability?.paypal
                                                 && !props.checkoutAvailability?.mercadoPago
+                                                && !props.liveWorkbench
                                             }
                                         />
                                         <FoundingListenerCheckout available={props.checkoutAvailability ?? {

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -225,4 +225,37 @@ describe('EarlyBird Listener home access chrome', () => {
         expect(footer).toContainElement(screen.getByRole('link', { name: 'Become a member for full access' }));
         expect(screen.getByLabelText('Account').closest('header')).not.toContainElement(footer);
     });
+
+    it('replaces the mail contact fallback with the private checkout action', () => {
+        render(
+            <LocaleProvider initialLocale="en">
+                <EarlyBirdHome
+                    displayName="Nico"
+                    membership={{ kind: 'none', state: 'none' }}
+                    accessKind="free-quota"
+                    serverNow="2026-08-07T15:00:00.000Z"
+                    quota={{
+                        policy: 'personal-7-day-v1',
+                        status: 'available',
+                        cycleStartedAt: '2026-08-07T15:00:00.000Z',
+                        cycleEndsAt: '2026-08-14T15:00:00.000Z',
+                        baseAllowanceMs: 10_800_000,
+                        bonusAllowanceMs: 0,
+                        consumedMs: 0,
+                        remainingMs: 10_800_000,
+                        activelyConsuming: false,
+                        exhaustsAt: null,
+                        nextCycleAt: '2026-08-14T15:00:00.000Z',
+                    }}
+                    dropIns={{ es: null, en: null }}
+                    liveWorkbench={{ provider: 'mercado_pago', csrfToken: 'csrf-proof' }}
+                />
+            </LocaleProvider>,
+        );
+
+        expect(screen.queryByRole('link', { name: 'Become a member for full access' })).toBeNull();
+        expect(document.querySelector('details[data-listener-live-workbench="private"]'))
+            .toHaveTextContent('Become a member for full access');
+        expect(document.querySelector('a[href^="mailto:"]')).toBeNull();
+    });
 });

--- a/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
@@ -178,6 +178,18 @@ describe('EarlyBird public landing', () => {
         expect(screen.queryByText(/daily time|first listen/i)).toBeNull();
     });
 
+    it('uses the private checkout action instead of the mail contact fallback', () => {
+        renderLanding({
+            signedIn: true,
+            liveWorkbench: { provider: 'mercado_pago', csrfToken: 'csrf-proof' },
+        });
+
+        expect(screen.queryByRole('link', { name: 'Become a member for full access' })).toBeNull();
+        expect(document.querySelector('details[data-listener-live-workbench="private"]'))
+            .toHaveTextContent('Become a member for full access');
+        expect(document.querySelector('a[href^="mailto:"]')).toBeNull();
+    });
+
     it('explains terminal Founder access and returns the account to truthful Free choices', () => {
         renderLanding({
             signedIn: true,


### PR DESCRIPTION
## Summary
- hide the legacy email contact CTA whenever a real checkout or private Live workbench is configured
- keep the mail fallback only when no checkout exists
- cover signed-in landing and Listener home integration

## Verification
- 4 focused suites / 37 tests
- full pre-commit suite: 1638 passed, 35 skipped
- TypeScript and focused ESLint green

No event, audio, commerce-authority, or provider behavior changes.