### PR TITLE
fix(listener): always show Google account selector

### DIFF
--- a/src/lib/early-birds/__tests__/auth.test.ts
+++ b/src/lib/early-birds/__tests__/auth.test.ts
@@ -43,7 +43,14 @@ describe('EarlyBird Better Auth isolation', () => {
         } as unknown as NodeJS.ProcessEnv;
 
         expect(earlyBirdOAuthAvailability(environment)).toEqual({ google: true, apple: false });
-        expect(Object.keys(earlyBirdSocialProviders(environment))).toEqual(['google']);
+        expect(earlyBirdSocialProviders(environment)).toEqual({
+            google: {
+                clientId: 'google-id',
+                clientSecret: 'google-secret',
+                accessType: 'online',
+                prompt: 'select_account',
+            },
+        });
     });
 
     it('accepts canonical auth config without mixing credential generations', () => {
@@ -55,7 +62,11 @@ describe('EarlyBird Better Auth isolation', () => {
         } as unknown as NodeJS.ProcessEnv;
         expect(earlyBirdOAuthAvailability(canonical)).toEqual({ google: true, apple: false });
         expect(earlyBirdSocialProviders(canonical)).toMatchObject({
-            google: { clientId: 'canonical-google-id', clientSecret: 'canonical-google-secret' },
+            google: {
+                clientId: 'canonical-google-id',
+                clientSecret: 'canonical-google-secret',
+                prompt: 'select_account',
+            },
         });
         expect(earlyBirdTrustedOrigins(canonical)).toEqual([
             'https://listen.example.test',

--- a/src/lib/early-birds/auth.ts
+++ b/src/lib/early-birds/auth.ts
@@ -96,6 +96,10 @@ export function earlyBirdSocialProviders(environment: NodeJS.ProcessEnv = proces
                 clientId: google.GOOGLE_CLIENT_ID,
                 clientSecret: google.GOOGLE_CLIENT_SECRET,
                 accessType: 'online' as const,
+                // Listener is commonly used on shared staff/test browsers. Do not
+                // let Google silently reuse the last account and strand the user
+                // behind an account_not_linked error with no way to switch.
+                prompt: 'select_account' as const,
             },
         } : {}),
         ...(apple ? {


### PR DESCRIPTION
## Outcome
Google sign-in always opens account selection instead of silently reusing the last Google identity on shared staff/test browsers.

## Security
- account linking remains completely disabled
- no user, identity, session, quota or membership row is mutated
- this only sets the official Google OAuth `prompt: select_account` provider option

## Verification
- focused auth tests: 6/6
- focused ESLint
- TypeScript
- production build

Refs: Better Auth official provider option for account selection.