### PR TITLE
feat: share global navigation across Live and Listener

### DIFF
--- a/src/app/__tests__/layout-locale.test.tsx
+++ b/src/app/__tests__/layout-locale.test.tsx
@@ -5,10 +5,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
     headers: vi.fn(),
     requestLocale: vi.fn(),
+    requestBrowserLocale: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({ headers: mocks.headers }));
-vi.mock('@/lib/i18n-server', () => ({ requestLocale: mocks.requestLocale }));
+vi.mock('@/lib/i18n-server', () => ({
+    requestLocale: mocks.requestLocale,
+    requestBrowserLocale: mocks.requestBrowserLocale,
+}));
 vi.mock('next/font/local', () => ({
     default: () => ({ variable: 'local-font' }),
 }));
@@ -34,6 +38,7 @@ describe('root document locale boundary', () => {
             'en-US,en;q=0.9,es;q=0.7',
         ));
         mocks.requestLocale.mockResolvedValue('es');
+        mocks.requestBrowserLocale.mockResolvedValue('en');
 
         const result = await RootLayout({ children: <main /> });
 
@@ -42,6 +47,7 @@ describe('root document locale boundary', () => {
         expect(result.props['data-hb-surface']).toBe('listener');
         expect(result.props.suppressHydrationWarning).toBe(true);
         expect(mocks.requestLocale).not.toHaveBeenCalled();
+        expect(mocks.requestBrowserLocale).toHaveBeenCalledOnce();
     });
 
     it('preserves the existing event locale decision on every non-Listener host', async () => {
@@ -57,6 +63,7 @@ describe('root document locale boundary', () => {
         expect(result.props['data-lang']).toBe('es');
         expect(result.props['data-hb-surface']).toBeUndefined();
         expect(mocks.requestLocale).toHaveBeenCalledOnce();
+        expect(mocks.requestBrowserLocale).not.toHaveBeenCalled();
     });
 
     it.each([

--- a/src/app/early-birds/layout.tsx
+++ b/src/app/early-birds/layout.tsx
@@ -1,11 +1,11 @@
 import { headers } from 'next/headers';
 
 import { LocaleProvider } from '@/context/LocaleContext';
-import { localeForBrowserLanguage } from '@/lib/i18n';
+import { requestBrowserLocale } from '@/lib/i18n-server';
 
 export default async function EarlyBirdLayout({ children }: { children: React.ReactNode }) {
     const requestHeaders = await headers();
-    const locale = localeForBrowserLanguage(requestHeaders.get('accept-language'));
+    const locale = await requestBrowserLocale(requestHeaders);
 
     return <LocaleProvider initialLocale={locale}>{children}</LocaleProvider>;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,66 @@
 @import "tailwindcss";
 
+/* Accessible light-DOM fallback while the canonical cross-product web
+   component loads from harmonicbeacon.com. Once defined, its shadow DOM owns
+   the exact desktop/mobile rendering shared by all three products. */
+hb-global-nav:not(:defined) {
+  display: block;
+  min-height: 72px;
+  background: rgba(22, 18, 13, 0.98);
+  border-bottom: 1px solid rgba(244, 238, 226, 0.1);
+  color: #f4eee2;
+  font-family: var(--font-hb-inter), Inter, system-ui, sans-serif;
+}
+
+.hb-global-navigation-fallback {
+  min-height: 72px;
+  max-width: 1180px;
+  margin-inline: auto;
+  padding: 12px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.hb-global-navigation-fallback__brand {
+  color: #f4eee2;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.hb-global-navigation-fallback ul {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.hb-global-navigation-fallback li a {
+  padding: 9px 8px;
+  color: #ada089;
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.hb-global-navigation-fallback li a[aria-current="page"] {
+  color: #c9a24e;
+}
+
+@media (max-width: 1120px) {
+  hb-global-nav:not(:defined) { min-height: 68px; }
+  .hb-global-navigation-fallback { min-height: 68px; padding-inline: 16px; }
+  .hb-global-navigation-fallback ul { display: none; }
+}
+
 /* ============================================
    HARMONIC PROJECTION — Design System
    Phase 5: Aligned with confirmation palette
@@ -1303,6 +1364,7 @@ html[data-hb-surface='listener'] body {
   display: flex;
   align-items: center;
   gap: 0.65rem;
+  margin-left: auto;
 }
 
 .listener-account {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,10 @@ import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import { headers } from "next/headers";
 import { LocaleProvider } from "@/context/LocaleContext";
-import { requestLocale } from "@/lib/i18n-server";
-import { isCanonicalListenerHost, listenerLocaleForHeaders } from "@/lib/listener/public-discovery";
+import { GlobalNavigation } from "@/components/brand/GlobalNavigation";
+import { globalNavigationSurface } from "@/lib/brand/global-navigation";
+import { requestBrowserLocale, requestLocale } from "@/lib/i18n-server";
+import { isCanonicalListenerHost } from "@/lib/listener/public-discovery";
 import "@/styles/hb-brand.css";
 import "./globals.css";
 import { Toaster } from "sonner";
@@ -87,12 +89,16 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const incomingHeaders = await headers();
-  // Listener content and metadata use the browser's primary language. Bind
-  // that behavior to the exact public host so event-language defaults on the
-  // rest of the application remain untouched.
+  // Listener content starts from the browser's primary language and then
+  // honors the shared navigation preference. Keep that policy bound to the
+  // exact public host so event-language defaults elsewhere remain untouched.
   const listenerHost = isCanonicalListenerHost(incomingHeaders);
+  // This application is the Live surface by default. Listener and its staging
+  // host opt into their own active item explicitly; local/E2E hosts continue
+  // to exercise the same global header as production Live.
+  const navigationSurface = globalNavigationSurface(incomingHeaders) ?? "events";
   const locale = listenerHost
-    ? listenerLocaleForHeaders(incomingHeaders)
+    ? await requestBrowserLocale(incomingHeaders)
     : await requestLocale();
 
   return (
@@ -104,6 +110,7 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <body className="antialiased">
+        <GlobalNavigation active={navigationSurface} locale={locale} />
         <LocaleProvider initialLocale={locale}>
           {/* Main content */}
           <div className="relative z-10">{children}</div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
  * Phase 5: Wider layout and bilingual control.
  *
  * Server component: fetches events from database.
- * Client components: LanguageControl, LoginClient.
+ * Client component: LoginClient.
  */
 
 import Link from "next/link";
@@ -12,8 +12,6 @@ import { prisma } from "@/lib/db";
 import { redactError } from "@/lib/redact";
 
 import LoginClient from "./login/LoginClient";
-import BrandLockup from "@/components/brand/BrandLockup";
-import LanguageControl from "@/components/brand/LanguageControl";
 import { messages } from "@/lib/i18n";
 import { requestLocale } from "@/lib/i18n-server";
 
@@ -97,12 +95,6 @@ export default async function LandingPage({
     return (
         <main className="event-shell">
             <div className="relative z-10 mx-auto flex min-h-screen max-w-[1120px] flex-col gap-10 px-6 py-12">
-                {/* Top bar */}
-                <header className="flex items-center justify-between">
-                    <BrandLockup />
-                    <LanguageControl />
-                </header>
-
                 {/* Hero */}
                 <section className="py-2 lg:py-6">
                     <div className="max-w-2xl space-y-5">

--- a/src/app/staff/login/page.tsx
+++ b/src/app/staff/login/page.tsx
@@ -12,8 +12,6 @@ import Link from "next/link";
 import { currentPrincipal } from "@/lib/auth";
 
 import StaffLoginClient from "./StaffLoginClient";
-import BrandLockup from "@/components/brand/BrandLockup";
-import LanguageControl from "@/components/brand/LanguageControl";
 import { messages } from "@/lib/i18n";
 import { requestLocale } from "@/lib/i18n-server";
 import { staffRoleLabel } from "@/lib/i18n";
@@ -35,11 +33,7 @@ export default async function StaffLoginPage() {
         <main className="event-shell">
             <div className="relative z-10 mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6 py-12">
                 <header className="space-y-1">
-                    <div className="flex items-center justify-between gap-4">
-                        <BrandLockup href="/" />
-                        <LanguageControl />
-                    </div>
-                    <h1 className="pt-4 font-serif text-2xl font-normal text-[var(--paper)]">
+                    <h1 className="font-serif text-2xl font-normal text-[var(--paper)]">
                         {copy.heading}
                     </h1>
                     <p className="text-sm text-[var(--text-muted)]">

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -23,6 +23,16 @@ The upstream files and all vendored artifacts are SHA-256 pinned in
 and the path. Updating the brand requires an explicit snapshot, provenance,
 manifest and visual-review update together.
 
+## Global navigation
+
+The cross-product header is intentionally not vendored. Listener and Live load
+the canonical web component directly from
+`https://harmonicbeacon.com/assets/hb-global-nav.js`, owned by
+`AlterMundi/harmonicbeacon.com` (introduced in main merge `9fa515f6` and last
+reviewed here at `51fe213b`). The local light-DOM links are an accessible,
+same-destination fallback only; the shared runtime asset owns the visible
+desktop/mobile component so a navigation edit propagates to all three products.
+
 ## Font source and license
 
 Both families are covered by the SIL Open Font License 1.1; the relevant
@@ -40,4 +50,5 @@ Both families are covered by the SIL Open Font License 1.1; the relevant
   is pinned from the Google Fonts repository commit above, with trailing
   whitespace normalized for the repository gate.
 
-No font, brand source, analytics or other asset is fetched at runtime.
+No font, analytics or decorative brand asset is fetched at runtime. The single
+global-navigation component above is the deliberate exception.

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -1,0 +1,61 @@
+import { createElement } from 'react';
+import Script from 'next/script';
+
+import type { UiLocale } from '@/lib/i18n';
+
+export const GLOBAL_NAVIGATION_ASSET = 'https://harmonicbeacon.com/assets/hb-global-nav.js';
+
+export type GlobalNavigationSurface = 'events' | 'listen';
+
+const links = [
+    { key: 'events', href: 'https://live.harmonicbeacon.com/', en: 'Events', es: 'Eventos' },
+    { key: 'listen', href: 'https://listen.harmonicbeacon.com/', en: 'Listen', es: 'Escuchar' },
+    { key: 'news', href: 'https://harmonicbeacon.com/eventos/', en: 'News', es: 'Novedades' },
+    { key: 'why', href: 'https://harmonicbeacon.com/#porque', en: 'Why it works', es: 'Por qué funciona' },
+    { key: 'team', href: 'https://harmonicbeacon.com/#team', en: 'Team', es: 'Equipo' },
+    { key: 'foundation', href: 'https://harmonicbeacon.com/#foundation', en: 'HIT', es: 'HIT' },
+    { key: 'contact', href: 'https://harmonicbeacon.com/#contact', en: 'Contact', es: 'Contacto' },
+] as const;
+
+function withLanguage(href: string, locale: UiLocale): string {
+    const url = new URL(href);
+    url.searchParams.set('lang', locale);
+    return url.toString();
+}
+
+export function GlobalNavigation({
+    active,
+    locale,
+}: {
+    active: GlobalNavigationSurface;
+    locale: UiLocale;
+}) {
+    const navLabel = locale === 'es' ? 'Navegación principal' : 'Primary navigation';
+    const fallback = (
+        <nav className="hb-global-navigation-fallback" aria-label={navLabel}>
+            <a className="hb-global-navigation-fallback__brand" href={withLanguage('https://harmonicbeacon.com/', locale)}>
+                Harmonic Beacon
+            </a>
+            <ul>
+                {links.map((link) => (
+                    <li key={link.key}>
+                        <a
+                            href={withLanguage(link.href, locale)}
+                            aria-current={link.key === active ? 'page' : undefined}
+                        >
+                            {locale === 'es' ? link.es : link.en}
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </nav>
+    );
+
+    return (
+        <>
+            {createElement('hb-global-nav', { 'data-surface': active }, fallback)}
+            <Script src={GLOBAL_NAVIGATION_ASSET} strategy="afterInteractive" />
+        </>
+    );
+}
+

--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import HarmonicBeaconBrand from '@/components/brand/HarmonicBeaconBrand';
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdAuthClient } from '@/lib/early-birds/auth-client';
 import { earlyBirdCopy, earlyBirdHomeCopy, listenerMembershipPresentationCopy } from '@/lib/early-birds/copy';
@@ -57,7 +56,6 @@ export default function EarlyBirdHome({
         <main className="listener-shell">
             <div className="listener-shell__frame listener-shell__frame--home">
                 <header className="listener-rail">
-                    <HarmonicBeaconBrand href={LISTENER_NAMESPACE.publicWebsite} />
                     <div className="listener-rail__actions">
                         {publicAccess && (
                             <FreeQuotaStatus serverNow={serverNow} unlimited="free-for-all" compact />

--- a/src/components/early-birds/EarlyBirdLanding.tsx
+++ b/src/components/early-birds/EarlyBirdLanding.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 
-import HarmonicBeaconBrand from '@/components/brand/HarmonicBeaconBrand';
 import { useLocale } from '@/context/LocaleContext';
 import { earlyBirdAuthClient } from '@/lib/early-birds/auth-client';
 import { earlyBirdCopy, listenerMembershipPresentationCopy } from '@/lib/early-birds/copy';
@@ -96,10 +95,6 @@ export default function EarlyBirdLanding(props: Props) {
     return (
         <main className="listener-shell listener-shell--public">
             <div className="listener-shell__frame">
-                <header className="listener-rail">
-                    <HarmonicBeaconBrand href={LISTENER_NAMESPACE.publicWebsite} />
-                </header>
-
                 <section className="listener-public-hero">
                     <BeaconField phase="ready" />
                     <div className="listener-public-hero__copy">

--- a/src/components/early-birds/EarlyBirdUnavailable.tsx
+++ b/src/components/early-birds/EarlyBirdUnavailable.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import HarmonicBeaconBrand from '@/components/brand/HarmonicBeaconBrand';
 import { useLocale } from '@/context/LocaleContext';
-import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
 const copy = {
     es: {
@@ -24,9 +22,6 @@ export default function EarlyBirdUnavailable() {
     return (
         <main className="listener-page-shell">
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-8 sm:px-10 sm:py-10">
-                <header className="flex items-center justify-between gap-4">
-                    <HarmonicBeaconBrand href={LISTENER_NAMESPACE.publicWebsite} />
-                </header>
                 <section className="flex flex-1 items-center py-14">
                     <div className="max-w-2xl space-y-7">
                         <p className="hb-eyebrow">

--- a/src/components/early-birds/FreeInvitationRedeemer.tsx
+++ b/src/components/early-birds/FreeInvitationRedeemer.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 
-import HarmonicBeaconBrand from '@/components/brand/HarmonicBeaconBrand';
 import { useLocale } from '@/context/LocaleContext';
 import { LISTENER_NAMESPACE } from '@/lib/listener/namespace';
 
@@ -46,9 +45,6 @@ export default function FreeInvitationRedeemer() {
     return (
         <main className="listener-page-shell">
             <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-lg flex-col justify-center gap-8 px-6 py-12">
-                <header className="flex items-center justify-between gap-4">
-                    <HarmonicBeaconBrand href={LISTENER_NAMESPACE.publicWebsite} />
-                </header>
                 <section className="space-y-6 rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-7 shadow-[var(--shadow-deep)]">
                     <p className="hb-eyebrow">{copy.eyebrow}</p>
                     <h1 className="hb-heading text-4xl leading-tight">{copy.heading}</h1>

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -61,7 +61,7 @@ describe('EarlyBird Listener home access chrome', () => {
         container.remove();
     });
 
-    it('uses the canonical public brand link without exposing the Reactive Lab', () => {
+    it('leaves the global brand link to the shared layout without exposing the Reactive Lab', () => {
         render(
             <LocaleProvider initialLocale="en">
                 <EarlyBirdHome
@@ -72,9 +72,7 @@ describe('EarlyBird Listener home access chrome', () => {
             </LocaleProvider>,
         );
 
-        expect(screen.getByRole('link', { name: 'Harmonic Beacon' }))
-            .toHaveAttribute('href', 'https://harmonicbeacon.com/');
-        expect(document.querySelector('.hb-brand__mark path')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Harmonic Beacon' })).not.toBeInTheDocument();
         expect(screen.getByLabelText('listener-player'))
             .toHaveAttribute('data-reactive-initially-enabled', 'false');
     });

--- a/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
@@ -66,9 +66,7 @@ describe('EarlyBird public landing', () => {
     it('keeps login in the compact hero and removes explanatory landing copy', () => {
         const { container } = renderLanding();
 
-        expect(screen.getByRole('link', { name: 'Harmonic Beacon' }))
-            .toHaveAttribute('href', 'https://harmonicbeacon.com/');
-        expect(container.querySelector('.hb-brand__mark path')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Harmonic Beacon' })).not.toBeInTheDocument();
         expect(container.querySelector('.listener-field__mark')).toHaveProperty('tagName', 'svg');
         expect(container.querySelector('.listener-public-hero .listener-access__card'))
             .toContainElement(screen.getByRole('button', { name: 'Continue with Google' }));

--- a/src/components/early-birds/__tests__/FreeInvitationRedeemer.test.tsx
+++ b/src/components/early-birds/__tests__/FreeInvitationRedeemer.test.tsx
@@ -39,7 +39,7 @@ describe('EarlyBird free invitation redeemer', () => {
         expect(await screen.findByRole('alert')).toHaveTextContent('This invitation is unavailable.');
         expect(screen.getByRole('button', { name: 'Activate invitation' })).toBeEnabled();
         expect(request).toHaveBeenCalledWith('/api/listener/free/redeem', { method: 'POST' });
-        expect(screen.getByRole('link', { name: 'Harmonic Beacon' })).toHaveAttribute('href', 'https://harmonicbeacon.com/');
+        expect(screen.queryByRole('link', { name: 'Harmonic Beacon' })).not.toBeInTheDocument();
         expect(JSON.stringify(request.mock.calls)).not.toContain('invitation-token');
     });
 });

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -112,12 +112,11 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
         expect(css).toContain('animation: listener-core-breathe 5.5s ease-in-out infinite;');
     });
 
-    it('uses the shared canonical Lissajous for Listener chrome and the field center', () => {
+    it('leaves chrome to the global layout and keeps the canonical field center', () => {
         const { container } = renderLanding();
 
-        expect(screen.getByRole('link', { name: 'Harmonic Beacon' }))
-            .toHaveAttribute('href', 'https://harmonicbeacon.com/');
-        expect(container.querySelectorAll('.hb-brand__mark path')).toHaveLength(2);
+        expect(screen.queryByRole('link', { name: 'Harmonic Beacon' })).not.toBeInTheDocument();
+        expect(container.querySelectorAll('.hb-brand__mark path')).toHaveLength(1);
         expect(container.textContent).not.toContain('✦');
     });
 

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GlobalNavigation, GLOBAL_NAVIGATION_ASSET } from '@/components/brand/GlobalNavigation';
+import { globalNavigationSurface } from '@/lib/brand/global-navigation';
+
+describe('canonical Harmonic Beacon global navigation', () => {
+    it.each([
+        ['live.harmonicbeacon.com', 'events'],
+        ['live.harmonicbeacon.com:443', 'events'],
+        ['listen.harmonicbeacon.com', 'listen'],
+        ['earlybirds-staging.harmonicbeacon.com', 'listen'],
+        ['harmonicbeacon.com', null],
+        ['live.harmonicbeacon.com, listen.harmonicbeacon.com', null],
+        ['live.harmonicbeacon.com@listen.harmonicbeacon.com', null],
+    ] as const)('maps exact host %s to %s', (host, expected) => {
+        expect(globalNavigationSurface(new Headers({ host }))).toBe(expected);
+    });
+
+    it('keeps an accessible same-destination fallback while the shared asset loads', () => {
+        render(<GlobalNavigation active="listen" locale="en" />);
+
+        expect(GLOBAL_NAVIGATION_ASSET).toBe('https://harmonicbeacon.com/assets/hb-global-nav.js');
+        expect(screen.getByRole('link', { name: 'Events' })).toHaveAttribute('href', 'https://live.harmonicbeacon.com/?lang=en');
+        expect(screen.getByRole('link', { name: 'Listen' })).toHaveAttribute('aria-current', 'page');
+        expect(screen.getByRole('link', { name: 'News' })).toHaveAttribute('href', 'https://harmonicbeacon.com/eventos/?lang=en');
+    });
+
+    it('renders the same destinations in Spanish', () => {
+        render(<GlobalNavigation active="events" locale="es" />);
+
+        expect(screen.getByRole('link', { name: 'Eventos' })).toHaveAttribute('aria-current', 'page');
+        expect(screen.getByRole('link', { name: 'Escuchar' })).toHaveAttribute('href', 'https://listen.harmonicbeacon.com/?lang=es');
+        expect(screen.getByRole('link', { name: 'Novedades' })).toBeInTheDocument();
+    });
+});

--- a/src/lib/brand/global-navigation.ts
+++ b/src/lib/brand/global-navigation.ts
@@ -1,0 +1,22 @@
+import type { GlobalNavigationSurface } from '@/components/brand/GlobalNavigation';
+
+const PUBLIC_SURFACES: Record<string, GlobalNavigationSurface> = {
+    'live.harmonicbeacon.com': 'events',
+    'listen.harmonicbeacon.com': 'listen',
+    'earlybirds-staging.harmonicbeacon.com': 'listen',
+};
+
+function normalizedHost(value: string | null): string | null {
+    const candidate = value?.trim().toLowerCase();
+    if (!candidate) return null;
+    const authority = /^([a-z0-9.-]+)(?::(\d{1,5}))?$/.exec(candidate);
+    if (!authority) return null;
+    if (authority[2] && Number(authority[2]) > 65_535) return null;
+    return authority[1];
+}
+
+export function globalNavigationSurface(headers: Pick<Headers, 'get'>): GlobalNavigationSurface | null {
+    const host = normalizedHost(headers.get('host'));
+    return host ? (PUBLIC_SURFACES[host] ?? null) : null;
+}
+

--- a/src/lib/i18n-server.ts
+++ b/src/lib/i18n-server.ts
@@ -1,6 +1,8 @@
 import { cookies } from 'next/headers';
 
 import {
+    localeForBrowserLanguage,
+    parseUiLocale,
     UI_LOCALE_COOKIE,
     resolveUiLocale,
     type EventLanguage,
@@ -10,4 +12,12 @@ import {
 export async function requestLocale(eventLanguage?: EventLanguage | null): Promise<UiLocale> {
     const cookieStore = await cookies();
     return resolveUiLocale(cookieStore.get(UI_LOCALE_COOKIE)?.value, eventLanguage);
+}
+
+export async function requestBrowserLocale(
+    headers: Pick<Headers, 'get'>,
+): Promise<UiLocale> {
+    const cookieStore = await cookies();
+    return parseUiLocale(cookieStore.get(UI_LOCALE_COOKIE)?.value)
+        ?? localeForBrowserLanguage(headers.get('accept-language'));
 }


### PR DESCRIPTION
Loads the single canonical global-navigation web component from harmonicbeacon.com across Listener and Live.

- Events → live.harmonicbeacon.com
- Listen → listen.harmonicbeacon.com
- News/Novedades → the former editorial Events archive
- exact ES/EN desktop/mobile destinations and active state
- accessible same-destination fallback if the shared asset is unavailable
- removes duplicated per-app brand/language bars
- preserves browser-first Listener language while honoring the shared preference

No audio, commerce, membership, LiveKit, room or event behavior changes.

Gates: 1,647 passed / 35 expected skips; TypeScript, ESLint and production build green.