### PR TITLE
fix(live): integrate global navigation with operations

### DIFF
--- a/e2e/tests/role-capabilities.spec.ts
+++ b/e2e/tests/role-capabilities.spec.ts
@@ -67,12 +67,11 @@ const ROLE_NAMES: Record<StaffDashboardRole, string> = {
 };
 
 async function setLocale(page: Page, locale: UiLocale): Promise<void> {
-    await page.goto('/');
-    await page.context().addCookies([{
-        name: 'hb_locale',
-        value: locale,
-        url: new URL(page.url()).origin,
-    }]);
+    await page.goto(`/?lang=${locale}`);
+    await page.waitForFunction((expectedLocale) => (
+        document.documentElement.lang === expectedLocale
+        && new URL(window.location.href).searchParams.has('lang') === false
+    ), locale);
 }
 
 async function withPage<T>(browser: Browser, run: (page: Page) => Promise<T>): Promise<T> {
@@ -98,10 +97,13 @@ async function expectStaffIdentity(
     await expect(identity).toContainText(copy.description);
     await expect(page.locator('body')).not.toContainText(role);
 
+    const operationsNavigation = page.getByRole('navigation', {
+        name: locale === 'es' ? 'Operaciones de eventos' : 'Event operations',
+    });
     for (const label of locale === 'es'
         ? ['Eventos', 'Estado técnico', 'Entradas']
         : ['Events', 'System health', 'Admission']) {
-        await expect(page.getByRole('link', { name: label, exact: true })).toBeVisible();
+        await expect(operationsNavigation.getByRole('link', { name: label, exact: true })).toBeVisible();
     }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,14 @@ html[data-hb-embedded-surface="cockpit"] hb-global-nav {
   display: none;
 }
 
+/* A cockpit drawer is a modal operational surface. Keep the shared product
+   header visible everywhere else, but remove it from the modal stacking and
+   pointer boundary while the drawer owns focus. */
+body:has(.live-ops-shell [role="dialog"]:not(.hidden)) > hb-global-nav {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .hb-global-navigation-fallback {
   min-height: 72px;
   max-width: 1180px;

--- a/src/app/ops/layout.tsx
+++ b/src/app/ops/layout.tsx
@@ -36,7 +36,10 @@ export default async function OpsLayout({
 
     return (
         <div className="live-ops-shell min-h-screen bg-[var(--night)]">
-            <nav className="border-b border-[var(--border-subtle)] bg-[var(--forest)]/80 px-4 py-2.5">
+            <nav
+                aria-label={locale === 'es' ? 'Operaciones de eventos' : 'Event operations'}
+                className="border-b border-[var(--border-subtle)] bg-[var(--forest)]/80 px-4 py-2.5"
+            >
                 <div className="mx-auto flex max-w-5xl flex-wrap items-center gap-x-4 gap-y-1 text-sm">
                     <Link
                         href="/ops/events"

--- a/src/brand/__tests__/live-brand-theme.test.ts
+++ b/src/brand/__tests__/live-brand-theme.test.ts
@@ -73,4 +73,15 @@ describe("Live canonical brand boundary", () => {
     expect(css).not.toMatch(/div:has\(> iframe\) \{[^}]*backdrop-filter/);
     expect(css).not.toMatch(/\.stage-tile__identity \{[^}]*backdrop-filter/);
   });
+
+  it("keeps modal operations above the shared product header", () => {
+    const css = source("src/app/globals.css");
+    const opsLayout = source("src/app/ops/layout.tsx");
+
+    expect(css).toMatch(
+      /body:has\(\.live-ops-shell \[role="dialog"\]:not\(\.hidden\)\) > hb-global-nav \{[\s\S]*?visibility: hidden;[\s\S]*?pointer-events: none;/,
+    );
+    expect(opsLayout).toContain("'Operaciones de eventos'");
+    expect(opsLayout).toContain("'Event operations'");
+  });
 });


### PR DESCRIPTION
## Qué corrige

- oculta el header global mientras el drawer operativo modal está abierto, para no interceptar foco ni clicks;
- distingue por accesibilidad la navegación global de la navegación interna de operaciones;
- hace deterministas los tests de idioma usando la selección canónica explícita;
- agrega guards de marca para evitar regresiones.

## Evidencia

- 16 tests focalizados: verdes
- TypeScript + ESLint: verdes
- 6 fallos exactos del gate anterior: reproducidos y corregidos
- E2E focal Chromium + Android + whole-system + ES/EN: verdes
- no toca audio, LiveKit, rooms ni comportamiento de eventos