### PR TITLE
test(live): await camera switch readiness

### DIFF
--- a/src/components/session/__tests__/ThumbnailSender.test.tsx
+++ b/src/components/session/__tests__/ThumbnailSender.test.tsx
@@ -73,7 +73,10 @@ describe('ThumbnailSender', () => {
             audio: false,
         });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Switch to rear camera' }));
+        // getUserMedia resolving and React committing `enabled` are separate
+        // async boundaries. Wait for the control that proves the latter;
+        // checking only the mock call makes this test scheduler-dependent.
+        fireEvent.click(await screen.findByRole('button', { name: 'Switch to rear camera' }));
 
         await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
         expect(stops[0]).toHaveBeenCalledOnce();


### PR DESCRIPTION
Stabilizes the deploy gate by waiting for the React state commit that renders the camera-switch control. The previous test waited only for getUserMedia, which is an earlier async boundary. Product/runtime code is unchanged. Evidence: focused test 25 consecutive passes; full pre-commit suite 915 passed / 19 skipped; TypeScript, ESLint and diff-check green.