### PR TITLE
feat(listener): compose the selected Listening Altar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1363,10 +1363,10 @@ html[data-hb-surface='listener'] body {
   padding: clamp(1.1rem, 3vw, 2rem);
   border: 1px solid rgba(201, 162, 78, 0.24);
   border-radius: 2.15rem 2.15rem 1.15rem 1.15rem;
-  background: linear-gradient(160deg, rgba(36, 29, 21, 0.6), rgba(22, 18, 13, 0.74));
+  background: linear-gradient(160deg, rgba(36, 29, 21, 0.24), rgba(22, 18, 13, 0.44));
   box-shadow: 0 2.25rem 7rem rgba(0, 0, 0, 0.48), inset 0 1px rgba(244, 238, 226, 0.035);
-  -webkit-backdrop-filter: blur(16px) saturate(112%);
-  backdrop-filter: blur(16px) saturate(112%);
+  -webkit-backdrop-filter: blur(3px) saturate(105%);
+  backdrop-filter: blur(3px) saturate(105%);
 }
 
 .listener-altar::before,
@@ -1913,10 +1913,10 @@ html[data-hb-surface='listener'] body {
   padding: clamp(1.35rem, 4vw, 2.5rem);
   border: 1px solid rgba(201, 162, 78, 0.24);
   border-radius: 2.15rem 2.15rem 1.15rem 1.15rem;
-  background: linear-gradient(160deg, rgba(36, 29, 21, 0.6), rgba(22, 18, 13, 0.74));
+  background: linear-gradient(160deg, rgba(36, 29, 21, 0.24), rgba(22, 18, 13, 0.44));
   box-shadow: 0 2.25rem 7rem rgba(0, 0, 0, 0.48), inset 0 1px rgba(244, 238, 226, 0.035);
-  -webkit-backdrop-filter: blur(16px) saturate(112%);
-  backdrop-filter: blur(16px) saturate(112%);
+  -webkit-backdrop-filter: blur(3px) saturate(105%);
+  backdrop-filter: blur(3px) saturate(105%);
 }
 
 .listener-public-altar > * {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1841,7 +1841,7 @@ html[data-hb-surface='listener'] body {
 
 .listener-details input[type='range'] {
   width: 100%;
-  height: 1.7rem;
+  min-height: 2.75rem;
   margin-top: 0.35rem;
   appearance: none;
   background: transparent;
@@ -2011,6 +2011,9 @@ html[data-hb-surface='listener'] body {
 
 .listener-quota a {
   width: fit-content;
+  min-height: 2.75rem;
+  display: inline-flex;
+  align-items: center;
   color: var(--hb-gold-2);
   font-size: 0.75rem;
   text-decoration: underline;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1301,7 +1301,7 @@ html[data-hb-surface='listener'] body {
 }
 
 .listener-static-field {
-  position: absolute;
+  position: fixed;
   inset: 0;
   z-index: 0;
   overflow: hidden;
@@ -1309,7 +1309,7 @@ html[data-hb-surface='listener'] body {
   transition: opacity 240ms ease;
 }
 
-.listener-altar:has(.listener-reactive-field) > .listener-static-field {
+.listener-shell__frame--home:has(.listener-reactive-field) > .listener-static-field {
   opacity: 0;
 }
 
@@ -1323,17 +1323,17 @@ html[data-hb-surface='listener'] body {
   content: '';
 }
 
-.listener-altar > .listener-static-field .listener-field {
-  width: min(145%, 58rem);
-  aspect-ratio: 1.12;
+.listener-shell__frame--home > .listener-static-field .listener-field {
+  width: min(125vw, 90rem);
+  aspect-ratio: 1.35;
   margin: 0;
   position: absolute;
-  top: 43%;
+  top: 50%;
   left: 50%;
-  opacity: 0.62;
+  opacity: 0.58;
   transform: translate(-50%, -50%);
-  -webkit-mask-image: radial-gradient(circle, #000 18%, rgba(0, 0, 0, 0.8) 58%, transparent 83%);
-  mask-image: radial-gradient(circle, #000 18%, rgba(0, 0, 0, 0.8) 58%, transparent 83%);
+  -webkit-mask-image: radial-gradient(ellipse, #000 12%, rgba(0, 0, 0, 0.82) 62%, transparent 92%);
+  mask-image: radial-gradient(ellipse, #000 12%, rgba(0, 0, 0, 0.82) 62%, transparent 92%);
 }
 
 .listener-shell__frame {
@@ -1382,7 +1382,7 @@ html[data-hb-surface='listener'] body {
   transform: translateX(-50%);
 }
 
-.listener-altar > :not(.listener-static-field) {
+.listener-altar > * {
   position: relative;
   z-index: 2;
 }
@@ -1919,22 +1919,23 @@ html[data-hb-surface='listener'] body {
   backdrop-filter: blur(16px) saturate(112%);
 }
 
-.listener-public-altar > :not(.listener-field) {
+.listener-public-altar > * {
   position: relative;
   z-index: 2;
 }
 
-.listener-public-altar > .listener-field {
-  width: min(138%, 52rem);
+.listener-public-hero > .listener-field {
+  width: min(125vw, 88rem);
+  aspect-ratio: 1.35;
   margin: 0;
   position: absolute;
   z-index: 0;
-  top: 34%;
+  top: 50%;
   left: 50%;
-  opacity: 0.46;
+  opacity: 0.52;
   transform: translate(-50%, -50%);
-  -webkit-mask-image: radial-gradient(circle, #000 18%, rgba(0, 0, 0, 0.78) 56%, transparent 78%);
-  mask-image: radial-gradient(circle, #000 18%, rgba(0, 0, 0, 0.78) 56%, transparent 78%);
+  -webkit-mask-image: radial-gradient(ellipse, #000 12%, rgba(0, 0, 0, 0.8) 62%, transparent 92%);
+  mask-image: radial-gradient(ellipse, #000 12%, rgba(0, 0, 0, 0.8) 62%, transparent 92%);
 }
 
 .listener-public-hero__copy {
@@ -2586,10 +2587,10 @@ html[data-hb-surface='listener'] body {
     border-radius: 1.65rem 1.65rem 0.9rem 0.9rem;
   }
 
-  .listener-public-altar > .listener-field {
-    width: min(155vw, 40rem);
-    top: 31%;
-    opacity: 0.34;
+  .listener-public-hero > .listener-field {
+    width: min(190vw, 54rem);
+    top: 48%;
+    opacity: 0.4;
   }
 
   .listener-public-hero__copy h1 { font-size: clamp(2.25rem, 13vw, 3.5rem); }
@@ -2599,10 +2600,10 @@ html[data-hb-surface='listener'] body {
     margin: clamp(5.25rem, 15vh, 8rem) auto 0;
   }
 
-  .listener-altar > .listener-static-field .listener-field {
-    width: min(170vw, 45rem);
-    top: 40%;
-    opacity: 0.54;
+  .listener-shell__frame--home > .listener-static-field .listener-field {
+    width: min(190vw, 54rem);
+    top: 48%;
+    opacity: 0.48;
   }
 
   .listener-account__menu {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1259,7 +1259,7 @@ html[data-hb-surface='listener'] body {
   --listener-accent: var(--hb-gold);
   min-height: 100vh;
   position: relative;
-  overflow: clip;
+  overflow-x: clip;
   background:
     radial-gradient(120% 80% at 12% -8%, rgba(201, 162, 78, 0.1), transparent 60%),
     radial-gradient(120% 90% at 92% 108%, rgba(110, 94, 68, 0.16), transparent 60%),
@@ -1301,7 +1301,7 @@ html[data-hb-surface='listener'] body {
 }
 
 .listener-static-field {
-  position: fixed;
+  position: absolute;
   inset: 0;
   z-index: 0;
   overflow: hidden;
@@ -1309,7 +1309,7 @@ html[data-hb-surface='listener'] body {
   transition: opacity 240ms ease;
 }
 
-.listener-shell__frame--home:has(.listener-reactive-field) > .listener-static-field {
+.listener-altar:has(.listener-reactive-field) > .listener-static-field {
   opacity: 0;
 }
 
@@ -1323,17 +1323,17 @@ html[data-hb-surface='listener'] body {
   content: '';
 }
 
-.listener-shell__frame--home > .listener-static-field .listener-field {
-  width: min(92vw, 66rem);
-  aspect-ratio: 1.3;
+.listener-altar > .listener-static-field .listener-field {
+  width: min(145%, 58rem);
+  aspect-ratio: 1.12;
   margin: 0;
   position: absolute;
-  top: 48%;
+  top: 43%;
   left: 50%;
-  opacity: 0.68;
+  opacity: 0.62;
   transform: translate(-50%, -50%);
-  -webkit-mask-image: radial-gradient(circle, #000 22%, rgba(0, 0, 0, 0.82) 60%, transparent 82%);
-  mask-image: radial-gradient(circle, #000 22%, rgba(0, 0, 0, 0.82) 60%, transparent 82%);
+  -webkit-mask-image: radial-gradient(circle, #000 18%, rgba(0, 0, 0, 0.8) 58%, transparent 83%);
+  mask-image: radial-gradient(circle, #000 18%, rgba(0, 0, 0, 0.8) 58%, transparent 83%);
 }
 
 .listener-shell__frame {
@@ -1347,7 +1347,66 @@ html[data-hb-surface='listener'] body {
 
 .listener-shell__frame--home {
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  width: min(100%, 90rem);
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: clamp(0.5rem, 1.5vh, 1rem);
+}
+
+.listener-altar {
+  width: min(100%, 46rem);
+  min-height: min(43rem, calc(100dvh - 8rem));
+  align-self: center;
+  justify-self: center;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  padding: clamp(1.1rem, 3vw, 2rem);
+  border: 1px solid rgba(201, 162, 78, 0.24);
+  border-radius: 2.15rem 2.15rem 1.15rem 1.15rem;
+  background: linear-gradient(160deg, rgba(36, 29, 21, 0.6), rgba(22, 18, 13, 0.74));
+  box-shadow: 0 2.25rem 7rem rgba(0, 0, 0, 0.48), inset 0 1px rgba(244, 238, 226, 0.035);
+  -webkit-backdrop-filter: blur(16px) saturate(112%);
+  backdrop-filter: blur(16px) saturate(112%);
+}
+
+.listener-altar::before,
+.listener-public-altar::before {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  z-index: 3;
+  width: 54%;
+  height: 1px;
+  content: '';
+  background: linear-gradient(90deg, transparent, var(--hb-gold-2), transparent);
+  transform: translateX(-50%);
+}
+
+.listener-altar > :not(.listener-static-field) {
+  position: relative;
+  z-index: 2;
+}
+
+.listener-altar__heading {
+  display: grid;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.listener-altar__heading p {
+  color: var(--hb-gold);
+  font-size: 0.64rem;
+  font-weight: 500;
+  letter-spacing: var(--hb-track-eyebrow);
+  text-transform: uppercase;
+}
+
+.listener-altar__heading strong {
+  color: var(--hb-bone);
+  font-family: var(--hb-font-serif);
+  font-size: clamp(2rem, 5vw, 2.55rem);
+  font-weight: 500;
+  line-height: 1;
 }
 
 .listener-rail {
@@ -1420,10 +1479,10 @@ html[data-hb-surface='listener'] body {
 }
 
 .listener-experience {
-  width: min(100%, 780px);
-  align-self: end;
-  margin: clamp(0.65rem, 2vh, 1.5rem) auto 0;
-  padding-bottom: clamp(1.25rem, 6vh, 4rem);
+  width: 100%;
+  align-self: center;
+  margin: clamp(0.8rem, 2vh, 1.35rem) auto 0;
+  padding-bottom: 0;
   --listener-phase: var(--hb-gold);
 }
 
@@ -1439,19 +1498,18 @@ html[data-hb-surface='listener'] body {
 .listener-stage {
   position: relative;
   z-index: 2;
+  display: grid;
+  align-content: end;
+  min-height: clamp(23rem, 52vh, 31rem);
   text-align: center;
 }
 
 .listener-control-panel {
   width: min(100%, 34rem);
-  margin: 0.7rem auto 0;
-  padding: clamp(0.85rem, 2.2vw, 1.2rem);
-  border: 1px solid var(--hb-hair-soft);
-  border-radius: var(--hb-radius-card);
-  background: linear-gradient(145deg, rgba(36, 29, 21, 0.055), rgba(22, 18, 13, 0.025));
-  box-shadow: var(--hb-shadow-card), inset 0 1px rgba(244, 238, 226, 0.025);
-  -webkit-backdrop-filter: blur(2.5px) saturate(108%);
-  backdrop-filter: blur(2.5px) saturate(108%);
+  margin: 0.9rem auto 0;
+  padding: clamp(0.85rem, 2.2vw, 1.2rem) 0 0;
+  border-top: 1px solid var(--hb-hair-soft);
+  background: transparent;
 }
 
 .listener-stage__copy {
@@ -1596,8 +1654,9 @@ html[data-hb-surface='listener'] body {
   align-items: center;
   justify-content: center;
   gap: 0.6rem;
-  color: var(--paper);
-  font-size: 0.86rem;
+  color: var(--hb-bone);
+  font-family: var(--hb-font-serif);
+  font-size: clamp(1rem, 2.6vw, 1.2rem);
 }
 
 .listener-stage__status-dot {
@@ -1609,16 +1668,16 @@ html[data-hb-surface='listener'] body {
 }
 
 .listener-intro-option {
-  width: fit-content;
+  width: min(100%, 28rem);
   max-width: 100%;
   display: flex;
   align-items: center;
   gap: 0.7rem;
   margin: 0 auto;
-  padding: 0.7rem 0.9rem;
+  padding: 0.8rem 1rem;
   border: 1px solid var(--border-subtle);
-  border-radius: 999px;
-  background: var(--hb-surface);
+  border-radius: 0.85rem;
+  background: rgba(27, 21, 15, 0.62);
   color: var(--hb-bone);
   font-family: var(--hb-font-sans);
   font-size: 0.72rem;
@@ -1679,12 +1738,12 @@ html[data-hb-surface='listener'] body {
   display: flex;
   gap: 0.65rem;
   justify-content: center;
-  margin: 0.75rem auto 0;
+  margin: 0.9rem auto 0;
 }
 
 .listener-transport__primary,
 .listener-transport__secondary {
-  min-height: 3.5rem;
+  min-height: 3.25rem;
   border-radius: 999px;
   font-family: var(--hb-font-sans);
   font-weight: 500;
@@ -1707,16 +1766,17 @@ html[data-hb-surface='listener'] body {
 }
 
 .listener-experience:not([data-phase='ready']):not([data-phase='stopped']) .listener-transport__primary {
-  color: var(--paper);
-  background: color-mix(in srgb, var(--listener-phase) 13%, var(--hb-bg-card));
-  border-color: color-mix(in srgb, var(--listener-phase) 48%, transparent);
+  color: var(--hb-bg-0);
+  background: linear-gradient(135deg, var(--hb-gold-2), var(--hb-gold) 52%, var(--hb-gold-deep));
+  border-color: rgba(244, 238, 226, 0.2);
 }
 
 .listener-transport__secondary {
-  padding: 0 1.25rem;
-  border: 1px solid var(--border-subtle);
-  color: var(--hb-ink-800);
-  background: var(--hb-surface);
+  min-width: 4.5rem;
+  padding: 0 1rem;
+  border: 1px solid rgba(248, 113, 113, 0.34);
+  color: #fecaca;
+  background: rgba(69, 24, 20, 0.24);
 }
 
 .listener-transport button:disabled { opacity: 0.5; cursor: wait; }
@@ -1727,19 +1787,19 @@ html[data-hb-surface='listener'] body {
   width: min(100%, 32rem);
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(12rem, 100%), 1fr));
-  gap: 0.8rem;
-  margin: 0.75rem auto 0;
-  padding: 0.85rem 1rem;
+  gap: 0.9rem;
+  margin: 0.9rem auto 0;
+  padding: 0.9rem 1rem;
   border: 1px solid var(--hb-hair-soft);
   border-radius: var(--hb-radius-card);
-  background: linear-gradient(135deg, rgba(201, 162, 78, 0.045), rgba(244, 238, 226, 0.025));
+  background: rgba(27, 21, 15, 0.52);
   text-align: left;
 }
 
 .listener-control-panel .listener-details {
-  padding: 0.75rem 0 0;
-  border: 0;
-  background: transparent;
+  padding: 0.85rem;
+  border: 1px solid var(--hb-hair-soft);
+  background: rgba(27, 21, 15, 0.52);
 }
 
 .listener-details__control > span,
@@ -1838,67 +1898,78 @@ html[data-hb-surface='listener'] body {
 }
 
 .listener-public-hero {
-  min-height: min(660px, calc(100vh - 5rem));
+  min-height: calc(100dvh - 5rem);
   display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(19rem, 0.72fr);
-  align-items: center;
-  gap: clamp(1rem, 4vw, 4rem);
-  padding: clamp(2.5rem, 7vh, 5rem) 0 clamp(3rem, 9vh, 6rem);
+  place-items: center;
+  padding: clamp(1rem, 3vh, 2rem) 0 clamp(2rem, 5vh, 3.5rem);
+  position: relative;
+}
+
+.listener-public-altar {
+  width: min(100%, 42rem);
   position: relative;
   isolation: isolate;
   overflow: hidden;
+  padding: clamp(1.35rem, 4vw, 2.5rem);
+  border: 1px solid rgba(201, 162, 78, 0.24);
+  border-radius: 2.15rem 2.15rem 1.15rem 1.15rem;
+  background: linear-gradient(160deg, rgba(36, 29, 21, 0.6), rgba(22, 18, 13, 0.74));
+  box-shadow: 0 2.25rem 7rem rgba(0, 0, 0, 0.48), inset 0 1px rgba(244, 238, 226, 0.035);
+  -webkit-backdrop-filter: blur(16px) saturate(112%);
+  backdrop-filter: blur(16px) saturate(112%);
 }
 
-.listener-public-hero > :not(.listener-field) {
+.listener-public-altar > :not(.listener-field) {
   position: relative;
-  z-index: 1;
+  z-index: 2;
 }
 
-.listener-public-hero > .listener-field {
-  width: min(66vw, 45rem);
+.listener-public-altar > .listener-field {
+  width: min(138%, 52rem);
   margin: 0;
   position: absolute;
   z-index: 0;
-  top: 50%;
-  right: clamp(-12rem, -8vw, -4rem);
-  opacity: 0.52;
-  transform: translateY(-50%);
+  top: 34%;
+  left: 50%;
+  opacity: 0.46;
+  transform: translate(-50%, -50%);
   -webkit-mask-image: radial-gradient(circle, #000 18%, rgba(0, 0, 0, 0.78) 56%, transparent 78%);
   mask-image: radial-gradient(circle, #000 18%, rgba(0, 0, 0, 0.78) 56%, transparent 78%);
 }
 
+.listener-public-hero__copy {
+  text-align: center;
+}
+
 .listener-public-hero__copy h1 {
-  max-width: 13ch;
-  margin-top: 1rem;
+  max-width: 15ch;
+  margin: 0.7rem auto 0;
   color: var(--hb-bone);
   font-family: var(--hb-font-serif);
-  font-size: clamp(2.8rem, 6.2vw, 5.5rem);
+  font-size: clamp(2.35rem, 6.2vw, 4.5rem);
   font-weight: 400;
   line-height: 0.9;
 }
 
 .listener-public-hero__copy > p:nth-child(3) {
-  max-width: 32rem;
-  margin-top: 1.6rem;
+  max-width: 30rem;
+  margin: 1rem auto 0;
   color: var(--text-secondary);
   font-size: clamp(1rem, 2vw, 1.2rem);
   line-height: 1.7;
 }
 
 .listener-access {
-  width: 100%;
+  width: min(100%, 31rem);
+  margin: clamp(6rem, 16vh, 10rem) auto 0;
   padding: 0;
   scroll-margin-top: 2rem;
 }
 
 .listener-access__card {
-  padding: clamp(1.25rem, 3vw, 2rem);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--hb-radius-card);
-  background: linear-gradient(145deg, rgba(36, 29, 21, 0.055), rgba(22, 18, 13, 0.025));
-  box-shadow: var(--hb-shadow-card), inset 0 1px rgba(244, 238, 226, 0.025);
-  -webkit-backdrop-filter: blur(2.5px) saturate(108%);
-  backdrop-filter: blur(2.5px) saturate(108%);
+  padding: clamp(1rem, 3vw, 1.5rem) 0 0;
+  border-top: 1px solid var(--hb-hair-soft);
+  background: transparent;
 }
 
 .listener-quota {
@@ -1950,6 +2021,7 @@ html[data-hb-surface='listener'] body {
 .listener-listening-status {
   width: min(100%, 34rem);
   margin: 1rem auto 0;
+  padding-top: 0.25rem;
   align-self: end;
 }
 
@@ -2459,43 +2531,100 @@ html[data-hb-surface='listener'] body {
 }
 
 @media (max-width: 760px) {
-  .listener-shell__frame { padding-inline: 1rem; }
-  .listener-rail .hb-brand__wordmark { font-size: 0.68rem; }
-  .listener-experience {
-    margin-top: 0.55rem;
-    padding-bottom: max(1rem, var(--safe-bottom));
+  .listener-shell__frame {
+    padding-inline: max(0.75rem, var(--safe-left));
   }
+
+  .listener-shell__frame--home { gap: 0.4rem; }
+  .listener-rail .hb-brand__wordmark { font-size: 0.68rem; }
+
+  .listener-altar {
+    min-height: calc(100dvh - 6.5rem);
+    align-self: start;
+    padding: 1rem 0.85rem max(1rem, var(--safe-bottom));
+    border-radius: 1.65rem 1.65rem 0.9rem 0.9rem;
+  }
+
+  .listener-altar__heading strong { font-size: 2rem; }
+
+  .listener-experience {
+    margin-top: 0.45rem;
+    padding-bottom: 0;
+  }
+
+  .listener-stage { min-height: clamp(21rem, 50vh, 27rem); }
   .listener-field { width: min(100%, 28rem); aspect-ratio: 1.28; }
   .listener-experience .listener-field { width: min(100%, 25rem); aspect-ratio: 1.55; }
   .listener-intro-option { margin-top: 0.5rem; }
+
   .listener-transport {
-    position: sticky;
-    z-index: 10;
-    bottom: max(0.75rem, var(--safe-bottom));
-    padding: 0.4rem;
-    border: 1px solid var(--hb-hair-soft);
-    border-radius: 999px;
-    background: rgba(27, 21, 15, 0.86);
-    backdrop-filter: blur(18px);
+    width: 100%;
+    gap: 0.5rem;
   }
-  .listener-details { gap: 0.65rem; margin-top: 0.55rem; padding-block: 0.7rem; }
-  .listener-public-hero { min-height: auto; grid-template-columns: 1fr; padding: 3rem 0 4rem; }
-  .listener-public-hero__copy { text-align: center; }
-  .listener-public-hero__copy h1,
-  .listener-public-hero__copy > p:nth-child(3) { margin-inline: auto; }
-  .listener-public-hero > .listener-field {
-    width: min(145vw, 38rem);
-    top: 48%;
-    right: auto;
-    left: 50%;
+
+  .listener-transport__primary,
+  .listener-transport__secondary { min-height: 48px; }
+
+  .listener-details {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+    margin-top: 0.7rem;
+    padding: 0.75rem;
+  }
+
+  .listener-public-hero {
+    min-height: calc(100dvh - 4rem);
+    padding: 0.75rem 0 max(1.5rem, var(--safe-bottom));
+  }
+
+  .listener-public-altar {
+    min-height: calc(100dvh - 5.5rem);
+    padding: 1.1rem 0.9rem;
+    border-radius: 1.65rem 1.65rem 0.9rem 0.9rem;
+  }
+
+  .listener-public-altar > .listener-field {
+    width: min(155vw, 40rem);
+    top: 31%;
     opacity: 0.34;
-    transform: translate(-50%, -50%);
   }
-  .listener-access { width: min(100%, 30rem); margin-inline: auto; }
-  .listener-shell__frame--home > .listener-static-field .listener-field {
-    width: min(150vw, 44rem);
-    top: 43%;
+
+  .listener-public-hero__copy h1 { font-size: clamp(2.25rem, 13vw, 3.5rem); }
+
+  .listener-access {
+    width: min(100%, 30rem);
+    margin: clamp(5.25rem, 15vh, 8rem) auto 0;
+  }
+
+  .listener-altar > .listener-static-field .listener-field {
+    width: min(170vw, 45rem);
+    top: 40%;
     opacity: 0.54;
+  }
+
+  .listener-account__menu {
+    width: min(18rem, calc(100vw - 1.5rem));
+  }
+}
+
+@media (max-width: 360px) {
+  .listener-shell__frame {
+    padding-inline: max(0.55rem, var(--safe-left));
+  }
+
+  .listener-altar,
+  .listener-public-altar {
+    padding-inline: 0.65rem;
+    border-radius: 1.35rem 1.35rem 0.8rem 0.8rem;
+  }
+
+  .listener-stage { min-height: clamp(19rem, 47vh, 24rem); }
+  .listener-intro-option { padding-inline: 0.75rem; }
+  .listener-control-panel { padding-top: 0.75rem; }
+  .listener-details { padding-inline: 0.65rem; }
+
+  .listener-account__menu {
+    width: min(15rem, calc(100vw - 1.1rem));
   }
 }
 

--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -102,10 +102,10 @@ export default function EarlyBirdHome({
                         </details>}
                     </div>
                 </header>
+                <div className="listener-static-field" data-testid="listener-static-field">
+                    <BeaconField phase="ready" />
+                </div>
                 <section className="listener-altar" aria-labelledby="listener-heading">
-                    <div className="listener-static-field" data-testid="listener-static-field">
-                        <BeaconField phase="ready" />
-                    </div>
                     <div className="listener-altar__heading" aria-hidden="true">
                         <p>{copy.eyebrow}</p>
                         <strong>{copy.heading}</strong>

--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -102,34 +102,40 @@ export default function EarlyBirdHome({
                         </details>}
                     </div>
                 </header>
-                <div className="listener-static-field" data-testid="listener-static-field">
-                    <BeaconField phase="ready" />
-                </div>
-                <ListenerPlayer
-                    dropIns={dropIns}
-                    reactiveVisualizationAvailable={reactiveVisualizationAvailable}
-                    reactiveVisualizationInitiallyEnabled={false}
-                    reactiveFieldLabAvailable={reactiveFieldLabAvailable}
-                />
-                {!publicAccess && accessKind === 'free-quota' && (
-                    <footer className="listener-listening-status">
-                        <FreeQuotaStatus
-                            snapshot={quota}
-                            serverNow={serverNow}
-                            compact
-                            showMembershipLink={
-                                !checkoutAvailability.paypal
-                                && !checkoutAvailability.mercadoPago
-                                && !liveWorkbench
-                            }
-                        />
-                        <FoundingListenerCheckout
-                            available={checkoutAvailability}
-                            environment={checkoutEnvironment}
-                        />
-                        <FoundingListenerLiveWorkbench config={liveWorkbench} />
-                    </footer>
-                )}
+                <section className="listener-altar" aria-labelledby="listener-heading">
+                    <div className="listener-static-field" data-testid="listener-static-field">
+                        <BeaconField phase="ready" />
+                    </div>
+                    <div className="listener-altar__heading" aria-hidden="true">
+                        <p>{copy.eyebrow}</p>
+                        <strong>{copy.heading}</strong>
+                    </div>
+                    <ListenerPlayer
+                        dropIns={dropIns}
+                        reactiveVisualizationAvailable={reactiveVisualizationAvailable}
+                        reactiveVisualizationInitiallyEnabled={false}
+                        reactiveFieldLabAvailable={reactiveFieldLabAvailable}
+                    />
+                    {!publicAccess && accessKind === 'free-quota' && (
+                        <footer className="listener-listening-status">
+                            <FreeQuotaStatus
+                                snapshot={quota}
+                                serverNow={serverNow}
+                                compact
+                                showMembershipLink={
+                                    !checkoutAvailability.paypal
+                                    && !checkoutAvailability.mercadoPago
+                                    && !liveWorkbench
+                                }
+                            />
+                            <FoundingListenerCheckout
+                                available={checkoutAvailability}
+                                environment={checkoutEnvironment}
+                            />
+                            <FoundingListenerLiveWorkbench config={liveWorkbench} />
+                        </footer>
+                    )}
+                </section>
             </div>
         </main>
     );

--- a/src/components/early-birds/EarlyBirdLanding.tsx
+++ b/src/components/early-birds/EarlyBirdLanding.tsx
@@ -137,17 +137,18 @@ export default function EarlyBirdLanding(props: Props) {
     return (
         <main className="listener-shell listener-shell--public">
             <div className="listener-shell__frame">
-                <section className="listener-public-hero">
-                    <BeaconField phase="ready" />
-                    <div className="listener-public-hero__copy">
-                        <p>{copy.eyebrow}</p>
-                        <h1>
-                            {copy.title}
-                        </h1>
-                        <p>{copy.intro}</p>
-                    </div>
-                    <div id="listener-access" className="listener-access">
-                        <div className="listener-access__card">
+                <section className="listener-public-hero" aria-labelledby="listener-public-title">
+                    <div className="listener-public-altar">
+                        <BeaconField phase="ready" />
+                        <div className="listener-public-hero__copy">
+                            <p>{copy.eyebrow}</p>
+                            <h1 id="listener-public-title">
+                                {copy.title}
+                            </h1>
+                            <p>{copy.intro}</p>
+                        </div>
+                        <div id="listener-access" className="listener-access">
+                            <div className="listener-access__card">
                         {error && (
                             <p role="alert" className="mb-5 rounded-lg border border-red-400/30 bg-red-400/10 p-3 text-sm text-red-100">
                                 {copy.identityRecoveryFailed}
@@ -295,6 +296,7 @@ export default function EarlyBirdLanding(props: Props) {
                                 )}
                             </div>
                         )}
+                            </div>
                         </div>
                     </div>
                 </section>

--- a/src/components/early-birds/EarlyBirdLanding.tsx
+++ b/src/components/early-birds/EarlyBirdLanding.tsx
@@ -138,8 +138,8 @@ export default function EarlyBirdLanding(props: Props) {
         <main className="listener-shell listener-shell--public">
             <div className="listener-shell__frame">
                 <section className="listener-public-hero" aria-labelledby="listener-public-title">
+                    <BeaconField phase="ready" />
                     <div className="listener-public-altar">
-                        <BeaconField phase="ready" />
                         <div className="listener-public-hero__copy">
                             <p>{copy.eyebrow}</p>
                             <h1 id="listener-public-title">

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -91,7 +91,7 @@ describe('EarlyBird Listener home access chrome', () => {
     });
 
     it('leaves the global brand link to the shared layout without exposing the Reactive Lab', () => {
-        render(
+        const { container } = render(
             <LocaleProvider initialLocale="en">
                 <EarlyBirdHome
                     displayName="Nico"
@@ -102,6 +102,12 @@ describe('EarlyBird Listener home access chrome', () => {
         );
 
         expect(screen.queryByRole('link', { name: 'Harmonic Beacon' })).not.toBeInTheDocument();
+        expect(container.querySelector('.listener-altar'))
+            .toHaveAttribute('aria-labelledby', 'listener-heading');
+        expect(container.querySelector('.listener-altar')).toContainElement(
+            screen.getByLabelText('listener-player'),
+        );
+        expect(container.textContent).not.toMatch(/Presence|here now|Your listening space|Listening Altar/i);
         expect(screen.getByLabelText('listener-player'))
             .toHaveAttribute('data-reactive-initially-enabled', 'false');
     });

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -107,6 +107,11 @@ describe('EarlyBird Listener home access chrome', () => {
         expect(container.querySelector('.listener-altar')).toContainElement(
             screen.getByLabelText('listener-player'),
         );
+        expect(container.querySelector('.listener-altar')).not.toContainElement(
+            screen.getByTestId('listener-static-field'),
+        );
+        expect(screen.getByTestId('listener-static-field').parentElement)
+            .toHaveClass('listener-shell__frame--home');
         expect(container.textContent).not.toMatch(/Presence|here now|Your listening space|Listening Altar/i);
         expect(screen.getByLabelText('listener-player'))
             .toHaveAttribute('data-reactive-initially-enabled', 'false');

--- a/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
@@ -82,6 +82,9 @@ describe('EarlyBird public landing', () => {
     it('keeps login in the compact hero and removes explanatory landing copy', () => {
         const { container } = renderLanding();
 
+        expect(container.querySelector('.listener-public-hero'))
+            .toHaveAttribute('aria-labelledby', 'listener-public-title');
+        expect(container.querySelector('.listener-public-altar')).toBeInTheDocument();
         expect(screen.queryByRole('link', { name: 'Harmonic Beacon' })).not.toBeInTheDocument();
         expect(container.querySelector('.listener-field__spark')).toHaveTextContent('✦');
         expect(container.querySelector('.listener-field svg')).not.toBeInTheDocument();
@@ -93,6 +96,7 @@ describe('EarlyBird public landing', () => {
         expect(screen.queryByText('An optional introduction before entering the Beacon')).not.toBeInTheDocument();
         expect(screen.queryByText('Three Free hours each week')).not.toBeInTheDocument();
         expect(screen.queryByText(/Your account and membership manage access/)).not.toBeInTheDocument();
+        expect(container.textContent).not.toMatch(/Presence|here now|Your listening space|Listening Altar/i);
     });
 
     it('hides an unconfigured provider from the public identity surface', () => {

--- a/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdLanding.test.tsx
@@ -88,6 +88,8 @@ describe('EarlyBird public landing', () => {
         expect(screen.queryByRole('link', { name: 'Harmonic Beacon' })).not.toBeInTheDocument();
         expect(container.querySelector('.listener-field__spark')).toHaveTextContent('✦');
         expect(container.querySelector('.listener-field svg')).not.toBeInTheDocument();
+        expect(container.querySelector('.listener-public-altar .listener-field')).not.toBeInTheDocument();
+        expect(container.querySelector('.listener-public-hero > .listener-field')).toBeInTheDocument();
         expect(container.querySelector('.listener-public-hero .listener-access__card'))
             .toContainElement(screen.getByRole('button', { name: 'Continue with Google' }));
         expect(screen.getByRole('heading', { name: 'Remember your harmonic center.' }))

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -90,19 +90,27 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
         expect(listenerCss).not.toContain('rgba(255, 143, 200');
     });
 
-    it('keeps the real BeaconField visible through both large interaction panels', () => {
+    it('keeps the real BeaconField visible through the warm translucent altars', () => {
         const css = readFileSync('src/app/globals.css', 'utf8');
 
-        for (const selector of ['.listener-control-panel', '.listener-access__card']) {
+        for (const selector of ['.listener-altar', '.listener-public-altar']) {
             const start = css.indexOf(`${selector} {`);
             const end = css.indexOf('\n}', start);
             const rule = css.slice(start, end);
 
             expect(start, `${selector} must exist`).toBeGreaterThanOrEqual(0);
-            expect(rule).toContain('rgba(36, 29, 21, 0.055)');
-            expect(rule).toContain('rgba(22, 18, 13, 0.025)');
-            expect(rule).toContain('backdrop-filter: blur(2.5px) saturate(108%);');
-            expect(rule).not.toContain('blur(18px)');
+            expect(rule).toContain('rgba(36, 29, 21, 0.6)');
+            expect(rule).toContain('rgba(22, 18, 13, 0.74)');
+            expect(rule).toContain('backdrop-filter: blur(16px) saturate(112%);');
+            expect(rule).toContain('overflow: hidden;');
+        }
+
+        for (const selector of ['.listener-control-panel', '.listener-access__card']) {
+            const start = css.indexOf(`${selector} {`);
+            const end = css.indexOf('\n}', start);
+            const rule = css.slice(start, end);
+            expect(rule).toContain('background: transparent;');
+            expect(rule).toContain('border-top: 1px solid var(--hb-hair-soft);');
         }
     });
 
@@ -155,6 +163,28 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
         expect(reducedMotion).toContain('.listener-field__orbit');
         expect(reducedMotion).toContain('.listener-field__core');
         expect(reducedMotion).toContain('.listener-field__point { animation: none; }');
+    });
+
+    it('bounds the altar at 320/390 mobile and 768–1440 desktop widths', () => {
+        const css = readFileSync('src/app/globals.css', 'utf8');
+        const mobile = css.slice(
+            css.indexOf('@media (max-width: 760px)'),
+            css.indexOf('@media (max-width: 360px)'),
+        );
+        const narrowStart = css.indexOf('@media (max-width: 360px)');
+        const narrow = css.slice(
+            narrowStart,
+            css.indexOf('@media (prefers-reduced-motion: reduce)', narrowStart),
+        );
+
+        expect(css).toContain('width: min(100%, 90rem);');
+        expect(css).toContain('width: min(100%, 46rem);');
+        expect(css).toContain('width: min(100%, 42rem);');
+        expect(mobile).toContain('min-height: 48px;');
+        expect(mobile).toContain('width: min(18rem, calc(100vw - 1.5rem));');
+        expect(mobile).not.toContain('position: sticky;');
+        expect(narrow).toContain('width: min(15rem, calc(100vw - 1.1rem));');
+        expect(narrow).toContain('padding-inline: 0.65rem;');
     });
 
     it('standalone Listener pages render the listener page shell, never the event shell', () => {
@@ -234,7 +264,7 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
         expect(screen.getByRole('button', { name: 'Continue with Google' }))
             .toHaveClass('listener-button', 'listener-button--secondary');
         expect(anonymous.container.innerHTML).not.toMatch(EVENT_VISUAL_CLASS);
-        // The anonymous surface offers no competing primary action inside the access card.
+        // Identity providers remain equivalent and do not compete with a product action.
         expect(
             anonymous.container.querySelectorAll('.listener-access__card .listener-button--primary'),
         ).toHaveLength(0);

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -108,9 +108,9 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
             const rule = css.slice(start, end);
 
             expect(start, `${selector} must exist`).toBeGreaterThanOrEqual(0);
-            expect(rule).toContain('rgba(36, 29, 21, 0.6)');
-            expect(rule).toContain('rgba(22, 18, 13, 0.74)');
-            expect(rule).toContain('backdrop-filter: blur(16px) saturate(112%);');
+            expect(rule).toContain('rgba(36, 29, 21, 0.24)');
+            expect(rule).toContain('rgba(22, 18, 13, 0.44)');
+            expect(rule).toContain('backdrop-filter: blur(3px) saturate(105%);');
             expect(rule).toContain('overflow: hidden;');
         }
 

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -93,6 +93,15 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
     it('keeps the real BeaconField visible through the warm translucent altars', () => {
         const css = readFileSync('src/app/globals.css', 'utf8');
 
+        const staticFieldStart = css.indexOf('.listener-static-field {');
+        const staticFieldEnd = css.indexOf('\n}', staticFieldStart);
+        const staticField = css.slice(staticFieldStart, staticFieldEnd);
+        expect(staticField).toContain('position: fixed;');
+        expect(css).toContain('.listener-shell__frame--home > .listener-static-field .listener-field {');
+        expect(css).toContain('.listener-public-hero > .listener-field {');
+        expect(css).not.toContain('.listener-altar > .listener-static-field .listener-field {');
+        expect(css).not.toContain('.listener-public-altar > .listener-field {');
+
         for (const selector of ['.listener-altar', '.listener-public-altar']) {
             const start = css.indexOf(`${selector} {`);
             const end = css.indexOf('\n}', start);

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -185,6 +185,8 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
         expect(mobile).not.toContain('position: sticky;');
         expect(narrow).toContain('width: min(15rem, calc(100vw - 1.1rem));');
         expect(narrow).toContain('padding-inline: 0.65rem;');
+        expect(css).toMatch(/\.listener-details input\[type='range'\][\s\S]*?min-height: 2\.75rem;/);
+        expect(css).toMatch(/\.listener-quota a[\s\S]*?min-height: 2\.75rem;/);
     });
 
     it('standalone Listener pages render the listener page shell, never the event shell', () => {


### PR DESCRIPTION
Closes #397. Selected by human review from #394.

## Product decision

Implements the **Listening Altar** composition while retaining only real Listener copy, data and actions. It deliberately does not import prototype prose such as `Presence`, `here now`, `Your listening space` or other decorative status labels.

## Scope

- wraps the existing signed-in Listener surface in one centered warm translucent altar
- composes the anonymous identity/access surface with the same hierarchy
- preserves the actual intro checkbox/language, volume, transport, quota/renewal, Founder/FFA, profile, checkout and error states
- keeps Google and Apple equivalent secondary provider actions
- keeps profile in the current product strip; shared SSO/navbar profile belongs to #396
- presentation-only CSS/markup and focused tests

## Frozen boundaries

`ListenerPlayer.tsx` is byte-identical to the base. No audio, intro media, fade, gain, buffer, HLS, manifest, auth semantics, quota, membership, commerce authority, event, LiveKit, room or tapestry behavior changed.

## Evidence

- 40 layout/landing/home tests
- 50 ListenerPlayer/Transport/presentation tests
- TypeScript
- full ESLint
- production build
- diff-check
- adversarial review: GO, no P0/P1
- manual Chromium public/degraded surface at 320/390/1440: no horizontal overflow and no serious/critical axe findings

Authorized visual evidence will be collected from Listener staging before merge/deploy.
