### PR TITLE
fix(deps): update tsx for patched esbuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm ci
       - name: Reject high-severity production dependency regressions
         run: |
-          npm audit --omit=dev --audit-level=high
+          npm run audit:production
           npm audit --omit=dev --prefix services/tapestry --audit-level=high
           npm audit --omit=dev --prefix services/playlist-bot --audit-level=high
       - run: npm run lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
           npm run contract:commerce:verify
           npm test
           npm test --prefix services/tapestry
-          npm audit --omit=dev --audit-level=high
+          npm run audit:production
           npm audit --omit=dev --prefix services/tapestry --audit-level=high
           npm audit --omit=dev --prefix services/playlist-bot --audit-level=high
           npx tsc --noEmit

--- a/docs/operations/DEPENDENCY_SECURITY.md
+++ b/docs/operations/DEPENDENCY_SECURITY.md
@@ -18,10 +18,21 @@ has no `next/image` imports, but the production build and a native Sharp JPEG
 round trip remain required gates because the Sharp override crosses a major.
 Remove the overrides once a stable Next.js release declares fixed ranges.
 
-`npm audit --omit=dev --audit-level=high` is a pull-request gate. At this
-baseline it reports one low-severity esbuild issue limited to the Windows
-development server; production runs Linux standalone output and does not expose
-the esbuild development server. Review or remove that exception by 2026-09-01.
+`npm run audit:production` is the root pull-request and deploy gate. It parses
+the structured npm audit report and fails on every unreviewed high or critical
+finding. Its sole temporary exception is advisory 1145093
+(`GHSA-ggr8-5vv4-36mx`) for exactly `deepmerge-ts@7.1.5` through
+`@prisma/config@7.9.1` and `prisma@7.9.1`. Prisma pins that dependency and the
+patched deepmerge release is a major while Prisma 8 remains pre-release. The
+exposure is bounded because Prisma config processes only the repository-owned
+`prisma.config.ts` during trusted build and migration operations, never request
+or user data. The guard checks the advisory ID, dependency versions and exact
+installed paths, rejects any additional high/critical finding, and expires
+closed on 2026-09-15. Remove it earlier when a stable Prisma release adopts the
+patched dependency.
+
+The prior production `tsx` chain now resolves to `tsx@4.23.12` and patched
+`esbuild@0.28.2` within the already-declared compatible range.
 
 Every independently deployed Node package is audited, not only the repository
 root. The tapestry service is pinned to Sharp 0.35.3 after its prior 0.34 line

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,6 +605,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,6 +622,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -637,6 +639,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,6 +656,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -669,6 +673,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,6 +690,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -701,6 +707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,6 +724,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -733,6 +741,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -749,6 +758,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,6 +775,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -781,6 +792,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -797,6 +809,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -813,6 +826,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -829,6 +843,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -845,6 +860,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -861,6 +877,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -877,6 +894,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -893,6 +911,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -909,6 +928,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -925,6 +945,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -941,6 +962,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -957,6 +979,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -973,6 +996,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -989,6 +1013,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1005,6 +1030,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5614,6 +5640,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6527,6 +6554,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -9282,6 +9310,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10341,13 +10370,12 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -10357,6 +10385,463 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build --webpack",
+    "audit:production": "tsx scripts/audit-production-dependencies.ts",
     "start": "next start",
     "lint": "eslint",
     "prepare": "husky",

--- a/scripts/audit-production-dependencies.ts
+++ b/scripts/audit-production-dependencies.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+    evaluateProductionAudit,
+    type InstalledAuditPackage,
+    type InstalledAuditPackages,
+} from '../src/lib/production-audit-guard';
+
+function readInstalledPackage(relativePath: string): InstalledAuditPackage {
+    const packagePath = path.join(process.cwd(), relativePath, 'package.json');
+    const parsed = JSON.parse(readFileSync(packagePath, 'utf8')) as {
+        version?: unknown;
+        dependencies?: unknown;
+    };
+
+    if (typeof parsed.version !== 'string') {
+        throw new Error(`Missing package version at ${relativePath}`);
+    }
+
+    const dependencies = parsed.dependencies ?? {};
+    if (typeof dependencies !== 'object' || dependencies === null || Array.isArray(dependencies)) {
+        throw new Error(`Missing dependency map at ${relativePath}`);
+    }
+
+    return {
+        version: parsed.version,
+        dependencies: dependencies as Record<string, string>,
+    };
+}
+
+function readInstalledPackages(): InstalledAuditPackages {
+    return {
+        prisma: readInstalledPackage('node_modules/prisma'),
+        '@prisma/config': readInstalledPackage('node_modules/@prisma/config'),
+        'deepmerge-ts': readInstalledPackage('node_modules/deepmerge-ts'),
+    };
+}
+
+const audit = spawnSync(
+    'npm',
+    ['audit', '--omit=dev', '--audit-level=high', '--json'],
+    { cwd: process.cwd(), encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+);
+
+if (audit.error || audit.signal || (audit.status !== 0 && audit.status !== 1)) {
+    console.error(`Production dependency audit could not complete (status ${audit.status ?? 'unknown'}).`);
+    process.exit(1);
+}
+
+let report: unknown;
+try {
+    report = JSON.parse(audit.stdout);
+} catch {
+    console.error('Production dependency audit returned invalid JSON.');
+    process.exit(1);
+}
+
+let installed: InstalledAuditPackages | undefined;
+try {
+    installed = readInstalledPackages();
+} catch {
+    installed = undefined;
+}
+
+const decision = evaluateProductionAudit(report, installed);
+const log = decision.ok ? console.log : console.error;
+log(decision.message);
+process.exit(decision.ok ? 0 : 1);

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -154,7 +154,7 @@ describe('production deploy contract', () => {
 
   it('audits the production dependencies of both deployable packages', () => {
     for (const contents of [ciWorkflow, workflow]) {
-      expect(contents).toContain('npm audit --omit=dev --audit-level=high');
+      expect(contents).toContain('npm run audit:production');
       expect(contents).toContain(
         'npm audit --omit=dev --prefix services/tapestry --audit-level=high',
       );

--- a/src/lib/__tests__/production-audit-guard.test.ts
+++ b/src/lib/__tests__/production-audit-guard.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    evaluateProductionAudit,
+    type InstalledAuditPackages,
+} from '../production-audit-guard';
+
+const installed: InstalledAuditPackages = {
+    prisma: {
+        version: '7.9.1',
+        dependencies: { '@prisma/config': '7.9.1' },
+    },
+    '@prisma/config': {
+        version: '7.9.1',
+        dependencies: { 'deepmerge-ts': '7.1.5' },
+    },
+    'deepmerge-ts': {
+        version: '7.1.5',
+        dependencies: {},
+    },
+};
+
+function exactReport() {
+    return {
+        auditReportVersion: 2,
+        vulnerabilities: {
+            '@prisma/config': {
+                name: '@prisma/config',
+                severity: 'high',
+                isDirect: false,
+                via: ['deepmerge-ts'],
+                effects: ['prisma'],
+                range: '>=6.13.0-dev.1',
+                nodes: ['node_modules/@prisma/config'],
+            },
+            'deepmerge-ts': {
+                name: 'deepmerge-ts',
+                severity: 'high',
+                isDirect: false,
+                via: [{
+                    source: 1145093,
+                    name: 'deepmerge-ts',
+                    dependency: 'deepmerge-ts',
+                    url: 'https://github.com/advisories/GHSA-ggr8-5vv4-36mx',
+                    severity: 'high',
+                    range: '<8.0.0',
+                }],
+                effects: ['@prisma/config'],
+                range: '<8.0.0',
+                nodes: ['node_modules/deepmerge-ts'],
+            },
+            prisma: {
+                name: 'prisma',
+                severity: 'high',
+                isDirect: true,
+                via: ['@prisma/config'],
+                effects: [],
+                range: '6.13.0-dev.1 - 7.10.0-integration-fix-prisma-publish-token.1',
+                nodes: ['node_modules/prisma'],
+            },
+        },
+        metadata: { vulnerabilities: { high: 3, critical: 0 } },
+    };
+}
+
+describe('production dependency audit guard', () => {
+    it('passes a clean high/critical report without using the exception', () => {
+        const decision = evaluateProductionAudit(
+            { auditReportVersion: 2, vulnerabilities: {}, metadata: {} },
+            undefined,
+        );
+
+        expect(decision).toMatchObject({ ok: true, usedException: false });
+    });
+
+    it('allows only the exact reviewed Prisma deepmerge advisory chain', () => {
+        const decision = evaluateProductionAudit(exactReport(), installed, new Date('2026-08-18T00:00:00Z'));
+
+        expect(decision).toMatchObject({ ok: true, usedException: true });
+    });
+
+    it('fails when any additional high advisory appears', () => {
+        const report = exactReport();
+        Object.assign(report.vulnerabilities, {
+            other: {
+                name: 'other',
+                severity: 'critical',
+                isDirect: true,
+                via: [],
+                effects: [],
+                range: '*',
+                nodes: ['node_modules/other'],
+            },
+        });
+
+        expect(evaluateProductionAudit(report, installed)).toMatchObject({ ok: false });
+    });
+
+    it('fails if the advisory identity or installed package path changes', () => {
+        const wrongAdvisory = exactReport();
+        wrongAdvisory.vulnerabilities['deepmerge-ts'].via[0].source = 999;
+        expect(evaluateProductionAudit(wrongAdvisory, installed)).toMatchObject({ ok: false });
+
+        const wrongPath = exactReport();
+        wrongPath.vulnerabilities['deepmerge-ts'].nodes = ['node_modules/prisma/node_modules/deepmerge-ts'];
+        expect(evaluateProductionAudit(wrongPath, installed)).toMatchObject({ ok: false });
+    });
+
+    it('fails if any reviewed package version or direct dependency edge changes', () => {
+        const changedVersion = structuredClone(installed);
+        changedVersion['deepmerge-ts'].version = '8.0.0';
+        expect(evaluateProductionAudit(exactReport(), changedVersion)).toMatchObject({ ok: false });
+
+        const changedEdge = structuredClone(installed);
+        changedEdge.prisma.dependencies['@prisma/config'] = '^7.9.1';
+        expect(evaluateProductionAudit(exactReport(), changedEdge)).toMatchObject({ ok: false });
+    });
+
+    it('expires closed on the mandatory review date', () => {
+        const decision = evaluateProductionAudit(exactReport(), installed, new Date('2026-09-15T00:00:00Z'));
+
+        expect(decision).toMatchObject({ ok: false });
+        expect(decision.message).toContain('expired');
+    });
+});

--- a/src/lib/production-audit-guard.ts
+++ b/src/lib/production-audit-guard.ts
@@ -1,0 +1,177 @@
+const PRISMA_EXCEPTION = {
+    advisorySource: 1145093,
+    advisoryUrl: 'https://github.com/advisories/GHSA-ggr8-5vv4-36mx',
+    reviewBy: '2026-09-15T00:00:00.000Z',
+    packages: {
+        prisma: '7.9.1',
+        '@prisma/config': '7.9.1',
+        'deepmerge-ts': '7.1.5',
+    },
+} as const;
+
+export type InstalledAuditPackage = {
+    version: string;
+    dependencies: Record<string, string>;
+};
+
+export type InstalledAuditPackages = Record<
+    keyof typeof PRISMA_EXCEPTION.packages,
+    InstalledAuditPackage
+>;
+
+type AuditRecord = {
+    name?: unknown;
+    severity?: unknown;
+    isDirect?: unknown;
+    via?: unknown;
+    effects?: unknown;
+    range?: unknown;
+    nodes?: unknown;
+    fixAvailable?: unknown;
+};
+
+type AuditReport = {
+    auditReportVersion?: unknown;
+    vulnerabilities?: unknown;
+    metadata?: unknown;
+};
+
+export type ProductionAuditDecision = {
+    ok: boolean;
+    usedException: boolean;
+    message: string;
+};
+
+const HIGH_SEVERITIES = new Set(['high', 'critical']);
+const EXPECTED_NAMES = ['@prisma/config', 'deepmerge-ts', 'prisma'] as const;
+
+function fail(message: string): ProductionAuditDecision {
+    return { ok: false, usedException: false, message };
+}
+
+function exactStrings(value: unknown, expected: readonly string[]): boolean {
+    return Array.isArray(value)
+        && value.length === expected.length
+        && value.every((item, index) => item === expected[index]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateInstalledChain(installed: InstalledAuditPackages): string | null {
+    for (const [name, version] of Object.entries(PRISMA_EXCEPTION.packages)) {
+        if (installed[name as keyof InstalledAuditPackages]?.version !== version) {
+            return `${name} must remain exactly ${version} while the exception is active`;
+        }
+    }
+
+    if (installed.prisma.dependencies['@prisma/config'] !== '7.9.1') {
+        return 'prisma must depend directly on @prisma/config 7.9.1';
+    }
+    if (installed['@prisma/config'].dependencies['deepmerge-ts'] !== '7.1.5') {
+        return '@prisma/config must depend directly on deepmerge-ts 7.1.5';
+    }
+
+    return null;
+}
+
+function validateDeepmergeAdvisory(record: AuditRecord): boolean {
+    if (!Array.isArray(record.via) || record.via.length !== 1 || !isRecord(record.via[0])) {
+        return false;
+    }
+
+    const advisory = record.via[0];
+    return record.name === 'deepmerge-ts'
+        && record.severity === 'high'
+        && record.isDirect === false
+        && exactStrings(record.effects, ['@prisma/config'])
+        && record.range === '<8.0.0'
+        && exactStrings(record.nodes, ['node_modules/deepmerge-ts'])
+        && advisory.source === PRISMA_EXCEPTION.advisorySource
+        && advisory.name === 'deepmerge-ts'
+        && advisory.dependency === 'deepmerge-ts'
+        && advisory.url === PRISMA_EXCEPTION.advisoryUrl
+        && advisory.severity === 'high'
+        && advisory.range === '<8.0.0';
+}
+
+function validateDependentRecords(vulnerabilities: Record<string, AuditRecord>): boolean {
+    const config = vulnerabilities['@prisma/config'];
+    const prisma = vulnerabilities.prisma;
+
+    return config.name === '@prisma/config'
+        && config.severity === 'high'
+        && config.isDirect === false
+        && exactStrings(config.via, ['deepmerge-ts'])
+        && exactStrings(config.effects, ['prisma'])
+        && exactStrings(config.nodes, ['node_modules/@prisma/config'])
+        && prisma.name === 'prisma'
+        && prisma.severity === 'high'
+        && prisma.isDirect === true
+        && exactStrings(prisma.via, ['@prisma/config'])
+        && exactStrings(prisma.effects, [])
+        && exactStrings(prisma.nodes, ['node_modules/prisma']);
+}
+
+export function evaluateProductionAudit(
+    reportValue: unknown,
+    installed: InstalledAuditPackages | undefined,
+    now = new Date(),
+): ProductionAuditDecision {
+    if (!isRecord(reportValue)) {
+        return fail('npm audit returned a non-object report');
+    }
+
+    const report = reportValue as AuditReport;
+    if (report.auditReportVersion !== 2 || !isRecord(report.vulnerabilities)) {
+        return fail('npm audit report schema is not the reviewed v2 shape');
+    }
+
+    const vulnerabilities = report.vulnerabilities as Record<string, AuditRecord>;
+    const highNames = Object.entries(vulnerabilities)
+        .filter(([, record]) => HIGH_SEVERITIES.has(String(record.severity)))
+        .map(([name]) => name)
+        .sort();
+
+    if (highNames.length === 0) {
+        return {
+            ok: true,
+            usedException: false,
+            message: 'No high or critical production dependency advisories found.',
+        };
+    }
+
+    if (!exactStrings(highNames, EXPECTED_NAMES)) {
+        return fail(`unexpected high/critical production advisories: ${highNames.join(', ')}`);
+    }
+
+    if (!installed) {
+        return fail('could not inspect the exact installed Prisma dependency chain');
+    }
+
+    const reviewBy = new Date(PRISMA_EXCEPTION.reviewBy);
+    if (!Number.isFinite(now.getTime()) || now >= reviewBy) {
+        return fail(`Prisma deepmerge exception expired for review on ${PRISMA_EXCEPTION.reviewBy}`);
+    }
+
+    const chainError = validateInstalledChain(installed);
+    if (chainError) {
+        return fail(chainError);
+    }
+
+    if (!validateDeepmergeAdvisory(vulnerabilities['deepmerge-ts'])) {
+        return fail('deepmerge-ts advisory no longer matches the exact reviewed advisory and path');
+    }
+    if (!validateDependentRecords(vulnerabilities)) {
+        return fail('Prisma advisory propagation no longer matches the exact reviewed dependency path');
+    }
+
+    return {
+        ok: true,
+        usedException: true,
+        message: `Allowed only ${PRISMA_EXCEPTION.advisoryUrl} through Prisma 7.9.1; review by ${PRISMA_EXCEPTION.reviewBy}.`,
+    };
+}
+
+export { PRISMA_EXCEPTION };


### PR DESCRIPTION
## Summary

- refreshes the existing `tsx ^4.21.0` lock resolution to 4.23.12, so its production chain uses patched `esbuild 0.28.2`
- adds a structured, fail-closed root production-audit guard
- permits only advisory `1145093` / `GHSA-ggr8-5vv4-36mx` for exact `deepmerge-ts@7.1.5 -> @prisma/config@7.9.1 -> prisma@7.9.1` paths
- rejects every additional high/critical advisory and every advisory ID, version, edge, or installed-path change
- expires the exception closed on 2026-09-15 and documents earlier removal when Prisma 8 stable carries the fix
- keeps tapestry and playlist-bot on ordinary zero-exception production audits

## Bounded rationale

Prisma 7.9.1 is the latest stable release and pins `deepmerge-ts@7.1.5`. The patched deepmerge release is 8.0.0 (major), Prisma 8 is currently pre-release, and `npm audit fix --force` proposes a breaking downgrade to Prisma 6.12.0. The vulnerable merge surface processes only repository-controlled `prisma.config.ts` during trusted build/migration operations, never request or user data. No override, downgrade, or general audit bypass is introduced.

## Verification

- `npm ci --ignore-scripts`
- `npm run db:generate`
- `npm run audit:production`
- `npm audit --omit=dev --prefix services/tapestry --audit-level=high`
- `npm audit --omit=dev --prefix services/playlist-bot --audit-level=high`
- focused guard/deploy-contract tests: 18 passed
- full suite: 946 passed, 19 skipped
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- frozen audio paths: 0 changed

This PR is intentionally independent from #399.