### PR TITLE
security(live): serve pinned global navigation locally

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,9 @@ const eslintConfig = defineConfig([
     // regardless of whether Playwright ran first.
     "playwright-report/**",
     "test-results/**",
+    // Byte-exact canonical snapshot. Its digest is the source-of-truth gate;
+    // lint fixes would make the vendored bytes diverge from upstream.
+    "public/assets/hb-global-nav.js",
     // Compiled output of the playlist-bot, checked in so the deploy does not
     // need a build step for it. It is generated CommonJS, so linting it reports
     // `require()` against a rule written for our source — five errors that no

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,19 @@ import path from "path";
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "script-src 'self' 'unsafe-inline'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'",
+          },
+        ],
+      },
+    ];
+  },
   turbopack: {
     root: path.resolve(__dirname),
   },

--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -4,7 +4,9 @@
 
   var MAIN_ORIGIN = 'https://harmonicbeacon.com';
   var LISTENER_ORIGIN = 'https://listen.harmonicbeacon.com';
+  var LISTENER_STAGING_ORIGIN = 'https://earlybirds-staging.harmonicbeacon.com';
   var LIVE_ORIGIN = 'https://live.harmonicbeacon.com';
+  var LIVE_STAGING_ORIGIN = 'https://live-staging.harmonicbeacon.com';
   var ACCOUNT_ORIGIN = 'https://account.harmonicbeacon.com';
   var ACCOUNT_STAGING_ORIGIN = 'https://account-staging.harmonicbeacon.com';
   var ELEMENT_NAME = 'hb-global-nav';
@@ -94,7 +96,9 @@
   }
 
   function accountOrigin() {
-    return location.hostname === 'earlybirds-staging.harmonicbeacon.com'
+    return (location.hostname === 'earlybirds-staging.harmonicbeacon.com' ||
+      location.hostname === 'live-staging.harmonicbeacon.com' ||
+      location.hostname === 'account-staging.harmonicbeacon.com')
       ? ACCOUNT_STAGING_ORIGIN
       : ACCOUNT_ORIGIN;
   }
@@ -103,8 +107,9 @@
     var host = location.hostname.toLowerCase();
     if (host === 'listen.harmonicbeacon.com') return LISTENER_ORIGIN + '/';
     if (host === 'earlybirds-staging.harmonicbeacon.com') {
-      return 'https://earlybirds-staging.harmonicbeacon.com/';
+      return LISTENER_STAGING_ORIGIN + '/';
     }
+    if (host === 'live-staging.harmonicbeacon.com') return LIVE_STAGING_ORIGIN + '/';
     if (host === 'live.harmonicbeacon.com') return LIVE_ORIGIN + '/';
     return MAIN_ORIGIN + '/';
   }

--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -1,0 +1,256 @@
+/* Harmonic Beacon global navigation — canonical cross-product asset. */
+(function () {
+  'use strict';
+
+  var MAIN_ORIGIN = 'https://harmonicbeacon.com';
+  var LISTENER_ORIGIN = 'https://listen.harmonicbeacon.com';
+  var LIVE_ORIGIN = 'https://live.harmonicbeacon.com';
+  var ACCOUNT_ORIGIN = 'https://account.harmonicbeacon.com';
+  var ACCOUNT_STAGING_ORIGIN = 'https://account-staging.harmonicbeacon.com';
+  var ELEMENT_NAME = 'hb-global-nav';
+
+  var links = [
+    { key: 'events', href: LIVE_ORIGIN + '/', en: 'Events', es: 'Eventos' },
+    { key: 'listen', href: LISTENER_ORIGIN + '/', en: 'Listen', es: 'Escuchar' },
+    { key: 'news', href: MAIN_ORIGIN + '/eventos/', en: 'News', es: 'Novedades' },
+    { key: 'why', href: MAIN_ORIGIN + '/#porque', en: 'Why it works', es: 'Por qué funciona' },
+    { key: 'team', href: MAIN_ORIGIN + '/#team', en: 'Team', es: 'Equipo' },
+    { key: 'foundation', href: MAIN_ORIGIN + '/#foundation', en: 'HIT', es: 'HIT' },
+    { key: 'contact', href: MAIN_ORIGIN + '/#contact', en: 'Contact', es: 'Contacto' }
+  ];
+
+  function validLanguage(value) {
+    return value === 'es' || value === 'en' ? value : null;
+  }
+
+  function storedLanguage() {
+    try {
+      return validLanguage(localStorage.getItem('hb-locale')) || validLanguage(localStorage.getItem('hb-lang'));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function currentLanguage() {
+    var params = new URLSearchParams(location.search);
+    var documentLanguage = validLanguage(document.documentElement.getAttribute('data-lang')) ||
+      validLanguage(document.documentElement.getAttribute('data-active-lang'));
+    var mainSite = location.hostname === 'harmonicbeacon.com' || location.hostname === 'www.harmonicbeacon.com';
+    return validLanguage(params.get('lang')) ||
+      (mainSite ? storedLanguage() : documentLanguage) ||
+      (mainSite ? documentLanguage : storedLanguage()) ||
+      ((document.documentElement.lang || navigator.language || 'en').toLowerCase().indexOf('es') === 0 ? 'es' : 'en');
+  }
+
+  function persistLanguage(language) {
+    document.documentElement.lang = language;
+    document.documentElement.setAttribute('data-lang', language);
+    document.documentElement.setAttribute('data-active-lang', language);
+    try {
+      localStorage.setItem('hb-lang', language);
+      localStorage.setItem('hb-locale', language);
+    } catch (error) {
+      // Hardened browsers may disable local storage; the cookie still works.
+    }
+    document.cookie = 'hb_locale=' + language + '; Path=/; Max-Age=31536000; SameSite=Lax';
+  }
+
+  function applyLinkedLanguage() {
+    var url = new URL(location.href);
+    var requested = validLanguage(url.searchParams.get('lang'));
+    if (!requested) return false;
+    var rendered = validLanguage(document.documentElement.getAttribute('data-lang')) ||
+      validLanguage(document.documentElement.getAttribute('data-active-lang'));
+    persistLanguage(requested);
+    url.searchParams.delete('lang');
+    if (location.hostname === 'harmonicbeacon.com' || location.hostname === 'www.harmonicbeacon.com') {
+      history.replaceState(history.state, '', url.pathname + url.search + url.hash);
+      return false;
+    }
+    if (rendered !== requested) {
+      location.replace(url.toString());
+      return true;
+    }
+    history.replaceState(history.state, '', url.pathname + url.search + url.hash);
+    return false;
+  }
+
+  function localizedHref(href, language) {
+    var url = new URL(href);
+    url.searchParams.set('lang', language);
+    return url.toString();
+  }
+
+  function activeKey() {
+    var host = location.hostname.toLowerCase();
+    if (host === 'listen.harmonicbeacon.com' || host === 'earlybirds-staging.harmonicbeacon.com') return 'listen';
+    if (host === 'live.harmonicbeacon.com') return 'events';
+    if (location.pathname.indexOf('/eventos') === 0) return 'news';
+    if (location.hash === '#porque') return 'why';
+    if (location.hash === '#team') return 'team';
+    if (location.hash === '#foundation') return 'foundation';
+    if (location.hash === '#contact') return 'contact';
+    return null;
+  }
+
+  function accountOrigin() {
+    return location.hostname === 'earlybirds-staging.harmonicbeacon.com'
+      ? ACCOUNT_STAGING_ORIGIN
+      : ACCOUNT_ORIGIN;
+  }
+
+  function accountReturnTo() {
+    var host = location.hostname.toLowerCase();
+    if (host === 'listen.harmonicbeacon.com') return LISTENER_ORIGIN + '/';
+    if (host === 'earlybirds-staging.harmonicbeacon.com') {
+      return 'https://earlybirds-staging.harmonicbeacon.com/';
+    }
+    if (host === 'live.harmonicbeacon.com') return LIVE_ORIGIN + '/';
+    return MAIN_ORIGIN + '/';
+  }
+
+  function accountSlotHref(language) {
+    var url = new URL('/nav-slot', accountOrigin());
+    url.searchParams.set('lang', language);
+    return url.toString();
+  }
+
+  function accountPageHref(language) {
+    var url = new URL('/account', accountOrigin());
+    url.searchParams.set('lang', language);
+    url.searchParams.set('return_to', accountReturnTo());
+    return url.toString();
+  }
+
+  function label(item, language) {
+    return language === 'es' ? item.es : item.en;
+  }
+
+  var style = `
+    :host { display:block; height:72px; color:#E9E0D0; font-family:Inter,system-ui,-apple-system,sans-serif; }
+    :host([overlay]) { height:0; }
+    * { box-sizing:border-box; }
+    a { color:inherit; text-decoration:none; }
+    .nav { position:fixed; inset:0 0 auto; z-index:2147483000; min-height:72px; border-bottom:1px solid rgba(244,238,226,.08); background:rgba(22,18,13,.82); backdrop-filter:blur(14px); -webkit-backdrop-filter:blur(14px); }
+    .inner { width:100%; max-width:1180px; min-height:72px; margin:0 auto; padding:12px 24px; display:flex; align-items:center; justify-content:space-between; gap:18px; }
+    .brand { display:flex; align-items:center; gap:10px; flex:0 0 auto; border-radius:8px; }
+    .mark { width:30px; height:30px; display:block; filter:drop-shadow(0 2px 14px rgba(201,162,78,.18)); }
+    .wordmark { color:#F4EEE2; font-size:12px; font-weight:600; letter-spacing:.18em; text-transform:uppercase; white-space:nowrap; }
+    .links { display:flex; align-items:center; justify-content:flex-end; gap:1px; margin:0; padding:0; list-style:none; }
+    .links a { position:relative; display:block; padding:9px 8px; border-radius:999px; color:#ADA089; font-size:10.5px; font-weight:500; letter-spacing:.12em; line-height:1.2; text-transform:uppercase; white-space:nowrap; transition:color .25s ease,background .25s ease; }
+    .links a:hover { color:#F4EEE2; background:rgba(244,238,226,.035); }
+    .links a[aria-current=page] { color:#C9A24E; }
+    .links a[aria-current=page]::after { content:""; position:absolute; left:9px; right:9px; bottom:3px; height:1.5px; border-radius:2px; background:#C9A24E; }
+    .language { min-width:60px; min-height:44px; padding:0 5px; border:0; border-radius:999px; color:#8A7F6B; background:transparent; cursor:pointer; font:500 11px/1 Inter,system-ui,sans-serif; letter-spacing:.1em; }
+    .language strong { color:#C9A24E; font-weight:600; }
+    .sep { opacity:.42; padding:0 2px; }
+    .account-link { display:block; width:44px; height:44px; border-radius:999px; }
+    .account { display:block; width:44px; height:44px; border:0; border-radius:999px; pointer-events:none; background:transparent; color-scheme:dark; }
+    .toggle { display:none; width:44px; height:44px; padding:0 10px; border:0; background:transparent; cursor:pointer; }
+    .toggle span { display:block; height:1.5px; margin:5px 0; background:#ADA089; transition:transform .25s ease,opacity .2s ease; }
+    .toggle[aria-expanded=true] span:nth-child(1) { transform:translateY(6.5px) rotate(45deg); }
+    .toggle[aria-expanded=true] span:nth-child(2) { opacity:0; }
+    .toggle[aria-expanded=true] span:nth-child(3) { transform:translateY(-6.5px) rotate(-45deg); }
+    .mobile { display:none; border-top:1px solid rgba(244,238,226,.08); background:rgba(22,18,13,.98); }
+    .mobile.open { display:block; }
+    .mobile ul { margin:0; padding:8px 24px 18px; list-style:none; }
+    .mobile a { display:block; min-height:44px; padding:13px 0; border-top:1px solid rgba(244,238,226,.08); color:#E9E0D0; font-size:12px; letter-spacing:.14em; text-transform:uppercase; }
+    .mobile a[aria-current=page] { color:#C9A24E; }
+    :focus-visible { outline:2px solid #C9A24E; outline-offset:3px; }
+    @media (max-width:1120px) { .links { display:none; } .toggle { display:block; } .inner { min-height:68px; padding-top:10px; padding-bottom:10px; } :host { height:68px; } :host([overlay]) { height:0; } }
+    @media (max-width:430px) { .inner { padding-left:16px; padding-right:12px; } .wordmark { font-size:10.5px; letter-spacing:.14em; } .mark { width:27px; height:27px; } .language { min-width:54px; } }
+    @media (prefers-reduced-motion:reduce) { * { scroll-behavior:auto !important; transition:none !important; } }
+    @supports not ((backdrop-filter:blur(1px)) or (-webkit-backdrop-filter:blur(1px))) { .nav { background:#16120D; } }
+  `;
+
+  function isCockpitEmbed() {
+    return window.self !== window.top && new URLSearchParams(window.location.search).get('surface') === 'cockpit';
+  }
+
+  class HarmonicBeaconGlobalNav extends HTMLElement {
+    connectedCallback() {
+      if (this.shadowRoot) return;
+      // The conductor cockpit embeds the ordinary room as an operational
+      // surface. Its outer document already owns the product navigation;
+      // repeating it inside the iframe wastes scarce room space and creates
+      // two competing global headers.
+      if (isCockpitEmbed()) {
+        this.hidden = true;
+        return;
+      }
+      this.language = currentLanguage();
+      this.attachShadow({ mode: 'open' });
+      this.render();
+      this.observer = new MutationObserver(() => {
+        var next = currentLanguage();
+        if (next !== this.language) {
+          this.language = next;
+          this.render();
+        }
+      });
+      this.observer.observe(document.documentElement, { attributes:true, attributeFilter:['lang','data-lang','data-active-lang'] });
+    }
+
+    disconnectedCallback() {
+      if (this.observer) this.observer.disconnect();
+    }
+
+    render() {
+      var language = this.language;
+      var active = this.getAttribute('data-surface') || activeKey();
+      var items = links.map(function (item) {
+        var current = active === item.key ? ' aria-current="page"' : '';
+        return '<li><a data-key="' + item.key + '" href="' + localizedHref(item.href, language) + '"' + current + '>' + label(item, language) + '</a></li>';
+      }).join('');
+      var brandHref = localizedHref(MAIN_ORIGIN + '/', language);
+      var menuLabel = language === 'es' ? 'Menú' : 'Menu';
+      var navLabel = language === 'es' ? 'Navegación principal' : 'Primary navigation';
+      var accountLabel = language === 'es' ? 'Cuenta y perfil de Harmonic Beacon' : 'Harmonic Beacon account and profile';
+      this.shadowRoot.innerHTML = '<style>' + style + '</style>' +
+        '<header class="nav"><div class="inner">' +
+          '<a class="brand" href="' + brandHref + '" aria-label="Harmonic Beacon">' +
+            '<img class="mark" src="' + MAIN_ORIGIN + '/favicon.svg" alt="">' +
+            '<span class="wordmark">Harmonic Beacon</span></a>' +
+          '<nav aria-label="' + navLabel + '"><ul class="links">' + items + '</ul></nav>' +
+          '<div style="display:flex;align-items:center;gap:2px">' +
+            '<button class="language" type="button" aria-label="Language / Idioma"><span class="en">EN</span><span class="sep">/</span><span class="es">ES</span></button>' +
+            '<a class="account-link" href="' + accountPageHref(language) + '" aria-label="' + accountLabel + '">' +
+              '<iframe class="account" src="' + accountSlotHref(language) + '" title="' + accountLabel + '" aria-hidden="true" tabindex="-1" referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>' +
+            '</a>' +
+            '<button class="toggle" type="button" aria-label="' + menuLabel + '" aria-expanded="false"><span></span><span></span><span></span></button>' +
+          '</div>' +
+        '</div><nav class="mobile" aria-label="' + navLabel + '"><ul>' + items + '</ul></nav></header>';
+      this.shadowRoot.querySelector('.' + language).outerHTML = '<strong class="' + language + '">' + language.toUpperCase() + '</strong>';
+      var languageButton = this.shadowRoot.querySelector('.language');
+      languageButton.addEventListener('click', () => {
+        var next = this.language === 'es' ? 'en' : 'es';
+        persistLanguage(next);
+        window.dispatchEvent(new CustomEvent('hb-language-change', { detail:{ language:next } }));
+        this.language = next;
+        this.render();
+        if (location.hostname !== 'harmonicbeacon.com' && location.hostname !== 'www.harmonicbeacon.com') location.reload();
+      });
+      var toggle = this.shadowRoot.querySelector('.toggle');
+      var mobile = this.shadowRoot.querySelector('.mobile');
+      toggle.addEventListener('click', function () {
+        var open = toggle.getAttribute('aria-expanded') !== 'true';
+        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        mobile.classList.toggle('open', open);
+      });
+      mobile.querySelectorAll('a').forEach(function (link) {
+        link.addEventListener('click', function () {
+          toggle.setAttribute('aria-expanded', 'false');
+          mobile.classList.remove('open');
+        });
+      });
+    }
+  }
+
+  if (applyLinkedLanguage()) return;
+  if (!customElements.get(ELEMENT_NAME)) customElements.define(ELEMENT_NAME, HarmonicBeaconGlobalNav);
+  if (!document.querySelector(ELEMENT_NAME)) {
+    var element = document.createElement(ELEMENT_NAME);
+    element.setAttribute('overlay', '');
+    document.body.insertBefore(element, document.body.firstChild);
+  }
+})();

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -25,13 +25,19 @@ manifest and visual-review update together.
 
 ## Global navigation
 
-The cross-product header is intentionally not vendored. Listener and Live load
-the canonical web component directly from
-`https://harmonicbeacon.com/assets/hb-global-nav.js`, owned by
-`AlterMundi/harmonicbeacon.com` (introduced in main merge `9fa515f6` and last
-reviewed here at `51fe213b`). The local light-DOM links are an accessible,
-same-destination fallback only; the shared runtime asset owns the visible
-desktop/mobile component so a navigation edit propagates to all three products.
+The cross-product header is vendored byte-for-byte at
+`public/assets/hb-global-nav.js` from `AlterMundi/harmonicbeacon.com` commit
+`70400675b807ba90988517eb28871ad81c6ac369`, with SHA-256
+`8dce4c2b234ef1369730e839c9d93e1bbc4134c86afb1619b63369981cbb67b0`.
+Live serves that reviewed snapshot from its own `/assets/hb-global-nav.js` path;
+it never executes navigation JavaScript fetched from another origin with Live
+cookies in scope. The local light-DOM links remain an accessible,
+same-destination fallback while the component initializes.
+
+The snapshot is intentionally updated, reviewed and deployed rather than
+silently tracking upstream. `manifest.json` and the brand contract test pin the
+canonical commit, source path, local path and identical digest. A navigation
+sync must update the asset, provenance and manifest together.
 
 ## Font source and license
 
@@ -50,5 +56,7 @@ Both families are covered by the SIL Open Font License 1.1; the relevant
   is pinned from the Google Fonts repository commit above, with trailing
   whitespace normalized for the repository gate.
 
-No font, analytics or decorative brand asset is fetched at runtime. The single
-global-navigation component above is the deliberate exception.
+No font, brand source, analytics or navigation script is fetched from another
+origin at runtime. The navigation may still display the isolated cross-origin
+Account slot and canonical mark; its sandbox prevents the parent navigation
+script from reading Account state.

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -27,8 +27,8 @@ manifest and visual-review update together.
 
 The cross-product header is vendored byte-for-byte at
 `public/assets/hb-global-nav.js` from `AlterMundi/harmonicbeacon.com` commit
-`70400675b807ba90988517eb28871ad81c6ac369`, with SHA-256
-`8dce4c2b234ef1369730e839c9d93e1bbc4134c86afb1619b63369981cbb67b0`.
+`ceeea30a94417331450c420fbfb8fc2e6a0a9b2d`, with SHA-256
+`16f17fdd9dfde76e5d574dd0e408a5b533d9138f222910821a4425169e147151`.
 Live serves that reviewed snapshot from its own `/assets/hb-global-nav.js` path;
 it never executes navigation JavaScript fetched from another origin with Live
 cookies in scope. The local light-DOM links remain an accessible,

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -11,15 +11,15 @@
   },
   "globalNavigation": {
     "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
-    "commit": "70400675b807ba90988517eb28871ad81c6ac369",
+    "commit": "ceeea30a94417331450c420fbfb8fc2e6a0a9b2d",
     "sourceFile": "assets/hb-global-nav.js",
     "snapshotFile": "public/assets/hb-global-nav.js",
-    "sha256": "8dce4c2b234ef1369730e839c9d93e1bbc4134c86afb1619b63369981cbb67b0"
+    "sha256": "16f17fdd9dfde76e5d574dd0e408a5b533d9138f222910821a4425169e147151"
   },
   "snapshots": {
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881",
-    "public/assets/hb-global-nav.js": "8dce4c2b234ef1369730e839c9d93e1bbc4134c86afb1619b63369981cbb67b0"
+    "public/assets/hb-global-nav.js": "16f17fdd9dfde76e5d574dd0e408a5b533d9138f222910821a4425169e147151"
   },
   "extractedPayloads": {
     "canonicalRootBlock": "6c67b427993ef589c4316ca1b9e894344679009fca997875fb31dbf7ce7f3167",

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -9,9 +9,17 @@
       "docs/brand/BRANDING.md": "68abcacb4263277071309f808455c08c9a8afdb5f0caeae6bf1599b9d2f66c31"
     }
   },
+  "globalNavigation": {
+    "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
+    "commit": "70400675b807ba90988517eb28871ad81c6ac369",
+    "sourceFile": "assets/hb-global-nav.js",
+    "snapshotFile": "public/assets/hb-global-nav.js",
+    "sha256": "8dce4c2b234ef1369730e839c9d93e1bbc4134c86afb1619b63369981cbb67b0"
+  },
   "snapshots": {
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
-    "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
+    "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881",
+    "public/assets/hb-global-nav.js": "8dce4c2b234ef1369730e839c9d93e1bbc4134c86afb1619b63369981cbb67b0"
   },
   "extractedPayloads": {
     "canonicalRootBlock": "6c67b427993ef589c4316ca1b9e894344679009fca997875fb31dbf7ce7f3167",

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -3,7 +3,7 @@ import Script from 'next/script';
 
 import type { UiLocale } from '@/lib/i18n';
 
-export const GLOBAL_NAVIGATION_ASSET = 'https://harmonicbeacon.com/assets/hb-global-nav.js';
+export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
 export const GLOBAL_NAVIGATION_EMBED_GUARD = `
 (() => {
     if (window.self === window.top) return;

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -56,7 +56,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
         const source = asset.toString('utf8');
         const digest = createHash('sha256').update(asset).digest('hex');
 
-        expect(manifest.globalNavigation.commit).toBe('70400675b807ba90988517eb28871ad81c6ac369');
+        expect(manifest.globalNavigation.commit).toBe('ceeea30a94417331450c420fbfb8fc2e6a0a9b2d');
         expect(manifest.globalNavigation.sourceFile).toBe('assets/hb-global-nav.js');
         expect(digest).toBe(manifest.globalNavigation.sha256);
         const snapshotKey = manifest.globalNavigation.snapshotFile as keyof typeof manifest.snapshots;

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
 
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
+import manifest from '@/brand/canonical/manifest.json';
 import {
     GlobalNavigation,
     GLOBAL_NAVIGATION_ASSET,
@@ -23,10 +27,10 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(globalNavigationSurface(new Headers({ host }))).toBe(expected);
     });
 
-    it('keeps an accessible same-destination fallback while the shared asset loads', () => {
+    it('keeps an accessible same-destination fallback while the local snapshot loads', () => {
         render(<GlobalNavigation active="listen" locale="en" />);
 
-        expect(GLOBAL_NAVIGATION_ASSET).toBe('https://harmonicbeacon.com/assets/hb-global-nav.js');
+        expect(GLOBAL_NAVIGATION_ASSET).toBe('/assets/hb-global-nav.js');
         expect(screen.getByRole('link', { name: 'Events' })).toHaveAttribute('href', 'https://live.harmonicbeacon.com/?lang=en');
         expect(screen.getByRole('link', { name: 'Listen' })).toHaveAttribute('aria-current', 'page');
         expect(screen.getByRole('link', { name: 'News' })).toHaveAttribute('href', 'https://harmonicbeacon.com/eventos/?lang=en');
@@ -44,5 +48,29 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(GLOBAL_NAVIGATION_EMBED_GUARD).toContain('window.self === window.top');
         expect(GLOBAL_NAVIGATION_EMBED_GUARD).toContain("get('surface') !== 'cockpit'");
         expect(GLOBAL_NAVIGATION_EMBED_GUARD).toContain("hbEmbeddedSurface = 'cockpit'");
+    });
+
+    it('loads only the byte-pinned local snapshot without token or PII access', () => {
+        const assetPath = join(process.cwd(), manifest.globalNavigation.snapshotFile);
+        const asset = readFileSync(assetPath);
+        const source = asset.toString('utf8');
+        const digest = createHash('sha256').update(asset).digest('hex');
+
+        expect(manifest.globalNavigation.commit).toBe('70400675b807ba90988517eb28871ad81c6ac369');
+        expect(manifest.globalNavigation.sourceFile).toBe('assets/hb-global-nav.js');
+        expect(digest).toBe(manifest.globalNavigation.sha256);
+        const snapshotKey = manifest.globalNavigation.snapshotFile as keyof typeof manifest.snapshots;
+        expect(digest).toBe(manifest.snapshots[snapshotKey]);
+        expect(source).not.toMatch(/\bfetch\s*\(|XMLHttpRequest|WebSocket|postMessage/);
+        expect(source).not.toMatch(/access[_-]?token|id[_-]?token|authorization|\bemail\b/i);
+        expect(source.match(/document\.cookie/g)).toHaveLength(1);
+        expect(source).toContain("document.cookie = 'hb_locale='");
+    });
+
+    it('restricts executable scripts to the Live origin', () => {
+        const nextConfig = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
+
+        expect(nextConfig).toContain("script-src 'self' 'unsafe-inline'");
+        expect(nextConfig).not.toMatch(/script-src[^;]*https?:/);
     });
 });


### PR DESCRIPTION
## Summary

- vendors `harmonicbeacon.com@ceeea30a` `assets/hb-global-nav.js` byte-for-byte at Live `/assets/hb-global-nav.js`
- removes the cross-origin executable script URL from `GlobalNavigation`
- pins canonical commit/source/local path/SHA-256 in the brand manifest and provenance
- keeps Listener, Live and Account staging destinations strictly inside staging
- adds a sync guard for digest equivalence plus negative checks for network, token and PII access
- restricts executable scripts to Live same-origin through CSP while preserving inline Next bootstrap and blob workers

## Security boundary

The navigation asset no longer executes newly published `harmonicbeacon.com` JavaScript with Live cookies and API reach. Its isolated Account iframe remains cross-origin/sandboxed and the snapshot itself contains no fetch/XHR/WebSocket/postMessage or token/email handling. Updates are explicit reviewed snapshots, not silent runtime updates.

## Verification

- canonical byte comparison: exact
- source commit: `ceeea30a94417331450c420fbfb8fc2e6a0a9b2d`
- SHA-256 served and on disk: `16f17fdd9dfde76e5d574dd0e408a5b533d9138f222910821a4425169e147151`
- focused navigation tests: 12 passed
- full suite: 917 passed, 19 skipped
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- local HTTP smoke: 200, exact CSP header, served asset digest exact
- frozen audio/session/playlist paths: 0 changed

No merge or deploy in this PR.
