### PR TITLE
ops: provision audited Live staging staff Account binding

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,6 +118,12 @@ jobs:
           DATABASE_URL: ${{ env.E2E_DATABASE_URL }}
           CONTRIBUTIONS_INTEGRATION_TEST: '1'
 
+      - name: Verify staging staff Account binding contract in PostgreSQL
+        run: npx vitest run --no-file-parallelism scripts/live-staging/__tests__/bind-staff-account.integration.test.ts
+        env:
+          DATABASE_URL: ${{ env.E2E_DATABASE_URL }}
+          STAFF_BINDING_INTEGRATION_TEST: '1'
+
       - name: Verify every migration against a clean database
         # The fixture proves migrations apply on an existing database; this
         # proves the whole chain also builds from zero. The scratch database

--- a/deploy/LIVE_STAGING.md
+++ b/deploy/LIVE_STAGING.md
@@ -157,6 +157,70 @@ Recreate only `hb-live-staging-app` with the feature still off, then repeat the
 ordinary smoke. The expected readiness remains `account: disabled` and all
 three Account RP routes remain `404`. This is the safe rollback checkpoint.
 
+## Bind an existing staging staff user to Account
+
+This optional one-shot utility provisions only the explicit one-to-one bridge
+between an existing local `staffUserId` and an opaque Account staging subject.
+It never runs the seed, searches by email, creates staff, changes roles, issues
+sessions, or reads or writes events and tickets. It is disabled unless each
+invocation supplies both staging guard variables.
+
+Obtain the exact opaque `sub` from the Account staging operator surface and the
+existing staff UUID from the isolated Live staging database. Do not put either
+value on a command line. Copy
+`deploy/live-staging-staff-binding.env.example` to the fixed host path below,
+edit it with a root-owned editor, and verify ownership before mounting it:
+
+```bash
+sudo install -d -o root -g root -m 0700 /etc/harmonic-beacon/live-staging-secrets
+sudo install -o root -g root -m 0600 \
+  deploy/live-staging-staff-binding.env.example \
+  /etc/harmonic-beacon/live-staging-secrets/staff-account-binding.env
+sudoedit /etc/harmonic-beacon/live-staging-secrets/staff-account-binding.env
+test "$(sudo stat -c '%U:%G %a' /etc/harmonic-beacon/live-staging-secrets/staff-account-binding.env)" = \
+  'root:root 600'
+```
+
+Run the read-only preflight first. The one-shot uses the already-migrated image
+and the internal database network only; it receives neither the Account client
+secret nor application egress. The fixed mount destination prevents an
+operator-controlled path from entering the utility.
+
+```bash
+docker compose --file deploy/live-staging.compose.yml \
+  --env-file /etc/harmonic-beacon/live-staging.env \
+  run --rm --no-deps --user 0:0 \
+  -e LIVE_STAGING_STAFF_BINDING_ENABLED=1 \
+  -e LIVE_STAGING_ENVIRONMENT=live-staging \
+  -v /etc/harmonic-beacon/live-staging-secrets/staff-account-binding.env:/run/harmonic-beacon/staff-account-binding.env:ro \
+  migrate npx tsx /app/scripts/live-staging/bind-staff-account.ts --dry-run
+```
+
+Proceed only when the single sanitized JSON line reports `would-create` (or
+`already-bound` for an exact replay). Apply with the same immutable image and
+mount, changing only the final mode:
+
+```bash
+docker compose --file deploy/live-staging.compose.yml \
+  --env-file /etc/harmonic-beacon/live-staging.env \
+  run --rm --no-deps --user 0:0 \
+  -e LIVE_STAGING_STAFF_BINDING_ENABLED=1 \
+  -e LIVE_STAGING_ENVIRONMENT=live-staging \
+  -v /etc/harmonic-beacon/live-staging-secrets/staff-account-binding.env:/run/harmonic-beacon/staff-account-binding.env:ro \
+  migrate npx tsx /app/scripts/live-staging/bind-staff-account.ts --apply
+```
+
+The apply is a serializable transaction: binding and audit record commit
+together, exact retries are no-ops, and conflicting or disabled mappings fail
+closed. Output contains only the staff UUID and a short one-way subject digest.
+Remove the input after recording the audit row; rollback is an explicit audited
+disable/revoke operation, never a database delete or reuse of this provisioning
+utility.
+
+```bash
+sudo shred -u /etc/harmonic-beacon/live-staging-secrets/staff-account-binding.env
+```
+
 ## Public edge and Account activation
 
 Do not execute this section until the prepared checkpoint above is green.

--- a/deploy/live-staging-staff-binding.env.example
+++ b/deploy/live-staging-staff-binding.env.example
@@ -1,0 +1,6 @@
+# Copy to /etc/harmonic-beacon/live-staging-secrets/staff-account-binding.env,
+# replace all values locally, then keep the file root:root mode 0600. Never
+# commit or paste the real opaque subject into chat, shell history or an issue.
+ACCOUNT_ISSUER=https://account-staging.harmonicbeacon.com
+ACCOUNT_SUBJECT=opaque-account-subject-from-the-account-staging-operator
+STAFF_USER_ID=00000000-0000-4000-8000-000000000000

--- a/scripts/live-staging/__tests__/bind-staff-account.integration.test.ts
+++ b/scripts/live-staging/__tests__/bind-staff-account.integration.test.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+    AUDIT_ACTION,
+    BindingConflictError,
+    STAGING_ACCOUNT_ISSUER,
+    provisionStaffAccountBinding,
+} from '../bind-staff-account';
+
+const enabled = process.env.STAFF_BINDING_INTEGRATION_TEST === '1';
+const databaseUrl = process.env.DATABASE_URL ?? '';
+const suite = enabled ? describe : describe.skip;
+let pool: Pool;
+let prisma: PrismaClient;
+const userIds: string[] = [];
+
+function input(staffUserId: string, accountSubject: string) {
+    return { accountIssuer: STAGING_ACCOUNT_ISSUER, accountSubject, staffUserId };
+}
+
+async function createStaff(disabled = false): Promise<string> {
+    const id = randomUUID();
+    userIds.push(id);
+    await prisma.user.create({
+        data: {
+            id,
+            email: `staff-binding-${id}@invalid.example`,
+            name: 'Synthetic staff binding test',
+            role: 'ADMIN',
+            passwordDigest: 'synthetic-not-a-login-secret',
+            disabledAt: disabled ? new Date() : null,
+        },
+    });
+    return id;
+}
+
+suite('Live staging staff Account binding PostgreSQL contract', () => {
+    beforeAll(async () => {
+        const parsed = new URL(databaseUrl);
+        if (!parsed.pathname.endsWith('_test') && parsed.pathname !== '/beacon_test') {
+            throw new Error('staff binding integration test refuses a non-test database');
+        }
+        pool = new Pool({ connectionString: databaseUrl, max: 8 });
+        prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    });
+
+    afterAll(async () => {
+        if (!prisma) return;
+        await prisma.auditLog.deleteMany({
+            where: { action: AUDIT_ACTION, reason: 'live_staging_operator_provision' },
+        });
+        await prisma.staffAccountBinding.deleteMany({ where: { staffUserId: { in: userIds } } });
+        await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+        await prisma.$disconnect();
+        await pool.end();
+    });
+
+    it('dry-runs read-only, creates atomically and replays without duplicate audit', async () => {
+        const staffUserId = await createStaff();
+        const bindingInput = input(staffUserId, `opaque-${randomUUID()}`);
+        const before = {
+            sessions: await prisma.webSession.count(),
+            tickets: await prisma.ticketEntitlement.count(),
+            events: await prisma.scheduledSession.count(),
+        };
+
+        await expect(provisionStaffAccountBinding(prisma, bindingInput, false)).resolves.toMatchObject({
+            outcome: 'would-create', bindingId: null,
+        });
+        expect(await prisma.staffAccountBinding.count({ where: { staffUserId } })).toBe(0);
+
+        const created = await provisionStaffAccountBinding(prisma, bindingInput, true);
+        expect(created.outcome).toBe('created');
+        await expect(provisionStaffAccountBinding(prisma, bindingInput, true)).resolves.toMatchObject({
+            outcome: 'already-bound', bindingId: created.bindingId,
+        });
+        expect(await prisma.auditLog.count({
+            where: { action: AUDIT_ACTION, targetId: created.bindingId ?? undefined },
+        })).toBe(1);
+        expect(await prisma.auditLog.findFirstOrThrow({
+            where: { action: AUDIT_ACTION, targetId: created.bindingId ?? undefined },
+            select: { actorUserId: true, reason: true, metadata: true },
+        })).toEqual({
+            actorUserId: null,
+            reason: 'live_staging_operator_provision',
+            metadata: { accountIssuer: STAGING_ACCOUNT_ISSUER, source: 'root_one_shot_utility' },
+        });
+        expect({
+            sessions: await prisma.webSession.count(),
+            tickets: await prisma.ticketEntitlement.count(),
+            events: await prisma.scheduledSession.count(),
+        }).toEqual(before);
+    });
+
+    it('keeps the mapping one-to-one under concurrency', async () => {
+        const firstStaff = await createStaff();
+        const secondStaff = await createStaff();
+        const subject = `opaque-race-${randomUUID()}`;
+        const outcomes = await Promise.allSettled([
+            provisionStaffAccountBinding(prisma, input(firstStaff, subject), true),
+            provisionStaffAccountBinding(prisma, input(secondStaff, subject), true),
+        ]);
+        expect(outcomes.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+        expect(outcomes.filter((result) => result.status === 'rejected')).toHaveLength(1);
+        expect(await prisma.staffAccountBinding.count({
+            where: { accountIssuer: STAGING_ACCOUNT_ISSUER, accountSubject: subject },
+        })).toBe(1);
+    });
+
+    it('fails closed for conflicting, disabled or missing local authority', async () => {
+        const staff = await createStaff();
+        const otherStaff = await createStaff();
+        const subject = `opaque-conflict-${randomUUID()}`;
+        await provisionStaffAccountBinding(prisma, input(staff, subject), true);
+        await expect(provisionStaffAccountBinding(prisma, input(otherStaff, subject), true))
+            .rejects.toBeInstanceOf(BindingConflictError);
+        await expect(provisionStaffAccountBinding(prisma, input(staff, `opaque-other-${randomUUID()}`), true))
+            .rejects.toBeInstanceOf(BindingConflictError);
+
+        const disabledStaff = await createStaff(true);
+        await expect(provisionStaffAccountBinding(prisma, input(disabledStaff, `opaque-disabled-${randomUUID()}`), true))
+            .rejects.toBeInstanceOf(BindingConflictError);
+        await expect(provisionStaffAccountBinding(prisma, input(randomUUID(), `opaque-missing-${randomUUID()}`), true))
+            .rejects.toBeInstanceOf(BindingConflictError);
+
+        await prisma.staffAccountBinding.update({
+            where: { staffUserId: staff },
+            data: { disabledAt: new Date() },
+        });
+        await expect(provisionStaffAccountBinding(prisma, input(staff, subject), true))
+            .rejects.toBeInstanceOf(BindingConflictError);
+    });
+});

--- a/scripts/live-staging/__tests__/bind-staff-account.test.ts
+++ b/scripts/live-staging/__tests__/bind-staff-account.test.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import {
+    INPUT_PATH,
+    STAGING_ACCOUNT_ISSUER,
+    parseBindingInput,
+    readRootOnlyBindingInput,
+    validateStagingEnvironment,
+} from '../bind-staff-account';
+
+const validInput = [
+    `ACCOUNT_ISSUER=${STAGING_ACCOUNT_ISSUER}`,
+    'ACCOUNT_SUBJECT=opaque_subject:staging-123',
+    'STAFF_USER_ID=123e4567-e89b-42d3-a456-426614174000',
+].join('\n');
+
+describe('Live staging staff Account binding guardrails', () => {
+    it('parses only the exact non-email authority contract', () => {
+        expect(parseBindingInput(validInput)).toEqual({
+            accountIssuer: STAGING_ACCOUNT_ISSUER,
+            accountSubject: 'opaque_subject:staging-123',
+            staffUserId: '123e4567-e89b-42d3-a456-426614174000',
+        });
+        expect(() => parseBindingInput(`${validInput}\nEMAIL=operator@example.com`)).toThrow(/exactly/);
+        expect(() => parseBindingInput(validInput.replace('opaque_subject:staging-123', 'contains whitespace'))).toThrow(/opaque/);
+        expect(() => parseBindingInput(validInput.replace(STAGING_ACCOUNT_ISSUER, 'https://account.harmonicbeacon.com'))).toThrow(/staging issuer/);
+    });
+
+    it('is default-off and accepts only the isolated staging database', () => {
+        expect(() => validateStagingEnvironment({
+            LIVE_STAGING_ENVIRONMENT: 'live-staging',
+            DATABASE_URL: 'postgresql://unused@postgres/beacon_live_staging',
+        })).toThrow(/disabled/);
+        expect(() => validateStagingEnvironment({
+            LIVE_STAGING_STAFF_BINDING_ENABLED: '1',
+            LIVE_STAGING_ENVIRONMENT: 'live-staging',
+            DATABASE_URL: 'postgresql://unused@postgres/beacon',
+        })).toThrow(/other than/);
+        expect(validateStagingEnvironment({
+            LIVE_STAGING_STAFF_BINDING_ENABLED: '1',
+            LIVE_STAGING_ENVIRONMENT: 'live-staging',
+            DATABASE_URL: 'postgresql://unused@postgres/beacon_live_staging',
+        }).pathname).toBe('/beacon_live_staging');
+    });
+
+    it('does not permit an operator-selected input path', async () => {
+        await expect(readRootOnlyBindingInput('/tmp/operator-selected.env')).rejects.toThrow(/fixed/);
+        expect(INPUT_PATH).toBe('/run/harmonic-beacon/staff-account-binding.env');
+    });
+
+    it('has no code path to sessions, tickets, events or email matching', async () => {
+        const source = await readFile(new URL('../bind-staff-account.ts', import.meta.url), 'utf8');
+        for (const forbidden of ['webSession.', 'ticketEntitlement.', 'scheduledSession.', 'email:']) {
+            expect(source).not.toContain(forbidden);
+        }
+    });
+});

--- a/scripts/live-staging/bind-staff-account.ts
+++ b/scripts/live-staging/bind-staff-account.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { lstat, readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
+
+export const STAGING_ACCOUNT_ISSUER = 'https://account-staging.harmonicbeacon.com';
+export const STAGING_DATABASE_NAME = 'beacon_live_staging';
+export const INPUT_PATH = '/run/harmonic-beacon/staff-account-binding.env';
+export const AUDIT_ACTION = 'account.staff.binding.provisioned';
+
+export type BindingInput = {
+    accountIssuer: string;
+    accountSubject: string;
+    staffUserId: string;
+};
+
+export type BindingResult = {
+    outcome: 'would-create' | 'created' | 'already-bound';
+    bindingId: string | null;
+};
+
+export class BindingConflictError extends Error {}
+
+function fail(message: string): never {
+    throw new Error(message);
+}
+
+export function parseBindingInput(contents: string): BindingInput {
+    const values = new Map<string, string>();
+    for (const rawLine of contents.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+        const separator = line.indexOf('=');
+        if (separator < 1) fail('invalid binding input');
+        const key = line.slice(0, separator).trim();
+        const value = line.slice(separator + 1);
+        if (!/^[A-Z][A-Z0-9_]*$/.test(key) || values.has(key)) fail('invalid or duplicate binding input key');
+        values.set(key, value);
+    }
+
+    const allowed = new Set(['ACCOUNT_ISSUER', 'ACCOUNT_SUBJECT', 'STAFF_USER_ID']);
+    if ([...values.keys()].some((key) => !allowed.has(key)) || values.size !== allowed.size) {
+        fail('binding input must contain exactly ACCOUNT_ISSUER, ACCOUNT_SUBJECT and STAFF_USER_ID');
+    }
+
+    const accountIssuer = values.get('ACCOUNT_ISSUER') ?? '';
+    const accountSubject = values.get('ACCOUNT_SUBJECT') ?? '';
+    const staffUserId = values.get('STAFF_USER_ID') ?? '';
+    if (accountIssuer !== STAGING_ACCOUNT_ISSUER) fail('Account issuer is not the exact staging issuer');
+    if (accountSubject.length < 1 || accountSubject.length > 255 || /[\u0000-\u0020\u007f]/.test(accountSubject)) {
+        fail('Account subject must be an opaque, non-empty value without whitespace or control characters');
+    }
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(staffUserId)) {
+        fail('staff user ID must be a UUID');
+    }
+    return { accountIssuer, accountSubject, staffUserId: staffUserId.toLowerCase() };
+}
+
+export function validateStagingEnvironment(environment: Record<string, string | undefined>): URL {
+    if (environment.LIVE_STAGING_STAFF_BINDING_ENABLED !== '1') {
+        fail('staff binding utility is disabled; set LIVE_STAGING_STAFF_BINDING_ENABLED=1 explicitly');
+    }
+    if (environment.LIVE_STAGING_ENVIRONMENT !== 'live-staging') fail('exact live-staging environment marker required');
+    const databaseUrl = new URL(environment.DATABASE_URL ?? fail('DATABASE_URL is required'));
+    if (databaseUrl.protocol !== 'postgresql:' && databaseUrl.protocol !== 'postgres:') fail('PostgreSQL DATABASE_URL required');
+    if (databaseUrl.pathname !== `/${STAGING_DATABASE_NAME}`) fail('refusing a database other than beacon_live_staging');
+    return databaseUrl;
+}
+
+export async function readRootOnlyBindingInput(path = INPUT_PATH): Promise<BindingInput> {
+    if (path !== INPUT_PATH) fail('binding input path is fixed');
+    const metadata = await lstat(path);
+    if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.uid !== 0 || metadata.gid !== 0 ||
+        (metadata.mode & 0o777) !== 0o600) {
+        fail(`${INPUT_PATH} must be a root:root mode-0600 regular file`);
+    }
+    return parseBindingInput(await readFile(path, 'utf8'));
+}
+
+async function inspectBinding(tx: Prisma.TransactionClient, input: BindingInput): Promise<BindingResult> {
+    const staff = await tx.user.findUnique({
+        where: { id: input.staffUserId },
+        select: { id: true, disabledAt: true },
+    });
+    if (!staff) throw new BindingConflictError('staff user does not exist');
+    if (staff.disabledAt) throw new BindingConflictError('staff user is disabled');
+
+    const [byStaff, byAccount] = await Promise.all([
+        tx.staffAccountBinding.findUnique({ where: { staffUserId: input.staffUserId } }),
+        tx.staffAccountBinding.findUnique({
+            where: {
+                accountIssuer_accountSubject: {
+                    accountIssuer: input.accountIssuer,
+                    accountSubject: input.accountSubject,
+                },
+            },
+        }),
+    ]);
+
+    if (byStaff?.disabledAt || byAccount?.disabledAt) {
+        throw new BindingConflictError('a matching staff binding is disabled and cannot be re-enabled by this utility');
+    }
+    if (byStaff && (byStaff.accountIssuer !== input.accountIssuer || byStaff.accountSubject !== input.accountSubject)) {
+        throw new BindingConflictError('staff user is already bound to another Account identity');
+    }
+    if (byAccount && byAccount.staffUserId !== input.staffUserId) {
+        throw new BindingConflictError('Account identity is already bound to another staff user');
+    }
+    if (byStaff && byAccount && byStaff.id === byAccount.id) {
+        return { outcome: 'already-bound', bindingId: byStaff.id };
+    }
+    if (byStaff || byAccount) throw new BindingConflictError('inconsistent one-to-one staff binding state');
+    return { outcome: 'would-create', bindingId: null };
+}
+
+export async function provisionStaffAccountBinding(
+    prisma: PrismaClient,
+    input: BindingInput,
+    apply: boolean,
+): Promise<BindingResult> {
+    if (!apply) {
+        return prisma.$transaction((tx) => inspectBinding(tx, input), {
+            isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        });
+    }
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+            return await prisma.$transaction(async (tx) => {
+                const inspected = await inspectBinding(tx, input);
+                if (inspected.outcome === 'already-bound') return inspected;
+                const binding = await tx.staffAccountBinding.create({
+                    data: {
+                        accountIssuer: input.accountIssuer,
+                        accountSubject: input.accountSubject,
+                        staffUserId: input.staffUserId,
+                    },
+                    select: { id: true },
+                });
+                await tx.auditLog.create({
+                    data: {
+                        actorUserId: null,
+                        action: AUDIT_ACTION,
+                        targetType: 'STAFF_ACCOUNT_BINDING',
+                        targetId: binding.id,
+                        reason: 'live_staging_operator_provision',
+                        metadata: {
+                            accountIssuer: input.accountIssuer,
+                            source: 'root_one_shot_utility',
+                        },
+                    },
+                });
+                return { outcome: 'created', bindingId: binding.id };
+            }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+        } catch (error) {
+            const retryable = error instanceof Prisma.PrismaClientKnownRequestError &&
+                (error.code === 'P2002' || error.code === 'P2034');
+            if (!retryable || attempt === 2) throw error;
+        }
+    }
+    throw new Error('unreachable binding retry state');
+}
+
+async function assertDatabaseIdentity(prisma: PrismaClient): Promise<void> {
+    const rows = await prisma.$queryRaw<Array<{ database_name: string }>>`
+        SELECT current_database() AS database_name
+    `;
+    if (rows.length !== 1 || rows[0]?.database_name !== STAGING_DATABASE_NAME) {
+        fail('connected database is not the isolated Live staging database');
+    }
+}
+
+export async function main(
+    argv = process.argv.slice(2),
+    environment: Record<string, string | undefined> = process.env,
+): Promise<void> {
+    if (process.getuid?.() !== 0) fail('run as root');
+    if (argv.length !== 1 || !['--dry-run', '--apply'].includes(argv[0] ?? '')) {
+        fail('usage: bind-staff-account.ts (--dry-run|--apply)');
+    }
+    const databaseUrl = validateStagingEnvironment(environment);
+    const input = await readRootOnlyBindingInput();
+    const pool = new Pool({ connectionString: databaseUrl.toString(), max: 2 });
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    try {
+        await assertDatabaseIdentity(prisma);
+        const result = await provisionStaffAccountBinding(prisma, input, argv[0] === '--apply');
+        const subjectDigest = createHash('sha256').update(input.accountSubject).digest('hex').slice(0, 12);
+        process.stdout.write(JSON.stringify({
+            mode: argv[0] === '--apply' ? 'apply' : 'dry-run',
+            outcome: result.outcome,
+            staffUserId: input.staffUserId,
+            subjectDigest,
+        }) + '\n');
+    } finally {
+        await prisma.$disconnect();
+        await pool.end();
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        process.stderr.write(`Live staging staff binding failed: ${error instanceof Error ? error.message : 'unknown error'}\n`);
+        process.exitCode = 1;
+    });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
     test: {
         environment: 'node',
         setupFiles: ['src/__tests__/setup.ts'],
-        include: ['src/**/*.test.{ts,tsx}', 'middleware.test.ts'],
+        include: [
+            'src/**/*.test.{ts,tsx}',
+            'scripts/live-staging/**/*.test.ts',
+            'middleware.test.ts',
+        ],
         coverage: {
             provider: 'v8',
             include: ['src/lib/**', 'src/app/api/**', 'src/components/**', 'src/context/**'],


### PR DESCRIPTION
Closes the staging staff provisioning slice of #396.

## Scope
- root-only, fixed-path one-shot for exact Account staging issuer + opaque `sub` + existing `staffUserId`
- default-off and exact isolated staging DB guard
- serializable 1:1 transaction with idempotent replay and same-transaction audit
- dry-run-first runbook; no seeds, email authority, sessions, events, tickets, LiveKit, audio, or payments
- PostgreSQL integration coverage including concurrency and fail-closed conflicts

## Gates
- unit/full Vitest hook: 977 passed, 23 skipped
- PostgreSQL 16 integration: 3 passed after all 12 migrations on throwaway `beacon_test`
- `npx tsc --noEmit`: pass
- focused ESLint: pass
- `npm run build`: pass
- frozen Live/event/audio paths byte-exact against `main`

No deploy or merge performed.