### PR TITLE
fix(account): make credential signup usable

### DIFF
--- a/docs/architecture/BEACON_ACCOUNT_AUTHORITY.md
+++ b/docs/architecture/BEACON_ACCOUNT_AUTHORITY.md
@@ -51,9 +51,10 @@ tokens. `return_to` is an exact product-root allowlist.
 Credential signup is two-step. Verification, reset and email-change tokens are
 hashed, one-use, at most 15 minutes, and consumed in the same Serializable
 transaction as their mutation. Pages capture the query token client-side,
-immediately scrub history, and send no referrer. Passwords are 12–128 chars and
-use the single Better Auth scrypt implementation. Public outcomes and durable
-HMAC rate buckets resist enumeration and distributed abuse.
+immediately scrub history, and send no referrer. Passwords are 8–128 characters
+with no composition or complexity rules and use the single Better Auth scrypt
+implementation. Verification-before-access, reauthentication, durable HMAC rate
+buckets and session revocation remain independent security boundaries.
 
 Mail uses the byte-pinned `contracts/listener-account-mail/v1` contract and a
 durable AES-GCM outbox. Retry reuses the same sealed token and exact 64-lowercase

--- a/docs/operations/BEACON_ACCOUNT_STAGING_ACCEPTANCE.md
+++ b/docs/operations/BEACON_ACCOUNT_STAGING_ACCEPTANCE.md
@@ -1,0 +1,43 @@
+# Beacon Account staging acceptance
+
+Use only a disposable experimental address and a password that is not reused
+elsewhere. Never paste a password, action link or token into GitHub, chat, logs
+or screenshots.
+
+## Password contract
+
+- Minimum: 8 characters.
+- Maximum: 128 characters.
+- No composition or complexity rules: digits, letters, spaces and symbols are
+  not individually required.
+- Passwords still use the versioned scrypt credential format. Email
+  verification, rate limits, reauthentication and session revocation remain
+  mandatory and independent of password length.
+
+## Staging checklist
+
+1. Start from `https://earlybirds-staging.harmonicbeacon.com` and enter the
+   Account flow.
+2. Create a credential account with a display name, disposable email and an
+   8–128 character password, repeat it, and exercise the accessible show/hide
+   control. Confirm mismatches stay client-side and the response is visible
+   beside the submit action without revealing whether an address already
+   exists.
+3. Confirm the email sender is Harmonic Beacon and the action URL uses exact
+   HTTPS host `account-staging.harmonicbeacon.com`.
+4. Open the verification link within 15 minutes, then sign in and return to
+   Listener staging.
+5. Change the Beacon display name, reload and confirm persistence.
+6. Sign out of the current device, sign in again and confirm the page remains
+   usable throughout.
+7. Request password recovery. Confirm the public response remains generic and
+   a separate reset email arrives.
+8. Complete reset within 15 minutes. Confirm the action token is one-use, the
+   old password fails and the repeated new 8–128 character password succeeds.
+9. Open a second browser session, choose all-device logout and confirm both
+   product sessions converge to signed out.
+10. Repeat the visible flow in ES and EN. Record only sanitized status and
+    timestamps; never record credentials or action URLs.
+
+This checklist does not authorize payments, Provider activation, production
+Account, Live, events or audio changes.

--- a/src/app/api/account/auth/[...all]/route.test.ts
+++ b/src/app/api/account/auth/[...all]/route.test.ts
@@ -4,16 +4,20 @@ const authHandler = vi.hoisted(() => vi.fn());
 const getSession = vi.hoisted(() => vi.fn());
 const transaction = vi.hoisted(() => vi.fn());
 const revokeAccountSession = vi.hoisted(() => vi.fn());
+const userFindUnique = vi.hoisted(() => vi.fn());
+const sessionFindUnique = vi.hoisted(() => vi.fn());
+const sessionDeleteMany = vi.hoisted(() => vi.fn());
 vi.mock('@/lib/account/auth', () => ({
     accountAuth: () => ({ handler: authHandler, api: { getSession } }),
 }));
 vi.mock('@/lib/account/authority-db', () => ({ accountAuthorityDatabaseReady: () => true }));
 vi.mock('@/lib/account/revocation', () => ({ revokeAccountSession }));
+vi.mock('@/lib/account/rate-limit', () => ({ consumeAccountRateLimit: () => true }));
 vi.mock('@/lib/db', () => ({
     prisma: {
         $transaction: transaction,
-        earlyBirdAuthSession: { findUnique: vi.fn() },
-        earlyBirdUser: { findUnique: vi.fn() },
+        earlyBirdAuthSession: { findUnique: sessionFindUnique, deleteMany: sessionDeleteMany },
+        earlyBirdUser: { findUnique: userFindUnique },
     },
 }));
 
@@ -39,11 +43,13 @@ function tokenRequest(body: Record<string, string>, authorization?: string) {
 describe('Account catch-all route confidential OAuth boundary', () => {
     beforeEach(() => {
         vi.stubEnv('BEACON_ACCOUNT_BASE_URL', origin);
+        vi.stubEnv('BEACON_ACCOUNT_RATE_SECRET', 'route-test-rate-secret-at-least-thirty-two-characters');
         vi.stubEnv('BEACON_ACCOUNT_CLIENT_SECRET_HB_LISTENER', secret);
         getSession.mockResolvedValue(null);
         authHandler.mockResolvedValue(Response.json({ access_token: 'opaque' }));
         transaction.mockImplementation(async (callback) => callback({}));
         revokeAccountSession.mockResolvedValue(undefined);
+        sessionDeleteMany.mockResolvedValue({ count: 0 });
     });
     afterEach(() => { vi.unstubAllEnvs(); vi.clearAllMocks(); });
 
@@ -62,6 +68,74 @@ describe('Account catch-all route confidential OAuth boundary', () => {
             tokenRequest({ client_secret: secret }, basic),
         ]) expect((await POST(request)).status).toBe(404);
         expect(authHandler).not.toHaveBeenCalled();
+    });
+
+    it('preserves every Better Auth cookie and validates the exact host-only session cookie', async () => {
+        const headers = new Headers({ 'Content-Type': 'application/json' });
+        headers.append('Set-Cookie', '__Host-hb_account_session=opaque-session; Path=/; HttpOnly; Secure; SameSite=Lax');
+        headers.append('Set-Cookie', 'hb_account_auxiliary=opaque-state; Path=/; HttpOnly; Secure; SameSite=Lax');
+        authHandler.mockResolvedValueOnce(Response.json({ redirect: false }, { headers }));
+        userFindUnique.mockResolvedValueOnce({ id: 'account-1', securityRevision: 3 });
+        getSession
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ user: { id: 'account-1' }, session: { id: 'session-1' } });
+        transaction.mockImplementationOnce(async (callback) => callback({
+            $queryRaw: vi.fn(),
+            earlyBirdAuthSession: {
+                findUnique: vi.fn().mockResolvedValue({
+                    id: 'session-1', userId: 'account-1', securityRevision: 3,
+                    user: { securityRevision: 3 },
+                }),
+                deleteMany: vi.fn(),
+            },
+        }));
+
+        const response = await POST(new Request(`${origin}/api/account/auth/sign-in/email`, {
+            method: 'POST',
+            headers: {
+                host: 'account.harmonicbeacon.com', origin,
+                'sec-fetch-site': 'same-origin', 'content-type': 'application/json',
+            },
+            body: JSON.stringify({ email: 'listener@example.invalid', password: '12345678' }),
+        }));
+
+        expect(response.status).toBe(200);
+        expect(response.headers.getSetCookie()).toEqual([
+            '__Host-hb_account_session=opaque-session; Path=/; HttpOnly; Secure; SameSite=Lax',
+            'hb_account_auxiliary=opaque-state; Path=/; HttpOnly; Secure; SameSite=Lax',
+        ]);
+        expect(response.headers.getSetCookie().join('\n')).not.toContain('__Secure-__Host-');
+        expect(getSession.mock.calls[1]?.[0]?.headers.get('cookie'))
+            .toBe('__Host-hb_account_session=opaque-session');
+    });
+
+    it('rejects an unforwardable successful sign-in and removes only its exact new session token', async () => {
+        const headers = new Headers();
+        headers.append('Set-Cookie', '__Host-hb_account_session=newly-created-session-token.signature; Path=/; HttpOnly; Secure; SameSite=Lax');
+        authHandler.mockResolvedValueOnce(Response.json({
+            token: 'newly-created-session-token', redirect: false,
+        }, { headers }));
+        userFindUnique.mockResolvedValueOnce({ id: 'account-1', securityRevision: 3 });
+        getSession.mockResolvedValueOnce(null);
+
+        const response = await POST(new Request(`${origin}/api/account/auth/sign-in/email`, {
+            method: 'POST',
+            headers: {
+                host: 'account.harmonicbeacon.com', origin,
+                'sec-fetch-site': 'same-origin', 'content-type': 'application/json',
+            },
+            body: JSON.stringify({ email: 'listener@example.invalid', password: '12345678' }),
+        }));
+
+        expect(response.status).toBe(401);
+        expect(response.headers.getSetCookie()).toEqual([]);
+        expect(sessionDeleteMany).toHaveBeenCalledOnce();
+        expect(sessionDeleteMany).toHaveBeenCalledWith({
+            where: { token: 'newly-created-session-token' },
+        });
+        expect(sessionDeleteMany).not.toHaveBeenCalledWith(expect.objectContaining({
+            where: expect.objectContaining({ userId: 'account-1' }),
+        }));
     });
 
     it('wraps verified end-session success in a signed exact frontchannel redirect', async () => {

--- a/src/app/api/account/auth/[...all]/route.ts
+++ b/src/app/api/account/auth/[...all]/route.ts
@@ -41,8 +41,11 @@ async function genericCredentialResponse(response: Response, path: string): Prom
     const signup = path === '/api/account/auth/sign-up/email';
     const successful = response.ok;
     const headers = new Headers({ 'Cache-Control': 'private, no-store' });
-    const cookie = response.headers.get('set-cookie');
-    if (successful && cookie) headers.set('Set-Cookie', cookie);
+    if (successful) {
+        for (const cookie of response.headers.getSetCookie()) {
+            headers.append('Set-Cookie', cookie);
+        }
+    }
     const redirect = successful && !signup ? await safeRPRedirect(response) : null;
     return Response.json({
         status: signup ? 'accepted' : successful ? 'authenticated' : 'unavailable',
@@ -60,14 +63,33 @@ async function credentialSignInRevisionStillValid(input: {
     securityRevision: number;
 }): Promise<boolean> {
     if (!input.response.ok) return true;
-    const setCookie = input.response.headers.get('set-cookie') ?? '';
-    const escaped = ACCOUNT_SESSION_COOKIE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const token = setCookie.match(new RegExp(`(?:^|,\\s*)${escaped}=([^;,\\s]+)`))?.[1];
+    const sessionCookies = input.response.headers.getSetCookie().filter((cookie) =>
+        cookie.startsWith(`${ACCOUNT_SESSION_COOKIE}=`));
+    const body = await input.response.clone().json().catch(() => null) as { token?: unknown } | null;
+    const bodyToken = typeof body?.token === 'string' && body.token.length <= 512
+        ? body.token : null;
+    if (sessionCookies.length !== 1) {
+        if (bodyToken) {
+            await prisma.earlyBirdAuthSession.deleteMany({ where: { token: bodyToken } })
+                .catch(() => undefined);
+        }
+        return false;
+    }
+    const token = sessionCookies[0].slice(ACCOUNT_SESSION_COOKIE.length + 1).split(';', 1)[0];
     if (!token) return false;
     const headers = new Headers(input.request.headers);
     headers.set('cookie', `${ACCOUNT_SESSION_COOKIE}=${token}`);
     const created = await accountAuth().api.getSession({ headers }).catch(() => null);
-    if (!created || created.user.id !== input.accountId) return false;
+    if (!created || created.user.id !== input.accountId) {
+        // Better Auth may have persisted a session before an output seam
+        // failed. Delete only the exact token it just returned; never revoke
+        // pre-existing sessions for the account.
+        if (bodyToken) {
+            await prisma.earlyBirdAuthSession.deleteMany({ where: { token: bodyToken } })
+                .catch(() => undefined);
+        }
+        return false;
+    }
     return prisma.$transaction(async (transaction) => {
         // This lock gives reset/change a total order with the final sign-in
         // check. If sign-in wins, the later mutation revokes this session; if

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,6 +55,9 @@ hb-global-nav:not(:defined) {
   border: 1px solid rgba(244, 238, 226, .22);
   border-radius: 10px;
 }
+.account-password-field { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .45rem; align-items: stretch; }
+.account-password-field input { min-width: 0; }
+.account-password-toggle { min-width: 4.5rem; padding-inline: .7rem !important; }
 .account-form input:focus-visible, .account-card button:focus-visible, .account-card a:focus-visible {
   outline: 2px solid #e0bd69;
   outline-offset: 3px;

--- a/src/components/account/AccountClient.tsx
+++ b/src/components/account/AccountClient.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useRef, useState, type FormEvent } from 'react';
+
+import {
+    ACCOUNT_PASSWORD_MAX_LENGTH,
+    ACCOUNT_PASSWORD_MIN_LENGTH,
+    accountPasswordLengthValid,
+} from '@/lib/account/password-policy';
+import { AccountPasswordField } from './AccountPasswordField';
 
 type AccountSession = {
     user: { email: string | null; emailVerified: boolean; accessMethod: 'email' | 'google' | 'apple' };
@@ -51,6 +58,18 @@ export default function AccountClient({
     returnTo: string | null;
 }) {
     const es = locale === 'es';
+    const passwordHint = es
+        ? `Usá entre ${ACCOUNT_PASSWORD_MIN_LENGTH} y ${ACCOUNT_PASSWORD_MAX_LENGTH} caracteres. No se exige ningún formato especial.`
+        : `Use ${ACCOUNT_PASSWORD_MIN_LENGTH} to ${ACCOUNT_PASSWORD_MAX_LENGTH} characters. No special format is required.`;
+    const passwordLengthError = es
+        ? `La contraseña debe tener entre ${ACCOUNT_PASSWORD_MIN_LENGTH} y ${ACCOUNT_PASSWORD_MAX_LENGTH} caracteres.`
+        : `Password must be ${ACCOUNT_PASSWORD_MIN_LENGTH} to ${ACCOUNT_PASSWORD_MAX_LENGTH} characters.`;
+    const credentialFailure = es
+        ? 'No se pudo completar la solicitud. Revisá los datos e intentá nuevamente.'
+        : 'The request could not be completed. Check the details and try again.';
+    const passwordMismatch = es ? 'Las contraseñas no coinciden.' : 'Passwords do not match.';
+    const showPassword = es ? 'Mostrar contraseña' : 'Show password';
+    const hidePassword = es ? 'Ocultar contraseña' : 'Hide password';
     const callbackURL = `/account?lang=${locale}${returnTo ? `&return_to=${encodeURIComponent(returnTo)}` : ''}`;
     const oauthQuery = () => {
         const params = new URLSearchParams(window.location.search);
@@ -61,17 +80,43 @@ export default function AccountClient({
     const [mode, setMode] = useState<'signin' | 'signup' | 'forgot'>('signin');
     const [message, setMessage] = useState('');
     const [busy, setBusy] = useState(false);
+    const feedbackRef = useRef<HTMLParagraphElement>(null);
+    const credentialSubmissionInFlight = useRef(false);
+
+    function announceCredentialResult(nextMessage: string) {
+        setMessage(nextMessage);
+        queueMicrotask(() => {
+            feedbackRef.current?.focus({ preventScroll: true });
+            feedbackRef.current?.scrollIntoView?.({ block: 'nearest' });
+        });
+    }
 
     async function submitCredentials(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
+        if (credentialSubmissionInFlight.current) return;
         const form = new FormData(event.currentTarget);
         const email = String(form.get('email') ?? '');
         const password = String(form.get('password') ?? '');
+        if (mode !== 'forgot' && !accountPasswordLengthValid(password)) {
+            setMessage(passwordLengthError);
+            const input = event.currentTarget.elements.namedItem('password');
+            if (input instanceof HTMLElement) input.focus();
+            return;
+        }
+        if (mode === 'signup' && password !== String(form.get('confirmPassword') ?? '')) {
+            setMessage(passwordMismatch);
+            const input = event.currentTarget.elements.namedItem('confirmPassword');
+            if (input instanceof HTMLElement) input.focus();
+            return;
+        }
+        credentialSubmissionInFlight.current = true;
         setBusy(true); setMessage('');
         try {
             if (mode === 'forgot') {
-                await post('/api/account/password/reset/request', locale, { email });
-                setMessage(es ? 'Si la dirección es válida, el correo ya está en camino.' : 'If the address is eligible, an email is on its way.');
+                const response = await post('/api/account/password/reset/request', locale, { email });
+                announceCredentialResult(response.ok
+                    ? (es ? 'Si la dirección es válida, el correo ya está en camino.' : 'If the address is eligible, an email is on its way.')
+                    : credentialFailure);
                 return;
             }
             const endpoint = mode === 'signup'
@@ -86,13 +131,20 @@ export default function AccountClient({
             });
             const result = await response.json().catch(() => null) as { redirect?: string } | null;
             if (mode === 'signup') {
-                setMessage(es ? 'Revisá tu correo para verificar la cuenta y después ingresá.' : 'Check your email to verify the account, then sign in.');
+                announceCredentialResult(response.ok
+                    ? (es ? 'Revisá tu correo para verificar la cuenta y después ingresá.' : 'Check your email to verify the account, then sign in.')
+                    : (es ? 'No se pudo crear la cuenta. Revisá los datos e intentá nuevamente.' : 'Account could not be created. Check the details and try again.'));
             } else if (response.ok) {
                 window.location.replace(result?.redirect ?? callbackURL);
             } else {
-                setMessage(es ? 'No se pudo ingresar. Revisá los datos e intentá nuevamente.' : 'Sign-in could not be completed. Check the details and try again.');
+                announceCredentialResult(es ? 'No se pudo ingresar. Revisá los datos e intentá nuevamente.' : 'Sign-in could not be completed. Check the details and try again.');
             }
-        } finally { setBusy(false); }
+        } catch {
+            announceCredentialResult(credentialFailure);
+        } finally {
+            credentialSubmissionInFlight.current = false;
+            setBusy(false);
+        }
     }
 
     async function social(provider: 'google' | 'apple') {
@@ -126,9 +178,18 @@ export default function AccountClient({
     async function changePassword(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
         const form = new FormData(event.currentTarget);
+        const newPassword = String(form.get('newPassword') ?? '');
+        if (!accountPasswordLengthValid(newPassword)) {
+            setMessage(passwordLengthError);
+            return;
+        }
+        if (newPassword !== String(form.get('confirmPassword') ?? '')) {
+            setMessage(passwordMismatch);
+            return;
+        }
         const response = await post('/api/account/password/change', locale, {
             currentPassword: String(form.get('currentPassword') ?? ''),
-            newPassword: String(form.get('newPassword') ?? ''),
+            newPassword,
         });
         if (response.ok) window.location.replace('/account');
         else setMessage(es ? 'No se pudo cambiar la contraseña.' : 'Password could not be changed.');
@@ -167,23 +228,53 @@ export default function AccountClient({
     if (!session) return (
         <div className="account-card">
             <div className="account-mode" role="group" aria-label={es ? 'Acción de cuenta' : 'Account action'}>
-                <button type="button" aria-pressed={mode === 'signin'} onClick={() => setMode('signin')}>{es ? 'Ingresar' : 'Sign in'}</button>
-                <button type="button" aria-pressed={mode === 'signup'} onClick={() => setMode('signup')}>{es ? 'Crear cuenta' : 'Create account'}</button>
+                <button type="button" disabled={busy} aria-pressed={mode === 'signin'} onClick={() => setMode('signin')}>{es ? 'Ingresar' : 'Sign in'}</button>
+                <button type="button" disabled={busy} aria-pressed={mode === 'signup'} onClick={() => setMode('signup')}>{es ? 'Crear cuenta' : 'Create account'}</button>
             </div>
             <div className="account-providers">
                 {providers.google && <button disabled={busy} onClick={() => social('google')}>{es ? 'Continuar con Google' : 'Continue with Google'}</button>}
                 {providers.apple && <button disabled={busy} onClick={() => social('apple')}>{es ? 'Continuar con Apple' : 'Continue with Apple'}</button>}
             </div>
-            <form onSubmit={submitCredentials} className="account-form">
+            <form onSubmit={submitCredentials} className="account-form" aria-busy={busy} onInvalid={(event) => {
+                const input = event.target;
+                if (input instanceof HTMLInputElement &&
+                    (input.name === 'password' || input.name === 'confirmPassword') &&
+                    !accountPasswordLengthValid(input.value)) {
+                    event.preventDefault();
+                    setMessage(passwordLengthError);
+                    input.focus();
+                }
+            }}>
                 {mode === 'signup' && <label>{es ? 'Nombre visible' : 'Display name'}<input name="displayName" required minLength={1} maxLength={60} autoComplete="nickname" /></label>}
                 <label>{es ? 'Correo' : 'Email'}<input name="email" type="email" required autoComplete="email" /></label>
-                {mode !== 'forgot' && <label>{es ? 'Contraseña' : 'Password'}<input name="password" type="password" required minLength={12} maxLength={128} autoComplete={mode === 'signup' ? 'new-password' : 'current-password'} /></label>}
+                {mode !== 'forgot' && <AccountPasswordField
+                    label={es ? 'Contraseña' : 'Password'}
+                    showLabel={showPassword}
+                    hideLabel={hidePassword}
+                    name="password"
+                    required
+                    minLength={ACCOUNT_PASSWORD_MIN_LENGTH}
+                    maxLength={ACCOUNT_PASSWORD_MAX_LENGTH}
+                    aria-describedby={mode === 'signup' ? 'account-password-policy' : undefined}
+                    autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
+                />}
+                {mode === 'signup' && <AccountPasswordField
+                    label={es ? 'Repetir contraseña' : 'Repeat password'}
+                    showLabel={showPassword}
+                    hideLabel={hidePassword}
+                    name="confirmPassword"
+                    required
+                    minLength={ACCOUNT_PASSWORD_MIN_LENGTH}
+                    maxLength={ACCOUNT_PASSWORD_MAX_LENGTH}
+                    autoComplete="new-password"
+                />}
+                {mode === 'signup' && <p id="account-password-policy" className="account-muted">{passwordHint}</p>}
+                <p ref={feedbackRef} className="account-message" role="status" aria-live="polite" tabIndex={-1} hidden={!message}>{message}</p>
                 <button className="account-primary" disabled={busy}>{mode === 'signin' ? (es ? 'Ingresar' : 'Sign in') : mode === 'signup' ? (es ? 'Crear cuenta' : 'Create account') : (es ? 'Enviar correo' : 'Send reset email')}</button>
             </form>
             <button className="account-link" type="button" onClick={() => setMode(mode === 'forgot' ? 'signin' : 'forgot')}>
                 {mode === 'forgot' ? (es ? 'Volver al ingreso' : 'Back to sign in') : (es ? '¿Olvidaste tu contraseña?' : 'Forgot password?')}
             </button>
-            {message && <p className="account-message" role="status">{message}</p>}
         </div>
     );
 
@@ -201,13 +292,15 @@ export default function AccountClient({
             {session.user.accessMethod === 'email' && <section className="account-card">
                 <h2>{es ? 'Seguridad' : 'Security'}</h2>
                 <form onSubmit={changePassword} className="account-form">
-                    <label>{es ? 'Contraseña actual' : 'Current password'}<input name="currentPassword" type="password" required autoComplete="current-password" /></label>
-                    <label>{es ? 'Contraseña nueva' : 'New password'}<input name="newPassword" type="password" required minLength={12} maxLength={128} autoComplete="new-password" /></label>
+                    <AccountPasswordField label={es ? 'Contraseña actual' : 'Current password'} showLabel={showPassword} hideLabel={hidePassword} name="currentPassword" required autoComplete="current-password" />
+                    <AccountPasswordField label={es ? 'Contraseña nueva' : 'New password'} showLabel={showPassword} hideLabel={hidePassword} name="newPassword" required minLength={ACCOUNT_PASSWORD_MIN_LENGTH} maxLength={ACCOUNT_PASSWORD_MAX_LENGTH} aria-describedby="account-new-password-policy" autoComplete="new-password" />
+                    <AccountPasswordField label={es ? 'Repetir contraseña nueva' : 'Repeat new password'} showLabel={showPassword} hideLabel={hidePassword} name="confirmPassword" required minLength={ACCOUNT_PASSWORD_MIN_LENGTH} maxLength={ACCOUNT_PASSWORD_MAX_LENGTH} autoComplete="new-password" />
+                    <p id="account-new-password-policy" className="account-muted">{passwordHint}</p>
                     <button>{es ? 'Cambiar contraseña' : 'Change password'}</button>
                 </form>
                 <form onSubmit={changeEmail} className="account-form">
                     <label>{es ? 'Correo nuevo' : 'New email'}<input name="email" type="email" required autoComplete="email" /></label>
-                    <label>{es ? 'Contraseña actual' : 'Current password'}<input name="password" type="password" required autoComplete="current-password" /></label>
+                    <AccountPasswordField label={es ? 'Contraseña actual' : 'Current password'} showLabel={showPassword} hideLabel={hidePassword} name="password" required autoComplete="current-password" />
                     <button>{es ? 'Cambiar correo' : 'Change email'}</button>
                 </form>
             </section>}

--- a/src/components/account/AccountPasswordField.tsx
+++ b/src/components/account/AccountPasswordField.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState, type InputHTMLAttributes } from 'react';
+
+type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+    label: string;
+    showLabel: string;
+    hideLabel: string;
+};
+
+/** Password input with a keyboard- and screen-reader-accessible reveal control. */
+export function AccountPasswordField({ label, showLabel, hideLabel, ...input }: Props) {
+    const [revealed, setRevealed] = useState(false);
+    return <label>{label}
+        <span className="account-password-field">
+            <input {...input} type={revealed ? 'text' : 'password'} />
+            <button
+                type="button"
+                className="account-password-toggle"
+                aria-label={revealed ? hideLabel : showLabel}
+                aria-pressed={revealed}
+                onClick={() => setRevealed((value) => !value)}
+            >{revealed ? hideLabel : showLabel}</button>
+        </span>
+    </label>;
+}

--- a/src/components/account/ResetPasswordClient.tsx
+++ b/src/components/account/ResetPasswordClient.tsx
@@ -2,10 +2,27 @@
 
 import { useEffect, useState, type FormEvent } from 'react';
 
+import {
+    ACCOUNT_PASSWORD_MAX_LENGTH,
+    ACCOUNT_PASSWORD_MIN_LENGTH,
+    accountPasswordLengthValid,
+} from '@/lib/account/password-policy';
+import { AccountPasswordField } from './AccountPasswordField';
+
 export function ResetPasswordClient({ locale }: { locale: 'es' | 'en' }) {
     const es = locale === 'es';
+    const passwordHint = es
+        ? `Usá entre ${ACCOUNT_PASSWORD_MIN_LENGTH} y ${ACCOUNT_PASSWORD_MAX_LENGTH} caracteres. No se exige ningún formato especial.`
+        : `Use ${ACCOUNT_PASSWORD_MIN_LENGTH} to ${ACCOUNT_PASSWORD_MAX_LENGTH} characters. No special format is required.`;
+    const passwordLengthError = es
+        ? `La contraseña debe tener entre ${ACCOUNT_PASSWORD_MIN_LENGTH} y ${ACCOUNT_PASSWORD_MAX_LENGTH} caracteres.`
+        : `Password must be ${ACCOUNT_PASSWORD_MIN_LENGTH} to ${ACCOUNT_PASSWORD_MAX_LENGTH} characters.`;
+    const passwordMismatch = es ? 'Las contraseñas no coinciden.' : 'Passwords do not match.';
+    const showPassword = es ? 'Mostrar contraseña' : 'Show password';
+    const hidePassword = es ? 'Ocultar contraseña' : 'Hide password';
     const [token, setToken] = useState<string | null | undefined>(undefined);
     const [message, setMessage] = useState('');
+    const [busy, setBusy] = useState(false);
     useEffect(() => {
         const url = new URL(window.location.href);
         const incomingToken = url.searchParams.get('token');
@@ -14,21 +31,45 @@ export function ResetPasswordClient({ locale }: { locale: 'es' | 'en' }) {
     }, []);
     async function submit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
-        const password = String(new FormData(event.currentTarget).get('password') ?? '');
-        const response = await fetch('/api/account/password/reset/complete', {
-            method: 'POST', headers: { 'Content-Type': 'application/json' },
-            credentials: 'same-origin', body: JSON.stringify({ token, password }),
-        });
-        setToken(null);
-        setMessage(response.ok ? (es ? 'Contraseña cambiada. Ya podés ingresar.' : 'Password changed. You can sign in now.') : (es ? 'El enlace es inválido o venció.' : 'This link is invalid or expired.'));
+        if (busy) return;
+        const form = new FormData(event.currentTarget);
+        const password = String(form.get('password') ?? '');
+        if (!accountPasswordLengthValid(password)) {
+            setMessage(passwordLengthError);
+            return;
+        }
+        if (password !== String(form.get('confirmPassword') ?? '')) {
+            setMessage(passwordMismatch);
+            return;
+        }
+        setBusy(true);
+        try {
+            const response = await fetch('/api/account/password/reset/complete', {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin', body: JSON.stringify({ token, password }),
+            });
+            setToken(null);
+            setMessage(response.ok ? (es ? 'Contraseña cambiada. Ya podés ingresar.' : 'Password changed. You can sign in now.') : (es ? 'El enlace es inválido o venció.' : 'This link is invalid or expired.'));
+        } catch {
+            // A transport failure must not consume the client-held one-use
+            // token or remove the form; the listener can retry safely.
+            setMessage(es
+                ? 'No se pudo completar la solicitud. Intentá nuevamente.'
+                : 'The request could not be completed. Try again.');
+        } finally {
+            setBusy(false);
+        }
     }
     return <div className="account-card">
         <h1>{es ? 'Restablecer contraseña' : 'Reset password'}</h1>
         {token === undefined ? <p className="account-message" role="status">
             {es ? 'Preparando…' : 'Preparing…'}
-        </p> : token ? <form className="account-form" onSubmit={submit}>
-            <label>{es ? 'Contraseña nueva' : 'New password'}<input name="password" type="password" minLength={12} maxLength={128} required autoComplete="new-password" /></label>
-            <button className="account-primary">{es ? 'Cambiar contraseña' : 'Change password'}</button>
+        </p> : token ? <form className="account-form" onSubmit={submit} aria-busy={busy}>
+            <AccountPasswordField label={es ? 'Contraseña nueva' : 'New password'} showLabel={showPassword} hideLabel={hidePassword} name="password" minLength={ACCOUNT_PASSWORD_MIN_LENGTH} maxLength={ACCOUNT_PASSWORD_MAX_LENGTH} aria-describedby="account-reset-password-policy" required autoComplete="new-password" />
+            <AccountPasswordField label={es ? 'Repetir contraseña nueva' : 'Repeat new password'} showLabel={showPassword} hideLabel={hidePassword} name="confirmPassword" minLength={ACCOUNT_PASSWORD_MIN_LENGTH} maxLength={ACCOUNT_PASSWORD_MAX_LENGTH} required autoComplete="new-password" />
+            <p id="account-reset-password-policy" className="account-muted">{passwordHint}</p>
+            {message && <p className="account-message" role="status" aria-live="polite">{message}</p>}
+            <button className="account-primary" disabled={busy}>{es ? 'Cambiar contraseña' : 'Change password'}</button>
         </form> : <p className="account-message" role="status">{message || (es ? 'El enlace es inválido o venció.' : 'This link is invalid or expired.')}</p>}
         {!token && <a href={`/account?lang=${locale}`}>{es ? 'Volver a Cuenta' : 'Back to Account'}</a>}
     </div>;

--- a/src/components/account/__tests__/AccountClient.test.ts
+++ b/src/components/account/__tests__/AccountClient.test.ts
@@ -60,4 +60,169 @@ describe('Account cross-product logout completion', () => {
         await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
         expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({ 'X-HB-Locale': 'en' });
     });
+
+    it.each([
+        ['en' as const, 'Use 8 to 128 characters. No special format is required.'],
+        ['es' as const, 'Usá entre 8 y 128 caracteres. No se exige ningún formato especial.'],
+    ])('renders the provider-independent %s signup policy without complexity rules', (locale, hint) => {
+        render(createElement(AccountClient, {
+            initialSession: null,
+            providers: { google: false, apple: false },
+            locale,
+            returnTo: null,
+        }));
+        fireEvent.click(screen.getAllByRole('button', {
+            name: locale === 'es' ? 'Crear cuenta' : 'Create account',
+        })[0]);
+        const password = screen.getByLabelText(locale === 'es' ? 'Contraseña' : 'Password');
+        expect(password).toHaveAttribute('minlength', '8');
+        expect(password).toHaveAttribute('maxlength', '128');
+        expect(password).toHaveAccessibleDescription(hint);
+    });
+
+    it('rejects a seven-character signup visibly before fetch and focuses the password', () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        render(createElement(AccountClient, {
+            initialSession: null,
+            providers: { google: false, apple: false },
+            locale: 'en',
+            returnTo: null,
+        }));
+        fireEvent.click(screen.getAllByRole('button', { name: 'Create account' })[0]);
+        const password = screen.getByLabelText('Password');
+        fireEvent.change(password, { target: { value: '1234567' } });
+        fireEvent.submit(password.closest('form')!);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(screen.getByRole('status')).toHaveTextContent('Password must be 8 to 128 characters.');
+        expect(password).toHaveFocus();
+    });
+
+    it('blocks mismatched repeated passwords and exposes an accessible reveal control', () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        render(createElement(AccountClient, {
+            initialSession: null,
+            providers: { google: false, apple: false },
+            locale: 'en',
+            returnTo: null,
+        }));
+        fireEvent.click(screen.getAllByRole('button', { name: 'Create account' })[0]);
+        const password = screen.getByLabelText('Password');
+        const repeated = screen.getByLabelText('Repeat password');
+        fireEvent.change(password, { target: { value: '12345678' } });
+        fireEvent.change(repeated, { target: { value: '87654321' } });
+        fireEvent.click(screen.getAllByRole('button', { name: 'Show password' })[0]);
+        expect(password).toHaveAttribute('type', 'text');
+        expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute('aria-pressed', 'true');
+        fireEvent.submit(password.closest('form')!);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(screen.getByRole('status')).toHaveTextContent('Passwords do not match.');
+        expect(repeated).toHaveFocus();
+    });
+
+    it('submits an eight-character signup and shows check-email only on success', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {
+            status: 202, headers: { 'Content-Type': 'application/json' },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(createElement(AccountClient, {
+            initialSession: null,
+            providers: { google: false, apple: false },
+            locale: 'en',
+            returnTo: null,
+        }));
+        fireEvent.click(screen.getAllByRole('button', { name: 'Create account' })[0]);
+        fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Test Listener' } });
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'listener@example.invalid' } });
+        const password = screen.getByLabelText('Password');
+        fireEvent.change(password, { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText('Repeat password'), { target: { value: '12345678' } });
+        fireEvent.submit(password.closest('form')!);
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+        const feedback = screen.getByRole('status');
+        expect(feedback).toHaveTextContent('Check your email to verify the account');
+        await waitFor(() => expect(feedback).toHaveFocus());
+    });
+
+    it('shows an enumeration-neutral server failure and always restores the submit button', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {
+            status: 400, headers: { 'Content-Type': 'application/json' },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(createElement(AccountClient, {
+            initialSession: null,
+            providers: { google: false, apple: false },
+            locale: 'en',
+            returnTo: null,
+        }));
+        fireEvent.click(screen.getAllByRole('button', { name: 'Create account' })[0]);
+        fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Test Listener' } });
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'listener@example.invalid' } });
+        const password = screen.getByLabelText('Password');
+        fireEvent.change(password, { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText('Repeat password'), { target: { value: '12345678' } });
+        fireEvent.submit(password.closest('form')!);
+        const feedback = await screen.findByRole('status');
+        await waitFor(() => expect(feedback).toHaveTextContent(
+            'Account could not be created. Check the details and try again.',
+        ));
+        expect(feedback).toHaveFocus();
+        expect(screen.getAllByRole('button', { name: 'Create account' }).at(-1)).toBeEnabled();
+        expect(screen.queryByText(/Check your email to verify/)).toBeNull();
+    });
+
+    it('coalesces duplicate credential submits while the first request is pending', async () => {
+        let resolveFetch!: (response: Response) => void;
+        const fetchMock = vi.fn().mockReturnValue(new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(createElement(AccountClient, {
+            initialSession: null,
+            providers: { google: false, apple: false },
+            locale: 'en',
+            returnTo: null,
+        }));
+        fireEvent.click(screen.getAllByRole('button', { name: 'Create account' })[0]);
+        fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Test Listener' } });
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'listener@example.invalid' } });
+        const password = screen.getByLabelText('Password');
+        fireEvent.change(password, { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText('Repeat password'), { target: { value: '12345678' } });
+        const form = password.closest('form')!;
+        fireEvent.submit(form);
+        fireEvent.submit(form);
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(screen.getAllByRole('button', { name: 'Create account' }).at(-1)).toBeDisabled();
+        resolveFetch(new Response('{}', {
+            status: 202, headers: { 'Content-Type': 'application/json' },
+        }));
+        await waitFor(() => expect(screen.getAllByRole('button', { name: 'Create account' }).at(-1)).toBeEnabled());
+    });
+
+    it('blocks a signed-in password change when the repeated value differs', () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        render(createElement(AccountClient, {
+            initialSession: {
+                user: { email: 'listener@example.invalid', emailVerified: true, accessMethod: 'email' },
+                profile: { displayName: 'Test Listener', revision: 1 },
+            },
+            providers: { google: false, apple: false },
+            locale: 'en',
+            returnTo: null,
+        }));
+        fireEvent.change(screen.getAllByLabelText('Current password')[0], {
+            target: { value: 'old-password' },
+        });
+        const password = screen.getByLabelText('New password');
+        fireEvent.change(password, { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText('Repeat new password'), {
+            target: { value: '87654321' },
+        });
+        fireEvent.submit(password.closest('form')!);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(screen.getByRole('status')).toHaveTextContent('Passwords do not match.');
+    });
 });

--- a/src/components/account/__tests__/ResetPasswordClient.test.tsx
+++ b/src/components/account/__tests__/ResetPasswordClient.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ResetPasswordClient } from '../ResetPasswordClient';
+
+describe('Account reset-password policy', () => {
+    afterEach(() => {
+        cleanup();
+        vi.unstubAllGlobals();
+        window.history.replaceState(null, '', '/');
+    });
+
+    it.each([
+        ['en' as const, 'New password', 'Use 8 to 128 characters. No special format is required.'],
+        ['es' as const, 'Contraseña nueva', 'Usá entre 8 y 128 caracteres. No se exige ningún formato especial.'],
+    ])('renders the %s policy from the shared bounds', async (locale, label, hint) => {
+        window.history.replaceState(null, '', '/reset-password?token=opaque-test-token');
+        render(<ResetPasswordClient locale={locale} />);
+        const password = await waitFor(() => screen.getByLabelText(label));
+        expect(password).toHaveAttribute('minlength', '8');
+        expect(password).toHaveAttribute('maxlength', '128');
+        expect(password).toHaveAccessibleDescription(hint);
+        expect(window.location.search).toBe('');
+    });
+
+    it('blocks a repeated-password mismatch before the reset endpoint', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        window.history.replaceState(null, '', '/reset-password?token=opaque-test-token');
+        render(<ResetPasswordClient locale="en" />);
+        const password = await waitFor(() => screen.getByLabelText('New password'));
+        fireEvent.change(password, { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText('Repeat new password'), {
+            target: { value: '87654321' },
+        });
+        fireEvent.submit(password.closest('form')!);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(screen.getByRole('status')).toHaveTextContent('Passwords do not match.');
+    });
+
+    it('keeps the token form retryable after a network failure', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network unavailable')));
+        window.history.replaceState(null, '', '/reset-password?token=opaque-test-token');
+        render(<ResetPasswordClient locale="en" />);
+        const password = await waitFor(() => screen.getByLabelText('New password'));
+        fireEvent.change(password, { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText('Repeat new password'), {
+            target: { value: '12345678' },
+        });
+        fireEvent.submit(password.closest('form')!);
+        expect(await screen.findByRole('status')).toHaveTextContent(
+            'The request could not be completed. Try again.',
+        );
+        expect(screen.getByLabelText('New password')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Change password' })).toBeEnabled();
+    });
+});

--- a/src/lib/__tests__/session-auth.test.ts
+++ b/src/lib/__tests__/session-auth.test.ts
@@ -9,7 +9,14 @@ import {
     sessionCookieOptions,
     sessionTokenMatchesDigest,
     verifyStaffPassword,
+    hashAccountPassword,
+    verifyAccountPassword,
 } from '../session-auth';
+import {
+    ACCOUNT_PASSWORD_MAX_LENGTH,
+    ACCOUNT_PASSWORD_MIN_LENGTH,
+    accountPasswordLengthValid,
+} from '@/lib/account/password-policy';
 
 describe('opaque web sessions', () => {
     it('returns plaintext only for the cookie and a one-way digest for persistence', () => {
@@ -54,5 +61,27 @@ describe('opaque web sessions', () => {
         await expect(verifyStaffPassword('strong test password', encoded)).resolves.toBe(true);
         await expect(verifyStaffPassword('wrong password', encoded)).resolves.toBe(false);
         await expect(verifyStaffPassword('strong test password', 'malformed')).resolves.toBe(false);
+    });
+});
+
+describe('Account password policy', () => {
+    it('accepts every composition at 8–128 characters and rejects only length boundaries', () => {
+        expect(ACCOUNT_PASSWORD_MIN_LENGTH).toBe(8);
+        expect(ACCOUNT_PASSWORD_MAX_LENGTH).toBe(128);
+        expect(accountPasswordLengthValid('12345678')).toBe(true);
+        expect(accountPasswordLengthValid('        ')).toBe(true);
+        expect(accountPasswordLengthValid('a'.repeat(128))).toBe(true);
+        expect(accountPasswordLengthValid('1234567')).toBe(false);
+        expect(accountPasswordLengthValid('a'.repeat(129))).toBe(false);
+    });
+
+    it('keeps the versioned scrypt credential interoperable at the new minimum', async () => {
+        const password = '12345678';
+        const digest = await hashAccountPassword(password);
+        expect(digest).toMatch(/^scrypt-v1\$/);
+        await expect(verifyAccountPassword({ hash: digest, password })).resolves.toBe(true);
+        await expect(verifyAccountPassword({ hash: digest, password: '1234567' })).resolves.toBe(false);
+        await expect(hashAccountPassword('1234567')).rejects.toThrow('outside the accepted range');
+        await expect(hashAccountPassword('a'.repeat(129))).rejects.toThrow('outside the accepted range');
     });
 });

--- a/src/lib/account/__tests__/oauth-provider.postgres.test.ts
+++ b/src/lib/account/__tests__/oauth-provider.postgres.test.ts
@@ -13,6 +13,8 @@ const email = `${accountId}@example.invalid`;
 const password = 'correct horse beacon battery staple';
 let prisma: PrismaClient;
 let handler: (request: Request) => Promise<Response>;
+let accountRoutePOST: (request: Request) => Promise<Response>;
+let currentAccountSession: typeof import('../auth').currentAccountSession;
 
 function jsonRequest(path: string, body: unknown) {
     return new Request(`${issuer}${path}`, {
@@ -33,6 +35,8 @@ postgres('pinned OAuth Provider 1.6.30 confidential-client lifecycle', () => {
         const { hashAccountPassword } = await import('@/lib/session-auth');
         const { hashAccountClientSecret } = await import('../client-secret');
         const { accountAuth } = await import('../auth');
+        ({ currentAccountSession } = await import('../auth'));
+        ({ POST: accountRoutePOST } = await import('@/app/api/account/auth/[...all]/route'));
         handler = accountAuth().handler;
         await prisma.beaconAccountAuthorityEnvironment.upsert({
             where: { id: 'authority' },
@@ -68,10 +72,21 @@ postgres('pinned OAuth Provider 1.6.30 confidential-client lifecycle', () => {
     });
 
     it('exchanges an auth code and introspects using the provisioned full secret', async () => {
-        const signIn = await handler(jsonRequest('/api/account/auth/sign-in/email', { email, password }));
+        const signIn = await accountRoutePOST(jsonRequest('/api/account/auth/sign-in/email', { email, password }));
         expect(signIn.status).toBe(200);
-        const sessionCookie = signIn.headers.get('set-cookie');
-        expect(sessionCookie).toBeTruthy();
+        const setCookies = signIn.headers.getSetCookie();
+        const sessionCookies = setCookies.filter((entry) =>
+            entry.startsWith('__Host-hb_account_session='));
+        expect(sessionCookies).toHaveLength(1);
+        expect(setCookies.join('\n')).not.toContain('__Secure-__Host-');
+        expect(sessionCookies[0]).toContain('Path=/');
+        expect(sessionCookies[0]).toContain('HttpOnly');
+        expect(sessionCookies[0]).toContain('Secure');
+        expect(sessionCookies[0]).toContain('SameSite=Lax');
+        expect(sessionCookies[0]).not.toContain('Domain=');
+        const sessionCookie = setCookies.map((entry) => entry.split(';', 1)[0]).join('; ');
+        const resolved = await currentAccountSession(new Headers({ cookie: sessionCookie }));
+        expect(resolved).toMatchObject({ user: { id: accountId, accessMethod: 'email' } });
 
         const verifier = randomBytes(48).toString('base64url');
         const challenge = createHash('sha256').update(verifier).digest('base64url');
@@ -84,7 +99,7 @@ postgres('pinned OAuth Provider 1.6.30 confidential-client lifecycle', () => {
             code_challenge: challenge, code_challenge_method: 'S256',
         }).toString();
         const authorize = await handler(new Request(authorizeURL, {
-            headers: { host: 'account.harmonicbeacon.com', cookie: sessionCookie! },
+            headers: { host: 'account.harmonicbeacon.com', cookie: sessionCookie },
         }));
         expect(authorize.status).toBeGreaterThanOrEqual(300);
         expect(authorize.status).toBeLessThan(400);

--- a/src/lib/account/auth.ts
+++ b/src/lib/account/auth.ts
@@ -23,9 +23,8 @@ import {
 import {
     ACCOUNT_PASSWORD_MAX_LENGTH,
     ACCOUNT_PASSWORD_MIN_LENGTH,
-    hashAccountPassword,
-    verifyAccountPassword,
-} from '@/lib/session-auth';
+} from '@/lib/account/password-policy';
+import { hashAccountPassword, verifyAccountPassword } from '@/lib/session-auth';
 import { normalizeBeaconDisplayName } from '@/lib/account/profile';
 
 function normalizedDisplayName(value: unknown): string {
@@ -257,7 +256,10 @@ function buildAccountAuth() {
         advanced: {
             cookiePrefix: ACCOUNT_COOKIE_PREFIX,
             cookies: { session_token: { name: ACCOUNT_SESSION_COOKIE } },
-            useSecureCookies: baseURL.startsWith('https://'),
+            // Better Auth prepends `__Secure-` when this flag is true, even to
+            // an explicit `__Host-` custom name. Attributes below provide the
+            // HTTPS guarantees without producing an invalid double prefix.
+            useSecureCookies: false,
             defaultCookieAttributes: {
                 httpOnly: true,
                 secure: baseURL.startsWith('https://'),

--- a/src/lib/account/password-policy.ts
+++ b/src/lib/account/password-policy.ts
@@ -1,0 +1,14 @@
+/**
+ * Canonical Account credential length policy.
+ *
+ * Passwords have no composition rules: every string inside this inclusive
+ * range is eligible. Hashing, rate limits and reauthentication remain separate
+ * security boundaries.
+ */
+export const ACCOUNT_PASSWORD_MIN_LENGTH = 8;
+export const ACCOUNT_PASSWORD_MAX_LENGTH = 128;
+
+export function accountPasswordLengthValid(password: string): boolean {
+    return password.length >= ACCOUNT_PASSWORD_MIN_LENGTH &&
+        password.length <= ACCOUNT_PASSWORD_MAX_LENGTH;
+}

--- a/src/lib/session-auth.ts
+++ b/src/lib/session-auth.ts
@@ -1,6 +1,8 @@
 import { createHash, randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
 import { promisify } from 'node:util';
 
+import { accountPasswordLengthValid } from '@/lib/account/password-policy';
+
 export const SESSION_COOKIE_NAME = 'hb_session';
 export const DEFAULT_SESSION_COOKIE_TTL_SECONDS = 7 * 24 * 60 * 60;
 
@@ -8,9 +10,6 @@ const SESSION_TOKEN_BYTES = 32;
 const SHA256_HEX_LENGTH = 64;
 const SCRYPT_KEY_LENGTH = 32;
 const scryptAsync = promisify(scrypt);
-
-export const ACCOUNT_PASSWORD_MIN_LENGTH = 12;
-export const ACCOUNT_PASSWORD_MAX_LENGTH = 128;
 
 export type IssuedSessionToken = {
     cookieValue: string;
@@ -71,8 +70,7 @@ export async function verifyStaffPassword(
 
 /** Shared credential format for Account password identities. */
 export async function hashAccountPassword(password: string): Promise<string> {
-    if (password.length < ACCOUNT_PASSWORD_MIN_LENGTH ||
-        password.length > ACCOUNT_PASSWORD_MAX_LENGTH) {
+    if (!accountPasswordLengthValid(password)) {
         throw new Error('Account password length is outside the accepted range');
     }
     const salt = randomBytes(16);
@@ -84,8 +82,7 @@ export async function verifyAccountPassword(input: {
     hash: string;
     password: string;
 }): Promise<boolean> {
-    if (input.password.length < ACCOUNT_PASSWORD_MIN_LENGTH ||
-        input.password.length > ACCOUNT_PASSWORD_MAX_LENGTH) return false;
+    if (!accountPasswordLengthValid(input.password)) return false;
     const match = /^scrypt-v1\$([A-Za-z0-9_-]+)\$([A-Za-z0-9_-]+)$/.exec(input.hash);
     if (!match) return false;
     const salt = Buffer.from(match[1], 'base64url');


### PR DESCRIPTION
Closes the staging Account credential UX and session-cookie failure reproduced during acceptance.

- sets the canonical password policy to 8–128 characters with no composition rules while preserving scrypt, verification, rate limits, reauthentication and revocation
- adds ES/EN guidance, repeated-password validation, accessible show/hide controls, focused in-form feedback and duplicate-submit protection
- fixes Better Auth double-prefixing the explicit host-only cookie (`__Secure-__Host-...`) and preserves every Set-Cookie across the credential facade
- deletes only the exact newly-created session if post-create validation cannot safely deliver it
- adds a disposable staging acceptance runbook

Verification:
- focused Account/UI/auth: 27 passed
- full Vitest: 1757 passed, 44 skipped
- real PostgreSQL catch-all sign-in → cookies → Account session → OAuth lifecycle: 1 passed
- TypeScript: green
- ESLint: green (2 pre-existing warnings in pinned public nav asset)
- production build: green
- diff-check: clean

No deploy or merge performed. Account staging acceptance remains required.