### PR TITLE
fix(account): move Account into the user menu

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -141,6 +141,18 @@ describe('middleware', () => {
             ));
             expect(response.headers.get('x-middleware-request-x-hb-account-locale')).toBe('en');
         });
+
+        it.each([
+            ['/account', '0'],
+            ['/verify-email', '0'],
+            ['/nav-slot', '1'],
+        ])('marks only the isolated avatar document as the navigation slot: %s', (pathname, expected) => {
+            const response = accountRequest(pathname);
+            expect(response.headers.get('x-middleware-request-x-hb-account-nav-slot')).toBe(expected);
+            if (pathname !== '/nav-slot') {
+                expect(response.headers.get('content-security-policy')).toContain("frame-src 'self'");
+            }
+        });
     });
     describe('EarlyBird invitation URL scrubbing', () => {
         it.each([

--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -149,8 +149,13 @@
     .language { min-width:60px; min-height:44px; padding:0 5px; border:0; border-radius:999px; color:#8A7F6B; background:transparent; cursor:pointer; font:500 11px/1 Inter,system-ui,sans-serif; letter-spacing:.1em; }
     .language strong { color:#C9A24E; font-weight:600; }
     .sep { opacity:.42; padding:0 2px; }
-    .account-link { display:block; width:44px; height:44px; border-radius:999px; }
-    .account { display:block; width:44px; height:44px; border:0; border-radius:999px; pointer-events:none; background:transparent; color-scheme:dark; }
+    .account-control { position:relative; width:44px; height:44px; flex:0 0 44px; }
+    .account { position:relative; z-index:1; display:block; width:44px; height:44px; border:0; border-radius:999px; pointer-events:none; background:transparent; color-scheme:dark; }
+    .account-trigger { position:absolute; z-index:2; inset:0; width:44px; height:44px; padding:0; border:0; border-radius:999px; background:transparent; cursor:pointer; }
+    .account-menu { position:absolute; z-index:4; top:calc(100% + 8px); right:0; min-width:164px; padding:6px; border:1px solid rgba(201,162,78,.34); border-radius:12px; background:#16120D; box-shadow:0 18px 48px rgba(0,0,0,.34); }
+    .account-menu[hidden] { display:none; }
+    .account-menu a { display:flex; min-height:44px; align-items:center; padding:10px 12px; border-radius:8px; color:#E9E0D0; font-size:11px; font-weight:600; letter-spacing:.12em; text-transform:uppercase; white-space:nowrap; }
+    .account-menu a:hover { color:#F4EEE2; background:rgba(201,162,78,.1); }
     .toggle { display:none; width:44px; height:44px; padding:0 10px; border:0; background:transparent; cursor:pointer; }
     .toggle span { display:block; height:1.5px; margin:5px 0; background:#ADA089; transition:transform .25s ease,opacity .2s ease; }
     .toggle[aria-expanded=true] span:nth-child(1) { transform:translateY(6.5px) rotate(45deg); }
@@ -198,6 +203,7 @@
 
     disconnectedCallback() {
       if (this.observer) this.observer.disconnect();
+      if (this.outsideClick) document.removeEventListener('click', this.outsideClick);
     }
 
     render() {
@@ -210,7 +216,8 @@
       var brandHref = localizedHref(MAIN_ORIGIN + '/', language);
       var menuLabel = language === 'es' ? 'Menú' : 'Menu';
       var navLabel = language === 'es' ? 'Navegación principal' : 'Primary navigation';
-      var accountLabel = language === 'es' ? 'Cuenta y perfil de Harmonic Beacon' : 'Harmonic Beacon account and profile';
+      var userMenuLabel = language === 'es' ? 'Menú de usuario' : 'User menu';
+      var accountLabel = language === 'es' ? 'Cuenta' : 'Account';
       this.shadowRoot.innerHTML = '<style>' + style + '</style>' +
         '<header class="nav"><div class="inner">' +
           '<a class="brand" href="' + brandHref + '" aria-label="Harmonic Beacon">' +
@@ -219,9 +226,11 @@
           '<nav aria-label="' + navLabel + '"><ul class="links">' + items + '</ul></nav>' +
           '<div style="display:flex;align-items:center;gap:2px">' +
             '<button class="language" type="button" aria-label="Language / Idioma"><span class="en">EN</span><span class="sep">/</span><span class="es">ES</span></button>' +
-            '<a class="account-link" href="' + accountPageHref(language) + '" aria-label="' + accountLabel + '">' +
+            '<div class="account-control">' +
               '<iframe class="account" src="' + accountSlotHref(language) + '" title="' + accountLabel + '" aria-hidden="true" tabindex="-1" referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>' +
-            '</a>' +
+              '<button class="account-trigger" type="button" aria-label="' + userMenuLabel + '" aria-haspopup="menu" aria-controls="hb-account-menu" aria-expanded="false"></button>' +
+              '<div class="account-menu" id="hb-account-menu" role="menu" hidden><a role="menuitem" href="' + accountPageHref(language) + '">' + accountLabel + '</a></div>' +
+            '</div>' +
             '<button class="toggle" type="button" aria-label="' + menuLabel + '" aria-expanded="false"><span></span><span></span><span></span></button>' +
           '</div>' +
         '</div><nav class="mobile" aria-label="' + navLabel + '"><ul>' + items + '</ul></nav></header>';
@@ -235,6 +244,34 @@
         this.render();
         if (location.hostname !== 'harmonicbeacon.com' && location.hostname !== 'www.harmonicbeacon.com') location.reload();
       });
+      var accountTrigger = this.shadowRoot.querySelector('.account-trigger');
+      var accountMenu = this.shadowRoot.querySelector('.account-menu');
+      var accountMenuLink = accountMenu.querySelector('a');
+      var setAccountMenuOpen = function (open) {
+        accountTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+        accountMenu.hidden = !open;
+      };
+      accountTrigger.addEventListener('click', function () {
+        setAccountMenuOpen(accountTrigger.getAttribute('aria-expanded') !== 'true');
+      });
+      accountTrigger.addEventListener('keydown', function (event) {
+        if (event.key !== 'ArrowDown') return;
+        event.preventDefault();
+        setAccountMenuOpen(true);
+        accountMenuLink.focus();
+      });
+      [accountTrigger, accountMenuLink].forEach(function (control) {
+        control.addEventListener('keydown', function (event) {
+          if (event.key !== 'Escape') return;
+          setAccountMenuOpen(false);
+          accountTrigger.focus();
+        });
+      });
+      if (this.outsideClick) document.removeEventListener('click', this.outsideClick);
+      this.outsideClick = function (event) {
+        if (event.target !== this) setAccountMenuOpen(false);
+      }.bind(this);
+      document.addEventListener('click', this.outsideClick);
       var toggle = this.shadowRoot.querySelector('.toggle');
       var mobile = this.shadowRoot.querySelector('.mobile');
       toggle.addEventListener('click', function () {

--- a/src/app/__tests__/layout-locale.test.tsx
+++ b/src/app/__tests__/layout-locale.test.tsx
@@ -81,6 +81,22 @@ describe('root document locale boundary', () => {
     });
 
     it.each([
+        ['0', true],
+        ['1', false],
+    ])('enhances Account navigation except inside the isolated avatar slot (%s)', async (slot, expected) => {
+        const incoming = requestHeaders('account-staging.harmonicbeacon.com', 'en-US');
+        incoming.set('x-hb-account-locale', 'en');
+        incoming.set('x-hb-account-nav-slot', slot);
+        mocks.headers.mockResolvedValue(incoming);
+
+        const result = await RootLayout({ children: <main /> });
+        const body = result.props.children;
+        const navigation = body.props.children[0];
+        expect(navigation.props.allowRemoteEnhancement).toBe(expected);
+        expect(navigation.props.accountHref).toBe('https://account-staging.harmonicbeacon.com/account');
+    });
+
+    it.each([
         ['listen.harmonicbeacon.com', '#16120D'],
         ['listen.harmonicbeacon.com:443', '#16120D'],
         ['live.harmonicbeacon.com', '#07120f'],

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,9 +55,30 @@ hb-global-nav:not(:defined) {
   border: 1px solid rgba(244, 238, 226, .22);
   border-radius: 10px;
 }
-.account-password-field { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .45rem; align-items: stretch; }
-.account-password-field input { min-width: 0; }
-.account-password-toggle { min-width: 4.5rem; padding-inline: .7rem !important; }
+.account-password-field { position: relative; display: block; }
+.account-password-field input { width: 100%; min-width: 0; padding-right: 3.35rem; }
+.account-password-toggle {
+  position: absolute;
+  inset: 0 .1rem 0 auto;
+  width: 44px;
+  min-width: 44px;
+  min-height: 44px !important;
+  margin: auto 0;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 8px !important;
+  color: rgba(244, 238, 226, .72) !important;
+  background: transparent !important;
+}
+.account-password-toggle:hover { color: #e0bd69 !important; background: rgba(201, 162, 78, .08) !important; }
+.account-password-toggle svg {
+  width: 21px;
+  height: 21px;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
 .account-form input:focus-visible, .account-card button:focus-visible, .account-card a:focus-visible {
   outline: 2px solid #e0bd69;
   outline-offset: 3px;
@@ -118,6 +139,77 @@ body:has(.account-nav-slot) > .relative { width: 44px; height: 44px; }
   padding: 0;
   list-style: none;
 }
+
+.hb-global-navigation-fallback__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hb-global-navigation-fallback__account-control {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+}
+
+.hb-global-navigation-fallback__account-control summary {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  list-style: none;
+  border: 1px solid rgba(201, 162, 78, .55);
+  border-radius: 999px;
+  color: #e9e0d0;
+  background: rgba(22, 18, 13, .82);
+  cursor: pointer;
+}
+
+.hb-global-navigation-fallback__account-control summary::-webkit-details-marker { display: none; }
+
+.hb-global-navigation-fallback__account-control summary:focus-visible {
+  outline: 2px solid #c9a24e;
+  outline-offset: 3px;
+}
+
+.hb-global-navigation-fallback__account-control svg {
+  width: 24px;
+  height: 24px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+}
+
+.hb-global-navigation-fallback__account-menu {
+  position: absolute;
+  z-index: 4;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 164px;
+  padding: 6px;
+  border: 1px solid rgba(201, 162, 78, .34);
+  border-radius: 12px;
+  background: #16120d;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, .34);
+}
+
+.hb-global-navigation-fallback__account-menu a {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 8px;
+  color: #e9e0d0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.hb-global-navigation-fallback__account-menu a[aria-current="page"] { color: #c9a24e; }
 
 .hb-global-navigation-fallback li a {
   padding: 9px 8px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,10 @@ import localFont from "next/font/local";
 import { headers } from "next/headers";
 import { LocaleProvider } from "@/context/LocaleContext";
 import { GlobalNavigation } from "@/components/brand/GlobalNavigation";
-import { globalNavigationSurface } from "@/lib/brand/global-navigation";
+import {
+  globalNavigationAccountHref,
+  globalNavigationSurface,
+} from "@/lib/brand/global-navigation";
 import { requestBrowserLocale, requestLocale } from "@/lib/i18n-server";
 import { isCanonicalListenerHost } from "@/lib/listener/public-discovery";
 import { isAccountHost } from "@/lib/account/config";
@@ -112,10 +115,8 @@ export default async function RootLayout({
   // exact public host so event-language defaults elsewhere remain untouched.
   const listenerHost = isCanonicalListenerHost(incomingHeaders);
   const accountHost = isAccountHost(incomingHeaders.get('host'));
-  const accountHref = incomingHeaders.get('host')?.toLowerCase().split(':')[0] ===
-    'account-staging.harmonicbeacon.com'
-    ? 'https://account-staging.harmonicbeacon.com/account' as const
-    : 'https://account.harmonicbeacon.com/account' as const;
+  const accountNavSlot = accountHost && incomingHeaders.get('x-hb-account-nav-slot') === '1';
+  const accountHref = globalNavigationAccountHref(incomingHeaders);
   // This application is the Live surface by default. Listener and its staging
   // host opt into their own active item explicitly; local/E2E hosts continue
   // to exercise the same global header as production Live.
@@ -139,8 +140,8 @@ export default async function RootLayout({
         <GlobalNavigation
           active={navigationSurface}
           locale={locale}
-          allowRemoteEnhancement={!accountHost}
-          accountHref={accountHost ? accountHref : undefined}
+          allowRemoteEnhancement={!accountNavSlot}
+          accountHref={accountHref}
         />
         <LocaleProvider initialLocale={locale}>
           {/* Main content */}

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -25,15 +25,15 @@ manifest and visual-review update together.
 
 ## Global navigation
 
-The cross-product header is intentionally not vendored. Listener and Live load
-the canonical web component directly from
-`https://harmonicbeacon.com/assets/hb-global-nav.js`, owned by
-`AlterMundi/harmonicbeacon.com` (introduced in main merge `9fa515f6` and last
-reviewed here at `28ab05d67b3dfe020a28b62c27ba4d2ee8bafe66`; the reviewed
-asset SHA-256 is `3761c4d497024093f0180863247ca39e7009ec1ff3a96bddeb1a833bfdc992bc`).
-The local light-DOM links are an accessible,
-same-destination fallback only; the shared runtime asset owns the visible
-desktop/mobile component so a navigation edit propagates to all three products.
+Listener, Live and Account serve a byte-pinned local snapshot of the canonical
+web component rather than executing JavaScript supplied at runtime by another
+origin. The source is `AlterMundi/harmonicbeacon.com` commit
+`ae3608e3ec603b424efb729373dddd8d3a7f6e93`; the vendored
+`public/assets/hb-global-nav.js` SHA-256 is
+`be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f`.
+The local light-DOM markup remains the accessible, same-destination fallback.
+Both implementations keep Account out of the primary destination list and
+expose it from the user-icon menu.
 
 ## Font source and license
 

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -9,7 +9,15 @@
       "docs/brand/BRANDING.md": "68abcacb4263277071309f808455c08c9a8afdb5f0caeae6bf1599b9d2f66c31"
     }
   },
+  "globalNavigation": {
+    "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
+    "commit": "ae3608e3ec603b424efb729373dddd8d3a7f6e93",
+    "source": "assets/hb-global-nav.js",
+    "path": "public/assets/hb-global-nav.js",
+    "sha256": "be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f"
+  },
   "snapshots": {
+    "public/assets/hb-global-nav.js": "be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f",
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
   },

--- a/src/components/account/AccountPasswordField.tsx
+++ b/src/components/account/AccountPasswordField.tsx
@@ -20,7 +20,19 @@ export function AccountPasswordField({ label, showLabel, hideLabel, ...input }: 
                 aria-label={revealed ? hideLabel : showLabel}
                 aria-pressed={revealed}
                 onClick={() => setRevealed((value) => !value)}
-            >{revealed ? hideLabel : showLabel}</button>
+            >
+                {revealed ? (
+                    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                        <path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6-9.5-6-9.5-6Z" />
+                        <circle cx="12" cy="12" r="2.75" />
+                    </svg>
+                ) : (
+                    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                        <path d="M3 3l18 18" />
+                        <path d="M10.6 6.1A10.8 10.8 0 0 1 12 6c6 0 9.5 6 9.5 6a16.8 16.8 0 0 1-2.3 3.1M14.1 14.2a3 3 0 0 1-4.3-4.3M6.2 6.3C3.8 8 2.5 12 2.5 12s3.5 6 9.5 6c1.3 0 2.5-.3 3.5-.7" />
+                    </svg>
+                )}
+            </button>
         </span>
     </label>;
 }

--- a/src/components/account/__tests__/AccountClient.test.ts
+++ b/src/components/account/__tests__/AccountClient.test.ts
@@ -112,9 +112,14 @@ describe('Account cross-product logout completion', () => {
         const repeated = screen.getByLabelText('Repeat password');
         fireEvent.change(password, { target: { value: '12345678' } });
         fireEvent.change(repeated, { target: { value: '87654321' } });
-        fireEvent.click(screen.getAllByRole('button', { name: 'Show password' })[0]);
+        const reveal = screen.getAllByRole('button', { name: 'Show password' })[0];
+        expect(reveal).toHaveTextContent('');
+        expect(reveal.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
+        fireEvent.click(reveal);
         expect(password).toHaveAttribute('type', 'text');
-        expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute('aria-pressed', 'true');
+        const conceal = screen.getByRole('button', { name: 'Hide password' });
+        expect(conceal).toHaveAttribute('aria-pressed', 'true');
+        expect(conceal).toHaveTextContent('');
         fireEvent.submit(password.closest('form')!);
         expect(fetchMock).not.toHaveBeenCalled();
         expect(screen.getByRole('status')).toHaveTextContent('Passwords do not match.');

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -3,18 +3,17 @@ import Script from 'next/script';
 
 import type { UiLocale } from '@/lib/i18n';
 
-// Byte-pinned local snapshot of harmonicbeacon.com@ceeea30a. Protected product
+// Byte-pinned local snapshot of harmonicbeacon.com@ae3608e3. Protected product
 // origins never execute remotely supplied JavaScript with their host cookies.
 export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
-export const GLOBAL_NAVIGATION_PROVENANCE = 'ceeea30a94417331450c420fbfb8fc2e6a0a9b2d';
-export const GLOBAL_NAVIGATION_SHA256 = '16f17fdd9dfde76e5d574dd0e408a5b533d9138f222910821a4425169e147151';
+export const GLOBAL_NAVIGATION_PROVENANCE = 'ae3608e3ec603b424efb729373dddd8d3a7f6e93';
+export const GLOBAL_NAVIGATION_SHA256 = 'be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f';
 
 export type GlobalNavigationSurface = 'events' | 'listen' | 'account';
 
 const links = [
     { key: 'events', href: 'https://live.harmonicbeacon.com/', en: 'Events', es: 'Eventos' },
     { key: 'listen', href: 'https://listen.harmonicbeacon.com/', en: 'Listen', es: 'Escuchar' },
-    { key: 'account', href: 'https://account.harmonicbeacon.com/account', en: 'Account', es: 'Cuenta' },
     { key: 'news', href: 'https://harmonicbeacon.com/eventos/', en: 'News', es: 'Novedades' },
     { key: 'why', href: 'https://harmonicbeacon.com/#porque', en: 'Why it works', es: 'Por qué funciona' },
     { key: 'team', href: 'https://harmonicbeacon.com/#team', en: 'Team', es: 'Equipo' },
@@ -40,24 +39,45 @@ export function GlobalNavigation({
     accountHref?: 'https://account.harmonicbeacon.com/account' | 'https://account-staging.harmonicbeacon.com/account';
 }) {
     const navLabel = locale === 'es' ? 'Navegación principal' : 'Primary navigation';
+    const userMenuLabel = locale === 'es' ? 'Menú de usuario' : 'User menu';
+    const accountLabel = locale === 'es' ? 'Cuenta' : 'Account';
+    const resolvedAccountHref = accountHref ?? 'https://account.harmonicbeacon.com/account';
     const fallback = (
         <nav className="hb-global-navigation-fallback" aria-label={navLabel}>
             <a className="hb-global-navigation-fallback__brand" href={withLanguage('https://harmonicbeacon.com/', locale)}>
                 Harmonic Beacon
             </a>
-            <ul>
-                {links.map((link) => (
-                    <li key={link.key}>
+            <div className="hb-global-navigation-fallback__actions">
+                <ul>
+                    {links.map((link) => (
+                        <li key={link.key}>
+                            <a
+                                href={withLanguage(link.href, locale)}
+                                aria-current={link.key === active ? 'page' : undefined}
+                            >
+                                {locale === 'es' ? link.es : link.en}
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+                <details className="hb-global-navigation-fallback__account-control">
+                    <summary aria-label={userMenuLabel}>
+                        <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+                            <circle cx="12" cy="8" r="3.25" />
+                            <path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5" />
+                        </svg>
+                    </summary>
+                    <div className="hb-global-navigation-fallback__account-menu" role="menu">
                         <a
-                            href={withLanguage(link.key === 'account' && accountHref
-                                ? accountHref : link.href, locale)}
-                            aria-current={link.key === active ? 'page' : undefined}
+                            href={withLanguage(resolvedAccountHref, locale)}
+                            role="menuitem"
+                            aria-current={active === 'account' ? 'page' : undefined}
                         >
-                            {locale === 'es' ? link.es : link.en}
+                            {accountLabel}
                         </a>
-                    </li>
-                ))}
-            </ul>
+                    </div>
+                </details>
+            </div>
         </nav>
     );
 

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -1,18 +1,22 @@
 // @vitest-environment jsdom
 
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import manifest from '@/brand/canonical/manifest.json';
 import {
     GlobalNavigation,
     GLOBAL_NAVIGATION_ASSET,
     GLOBAL_NAVIGATION_PROVENANCE,
     GLOBAL_NAVIGATION_SHA256,
 } from '@/components/brand/GlobalNavigation';
-import { globalNavigationSurface } from '@/lib/brand/global-navigation';
+import {
+    globalNavigationAccountHref,
+    globalNavigationSurface,
+} from '@/lib/brand/global-navigation';
 
 describe('canonical Harmonic Beacon global navigation', () => {
     it.each([
@@ -27,6 +31,16 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(globalNavigationSurface(new Headers({ host }))).toBe(expected);
     });
 
+    it.each([
+        ['account-staging.harmonicbeacon.com', 'https://account-staging.harmonicbeacon.com/account'],
+        ['earlybirds-staging.harmonicbeacon.com', 'https://account-staging.harmonicbeacon.com/account'],
+        ['live-staging.harmonicbeacon.com', 'https://account-staging.harmonicbeacon.com/account'],
+        ['listen.harmonicbeacon.com', 'https://account.harmonicbeacon.com/account'],
+        ['earlybirds-staging.harmonicbeacon.com, account.harmonicbeacon.com', 'https://account.harmonicbeacon.com/account'],
+    ] as const)('maps the exact host %s to Account href %s', (host, expected) => {
+        expect(globalNavigationAccountHref(new Headers({ host }))).toBe(expected);
+    });
+
     it('keeps an accessible same-destination fallback while the shared asset loads', () => {
         render(<GlobalNavigation active="listen" locale="en" />);
 
@@ -34,12 +48,27 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(screen.getByRole('link', { name: 'Events' })).toHaveAttribute('href', 'https://live.harmonicbeacon.com/?lang=en');
         expect(screen.getByRole('link', { name: 'Listen' })).toHaveAttribute('aria-current', 'page');
         expect(screen.getByRole('link', { name: 'News' })).toHaveAttribute('href', 'https://harmonicbeacon.com/eventos/?lang=en');
+        const userMenu = screen.getByLabelText('User menu');
+        expect(userMenu.tagName).toBe('SUMMARY');
+        const account = screen.getByRole('menuitem', { name: 'Account' });
+        expect(account).toHaveAttribute('href', 'https://account.harmonicbeacon.com/account?lang=en');
+        expect(account.closest('[role="menu"]')).toBeTruthy();
+        expect(account.closest('li')).toBeNull();
     });
 
     it('loads a byte-pinned local canonical asset instead of remote same-origin code', () => {
-        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('ceeea30a94417331450c420fbfb8fc2e6a0a9b2d');
+        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('ae3608e3ec603b424efb729373dddd8d3a7f6e93');
         const bytes = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'));
         expect(createHash('sha256').update(bytes).digest('hex')).toBe(GLOBAL_NAVIGATION_SHA256);
+        expect(manifest.globalNavigation.commit).toBe(GLOBAL_NAVIGATION_PROVENANCE);
+        expect(manifest.globalNavigation.sha256).toBe(GLOBAL_NAVIGATION_SHA256);
+        expect(manifest.snapshots[manifest.globalNavigation.path as keyof typeof manifest.snapshots])
+            .toBe(GLOBAL_NAVIGATION_SHA256);
+        const source = bytes.toString('utf8');
+        expect(source).toContain('class="account-trigger"');
+        expect(source).toContain('aria-haspopup="menu"');
+        expect(source).toContain('class="account-menu"');
+        expect(source).not.toContain('class="account-link"');
     });
 
     it('renders the same destinations in Spanish', () => {
@@ -57,8 +86,35 @@ describe('canonical Harmonic Beacon global navigation', () => {
             allowRemoteEnhancement={false}
             accountHref="https://account-staging.harmonicbeacon.com/account"
         />);
-        expect(within(view.container).getByRole('link', { name: 'Account' }))
+        const account = within(view.container).getByRole('menuitem', { name: 'Account' });
+        expect(account)
             .toHaveAttribute('href', 'https://account-staging.harmonicbeacon.com/account?lang=en');
+        expect(account).toHaveAttribute('aria-current', 'page');
+        expect(within(view.container).getByLabelText('User menu').querySelector('svg')).toBeTruthy();
         expect(view.container.querySelector('script')).toBeNull();
+    });
+
+    it('opens Account from the enhanced user menu instead of the primary links', () => {
+        document.body.innerHTML = '';
+        document.documentElement.lang = 'en';
+        const source = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'), 'utf8');
+        window.eval(source);
+
+        const navigation = document.querySelector('hb-global-nav');
+        const shadow = navigation?.shadowRoot;
+        expect(shadow).toBeTruthy();
+        expect(shadow?.querySelector('.links')?.textContent).not.toContain('Account');
+
+        const trigger = shadow?.querySelector<HTMLButtonElement>('.account-trigger');
+        const menu = shadow?.querySelector<HTMLElement>('.account-menu');
+        const account = menu?.querySelector<HTMLAnchorElement>('a');
+        expect(trigger).toHaveAttribute('aria-label', 'User menu');
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        expect(menu).toHaveAttribute('hidden');
+        expect(account?.textContent).toBe('Account');
+
+        fireEvent.click(trigger!);
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+        expect(menu).not.toHaveAttribute('hidden');
     });
 });

--- a/src/lib/brand/global-navigation.ts
+++ b/src/lib/brand/global-navigation.ts
@@ -1,5 +1,9 @@
 import type { GlobalNavigationSurface } from '@/components/brand/GlobalNavigation';
 
+export type GlobalNavigationAccountHref =
+    | 'https://account.harmonicbeacon.com/account'
+    | 'https://account-staging.harmonicbeacon.com/account';
+
 const PUBLIC_SURFACES: Record<string, GlobalNavigationSurface> = {
     'live.harmonicbeacon.com': 'events',
     'listen.harmonicbeacon.com': 'listen',
@@ -20,4 +24,17 @@ function normalizedHost(value: string | null): string | null {
 export function globalNavigationSurface(headers: Pick<Headers, 'get'>): GlobalNavigationSurface | null {
     const host = normalizedHost(headers.get('host'));
     return host ? (PUBLIC_SURFACES[host] ?? null) : null;
+}
+
+/** Keep every staging product inside the staging identity boundary, including
+ * the server-rendered fallback shown before the pinned navigation asset loads. */
+export function globalNavigationAccountHref(
+    headers: Pick<Headers, 'get'>,
+): GlobalNavigationAccountHref {
+    const host = normalizedHost(headers.get('host'));
+    return host === 'account-staging.harmonicbeacon.com' ||
+        host === 'earlybirds-staging.harmonicbeacon.com' ||
+        host === 'live-staging.harmonicbeacon.com'
+        ? 'https://account-staging.harmonicbeacon.com/account'
+        : 'https://account.harmonicbeacon.com/account';
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -136,10 +136,15 @@ export default function middleware(request: NextRequest): NextResponse {
                     : request.cookies.get('hb_locale')?.value === 'es' ? 'es'
                         : request.headers.get('accept-language')?.toLowerCase().startsWith('es') ? 'es' : 'en';
             forwarded.set('x-hb-account-locale', accountLocale);
+            // RootLayout may load the pinned navigation asset on every Account
+            // page except the isolated 44px avatar document itself. Overwrite
+            // this internal marker so a browser-supplied value cannot create or
+            // suppress the cross-origin iframe boundary.
+            forwarded.set('x-hb-account-nav-slot', pathname === '/nav-slot' ? '1' : '0');
             forwarded.set('x-nonce', nonce);
             const csp = pathname === '/nav-slot'
                 ? `default-src 'none'; style-src 'unsafe-inline'; frame-ancestors ${ACCOUNT_FRAME_ANCESTORS}`
-                : `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'strict-dynamic'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-src https://listen.harmonicbeacon.com https://earlybirds-staging.harmonicbeacon.com https://live.harmonicbeacon.com https://live-staging.harmonicbeacon.com; frame-ancestors 'none'; base-uri 'none'; object-src 'none'; form-action 'self'`;
+                : `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'strict-dynamic'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-src 'self' https://listen.harmonicbeacon.com https://earlybirds-staging.harmonicbeacon.com https://live.harmonicbeacon.com https://live-staging.harmonicbeacon.com; frame-ancestors 'none'; base-uri 'none'; object-src 'none'; form-action 'self'`;
             forwarded.set('Content-Security-Policy', csp);
             const response = pathname === '/'
                 ? NextResponse.rewrite(new URL('/account', request.url), { request: { headers: forwarded } })


### PR DESCRIPTION
## Outcome

- removes Account/Cuenta from the primary cross-product navigation destinations
- makes the user icon an explicit disclosure control whose menu contains Account
- keeps Listener/Live staging links inside Account staging before enhancement loads
- pins the matching canonical navigation asset from `harmonicbeacon.com@ae3608e3`
- replaces textual password reveal buttons with accessible open/closed eye icons

## Safety

- no auth, session, email, profile, payment, audio, LiveKit or event behavior changes
- no remote JavaScript execution; the navigation asset remains local and SHA-256 pinned
- 44px controls, keyboard disclosure, Escape handling and visible focus remain intact

## Verification

- 1,763 Vitest tests passed; 44 skipped
- focused navigation/account/brand tests: 48 passed
- TypeScript, focused ESLint and diff-check passed
- production Next build passed
- canonical site asset: 81 tests and static build passed

Tracks #396. Canonical source update: AlterMundi/harmonicbeacon.com#68.