### PR TITLE
fix(account): expose the pinned navigation asset

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -55,6 +55,7 @@ describe('middleware', () => {
 
         it.each([
             '/', '/account', '/verify-email', '/reset-password', '/nav-slot',
+            '/assets/hb-global-nav.js',
             '/.well-known/openid-configuration', '/api/account/health/ready',
             '/_next/static/chunk.js',
         ])('allows only the exact Account route inventory: %s', (pathname) => {
@@ -63,6 +64,7 @@ describe('middleware', () => {
 
         it.each([
             '/listener', '/early-birds', '/session/active', '/ops',
+            '/assets/other.js', '/assets/hb-global-nav.js/extra',
             '/api/early-birds/stream', '/api/livekit/token',
             '/api/founding-listeners/checkout', '/api/auth/ticket',
         ])('404s product/event/media route %s in the Account container', (pathname) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -124,6 +124,7 @@ export default function middleware(request: NextRequest): NextResponse {
             const allowed = pathname === '/' || pathname === '/account' ||
                 pathname.startsWith('/account/') || pathname === '/verify-email' ||
                 pathname === '/reset-password' || pathname === '/nav-slot' ||
+                pathname === '/assets/hb-global-nav.js' ||
                 pathname.startsWith('/.well-known/') || pathname.startsWith('/api/account/') ||
                 pathname.startsWith('/_next/') || pathname === '/favicon.ico';
             if (!allowed) return new NextResponse(null, { status: 404 });


### PR DESCRIPTION
## Outcome

Allow the dedicated Account runtime to serve exactly `/assets/hb-global-nav.js`, which #407 references from Account pages. Every other `/assets/*` path and every suffix remain 404.

## Why

The post-cutover HTTPS smoke caught the exact asset returning 404. Account staging was immediately rolled back to `160662cec69f9b766967d827b745990b9a3d3da7`; Listener staging was never changed. This follow-up closes that ingress seam before retrying staging.

## Verification

- 74 focused middleware/navigation tests passed
- TypeScript, focused ESLint and diff-check passed
- positive exact asset and negative other/suffix route cases are versioned

Tracks #396 and follows #407.