### PR TITLE
fix(account): expose pinned navigation asset at edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN npm run build
 
 FROM base AS runner
 WORKDIR /app
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    BEACON_ACCOUNT_NAV_ASSET=1
 
 ARG BEACON_GIT_SHA=unknown
 ARG BEACON_BUILD_TIME=unknown

--- a/ops/beacon-account/nginx/account-staging.harmonicbeacon.com.conf.template
+++ b/ops/beacon-account/nginx/account-staging.harmonicbeacon.com.conf.template
@@ -57,6 +57,16 @@ server {
         proxy_pass http://127.0.0.1:13003;
     }
 
+    location = /assets/hb-global-nav.js {
+        if ($request_method !~ ^(GET|HEAD)$) { return 405; }
+        access_log off;
+        proxy_pass http://127.0.0.1:13003;
+        add_header Cache-Control "public, max-age=300" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer" always;
+    }
+
     location = / {
         if ($request_method !~ ^(GET|HEAD)$) { return 405; }
         access_log off;

--- a/ops/beacon-account/nginx/account.harmonicbeacon.com.conf.template
+++ b/ops/beacon-account/nginx/account.harmonicbeacon.com.conf.template
@@ -57,6 +57,16 @@ server {
         proxy_pass http://127.0.0.1:13002;
     }
 
+    location = /assets/hb-global-nav.js {
+        if ($request_method !~ ^(GET|HEAD)$) { return 405; }
+        access_log off;
+        proxy_pass http://127.0.0.1:13002;
+        add_header Cache-Control "public, max-age=300" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer" always;
+    }
+
     location = / {
         if ($request_method !~ ^(GET|HEAD)$) { return 405; }
         access_log off;

--- a/ops/beacon-account/test/contract.test.mjs
+++ b/ops/beacon-account/test/contract.test.mjs
@@ -130,6 +130,38 @@ esac
   return result;
 }
 
+function navigationAssetCapabilityFixture(present) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'beacon-account-nav-capability-'));
+  const docker = path.join(directory, 'docker');
+  fs.writeFileSync(docker, `#!/bin/sh
+set -eu
+test "$1" = image
+test "$2" = inspect
+if [ "$MOCK_NAV_ASSET_PRESENT" -eq 1 ]; then
+  echo BEACON_ACCOUNT_NAV_ASSET=1
+else
+  echo NODE_ENV=production
+fi
+`);
+  fs.chmodSync(docker, 0o755);
+  const result = spawnSync('sh', ['-c', `
+    . "$ACCOUNT_LIFECYCLE_LIB"
+    actual=0
+    account_image_supports_navigation_asset "${'d'.repeat(40)}" && actual=1
+    test "$actual" = "$MOCK_NAV_ASSET_PRESENT"
+  `], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${directory}:${process.env.PATH}`,
+      ACCOUNT_LIFECYCLE_LIB,
+      MOCK_NAV_ASSET_PRESENT: present ? '1' : '0',
+    },
+  });
+  fs.rmSync(directory, { recursive: true, force: true });
+  return result;
+}
+
 const publicEd25519Key = {
   kid: 'staging-ed25519-key', kty: 'OKP', alg: 'EdDSA', crv: 'Ed25519', x: 'A'.repeat(43),
 };
@@ -254,7 +286,7 @@ test('lifecycle verifies immutable provenance and does not downgrade schemas', (
   assert.match(start, /docker image inspect "harmonic-beacon\/account:\$BEACON_ACCOUNT_IMAGE_TAG"/);
   assert.match(start, /account_compose build account-production[\s\S]*account_validate/);
   assert.match(start, /account_compose up -d "account-mail-worker-\$environment" "account-\$environment"/);
-  assert.match(start, /health-smoke\.sh"[\s\\]+"\$environment" "\$ACCOUNT_DEPLOY_FILE" "\$BEACON_ACCOUNT_GIT_SHA" 1/);
+  assert.match(start, /health-smoke\.sh"[\s\\]+"\$environment" "\$ACCOUNT_DEPLOY_FILE" "\$BEACON_ACCOUNT_GIT_SHA" 1 1/);
   assert.ok(start.indexOf('health-smoke.sh') < start.lastIndexOf('cutover_started=0'));
   assert.match(start, /account_check_production_migrations before/);
   assert.match(start, /account_check_production_migrations after/);
@@ -271,9 +303,12 @@ test('lifecycle verifies immutable provenance and does not downgrade schemas', (
   assert.doesNotMatch(lib, /account_wait_healthy\(\) \{\s+container=\$1/);
   assert.match(lib, /account_image_supports_mail_worker/);
   assert.match(lib, /scripts\/process-account-mail-outbox\.ts/);
+  assert.match(lib, /account_image_supports_navigation_asset/);
   assert.match(rollback, /previous_worker_present=0/);
   assert.match(rollback, /account_image_supports_mail_worker/);
-  assert.match(rollback, /health-smoke\.sh"[\s\\]+"\$environment" "\$ACCOUNT_DEPLOY_FILE" "\$previous_sha" "\$previous_worker_present"/);
+  assert.match(rollback, /previous_nav_asset_present=0/);
+  assert.match(rollback, /account_image_supports_navigation_asset/);
+  assert.match(rollback, /health-smoke\.sh"[\s\\]+"\$environment" "\$ACCOUNT_DEPLOY_FILE" "\$previous_sha" "\$previous_worker_present"[\s\\]+"\$previous_nav_asset_present"/);
   assert.doesNotMatch(rollback, /account_restore_previous_runtime "\$environment" "\$previous_sha" 1/);
   assert.match(start, /account_require_internal_mail_network "\$environment"/);
   assert.match(lib, /docker network inspect "\$network"/);
@@ -288,13 +323,17 @@ test('lifecycle verifies immutable provenance and does not downgrade schemas', (
   assert.match(lib, /database was not downgraded|account_restore_previous_runtime/);
   assert.match(smoke, /verify-health-json\.sh/);
   assert.match(smoke, /--connect-timeout 3 --max-time 8/);
-  assert.equal((smoke.match(/--proto '=https'/g) ?? []).length, 2);
+  assert.match(smoke, /\/assets\/hb-global-nav\.js\?v=\$expected_sha/);
+  assert.match(smoke, /docker exec "\$container" sha256sum \/app\/public\/assets\/hb-global-nav\.js/);
+  assert.match(smoke, /public navigation asset differs from running image/);
+  assert.equal((smoke.match(/--proto '=https'/g) ?? []).length, 3);
   assert.doesNotMatch(smoke, /\bnode\b/);
   const migrationGuard = fs.readFileSync(path.resolve(ROOT, '../../scripts/beacon-account/check-migrations.mjs'), 'utf8');
   assert.match(migrationGuard, /pending migrations differ from the reviewed Account-only list/);
   assert.match(migrationGuard, /unresolved migration/);
   assert.doesNotMatch(`${start}\n${lib}`, /migrate reset|migrate down|docker compose down|volume rm|prune/);
   const dockerfile = fs.readFileSync(path.resolve(ROOT, '../../Dockerfile'), 'utf8');
+  assert.match(dockerfile, /BEACON_ACCOUNT_NAV_ASSET=1/);
   assert.match(dockerfile, /ops\/beacon-account\/validate\.mjs/);
   for (const fixture of [
     'account.production.env.example',
@@ -318,6 +357,11 @@ test('runtime verification preserves the pre-worker rollback boundary', () => {
     verifyRunningFixture({ expectedWorkerPresent: 1, actualWorkerPresent: 0 }).status,
     0,
   );
+});
+
+test('navigation asset smoke preserves the pre-asset rollback boundary', () => {
+  assert.equal(navigationAssetCapabilityFixture(false).status, 0);
+  assert.equal(navigationAssetCapabilityFixture(true).status, 0);
 });
 
 test('health verifier accepts the exact public Ed25519 contract without optional use', () => {
@@ -365,7 +409,12 @@ test('nginx keeps Account hosts isolated and never logs token-bearing routes', (
     const nginx = fs.readFileSync(path.join(ROOT, 'nginx', name), 'utf8');
     assert.match(nginx, new RegExp(`proxy_pass http://127\\.0\\.0\\.1:${port}`));
     assert.match(nginx, new RegExp(`limit_req zone=${zone}`));
-    for (const route of ['/verify-email', '/reset-password', '/nav-slot']) {
+    for (const route of [
+      '/verify-email',
+      '/reset-password',
+      '/nav-slot',
+      '/assets/hb-global-nav.js',
+    ]) {
       const start = nginx.indexOf(`location = ${route} {`);
       assert.ok(start >= 0, `${route} must be exact`);
       assert.match(nginx.slice(start, nginx.indexOf('\n    }', start)), /access_log off;/);
@@ -374,6 +423,7 @@ test('nginx keeps Account hosts isolated and never logs token-bearing routes', (
     }
     const redirectServer = nginx.slice(0, nginx.indexOf('server {', nginx.indexOf('server {') + 1));
     assert.match(redirectServer, /access_log off;/);
+    assert.doesNotMatch(nginx, /location \^~ \/assets\//);
     assert.match(nginx, /location \/ \{ return 404; \}/);
     assert.doesNotMatch(nginx, /proxy_pass http:\/\/127\.0\.0\.1:(?!13002|13003)/);
     assert.doesNotMatch(nginx, /livekit|listener\/checkout|webhooks|events/);

--- a/scripts/beacon-account/health-smoke.sh
+++ b/scripts/beacon-account/health-smoke.sh
@@ -2,8 +2,8 @@
 set -eu
 . "$(dirname -- "$0")/lib.sh"
 
-environment=${1:?usage: health-smoke.sh staging|production /secure/deploy.env [expected-sha40] [worker-present]}
-ACCOUNT_DEPLOY_FILE=${2:?usage: health-smoke.sh staging|production /secure/deploy.env [expected-sha40] [worker-present]}
+environment=${1:?usage: health-smoke.sh staging|production /secure/deploy.env [expected-sha40] [worker-present] [nav-asset-present]}
+ACCOUNT_DEPLOY_FILE=${2:?usage: health-smoke.sh staging|production /secure/deploy.env [expected-sha40] [worker-present] [nav-asset-present]}
 export ACCOUNT_DEPLOY_FILE
 account_load_deploy_env "$ACCOUNT_DEPLOY_FILE"
 expected_sha=${3:-$BEACON_ACCOUNT_GIT_SHA}
@@ -14,10 +14,17 @@ if [ -z "$expected_worker_present" ]; then
   account_image_supports_mail_worker "$expected_sha" && expected_worker_present=1
 fi
 case "$expected_worker_present" in 0|1) ;; *) account_fail 'worker presence must be 0 or 1' ;; esac
+expected_nav_asset_present=${5:-}
+if [ -z "$expected_nav_asset_present" ]; then
+  expected_nav_asset_present=0
+  account_image_supports_navigation_asset "$expected_sha" && expected_nav_asset_present=1
+fi
+case "$expected_nav_asset_present" in 0|1) ;; *) account_fail 'navigation asset presence must be 0 or 1' ;; esac
 account_validate
 account_verify_running "$environment" "$expected_sha" "$expected_sha" "$expected_worker_present"
 command -v curl >/dev/null 2>&1 || account_fail 'curl is required for Account health smoke'
 command -v jq >/dev/null 2>&1 || account_fail 'jq is required for Account health smoke'
+command -v sha256sum >/dev/null 2>&1 || account_fail 'sha256sum is required for Account health smoke'
 
 port=13002
 origin=https://account.harmonicbeacon.com
@@ -31,6 +38,15 @@ curl --fail --silent --show-error --proto '=https' --connect-timeout 3 --max-tim
   "$origin/.well-known/openid-configuration" > "$tmp/discovery.json"
 curl --fail --silent --show-error --proto '=https' --connect-timeout 3 --max-time 8 \
   "$origin/.well-known/jwks.json" > "$tmp/jwks.json"
+if [ "$expected_nav_asset_present" -eq 1 ]; then
+  curl --fail --silent --show-error --proto '=https' --connect-timeout 3 --max-time 8 \
+    "$origin/assets/hb-global-nav.js?v=$expected_sha" > "$tmp/hb-global-nav.js"
+  container=$(account_container_name "$environment")
+  expected_nav_sha=$(docker exec "$container" sha256sum /app/public/assets/hb-global-nav.js | awk '{print $1}')
+  echo "$expected_nav_sha" | grep -Eq '^[0-9a-f]{64}$' || account_fail 'running navigation asset digest is invalid'
+  actual_nav_sha=$(sha256sum "$tmp/hb-global-nav.js" | awk '{print $1}')
+  test "$actual_nav_sha" = "$expected_nav_sha" || account_fail 'public navigation asset differs from running image'
+fi
 "$(dirname -- "$0")/verify-health-json.sh" \
   "$tmp" "$origin" "$expected_sha" "$BEACON_ACCOUNT_SCHEMA_VERSION"
 echo "Beacon Account $environment loopback and HTTPS discovery are healthy."

--- a/scripts/beacon-account/lib.sh
+++ b/scripts/beacon-account/lib.sh
@@ -241,6 +241,13 @@ account_image_supports_mail_worker() {
     >/dev/null 2>&1
 }
 
+account_image_supports_navigation_asset() {
+  sha=$1
+  docker image inspect "harmonic-beacon/account:$sha" \
+    --format '{{range .Config.Env}}{{println .}}{{end}}' |
+    grep -Fxq 'BEACON_ACCOUNT_NAV_ASSET=1'
+}
+
 account_restore_previous_runtime() {
   environment=$1
   previous_sha=$2

--- a/scripts/beacon-account/rollback-app.sh
+++ b/scripts/beacon-account/rollback-app.sh
@@ -17,7 +17,12 @@ previous_worker_present=0
 if account_image_supports_mail_worker "$previous_sha"; then
   previous_worker_present=1
 fi
+previous_nav_asset_present=0
+if account_image_supports_navigation_asset "$previous_sha"; then
+  previous_nav_asset_present=1
+fi
 account_restore_previous_runtime "$environment" "$previous_sha" "$previous_worker_present"
 "$(dirname -- "$0")/health-smoke.sh" \
-  "$environment" "$ACCOUNT_DEPLOY_FILE" "$previous_sha" "$previous_worker_present"
+  "$environment" "$ACCOUNT_DEPLOY_FILE" "$previous_sha" "$previous_worker_present" \
+  "$previous_nav_asset_present"
 echo "Beacon Account $environment runtime rolled back to $previous_sha; database was not downgraded."

--- a/scripts/beacon-account/start.sh
+++ b/scripts/beacon-account/start.sh
@@ -43,7 +43,7 @@ account_compose up -d "account-mail-worker-$environment" "account-$environment"
 [ "$environment" != production ] || account_check_production_migrations after
 account_verify_running "$environment"
 "$root/scripts/beacon-account/health-smoke.sh" \
-  "$environment" "$ACCOUNT_DEPLOY_FILE" "$BEACON_ACCOUNT_GIT_SHA" 1
+  "$environment" "$ACCOUNT_DEPLOY_FILE" "$BEACON_ACCOUNT_GIT_SHA" 1 1
 cutover_started=0
 trap - EXIT HUP INT TERM
 echo "Beacon Account $environment is healthy at exact SHA $BEACON_ACCOUNT_GIT_SHA."


### PR DESCRIPTION
Closes the Account staging edge gap discovered during the controlled f27d0e5 cutover.\n\n- proxies only exact `/assets/hb-global-nav.js` on Account prod/staging\n- keeps `/assets/*` deny-default and preserves no-log/security headers\n- extends lifecycle smoke to compare the public asset digest with the exact running image\n- adds contract coverage for both vhosts and the smoke\n\nObserved before this patch: app loopback returned the canonical asset with SHA-256 `be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f`, while nginx returned 404. Listener staging was not changed.\n\nGates: Account infra 17/17, shell syntax, ESLint focal, diff-check.