### PR TITLE
fix(nav): remove iframe and remote icon dependencies

### DIFF
--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -114,12 +114,6 @@
     return MAIN_ORIGIN + '/';
   }
 
-  function accountSlotHref(language) {
-    var url = new URL('/nav-slot', accountOrigin());
-    url.searchParams.set('lang', language);
-    return url.toString();
-  }
-
   function accountPageHref(language) {
     var url = new URL('/account', accountOrigin());
     url.searchParams.set('lang', language);
@@ -131,6 +125,17 @@
     return language === 'es' ? item.es : item.en;
   }
 
+  function beaconMarkPath() {
+    var points = [];
+    for (var index = 0; index <= 180; index += 1) {
+      var angle = Math.PI * 2 * index / 180;
+      var x = 100 + 92 * Math.cos(angle);
+      var y = 100 + 92 * Math.sin(angle * 3);
+      points.push((index === 0 ? 'M' : 'L') + x.toFixed(2) + ' ' + y.toFixed(2));
+    }
+    return points.join(' ');
+  }
+
   var style = `
     :host { display:block; height:72px; color:#E9E0D0; font-family:Inter,system-ui,-apple-system,sans-serif; }
     :host([overlay]) { height:0; }
@@ -139,7 +144,8 @@
     .nav { position:fixed; inset:0 0 auto; z-index:2147483000; min-height:72px; border-bottom:1px solid rgba(244,238,226,.08); background:rgba(22,18,13,.82); backdrop-filter:blur(14px); -webkit-backdrop-filter:blur(14px); }
     .inner { width:100%; max-width:1180px; min-height:72px; margin:0 auto; padding:12px 24px; display:flex; align-items:center; justify-content:space-between; gap:18px; }
     .brand { display:flex; align-items:center; gap:10px; flex:0 0 auto; border-radius:8px; }
-    .mark { width:30px; height:30px; display:block; filter:drop-shadow(0 2px 14px rgba(201,162,78,.18)); }
+    .mark { width:30px; height:30px; display:block; color:#C9A24E; filter:drop-shadow(0 2px 14px rgba(201,162,78,.18)); }
+    .mark path { fill:none; stroke:currentColor; stroke-width:3.4; stroke-linecap:round; stroke-linejoin:round; vector-effect:non-scaling-stroke; }
     .wordmark { color:#F4EEE2; font-size:12px; font-weight:600; letter-spacing:.18em; text-transform:uppercase; white-space:nowrap; }
     .links { display:flex; align-items:center; justify-content:flex-end; gap:1px; margin:0; padding:0; list-style:none; }
     .links a { position:relative; display:block; padding:9px 8px; border-radius:999px; color:#ADA089; font-size:10.5px; font-weight:500; letter-spacing:.12em; line-height:1.2; text-transform:uppercase; white-space:nowrap; transition:color .25s ease,background .25s ease; }
@@ -150,8 +156,9 @@
     .language strong { color:#C9A24E; font-weight:600; }
     .sep { opacity:.42; padding:0 2px; }
     .account-control { position:relative; width:44px; height:44px; flex:0 0 44px; }
-    .account { position:relative; z-index:1; display:block; width:44px; height:44px; border:0; border-radius:999px; pointer-events:none; background:transparent; color-scheme:dark; }
-    .account-trigger { position:absolute; z-index:2; inset:0; width:44px; height:44px; padding:0; border:0; border-radius:999px; background:transparent; cursor:pointer; }
+    .account-trigger { position:absolute; z-index:2; inset:0; display:grid; place-items:center; width:44px; height:44px; padding:0; border:1px solid rgba(201,162,78,.32); border-radius:999px; color:#E9E0D0; background:rgba(244,238,226,.045); cursor:pointer; transition:color .2s ease,border-color .2s ease,background .2s ease; }
+    .account-trigger:hover,.account-trigger[aria-expanded=true] { color:#F4EEE2; border-color:rgba(201,162,78,.62); background:rgba(201,162,78,.12); }
+    .account-trigger svg { width:22px; height:22px; fill:none; stroke:currentColor; stroke-width:1.65; stroke-linecap:round; stroke-linejoin:round; }
     .account-menu { position:absolute; z-index:4; top:calc(100% + 8px); right:0; min-width:164px; padding:6px; border:1px solid rgba(201,162,78,.34); border-radius:12px; background:#16120D; box-shadow:0 18px 48px rgba(0,0,0,.34); }
     .account-menu[hidden] { display:none; }
     .account-menu a { display:flex; min-height:44px; align-items:center; padding:10px 12px; border-radius:8px; color:#E9E0D0; font-size:11px; font-weight:600; letter-spacing:.12em; text-transform:uppercase; white-space:nowrap; }
@@ -221,14 +228,13 @@
       this.shadowRoot.innerHTML = '<style>' + style + '</style>' +
         '<header class="nav"><div class="inner">' +
           '<a class="brand" href="' + brandHref + '" aria-label="Harmonic Beacon">' +
-            '<img class="mark" src="' + MAIN_ORIGIN + '/favicon.svg" alt="">' +
+            '<svg class="mark" viewBox="0 0 200 200" aria-hidden="true" focusable="false"><path d="' + beaconMarkPath() + '"></path></svg>' +
             '<span class="wordmark">Harmonic Beacon</span></a>' +
           '<nav aria-label="' + navLabel + '"><ul class="links">' + items + '</ul></nav>' +
           '<div style="display:flex;align-items:center;gap:2px">' +
             '<button class="language" type="button" aria-label="Language / Idioma"><span class="en">EN</span><span class="sep">/</span><span class="es">ES</span></button>' +
             '<div class="account-control">' +
-              '<iframe class="account" src="' + accountSlotHref(language) + '" title="' + accountLabel + '" aria-hidden="true" tabindex="-1" referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>' +
-              '<button class="account-trigger" type="button" aria-label="' + userMenuLabel + '" aria-haspopup="menu" aria-controls="hb-account-menu" aria-expanded="false"></button>' +
+              '<button class="account-trigger" type="button" aria-label="' + userMenuLabel + '" aria-haspopup="menu" aria-controls="hb-account-menu" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="12" cy="8" r="3.25"></circle><path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5"></path></svg></button>' +
               '<div class="account-menu" id="hb-account-menu" role="menu" hidden><a role="menuitem" href="' + accountPageHref(language) + '">' + accountLabel + '</a></div>' +
             '</div>' +
             '<button class="toggle" type="button" aria-label="' + menuLabel + '" aria-expanded="false"><span></span><span></span><span></span></button>' +

--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -127,10 +127,10 @@
 
   function beaconMarkPath() {
     var points = [];
-    for (var index = 0; index <= 180; index += 1) {
-      var angle = Math.PI * 2 * index / 180;
-      var x = 100 + 92 * Math.cos(angle);
-      var y = 100 + 92 * Math.sin(angle * 3);
+    for (var index = 0; index <= 280; index += 1) {
+      var angle = Math.PI * 2 * index / 280;
+      var x = 100 + 92 * Math.cos(angle * 3);
+      var y = 100 + 92 * Math.sin(angle * 2);
       points.push((index === 0 ? 'M' : 'L') + x.toFixed(2) + ' ' + y.toFixed(2));
     }
     return points.join(' ');

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -28,12 +28,14 @@ manifest and visual-review update together.
 Listener, Live and Account serve a byte-pinned local snapshot of the canonical
 web component rather than executing JavaScript supplied at runtime by another
 origin. The source is `AlterMundi/harmonicbeacon.com` commit
-`ae3608e3ec603b424efb729373dddd8d3a7f6e93`; the vendored
+`ab453af247e31362fddd6bc2a91c7f266cf2b7ae`; the vendored
 `public/assets/hb-global-nav.js` SHA-256 is
-`be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f`.
+`65773aaf87e1112204b470d793f92b34ae9e2dae06929c6559458420f5045cc2`.
 The local light-DOM markup remains the accessible, same-destination fallback.
 Both implementations keep Account out of the primary destination list and
-expose it from the user-icon menu.
+expose it from the user-icon menu. The enhanced navigation renders both the
+Beacon mark and user glyph locally; it does not embed Account in an iframe or
+fetch a cross-origin image.
 
 ## Font source and license
 
@@ -52,5 +54,5 @@ Both families are covered by the SIL Open Font License 1.1; the relevant
   is pinned from the Google Fonts repository commit above, with trailing
   whitespace normalized for the repository gate.
 
-No font, analytics or decorative brand asset is fetched at runtime. The single
-global-navigation component above is the deliberate exception.
+No font, analytics or decorative brand asset is fetched at runtime. The global
+navigation is served as the byte-pinned local snapshot described above.

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -28,9 +28,9 @@ manifest and visual-review update together.
 Listener, Live and Account serve a byte-pinned local snapshot of the canonical
 web component rather than executing JavaScript supplied at runtime by another
 origin. The source is `AlterMundi/harmonicbeacon.com` commit
-`ab453af247e31362fddd6bc2a91c7f266cf2b7ae`; the vendored
+`10de81fd576aa9d65ec8c3861cc38903403a63f0`; the vendored
 `public/assets/hb-global-nav.js` SHA-256 is
-`65773aaf87e1112204b470d793f92b34ae9e2dae06929c6559458420f5045cc2`.
+`7637edccfc2250615274ff7c6b5464e2532fff0081ab0d2e76ec0413c0097d10`.
 The local light-DOM markup remains the accessible, same-destination fallback.
 Both implementations keep Account out of the primary destination list and
 expose it from the user-icon menu. The enhanced navigation renders both the

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -11,13 +11,13 @@
   },
   "globalNavigation": {
     "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
-    "commit": "ab453af247e31362fddd6bc2a91c7f266cf2b7ae",
+    "commit": "10de81fd576aa9d65ec8c3861cc38903403a63f0",
     "source": "assets/hb-global-nav.js",
     "path": "public/assets/hb-global-nav.js",
-    "sha256": "65773aaf87e1112204b470d793f92b34ae9e2dae06929c6559458420f5045cc2"
+    "sha256": "7637edccfc2250615274ff7c6b5464e2532fff0081ab0d2e76ec0413c0097d10"
   },
   "snapshots": {
-    "public/assets/hb-global-nav.js": "65773aaf87e1112204b470d793f92b34ae9e2dae06929c6559458420f5045cc2",
+    "public/assets/hb-global-nav.js": "7637edccfc2250615274ff7c6b5464e2532fff0081ab0d2e76ec0413c0097d10",
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
   },

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -11,13 +11,13 @@
   },
   "globalNavigation": {
     "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
-    "commit": "ae3608e3ec603b424efb729373dddd8d3a7f6e93",
+    "commit": "ab453af247e31362fddd6bc2a91c7f266cf2b7ae",
     "source": "assets/hb-global-nav.js",
     "path": "public/assets/hb-global-nav.js",
-    "sha256": "be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f"
+    "sha256": "65773aaf87e1112204b470d793f92b34ae9e2dae06929c6559458420f5045cc2"
   },
   "snapshots": {
-    "public/assets/hb-global-nav.js": "be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f",
+    "public/assets/hb-global-nav.js": "65773aaf87e1112204b470d793f92b34ae9e2dae06929c6559458420f5045cc2",
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
   },

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -3,11 +3,11 @@ import Script from 'next/script';
 
 import type { UiLocale } from '@/lib/i18n';
 
-// Byte-pinned local snapshot of harmonicbeacon.com@ab453af. Protected product
+// Byte-pinned local snapshot of harmonicbeacon.com@10de81f. Protected product
 // origins never execute remotely supplied JavaScript with their host cookies.
 export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
-export const GLOBAL_NAVIGATION_PROVENANCE = 'ab453af247e31362fddd6bc2a91c7f266cf2b7ae';
-export const GLOBAL_NAVIGATION_SHA256 = '65773aaf87e1112204b470d793f92b34ae9e2dae06929c6559458420f5045cc2';
+export const GLOBAL_NAVIGATION_PROVENANCE = '10de81fd576aa9d65ec8c3861cc38903403a63f0';
+export const GLOBAL_NAVIGATION_SHA256 = '7637edccfc2250615274ff7c6b5464e2532fff0081ab0d2e76ec0413c0097d10';
 
 export type GlobalNavigationSurface = 'events' | 'listen' | 'account';
 

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -3,11 +3,11 @@ import Script from 'next/script';
 
 import type { UiLocale } from '@/lib/i18n';
 
-// Byte-pinned local snapshot of harmonicbeacon.com@ae3608e3. Protected product
+// Byte-pinned local snapshot of harmonicbeacon.com@ab453af. Protected product
 // origins never execute remotely supplied JavaScript with their host cookies.
 export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
-export const GLOBAL_NAVIGATION_PROVENANCE = 'ae3608e3ec603b424efb729373dddd8d3a7f6e93';
-export const GLOBAL_NAVIGATION_SHA256 = 'be7fa241f393ec37b335756408897a47c16e86aaf30eb23a24fb7912a5ebb58f';
+export const GLOBAL_NAVIGATION_PROVENANCE = 'ab453af247e31362fddd6bc2a91c7f266cf2b7ae';
+export const GLOBAL_NAVIGATION_SHA256 = '65773aaf87e1112204b470d793f92b34ae9e2dae06929c6559458420f5045cc2';
 
 export type GlobalNavigationSurface = 'events' | 'listen' | 'account';
 

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -57,7 +57,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
     });
 
     it('loads a byte-pinned local canonical asset instead of remote same-origin code', () => {
-        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('ab453af247e31362fddd6bc2a91c7f266cf2b7ae');
+        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('10de81fd576aa9d65ec8c3861cc38903403a63f0');
         const bytes = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'));
         expect(createHash('sha256').update(bytes).digest('hex')).toBe(GLOBAL_NAVIGATION_SHA256);
         expect(manifest.globalNavigation.commit).toBe(GLOBAL_NAVIGATION_PROVENANCE);
@@ -67,6 +67,9 @@ describe('canonical Harmonic Beacon global navigation', () => {
         const source = bytes.toString('utf8');
         expect(source).toContain('class="account-trigger"');
         expect(source).toContain('beaconMarkPath()');
+        expect(source).toContain('Math.cos(angle * 3)');
+        expect(source).toContain('Math.sin(angle * 2)');
+        expect(source).toContain('index <= 280');
         expect(source).toContain('<svg class="mark"');
         expect(source).toContain('<circle cx="12" cy="8" r="3.25">');
         expect(source).toContain('aria-haspopup="menu"');
@@ -108,6 +111,10 @@ describe('canonical Harmonic Beacon global navigation', () => {
         const navigation = document.querySelector('hb-global-nav');
         const shadow = navigation?.shadowRoot;
         expect(shadow).toBeTruthy();
+        expect(shadow?.querySelector('iframe')).toBeNull();
+        const markPath = shadow?.querySelector<SVGPathElement>('.mark path')?.getAttribute('d');
+        expect(markPath).toMatch(/^M192\.00 100\.00 L191\.79 104\.13/);
+        expect(markPath?.match(/[ML]/g)).toHaveLength(281);
         expect(shadow?.querySelector('.links')?.textContent).not.toContain('Account');
 
         const trigger = shadow?.querySelector<HTMLButtonElement>('.account-trigger');

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -57,7 +57,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
     });
 
     it('loads a byte-pinned local canonical asset instead of remote same-origin code', () => {
-        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('ae3608e3ec603b424efb729373dddd8d3a7f6e93');
+        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('ab453af247e31362fddd6bc2a91c7f266cf2b7ae');
         const bytes = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'));
         expect(createHash('sha256').update(bytes).digest('hex')).toBe(GLOBAL_NAVIGATION_SHA256);
         expect(manifest.globalNavigation.commit).toBe(GLOBAL_NAVIGATION_PROVENANCE);
@@ -66,9 +66,14 @@ describe('canonical Harmonic Beacon global navigation', () => {
             .toBe(GLOBAL_NAVIGATION_SHA256);
         const source = bytes.toString('utf8');
         expect(source).toContain('class="account-trigger"');
+        expect(source).toContain('beaconMarkPath()');
+        expect(source).toContain('<svg class="mark"');
+        expect(source).toContain('<circle cx="12" cy="8" r="3.25">');
         expect(source).toContain('aria-haspopup="menu"');
         expect(source).toContain('class="account-menu"');
         expect(source).not.toContain('class="account-link"');
+        expect(source).not.toContain('<iframe');
+        expect(source).not.toContain('/favicon.svg');
     });
 
     it('renders the same destinations in Spanish', () => {


### PR DESCRIPTION
Closes the Account staging visual regression reported during human acceptance.\n\n- renders the canonical Harmonic Beacon mark inline instead of loading a cross-origin favicon\n- renders the profile glyph directly in the user-menu trigger\n- removes the Account nav iframe entirely\n- keeps Account out of the primary destination list\n- preserves local byte-pinned provenance and no-PII navigation\n\nCanonical source: AlterMundi/harmonicbeacon.com@10de81fd576aa9d65ec8c3861cc38903403a63f0\n\nGates: canonical 81/81 + build; webapp focused 31/31; full 1771 pass / 44 skip; TypeScript; focused ESLint; production build; local Chromium 390px confirms canonical mark + profile glyph and zero iframe.