### PR TITLE
fix(listener): serve pinned global navigation asset

### DIFF
--- a/ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/earlybirds-staging.harmonicbeacon.com.conf.template
@@ -172,6 +172,22 @@ server {
         add_header Cache-Control "private, no-store" always;
     }
 
+    # One byte-pinned navigation asset; never open the broader /assets prefix.
+    location = /assets/hb-global-nav.js {
+        if ($request_method !~ ^(GET|HEAD)$) { return 405; }
+        access_log off;
+        proxy_pass http://127.0.0.1:13001;
+        proxy_http_version 1.1;
+        proxy_set_header Host earlybirds-staging.harmonicbeacon.com;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+        add_header Cache-Control "public, max-age=300" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header X-Harmonic-Beacon-Environment "early-birds-staging" always;
+    }
+
     location /_next/webpack-hmr {
         proxy_pass http://127.0.0.1:13001;
         proxy_http_version 1.1;

--- a/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
+++ b/ops/early-birds-preview/nginx/listen.harmonicbeacon.com.conf.template
@@ -118,6 +118,22 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # One byte-pinned navigation asset; never open the broader /assets prefix.
+    location = /assets/hb-global-nav.js {
+        if ($request_method !~ ^(GET|HEAD)$) { return 405; }
+        access_log off;
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host listen.harmonicbeacon.com;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+        add_header Cache-Control "public, max-age=300" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header X-Harmonic-Beacon-Environment "listener-public-free" always;
+    }
+
     location = /api/health {
         proxy_pass http://127.0.0.1:13000;
         proxy_http_version 1.1;

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -406,17 +406,35 @@ test('nginx templates isolate staging, stream and the constrained public Listene
   assert.match(app, /location \^~ \/api\/early-birds\//);
   assert.equal(
     (app.match(/X-Harmonic-Beacon-Environment "early-birds-staging"/g) ?? []).length,
-    11,
-    'server plus ten sensitive HTTPS staging locations retain the environment attestation when add_header inheritance stops',
+    12,
+    'server plus eleven sensitive HTTPS staging locations retain the environment attestation when add_header inheritance stops',
   );
   assert.equal(
     (listener.match(/X-Harmonic-Beacon-Environment "listener-public-free"/g) ?? []).length,
-    10,
-    'server plus nine sensitive HTTPS locations retain the environment attestation when add_header inheritance stops',
+    11,
+    'server plus ten sensitive HTTPS locations retain the environment attestation when add_header inheritance stops',
   );
   assert.match(app, /location = \/ \{[^}]*access_log off;[^}]*rewrite \^ \/listener break;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13001;/s);
   assert.match(app, /location \/_next\/webpack-hmr \{[^}]*proxy_pass http:\/\/127\.0\.0\.1:13001;[^}]*Upgrade \$http_upgrade;[^}]*Connection "upgrade";/s);
   assert.match(app, /location \/_next\/static\/ \{[^}]*proxy_pass http:\/\/127\.0\.0\.1:13001;[^}]*Cache-Control "private, no-store"/s);
+  for (const [source, host, port, environment] of [
+    [listener, 'listen.harmonicbeacon.com', '13000', 'listener-public-free'],
+    [app, 'earlybirds-staging.harmonicbeacon.com', '13001', 'early-birds-staging'],
+  ]) {
+    const marker = 'location = /assets/hb-global-nav.js {';
+    assert.equal(source.split(marker).length - 1, 1);
+    const block = source.slice(source.indexOf(marker), source.indexOf('\n    }', source.indexOf(marker)) + 6);
+    assert.match(block, /request_method !~ \^\(GET\|HEAD\)\$/);
+    assert.match(block, /access_log off;/);
+    assert.match(block, new RegExp(`proxy_pass http://127\\.0\\.0\\.1:${port};`));
+    assert.match(block, new RegExp(`proxy_set_header Host ${host.replaceAll('.', '\\.')};`));
+    assert.match(block, /Cache-Control "public, max-age=300"/);
+    assert.match(block, /X-Content-Type-Options nosniff/);
+    assert.match(block, /Referrer-Policy "no-referrer"/);
+    assert.match(block, new RegExp(`X-Harmonic-Beacon-Environment "${environment}"`));
+  }
+  assert.doesNotMatch(app, /location \^~ \/assets\//);
+  assert.doesNotMatch(listener, /location \^~ \/assets\//);
   assert.match(app, /location = \/api\/listener\/analysis\/frame \{[^}]*proxy_pass http:\/\/127\.0\.0\.1:13001;[^}]*Cache-Control "private, no-store"/s);
   assert.match(app, /location = \/api\/listener\/checkout \{[^}]*access_log off;[^}]*client_max_body_size 512;[^}]*limit_req zone=listener_checkout burst=4 nodelay;[^}]*limit_req_status 429;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13001;[^}]*Cache-Control "private, no-store"/s);
   assert.match(app, /location = \/api\/listener\/checkout\/live-workbench \{[^}]*access_log off;[^}]*client_max_body_size 256;[^}]*limit_req zone=listener_checkout burst=2 nodelay;[^}]*limit_req_status 429;[^}]*proxy_pass http:\/\/127\.0\.0\.1:13001;[^}]*Cache-Control "private, no-store"/s);

--- a/scripts/listener-identity-staging/edge-smoke.sh
+++ b/scripts/listener-identity-staging/edge-smoke.sh
@@ -26,6 +26,30 @@ headers=$(mktemp)
 body=$(mktemp)
 trap 'rm -f "$headers" "$body"' EXIT HUP INT TERM
 
+nav_code=$(curl_edge --max-time 5 --dump-header "$headers" --output "$body" \
+  --write-out '%{http_code}' "$origin/assets/hb-global-nav.js")
+test "$nav_code" = 200 || listener_staging_fail 'canonical navigation asset is not available at the exact edge path'
+expected_nav_sha=$(docker exec listener-identity-staging-app \
+  sha256sum /app/public/assets/hb-global-nav.js | awk '{print $1}')
+test "$(sha256sum "$body" | awk '{print $1}')" = "$expected_nav_sha" ||
+  listener_staging_fail 'public navigation asset differs from the verified app image'
+grep -Eiq '^cache-control: public, max-age=300' "$headers" ||
+  listener_staging_fail 'navigation asset lost bounded public caching'
+grep -Eiq '^x-content-type-options: nosniff' "$headers" ||
+  listener_staging_fail 'navigation asset lost nosniff'
+grep -Eiq '^referrer-policy: no-referrer' "$headers" ||
+  listener_staging_fail 'navigation asset lost no-referrer'
+if grep -Fq '<iframe' "$body"; then
+  listener_staging_fail 'navigation asset unexpectedly embeds an iframe'
+fi
+if grep -Fq '/favicon.svg' "$body"; then
+  listener_staging_fail 'navigation asset unexpectedly fetches the remote favicon'
+fi
+for asset_path in /assets/other.js /assets/hb-global-nav.js/extra; do
+  code=$(curl_edge --max-time 5 --output /dev/null --write-out '%{http_code}' "$origin$asset_path")
+  test "$code" = 404 || listener_staging_fail "unexpected asset path escaped deny-default: $asset_path"
+done
+
 login_code=$(curl_edge --max-time 5 --dump-header "$headers" --output "$body" \
   --write-out '%{http_code}' "$origin/api/account/login")
 if test "$account_enabled" = 1; then


### PR DESCRIPTION
Completes the no-iframe navigation fix on Listener edges.\n\n- exposes only exact /assets/hb-global-nav.js on Listener production and staging templates\n- keeps /assets/other.js and suffixes deny-default\n- preserves no-log, bounded cache, nosniff, no-referrer and environment attestation\n- extends staging edge smoke to compare the public bytes with the exact image and reject iframe/remote favicon regressions\n\nGates: preview + Listener identity contracts 51/51; POSIX shell syntax; diff-check.