### PR TITLE
fix(nav): repin narrow-mobile Account and Listener header

### DIFF
--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -176,6 +176,7 @@
     :focus-visible { outline:2px solid #C9A24E; outline-offset:3px; }
     @media (max-width:1120px) { .links { display:none; } .toggle { display:block; } .inner { min-height:68px; padding-top:10px; padding-bottom:10px; } :host { height:68px; } :host([overlay]) { height:0; } }
     @media (max-width:430px) { .inner { padding-left:16px; padding-right:12px; } .wordmark { font-size:10.5px; letter-spacing:.14em; } .mark { width:27px; height:27px; } .language { min-width:54px; } }
+    @media (max-width:365px) { .wordmark { display:none; } }
     @media (prefers-reduced-motion:reduce) { * { scroll-behavior:auto !important; transition:none !important; } }
     @supports not ((backdrop-filter:blur(1px)) or (-webkit-backdrop-filter:blur(1px))) { .nav { background:#16120D; } }
   `;

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -28,9 +28,9 @@ manifest and visual-review update together.
 Listener, Live and Account serve a byte-pinned local snapshot of the canonical
 web component rather than executing JavaScript supplied at runtime by another
 origin. The source is `AlterMundi/harmonicbeacon.com` commit
-`10de81fd576aa9d65ec8c3861cc38903403a63f0`; the vendored
+`8770e6a844960c90768d08a03f3232a47123cac9`; the vendored
 `public/assets/hb-global-nav.js` SHA-256 is
-`7637edccfc2250615274ff7c6b5464e2532fff0081ab0d2e76ec0413c0097d10`.
+`a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10`.
 The local light-DOM markup remains the accessible, same-destination fallback.
 Both implementations keep Account out of the primary destination list and
 expose it from the user-icon menu. The enhanced navigation renders both the

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -11,13 +11,13 @@
   },
   "globalNavigation": {
     "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
-    "commit": "10de81fd576aa9d65ec8c3861cc38903403a63f0",
+    "commit": "8770e6a844960c90768d08a03f3232a47123cac9",
     "source": "assets/hb-global-nav.js",
     "path": "public/assets/hb-global-nav.js",
-    "sha256": "7637edccfc2250615274ff7c6b5464e2532fff0081ab0d2e76ec0413c0097d10"
+    "sha256": "a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10"
   },
   "snapshots": {
-    "public/assets/hb-global-nav.js": "7637edccfc2250615274ff7c6b5464e2532fff0081ab0d2e76ec0413c0097d10",
+    "public/assets/hb-global-nav.js": "a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10",
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
   },

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -3,11 +3,11 @@ import Script from 'next/script';
 
 import type { UiLocale } from '@/lib/i18n';
 
-// Byte-pinned local snapshot of harmonicbeacon.com@10de81f. Protected product
+// Byte-pinned local snapshot of harmonicbeacon.com@8770e6a. Protected product
 // origins never execute remotely supplied JavaScript with their host cookies.
 export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
-export const GLOBAL_NAVIGATION_PROVENANCE = '10de81fd576aa9d65ec8c3861cc38903403a63f0';
-export const GLOBAL_NAVIGATION_SHA256 = '7637edccfc2250615274ff7c6b5464e2532fff0081ab0d2e76ec0413c0097d10';
+export const GLOBAL_NAVIGATION_PROVENANCE = '8770e6a844960c90768d08a03f3232a47123cac9';
+export const GLOBAL_NAVIGATION_SHA256 = 'a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10';
 
 export type GlobalNavigationSurface = 'events' | 'listen' | 'account';
 

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -57,7 +57,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
     });
 
     it('loads a byte-pinned local canonical asset instead of remote same-origin code', () => {
-        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('10de81fd576aa9d65ec8c3861cc38903403a63f0');
+        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('8770e6a844960c90768d08a03f3232a47123cac9');
         const bytes = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'));
         expect(createHash('sha256').update(bytes).digest('hex')).toBe(GLOBAL_NAVIGATION_SHA256);
         expect(manifest.globalNavigation.commit).toBe(GLOBAL_NAVIGATION_PROVENANCE);
@@ -70,6 +70,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(source).toContain('Math.cos(angle * 3)');
         expect(source).toContain('Math.sin(angle * 2)');
         expect(source).toContain('index <= 280');
+        expect(source).toContain('@media (max-width:365px) { .wordmark { display:none; } }');
         expect(source).toContain('<svg class="mark"');
         expect(source).toContain('<circle cx="12" cy="8" r="3.25">');
         expect(source).toContain('aria-haspopup="menu"');


### PR DESCRIPTION
## Outcome

Repins Account and Listener to the canonical navigation from harmonicbeacon.com@8770e6a (merged in canonical PR #69). The only asset behavior change hides the redundant wordmark at 365px and below so the canonical 44px hamburger remains fully reachable on narrow phones.

## Evidence

- asset byte-identical to canonical source
- SHA-256 a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10
- Chromium: full 44x44 hamburger and no overflow at 320, 351, 360, 365, 366 and 390px
- focal navigation/middleware: 74 passed
- TypeScript, ESLint and diff-check: pass
- no Account identity, Listener playback, audio, events, payments, schema or infrastructure changes

No deploy or DNS change in this PR. Tracks #396.