### PR TITLE
feat(nav): show local Account sign-in state in Live

### DIFF
--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -7,7 +7,6 @@
   var LISTENER_STAGING_ORIGIN = 'https://earlybirds-staging.harmonicbeacon.com';
   var LIVE_ORIGIN = 'https://live.harmonicbeacon.com';
   var LIVE_STAGING_ORIGIN = 'https://live-staging.harmonicbeacon.com';
-  var ACCOUNT_ORIGIN = 'https://account.harmonicbeacon.com';
   var ACCOUNT_STAGING_ORIGIN = 'https://account-staging.harmonicbeacon.com';
   var ELEMENT_NAME = 'hb-global-nav';
 
@@ -95,12 +94,11 @@
     return null;
   }
 
-  function accountOrigin() {
-    return (location.hostname === 'earlybirds-staging.harmonicbeacon.com' ||
-      location.hostname === 'live-staging.harmonicbeacon.com' ||
-      location.hostname === 'account-staging.harmonicbeacon.com')
-      ? ACCOUNT_STAGING_ORIGIN
-      : ACCOUNT_ORIGIN;
+  function accountControlAvailable() {
+    var host = location.hostname.toLowerCase();
+    return host === 'earlybirds-staging.harmonicbeacon.com' ||
+      host === 'live-staging.harmonicbeacon.com' ||
+      host === 'account-staging.harmonicbeacon.com';
   }
 
   function accountReturnTo() {
@@ -115,7 +113,7 @@
   }
 
   function accountPageHref(language) {
-    var url = new URL('/account', accountOrigin());
+    var url = new URL('/account', ACCOUNT_STAGING_ORIGIN);
     url.searchParams.set('lang', language);
     url.searchParams.set('return_to', accountReturnTo());
     return url.toString();
@@ -158,6 +156,8 @@
     .account-control { position:relative; width:44px; height:44px; flex:0 0 44px; }
     .account-trigger { position:absolute; z-index:2; inset:0; display:grid; place-items:center; width:44px; height:44px; padding:0; border:1px solid rgba(201,162,78,.32); border-radius:999px; color:#E9E0D0; background:rgba(244,238,226,.045); cursor:pointer; transition:color .2s ease,border-color .2s ease,background .2s ease; }
     .account-trigger:hover,.account-trigger[aria-expanded=true] { color:#F4EEE2; border-color:rgba(201,162,78,.62); background:rgba(201,162,78,.12); }
+    .account-trigger.signed-in { border-color:rgba(201,162,78,.72); background:rgba(201,162,78,.1); }
+    .account-trigger.signed-in::after { content:""; position:absolute; right:3px; bottom:3px; width:7px; height:7px; border:2px solid #16120D; border-radius:999px; background:#C9A24E; }
     .account-trigger svg { width:22px; height:22px; fill:none; stroke:currentColor; stroke-width:1.65; stroke-linecap:round; stroke-linejoin:round; }
     .account-menu { position:absolute; z-index:4; top:calc(100% + 8px); right:0; min-width:164px; padding:6px; border:1px solid rgba(201,162,78,.34); border-radius:12px; background:#16120D; box-shadow:0 18px 48px rgba(0,0,0,.34); }
     .account-menu[hidden] { display:none; }
@@ -186,6 +186,14 @@
   }
 
   class HarmonicBeaconGlobalNav extends HTMLElement {
+    static get observedAttributes() {
+      return ['data-account-signed-in'];
+    }
+
+    attributeChangedCallback(name, previous, next) {
+      if (name === 'data-account-signed-in' && previous !== next && this.shadowRoot) this.render();
+    }
+
     connectedCallback() {
       if (this.shadowRoot) return;
       // The conductor cockpit embeds the ordinary room as an operational
@@ -224,8 +232,17 @@
       var brandHref = localizedHref(MAIN_ORIGIN + '/', language);
       var menuLabel = language === 'es' ? 'Menú' : 'Menu';
       var navLabel = language === 'es' ? 'Navegación principal' : 'Primary navigation';
-      var userMenuLabel = language === 'es' ? 'Menú de usuario' : 'User menu';
+      var accountSignedIn = this.hasAttribute('data-account-signed-in');
+      var userMenuLabel = language === 'es'
+        ? (accountSignedIn ? 'Menú de usuario, sesión iniciada' : 'Menú de usuario')
+        : (accountSignedIn ? 'User menu, signed in' : 'User menu');
       var accountLabel = language === 'es' ? 'Cuenta' : 'Account';
+      var accountControl = accountControlAvailable()
+        ? '<div class="account-control">' +
+            '<button class="account-trigger' + (accountSignedIn ? ' signed-in' : '') + '" type="button" aria-label="' + userMenuLabel + '" aria-haspopup="menu" aria-controls="hb-account-menu" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="12" cy="8" r="3.25"></circle><path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5"></path></svg></button>' +
+            '<div class="account-menu" id="hb-account-menu" role="menu" hidden><a role="menuitem" href="' + accountPageHref(language) + '">' + accountLabel + '</a></div>' +
+          '</div>'
+        : '';
       this.shadowRoot.innerHTML = '<style>' + style + '</style>' +
         '<header class="nav"><div class="inner">' +
           '<a class="brand" href="' + brandHref + '" aria-label="Harmonic Beacon">' +
@@ -234,10 +251,7 @@
           '<nav aria-label="' + navLabel + '"><ul class="links">' + items + '</ul></nav>' +
           '<div style="display:flex;align-items:center;gap:2px">' +
             '<button class="language" type="button" aria-label="Language / Idioma"><span class="en">EN</span><span class="sep">/</span><span class="es">ES</span></button>' +
-            '<div class="account-control">' +
-              '<button class="account-trigger" type="button" aria-label="' + userMenuLabel + '" aria-haspopup="menu" aria-controls="hb-account-menu" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="12" cy="8" r="3.25"></circle><path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5"></path></svg></button>' +
-              '<div class="account-menu" id="hb-account-menu" role="menu" hidden><a role="menuitem" href="' + accountPageHref(language) + '">' + accountLabel + '</a></div>' +
-            '</div>' +
+            accountControl +
             '<button class="toggle" type="button" aria-label="' + menuLabel + '" aria-expanded="false"><span></span><span></span><span></span></button>' +
           '</div>' +
         '</div><nav class="mobile" aria-label="' + navLabel + '"><ul>' + items + '</ul></nav></header>';
@@ -253,32 +267,34 @@
       });
       var accountTrigger = this.shadowRoot.querySelector('.account-trigger');
       var accountMenu = this.shadowRoot.querySelector('.account-menu');
-      var accountMenuLink = accountMenu.querySelector('a');
-      var setAccountMenuOpen = function (open) {
-        accountTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
-        accountMenu.hidden = !open;
-      };
-      accountTrigger.addEventListener('click', function () {
-        setAccountMenuOpen(accountTrigger.getAttribute('aria-expanded') !== 'true');
-      });
-      accountTrigger.addEventListener('keydown', function (event) {
-        if (event.key !== 'ArrowDown') return;
-        event.preventDefault();
-        setAccountMenuOpen(true);
-        accountMenuLink.focus();
-      });
-      [accountTrigger, accountMenuLink].forEach(function (control) {
-        control.addEventListener('keydown', function (event) {
-          if (event.key !== 'Escape') return;
-          setAccountMenuOpen(false);
-          accountTrigger.focus();
+      if (accountTrigger && accountMenu) {
+        var accountMenuLink = accountMenu.querySelector('a');
+        var setAccountMenuOpen = function (open) {
+          accountTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+          accountMenu.hidden = !open;
+        };
+        accountTrigger.addEventListener('click', function () {
+          setAccountMenuOpen(accountTrigger.getAttribute('aria-expanded') !== 'true');
         });
-      });
-      if (this.outsideClick) document.removeEventListener('click', this.outsideClick);
-      this.outsideClick = function (event) {
-        if (event.target !== this) setAccountMenuOpen(false);
-      }.bind(this);
-      document.addEventListener('click', this.outsideClick);
+        accountTrigger.addEventListener('keydown', function (event) {
+          if (event.key !== 'ArrowDown') return;
+          event.preventDefault();
+          setAccountMenuOpen(true);
+          accountMenuLink.focus();
+        });
+        [accountTrigger, accountMenuLink].forEach(function (control) {
+          control.addEventListener('keydown', function (event) {
+            if (event.key !== 'Escape') return;
+            setAccountMenuOpen(false);
+            accountTrigger.focus();
+          });
+        });
+        if (this.outsideClick) document.removeEventListener('click', this.outsideClick);
+        this.outsideClick = function (event) {
+          if (event.target !== this) setAccountMenuOpen(false);
+        }.bind(this);
+        document.addEventListener('click', this.outsideClick);
+      }
       var toggle = this.shadowRoot.querySelector('.toggle');
       var mobile = this.shadowRoot.querySelector('.mobile');
       toggle.addEventListener('click', function () {

--- a/src/app/__tests__/layout-account-navigation.test.tsx
+++ b/src/app/__tests__/layout-account-navigation.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    headers: vi.fn(),
+    localAccountState: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({ headers: mocks.headers }));
+vi.mock('next/font/google', () => ({
+    Syne: () => ({ variable: '--font-syne' }),
+    Space_Mono: () => ({ variable: '--font-space-mono' }),
+}));
+vi.mock('next/font/local', () => ({
+    default: () => ({ variable: '--font-local' }),
+}));
+vi.mock('@/lib/i18n-server', () => ({ requestLocale: vi.fn().mockResolvedValue('en') }));
+vi.mock('@/lib/brand/account-navigation-state', () => ({
+    locallyKnownLiveAccountSession: mocks.localAccountState,
+}));
+vi.mock('@/components/brand/GlobalNavigation', () => ({
+    GlobalNavigation: ({ accountHref, accountSignedIn }: {
+        accountHref: string;
+        accountSignedIn: boolean;
+    }) => <div data-testid="global-navigation" data-account-href={accountHref} data-signed-in={accountSignedIn} />,
+}));
+vi.mock('@/context/LocaleContext', () => ({
+    LocaleProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('sonner', () => ({ Toaster: () => null }));
+
+import RootLayout from '../layout';
+
+describe('root layout Account navigation hint', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('derives the staging hint from the host-local session and SSRs only the boolean', async () => {
+        const requestHeaders = new Headers({
+            host: 'live-staging.harmonicbeacon.com',
+            cookie: `hb_session=${'a'.repeat(43)}`,
+        });
+        mocks.headers.mockResolvedValue(requestHeaders);
+        mocks.localAccountState.mockResolvedValue(true);
+
+        render(await RootLayout({ children: <main>Live</main> }), { container: document });
+
+        expect(mocks.localAccountState).toHaveBeenCalledWith(requestHeaders);
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute(
+            'data-account-href',
+            'https://account-staging.harmonicbeacon.com/account',
+        );
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-signed-in', 'true');
+    });
+
+    it('keeps production Account hidden without reading local identity state', async () => {
+        mocks.headers.mockResolvedValue(new Headers({
+            host: 'live.harmonicbeacon.com',
+            cookie: `hb_session=${'a'.repeat(43)}`,
+        }));
+
+        render(await RootLayout({ children: <main>Live</main> }), { container: document });
+
+        expect(mocks.localAccountState).not.toHaveBeenCalled();
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute(
+            'data-account-href',
+            'https://account.harmonicbeacon.com/account',
+        );
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-signed-in', 'false');
+    });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,6 +79,24 @@ body:has(.live-ops-shell [role="dialog"]:not(.hidden)) > hb-global-nav {
   cursor: pointer;
 }
 
+.hb-global-navigation-fallback__account-control[data-account-signed-in] summary {
+  position: relative;
+  border-color: rgba(201, 162, 78, 0.72);
+  background: rgba(201, 162, 78, 0.1);
+}
+
+.hb-global-navigation-fallback__account-control[data-account-signed-in] summary::after {
+  content: "";
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 7px;
+  height: 7px;
+  border: 2px solid #16120d;
+  border-radius: 999px;
+  background: #c9a24e;
+}
+
 .hb-global-navigation-fallback__account-control summary::-webkit-details-marker {
   display: none;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   globalNavigationAccountHref,
   globalNavigationSurface,
 } from "@/lib/brand/global-navigation";
+import { locallyKnownLiveAccountSession } from "@/lib/brand/account-navigation-state";
 import { requestLocale } from "@/lib/i18n-server";
 import "@/styles/hb-brand.css";
 import "./globals.css";
@@ -81,6 +82,9 @@ export default async function RootLayout({
   const locale = await requestLocale();
   const navigationSurface = globalNavigationSurface(incomingHeaders) ?? "events";
   const accountHref = globalNavigationAccountHref(incomingHeaders);
+  const accountSignedIn = accountHref === "https://account-staging.harmonicbeacon.com/account"
+    ? await locallyKnownLiveAccountSession(incomingHeaders)
+    : false;
 
   return (
     <html lang={locale} data-lang={locale} className={`${cormorant.variable} ${inter.variable} ${syne.variable} ${spaceMono.variable}`}>
@@ -89,6 +93,7 @@ export default async function RootLayout({
           active={navigationSurface}
           locale={locale}
           accountHref={accountHref}
+          accountSignedIn={accountSignedIn}
         />
         <LocaleProvider initialLocale={locale}>
           {/* Main content */}

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -28,14 +28,16 @@ manifest and visual-review update together.
 Listener, Live and Account serve a byte-pinned local snapshot of the canonical
 web component rather than executing JavaScript supplied at runtime by another
 origin. The source is `AlterMundi/harmonicbeacon.com` commit
-`8770e6a844960c90768d08a03f3232a47123cac9`; the vendored
+`ed7421616429681a37836f4698c73cf01799b75e`; the vendored
 `public/assets/hb-global-nav.js` SHA-256 is
-`a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10`.
+`4a8a18fea07e279c0f757abd3be61bd715b0c6e647e6bc389d84c228c312e691`.
 The local light-DOM markup remains the accessible, same-destination fallback.
 Both implementations keep Account out of the primary destination list and
-expose it from the user-icon menu. The enhanced navigation renders both the
-Beacon mark and user glyph locally; it does not embed Account in an iframe or
-fetch a cross-origin image.
+expose it from the user-icon menu only on staging while the production Account
+authority remains unavailable. The host may supply only the boolean
+`data-account-signed-in` hint; no name, email, subject, cookie or token enters
+the asset. The enhanced navigation renders both the Beacon mark and user glyph
+locally; it does not embed Account in an iframe or fetch a cross-origin image.
 
 ## Font source and license
 

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -11,13 +11,13 @@
   },
   "globalNavigation": {
     "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
-    "commit": "8770e6a844960c90768d08a03f3232a47123cac9",
+    "commit": "ed7421616429681a37836f4698c73cf01799b75e",
     "source": "assets/hb-global-nav.js",
     "path": "public/assets/hb-global-nav.js",
-    "sha256": "a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10"
+    "sha256": "4a8a18fea07e279c0f757abd3be61bd715b0c6e647e6bc389d84c228c312e691"
   },
   "snapshots": {
-    "public/assets/hb-global-nav.js": "a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10",
+    "public/assets/hb-global-nav.js": "4a8a18fea07e279c0f757abd3be61bd715b0c6e647e6bc389d84c228c312e691",
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
   },

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -3,11 +3,11 @@ import Script from 'next/script';
 
 import type { UiLocale } from '@/lib/i18n';
 
-// Byte-pinned local snapshot of harmonicbeacon.com@8770e6a. Protected product
+// Byte-pinned local snapshot of harmonicbeacon.com@ed74216. Protected product
 // origins never execute remotely supplied JavaScript with their host cookies.
 export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
-export const GLOBAL_NAVIGATION_PROVENANCE = '8770e6a844960c90768d08a03f3232a47123cac9';
-export const GLOBAL_NAVIGATION_SHA256 = 'a96e74bf4ad081769c533861df238b6a6b23d2bdc247530222cfddce67c62e10';
+export const GLOBAL_NAVIGATION_PROVENANCE = 'ed7421616429681a37836f4698c73cf01799b75e';
+export const GLOBAL_NAVIGATION_SHA256 = '4a8a18fea07e279c0f757abd3be61bd715b0c6e647e6bc389d84c228c312e691';
 export const GLOBAL_NAVIGATION_EMBED_GUARD = `
 (() => {
     if (window.self === window.top) return;
@@ -38,16 +38,23 @@ export function GlobalNavigation({
     locale,
     allowRemoteEnhancement = true,
     accountHref,
+    accountSignedIn = false,
 }: {
     active: GlobalNavigationSurface;
     locale: UiLocale;
     allowRemoteEnhancement?: boolean;
     accountHref?: 'https://account.harmonicbeacon.com/account' | 'https://account-staging.harmonicbeacon.com/account';
+    accountSignedIn?: boolean;
 }) {
     const navLabel = locale === 'es' ? 'Navegación principal' : 'Primary navigation';
     const userMenuLabel = locale === 'es' ? 'Menú de usuario' : 'User menu';
     const accountLabel = locale === 'es' ? 'Cuenta' : 'Account';
     const resolvedAccountHref = accountHref ?? 'https://account.harmonicbeacon.com/account';
+    const accountAvailable = resolvedAccountHref === 'https://account-staging.harmonicbeacon.com/account';
+    const showSignedIn = accountAvailable && accountSignedIn;
+    const accountControlLabel = showSignedIn
+        ? (locale === 'es' ? 'Menú de usuario, sesión iniciada' : 'User menu, signed in')
+        : userMenuLabel;
     const fallback = (
         <nav className="hb-global-navigation-fallback" aria-label={navLabel}>
             <a className="hb-global-navigation-fallback__brand" href={withLanguage('https://harmonicbeacon.com/', locale)}>
@@ -66,23 +73,28 @@ export function GlobalNavigation({
                         </li>
                     ))}
                 </ul>
-                <details className="hb-global-navigation-fallback__account-control">
-                    <summary aria-label={userMenuLabel}>
-                        <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
-                            <circle cx="12" cy="8" r="3.25" />
-                            <path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5" />
-                        </svg>
-                    </summary>
-                    <div className="hb-global-navigation-fallback__account-menu" role="menu">
-                        <a
-                            href={withLanguage(resolvedAccountHref, locale)}
-                            role="menuitem"
-                            aria-current={active === 'account' ? 'page' : undefined}
-                        >
-                            {accountLabel}
-                        </a>
-                    </div>
-                </details>
+                {accountAvailable && (
+                    <details
+                        className="hb-global-navigation-fallback__account-control"
+                        data-account-signed-in={showSignedIn ? '' : undefined}
+                    >
+                        <summary aria-label={accountControlLabel}>
+                            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+                                <circle cx="12" cy="8" r="3.25" />
+                                <path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5" />
+                            </svg>
+                        </summary>
+                        <div className="hb-global-navigation-fallback__account-menu" role="menu">
+                            <a
+                                href={withLanguage(resolvedAccountHref, locale)}
+                                role="menuitem"
+                                aria-current={active === 'account' ? 'page' : undefined}
+                            >
+                                {accountLabel}
+                            </a>
+                        </div>
+                    </details>
+                )}
             </div>
         </nav>
     );
@@ -93,7 +105,10 @@ export function GlobalNavigation({
                 id="hb-global-navigation-embed-guard"
                 dangerouslySetInnerHTML={{ __html: GLOBAL_NAVIGATION_EMBED_GUARD }}
             />
-            {createElement('hb-global-nav', { 'data-surface': active }, fallback)}
+            {createElement('hb-global-nav', {
+                'data-surface': active,
+                'data-account-signed-in': showSignedIn ? '' : undefined,
+            }, fallback)}
             {allowRemoteEnhancement && (
                 <Script src={`${GLOBAL_NAVIGATION_ASSET}?v=${GLOBAL_NAVIGATION_PROVENANCE}`} strategy="afterInteractive" />
             )}

--- a/src/lib/brand/__tests__/account-navigation-state.test.ts
+++ b/src/lib/brand/__tests__/account-navigation-state.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { digestSessionToken } from '@/lib/session-auth';
+
+const findUnique = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+    prisma: {
+        webSession: { findUnique },
+    },
+}));
+
+const NOW = new Date('2026-08-18T12:00:00.000Z');
+const TOKEN = 'a'.repeat(43);
+const ISSUER = 'https://account-staging.harmonicbeacon.com';
+
+function requestHeaders(cookie = `hb_session=${TOKEN}`): Headers {
+    return new Headers({ cookie });
+}
+
+function localSession(overrides: Record<string, unknown> = {}) {
+    return {
+        id: '00000000-0000-4000-8000-000000000001',
+        expiresAt: new Date(NOW.getTime() + 60_000),
+        revokedAt: null,
+        accountIssuer: ISSUER,
+        accountSubject: 'account-subject-opaque',
+        accountSessionId: 'account-session-opaque',
+        accountValidatedAt: new Date(NOW.getTime() - 60_000),
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.BEACON_ACCOUNT_ENABLED = 'true';
+    process.env.BEACON_ACCOUNT_ISSUER_URL = ISSUER;
+    process.env.BEACON_ACCOUNT_CLIENT_ID = 'hb-live-staging';
+    process.env.BEACON_ACCOUNT_CLIENT_SECRET = 'staging-test-secret-longer-than-thirty-two-characters';
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.BEACON_ACCOUNT_ENABLED;
+    delete process.env.BEACON_ACCOUNT_ISSUER_URL;
+    delete process.env.BEACON_ACCOUNT_CLIENT_ID;
+    delete process.env.BEACON_ACCOUNT_CLIENT_SECRET;
+});
+
+describe('local Account navigation state', () => {
+    it('returns only a boolean from a valid local Live session without backchannel or mutation', async () => {
+        findUnique.mockResolvedValue(localSession());
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+        const { locallyKnownLiveAccountSession } = await import('../account-navigation-state');
+
+        await expect(locallyKnownLiveAccountSession(requestHeaders(), NOW)).resolves.toBe(true);
+        expect(findUnique).toHaveBeenCalledWith({
+            where: { tokenDigest: digestSessionToken(TOKEN) },
+            select: {
+                id: true,
+                expiresAt: true,
+                revokedAt: true,
+                accountIssuer: true,
+                accountSubject: true,
+                accountSessionId: true,
+                accountValidatedAt: true,
+            },
+        });
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(findUnique.mock.calls[0][0].select).not.toHaveProperty('accountDisplayName');
+    });
+
+    it.each([
+        ['', 'missing'],
+        [`other=x; hb_session=${TOKEN}; hb_session=${TOKEN}`, 'duplicate'],
+        ['hb_session=short', 'malformed'],
+        [`hb_session=${'a'.repeat(43)}%0A`, 'encoded malformed'],
+    ])('fails neutral before the database for a %s cookie (%s)', async (cookie) => {
+        const { locallyKnownLiveAccountSession } = await import('../account-navigation-state');
+
+        await expect(locallyKnownLiveAccountSession(requestHeaders(cookie), NOW)).resolves.toBe(false);
+        expect(findUnique).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['unknown', null],
+        ['expired', localSession({ expiresAt: NOW })],
+        ['revoked', localSession({ revokedAt: NOW })],
+        ['wrong issuer', localSession({ accountIssuer: 'https://account.harmonicbeacon.com' })],
+        ['missing subject', localSession({ accountSubject: null })],
+        ['malformed subject', localSession({ accountSubject: 'has a space' })],
+        ['missing sid', localSession({ accountSessionId: null })],
+    ])('does not show signed-in state for a %s local record', async (_label, row) => {
+        findUnique.mockResolvedValue(row);
+        const { locallyKnownLiveAccountSession } = await import('../account-navigation-state');
+
+        await expect(locallyKnownLiveAccountSession(requestHeaders(), NOW)).resolves.toBe(false);
+    });
+
+    it('fails neutral when Account is disabled or local storage/configuration is unavailable', async () => {
+        const { locallyKnownLiveAccountSession } = await import('../account-navigation-state');
+        process.env.BEACON_ACCOUNT_ENABLED = 'false';
+        await expect(locallyKnownLiveAccountSession(requestHeaders(), NOW)).resolves.toBe(false);
+        expect(findUnique).not.toHaveBeenCalled();
+
+        process.env.BEACON_ACCOUNT_ENABLED = 'true';
+        findUnique.mockRejectedValue(new Error('database unavailable'));
+        await expect(locallyKnownLiveAccountSession(requestHeaders(), NOW)).resolves.toBe(false);
+    });
+});

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -43,23 +43,19 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(globalNavigationAccountHref(new Headers({ host }))).toBe(expected);
     });
 
-    it('keeps an accessible same-destination fallback while the shared asset loads', () => {
+    it('keeps accessible primary destinations while hiding unavailable production Account', () => {
         render(<GlobalNavigation active="listen" locale="en" />);
 
         expect(GLOBAL_NAVIGATION_ASSET).toBe('/assets/hb-global-nav.js');
         expect(screen.getByRole('link', { name: 'Events' })).toHaveAttribute('href', 'https://live.harmonicbeacon.com/?lang=en');
         expect(screen.getByRole('link', { name: 'Listen' })).toHaveAttribute('aria-current', 'page');
         expect(screen.getByRole('link', { name: 'News' })).toHaveAttribute('href', 'https://harmonicbeacon.com/eventos/?lang=en');
-        const userMenu = screen.getByLabelText('User menu');
-        expect(userMenu.tagName).toBe('SUMMARY');
-        const account = screen.getByRole('menuitem', { name: 'Account' });
-        expect(account).toHaveAttribute('href', 'https://account.harmonicbeacon.com/account?lang=en');
-        expect(account.closest('[role="menu"]')).toBeTruthy();
-        expect(account.closest('li')).toBeNull();
+        expect(screen.queryByLabelText('User menu')).toBeNull();
+        expect(screen.queryByRole('menuitem', { name: 'Account' })).toBeNull();
     });
 
     it('loads a byte-pinned local canonical asset instead of remote same-origin code', () => {
-        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('8770e6a844960c90768d08a03f3232a47123cac9');
+        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('ed7421616429681a37836f4698c73cf01799b75e');
         const bytes = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'));
         expect(createHash('sha256').update(bytes).digest('hex')).toBe(GLOBAL_NAVIGATION_SHA256);
         expect(manifest.globalNavigation.commit).toBe(GLOBAL_NAVIGATION_PROVENANCE);
@@ -67,7 +63,12 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(manifest.snapshots[manifest.globalNavigation.path as keyof typeof manifest.snapshots])
             .toBe(GLOBAL_NAVIGATION_SHA256);
         const source = bytes.toString('utf8');
-        expect(source).toContain('class="account-trigger"');
+        expect(source).toContain('class="account-trigger\' + (accountSignedIn ? \' signed-in\' : \'\')');
+        expect(source).toContain('function accountControlAvailable()');
+        expect(source).toContain("return ['data-account-signed-in'];");
+        expect(source).toContain('User menu, signed in');
+        expect(source).toContain('Menú de usuario, sesión iniciada');
+        expect(source).toContain('.account-trigger.signed-in::after');
         expect(source).toContain('beaconMarkPath()');
         expect(source).toContain('Math.cos(angle * 3)');
         expect(source).toContain('Math.sin(angle * 2)');
@@ -78,8 +79,16 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(source).toContain('aria-haspopup="menu"');
         expect(source).toContain('class="account-menu"');
         expect(source).not.toContain('class="account-link"');
+        expect(source).not.toContain('https://account.harmonicbeacon.com');
+        expect(source).not.toContain('fetch(');
         expect(source).not.toContain('<iframe');
         expect(source).not.toContain('/favicon.svg');
+
+        const fallbackCss = readFileSync(resolve(process.cwd(), 'src/app/globals.css'), 'utf8');
+        expect(fallbackCss).toContain(
+            '.hb-global-navigation-fallback__account-control[data-account-signed-in] summary::after',
+        );
+        expect(fallbackCss).toContain('background: #c9a24e');
     });
 
     it('renders the same destinations in Spanish', () => {
@@ -111,31 +120,36 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(view.container.querySelector('script[src]')).toBeNull();
     });
 
-    it('opens Account from the enhanced user menu instead of the primary links', () => {
-        document.body.innerHTML = '';
-        document.documentElement.lang = 'en';
-        const source = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'), 'utf8');
-        window.eval(source);
+    it('SSR-renders only a boolean signed-in hint and accessible staging label', () => {
+        const view = render(<GlobalNavigation
+            active="events"
+            locale="en"
+            accountHref="https://account-staging.harmonicbeacon.com/account"
+            accountSignedIn
+        />);
 
-        const navigation = document.querySelector('hb-global-nav');
-        const shadow = navigation?.shadowRoot;
-        expect(shadow).toBeTruthy();
-        expect(shadow?.querySelector('iframe')).toBeNull();
-        const markPath = shadow?.querySelector<SVGPathElement>('.mark path')?.getAttribute('d');
-        expect(markPath).toMatch(/^M192\.00 100\.00 L191\.79 104\.13/);
-        expect(markPath?.match(/[ML]/g)).toHaveLength(281);
-        expect(shadow?.querySelector('.links')?.textContent).not.toContain('Account');
+        expect(within(view.container).getByLabelText('User menu, signed in')).toBeInTheDocument();
+        expect(view.container.querySelector('hb-global-nav')).toHaveAttribute('data-account-signed-in', '');
+        expect(view.container.querySelector('details')).toHaveAttribute('data-account-signed-in', '');
+        expect(view.container.innerHTML).not.toContain('account-subject');
+        expect(view.container.innerHTML).not.toContain('email');
+    });
 
-        const trigger = shadow?.querySelector<HTMLButtonElement>('.account-trigger');
-        const menu = shadow?.querySelector<HTMLElement>('.account-menu');
-        const account = menu?.querySelector<HTMLAnchorElement>('a');
-        expect(trigger).toHaveAttribute('aria-label', 'User menu');
-        expect(trigger).toHaveAttribute('aria-expanded', 'false');
-        expect(menu).toHaveAttribute('hidden');
-        expect(account?.textContent).toBe('Account');
+    it('uses the signed-in accessible label in Spanish', () => {
+        render(<GlobalNavigation
+            active="events"
+            locale="es"
+            accountHref="https://account-staging.harmonicbeacon.com/account"
+            accountSignedIn
+        />);
 
-        fireEvent.click(trigger!);
-        expect(trigger).toHaveAttribute('aria-expanded', 'true');
-        expect(menu).not.toHaveAttribute('hidden');
+        expect(screen.getByLabelText('Menú de usuario, sesión iniciada')).toBeInTheDocument();
+    });
+
+    it('does not expose a signed-in marker when production Account is unavailable', () => {
+        const view = render(<GlobalNavigation active="events" locale="en" accountSignedIn />);
+
+        expect(view.container.querySelector('hb-global-nav')).not.toHaveAttribute('data-account-signed-in');
+        expect(view.container.querySelector('details')).toBeNull();
     });
 });

--- a/src/lib/brand/account-navigation-state.ts
+++ b/src/lib/brand/account-navigation-state.ts
@@ -1,0 +1,62 @@
+import { storedAccountIdentity } from '@/lib/account-rp';
+import { prisma } from '@/lib/db';
+import { SESSION_COOKIE_NAME, digestSessionToken } from '@/lib/session-auth';
+
+const MAX_COOKIE_HEADER_BYTES = 8_192;
+const SESSION_TOKEN = /^[A-Za-z0-9_-]{43}$/;
+
+function exactlyOneSessionToken(headers: Pick<Headers, 'get'>): string | null {
+    const cookieHeader = headers.get('cookie');
+    if (!cookieHeader || cookieHeader.length > MAX_COOKIE_HEADER_BYTES) return null;
+
+    const values = cookieHeader
+        .split(';')
+        .map((part) => part.trim())
+        .filter((part) => part.startsWith(`${SESSION_COOKIE_NAME}=`))
+        .map((part) => part.slice(SESSION_COOKIE_NAME.length + 1));
+
+    return values.length === 1 && SESSION_TOKEN.test(values[0]) ? values[0] : null;
+}
+
+/**
+ * Produce only a best-effort visual hint for the shared navigation.
+ *
+ * This deliberately reads the host-local Live session without revalidating it
+ * against Account and without updating last-seen or any authorization state.
+ * Protected transitions continue to use the ordinary Account authority path.
+ */
+export async function locallyKnownLiveAccountSession(
+    headers: Pick<Headers, 'get'>,
+    now = new Date(),
+): Promise<boolean> {
+    if (process.env.BEACON_ACCOUNT_ENABLED !== 'true') return false;
+    const token = exactlyOneSessionToken(headers);
+    if (!token) return false;
+
+    try {
+        const row = await prisma.webSession.findUnique({
+            where: { tokenDigest: digestSessionToken(token) },
+            select: {
+                id: true,
+                expiresAt: true,
+                revokedAt: true,
+                accountIssuer: true,
+                accountSubject: true,
+                accountSessionId: true,
+                accountValidatedAt: true,
+            },
+        });
+        if (!row || row.revokedAt || row.expiresAt <= now) return false;
+
+        return storedAccountIdentity({
+            ...row,
+            // The navigation consumes only a boolean and never reads profile
+            // data, so do not select the locally cached display name at all.
+            accountDisplayName: null,
+        }) !== null;
+    } catch {
+        // Navigation remains neutral when local state/configuration is
+        // unavailable. It never turns a display hint into an auth dependency.
+        return false;
+    }
+}


### PR DESCRIPTION
Closes the Live consumer portion of #396.

## What changed
- vendors the exact canonical navigation asset from harmonicbeacon.com PR #71 source ed742161 (SHA-256 4a8a18fe)
- keeps production Account hidden and exposes the fallback only for the staging Account href
- renders a boolean-only signed-in marker and accessible ES/EN label
- derives that marker from the unexpired host-local Live session only: no Account backchannel, writes, profile fields, tokens, or PII enter the navigation
- fails neutral when the cookie, local DB, or Account configuration is unavailable

## Verification
- canonical byte comparison and SHA-256: exact
- focal navigation/layout/local-session tests: 36 passed
- full Vitest: 1013 passed, 23 skipped integration tests
- ESLint: passed
- TypeScript: passed
- production build: passed
- frozen audio/session/LiveKit paths: unchanged

No deploy and no event, session, LiveKit, media, or audio behavior changes.