### PR TITLE
Publish free four-Saturday event cycle

### DIFF
--- a/prisma/migrations/20260818030000_four_saturday_public_cycle/migration.sql
+++ b/prisma/migrations/20260818030000_four_saturday_public_cycle/migration.sql
@@ -1,0 +1,78 @@
+-- Four free, synchronous Spanish-language gatherings. Access is granted by
+-- Beacon Account inside the app; there is no registration or commerce step.
+ALTER TABLE "scheduled_sessions"
+    ADD COLUMN "public_access" BOOLEAN NOT NULL DEFAULT false;
+
+WITH facilitator_source AS (
+    SELECT "facilitator_id"
+    FROM "scheduled_sessions"
+    WHERE "is_test" = false
+    ORDER BY "scheduled_at" DESC
+    LIMIT 1
+), cycle_sessions (
+    "id", "title", "room_name", "scheduled_at"
+) AS (
+    VALUES
+        ('50000000-0000-4000-8000-202608220001'::uuid, 'Del otro lado del umbral — Encuentro 1 de 4', 'umbral-2026-08-22-es', '2026-08-22 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202608290001'::uuid, 'Del otro lado del umbral — Encuentro 2 de 4', 'umbral-2026-08-29-es', '2026-08-29 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202609050001'::uuid, 'Del otro lado del umbral — Encuentro 3 de 4', 'umbral-2026-09-05-es', '2026-09-05 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202609120001'::uuid, 'Del otro lado del umbral — Encuentro 4 de 4', 'umbral-2026-09-12-es', '2026-09-12 16:00:00'::timestamp)
+)
+INSERT INTO "scheduled_sessions" (
+    "id", "title", "description", "room_name", "language", "scheduled_at",
+    "status", "is_test", "paid_mode", "public_access", "attendee_cap",
+    "max_publishers", "facilitator_id", "updated_at"
+)
+SELECT
+    cycle_sessions."id",
+    cycle_sessions."title",
+    'Ciclo gratuito en castellano · cuerpo, sonido y símbolo · virtual y sincrónico · 3–4 horas',
+    cycle_sessions."room_name",
+    'SPANISH'::"SessionLanguage",
+    cycle_sessions."scheduled_at",
+    'SCHEDULED'::"ScheduledSessionStatus",
+    false,
+    true,
+    true,
+    150,
+    6,
+    facilitator_source."facilitator_id",
+    CURRENT_TIMESTAMP
+FROM cycle_sessions
+CROSS JOIN facilitator_source;
+
+DO $$
+DECLARE
+    source_count integer;
+    target_count integer;
+BEGIN
+    SELECT count(*) INTO source_count
+    FROM (
+        SELECT "facilitator_id"
+        FROM "scheduled_sessions"
+        WHERE "is_test" = false
+          AND "id" NOT IN (
+              '50000000-0000-4000-8000-202608220001'::uuid,
+              '50000000-0000-4000-8000-202608290001'::uuid,
+              '50000000-0000-4000-8000-202609050001'::uuid,
+              '50000000-0000-4000-8000-202609120001'::uuid
+          )
+        LIMIT 1
+    ) AS source;
+
+    SELECT count(*) INTO target_count
+    FROM "scheduled_sessions"
+    WHERE "id" IN (
+        '50000000-0000-4000-8000-202608220001'::uuid,
+        '50000000-0000-4000-8000-202608290001'::uuid,
+        '50000000-0000-4000-8000-202609050001'::uuid,
+        '50000000-0000-4000-8000-202609120001'::uuid
+    )
+      AND "public_access" = true
+      AND "is_test" = false
+      AND "language" = 'SPANISH'::"SessionLanguage";
+
+    IF target_count <> source_count * 4 THEN
+        RAISE EXCEPTION 'Four-Saturday public cycle could not be created safely';
+    END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,7 @@ model ScheduledSession {
   status        ScheduledSessionStatus @default(SCHEDULED)
   isTest        Boolean                @default(false) @map("is_test")
   paidMode      Boolean                @default(true) @map("paid_mode")
+  publicAccess  Boolean                @default(false) @map("public_access")
   attendeeCap   Int                    @default(150) @map("attendee_cap")
   maxPublishers Int                    @default(6) @map("max_publishers")
   facilitatorId String                 @map("facilitator_id") @db.Uuid

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -27,13 +27,19 @@ vi.mock('@/app/login/LoginClient', () => ({
 
 const SATURDAY = {
     id: 'session-1',
+    title: 'Saturday',
+    description: null,
     language: 'SPANISH' as const,
     scheduledAt: new Date('2026-08-08T14:30:00.000Z'),
+    publicAccess: false,
 };
 const SESSION_2 = {
     id: 'session-2',
+    title: 'Session 2',
+    description: null,
     language: 'ENGLISH' as const,
     scheduledAt: new Date('2026-08-08T20:00:00.000Z'),
+    publicAccess: false,
 };
 const NOW = new Date('2026-08-05T12:00:00.000Z');
 
@@ -112,7 +118,9 @@ describe('landing page', () => {
         );
         // No paid-mode or attendee-cap columns leak into the public page.
         const select = findMany.mock.calls[0][0].select;
-        expect(Object.keys(select).sort()).toEqual(['id', 'language', 'scheduledAt']);
+        expect(Object.keys(select).sort()).toEqual([
+            'description', 'id', 'language', 'publicAccess', 'scheduledAt', 'title',
+        ]);
     });
 
     it('fails closed when a missed lifecycle transition leaves an old session LIVE', async () => {
@@ -168,6 +176,25 @@ describe('landing page', () => {
         expect(links[0]).toHaveAttribute('href', 'https://tickets.example.invalid/harmonic-beacon');
         expect(links[0]).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
         expect(screen.getAllByText(/USD \$50 Norte Global.*USD \$20 Sur Global/)).toHaveLength(2);
+    });
+
+    it('presents a public event as free direct app access without ticket commerce', async () => {
+        mountDb(vi.fn().mockResolvedValue([{
+            ...SATURDAY,
+            title: 'Del otro lado del umbral — Encuentro 1 de 4',
+            description: 'Cuerpo, sonido y símbolo',
+            publicAccess: true,
+        }]));
+        await renderPage();
+
+        expect(screen.getByText('Del otro lado del umbral — Encuentro 1 de 4')).toBeInTheDocument();
+        expect(screen.getByText('Gratis')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Ingresar al evento' })).toHaveAttribute(
+            'href',
+            '/api/account/login?flow=attendee&next=%2Fsession%2Fsession-1',
+        );
+        expect(screen.queryByRole('link', { name: /Comprar entrada/ })).toBeNull();
+        expect(screen.queryByTestId('ticket-login-form')).toBeNull();
     });
 
     it('says sales open shortly while the external platform is still TBD', async () => {

--- a/src/app/api/scheduled-sessions/[id]/entry/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/entry/__tests__/route.test.ts
@@ -2,12 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createRequest, mockParams, parseResponse } from '@/__tests__/helpers';
 
-const { principalFromToken, findUnique } = vi.hoisted(() => ({
+const { principalFromToken, accountIdentityFromToken, attachPublicSessionAccess, findUnique } = vi.hoisted(() => ({
     principalFromToken: vi.fn(),
+    accountIdentityFromToken: vi.fn(),
+    attachPublicSessionAccess: vi.fn(),
     findUnique: vi.fn(),
 }));
 
-vi.mock('@/lib/principal', () => ({ principalFromToken }));
+vi.mock('@/lib/principal', () => ({ principalFromToken, accountIdentityFromToken }));
+vi.mock('@/lib/public-session-access', () => ({ attachPublicSessionAccess }));
 vi.mock('@/lib/db', () => ({
     prisma: { scheduledSession: { findUnique } },
 }));
@@ -19,6 +22,7 @@ const session = {
     scheduledAt: new Date('2026-08-01T18:00:00Z'),
     status: 'SCHEDULED',
     facilitatorId: 'facilitator-1',
+    publicAccess: false,
 };
 
 const attendee = {
@@ -44,6 +48,8 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         principalFromToken.mockResolvedValue(attendee);
+        accountIdentityFromToken.mockResolvedValue(null);
+        attachPublicSessionAccess.mockResolvedValue(false);
         findUnique.mockResolvedValue(session);
     });
 
@@ -75,6 +81,29 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
     it('never lets a ticket inspect another event', async () => {
         principalFromToken.mockResolvedValue({ ...attendee, scheduledSessionId: 'event-2' });
         expect((await getEntry()).status).toBe(403);
+    });
+
+    it('turns a valid Beacon Account into free access for a public event', async () => {
+        const account = {
+            issuer: 'https://account.example',
+            subject: 'person-1',
+            sessionId: 'central-1',
+            displayName: 'Sai',
+            validatedAt: new Date(),
+        };
+        principalFromToken
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(attendee);
+        accountIdentityFromToken.mockResolvedValue(account);
+        findUnique.mockResolvedValue({ ...session, publicAccess: true });
+        attachPublicSessionAccess.mockResolvedValue(true);
+
+        expect((await getEntry()).status).toBe(200);
+        expect(attachPublicSessionAccess).toHaveBeenCalledWith(
+            'opaque',
+            expect.objectContaining({ id: 'event-1', publicAccess: true }),
+            account,
+        );
     });
 
     it('lets assigned facilitators preflight while scheduled', async () => {
@@ -109,6 +138,7 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
 
     it('does not reveal whether an event exists without a current entitlement', async () => {
         principalFromToken.mockResolvedValue(null);
+        accountIdentityFromToken.mockResolvedValue(null);
         expect((await getEntry()).status).toBe(401);
         expect(findUnique).not.toHaveBeenCalled();
     });

--- a/src/app/api/scheduled-sessions/[id]/entry/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/entry/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db';
-import { principalFromToken } from '@/lib/principal';
+import { accountIdentityFromToken, principalFromToken } from '@/lib/principal';
+import { attachPublicSessionAccess } from '@/lib/public-session-access';
 import { SESSION_COOKIE_NAME } from '@/lib/session-auth';
 import { eventStaffPolicy } from '@/lib/staff-capabilities';
 
@@ -16,10 +17,10 @@ export async function GET(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> },
 ) {
-    const principal = await principalFromToken(
-        request.cookies.get(SESSION_COOKIE_NAME)?.value,
-    );
-    if (!principal) {
+    const cookieValue = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+    let principal = await principalFromToken(cookieValue);
+    const account = principal ? null : await accountIdentityFromToken(cookieValue);
+    if (!principal && !account) {
         return NextResponse.json(
             { error: 'Authentication required' },
             { status: 401 },
@@ -36,10 +37,19 @@ export async function GET(
             scheduledAt: true,
             status: true,
             facilitatorId: true,
+            publicAccess: true,
         },
     });
     if (!session) {
         return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+    }
+
+    if (!principal && account && cookieValue && session.publicAccess) {
+        const attached = await attachPublicSessionAccess(cookieValue, session, account);
+        if (attached) principal = await principalFromToken(cookieValue);
+    }
+    if (!principal) {
+        return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
     }
 
     if (principal.kind === 'attendee' && principal.scheduledSessionId !== session.id) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,8 +21,11 @@ export const dynamic = "force-dynamic";
 
 type WeekendEvent = {
     id: string;
+    title: string;
+    description: string | null;
     language: "ENGLISH" | "SPANISH";
     scheduledAt: Date;
+    publicAccess: boolean;
 };
 
 const INTERNAL_NEXT = /^\/session(\/[A-Za-z0-9_-]+)*$/;
@@ -52,7 +55,14 @@ async function weekendEvents(): Promise<WeekendEvent[] | null> {
                 ],
             },
             orderBy: { scheduledAt: "asc" },
-            select: { id: true, language: true, scheduledAt: true },
+            select: {
+                id: true,
+                title: true,
+                description: true,
+                language: true,
+                scheduledAt: true,
+                publicAccess: true,
+            },
         });
     } catch (error) {
         console.error(`[landing] could not load the event schedule: ${redactError(error)}`);
@@ -95,6 +105,7 @@ export default async function LandingPage({
         : null;
     const accountError = params.account_error === '1';
     const events = await weekendEvents();
+    const hasTicketedEvents = events === null || events.some((event) => !event.publicAccess);
     const purchaseUrlSession1 = process.env.TICKET_PURCHASE_URL_SESSION_1 || process.env.TICKET_PURCHASE_URL;
     const purchaseUrlSession2 = process.env.TICKET_PURCHASE_URL_SESSION_2 || process.env.TICKET_PURCHASE_URL;
     const purchaseUrlFor = (language: string) =>
@@ -145,6 +156,14 @@ export default async function LandingPage({
                                             <p className="event-card__label">
                                                 {event.language === "ENGLISH" ? copy.english : copy.spanish}
                                             </p>
+                                            {event.publicAccess && (
+                                                <>
+                                                    <h3 className="font-serif text-xl text-[var(--paper)]">{event.title}</h3>
+                                                    {event.description && (
+                                                        <p className="text-xs leading-relaxed text-[var(--text-muted)]">{event.description}</p>
+                                                    )}
+                                                </>
+                                            )}
                                             <p className="text-sm text-[var(--text-secondary)]">
                                                 <span className="font-medium text-[var(--paper)]">{copy.costaRica}: </span>
                                                 {formatEventTime(event.scheduledAt, locale === "en" ? "en-US" : "es-CR", "America/Costa_Rica")}
@@ -163,16 +182,20 @@ export default async function LandingPage({
                                                 {formatTimeOnly(event.scheduledAt, locale === "en" ? "en-US" : "es-CR", "America/Costa_Rica")}
                                             </p>
                                             <p className="text-xs font-mono text-[var(--text-secondary)]">
-                                                {event.language === "ENGLISH" ? "US $50" : "US $20"}
+                                                {event.publicAccess ? (locale === 'en' ? 'Free' : 'Gratis') : (event.language === "ENGLISH" ? "US $50" : "US $20")}
                                             </p>
                                         </div>
                                     </div>
 
                                     <div className="mt-4 pt-4 border-t border-[var(--border-subtle)]">
-                                        <p className="text-xs text-[var(--text-secondary)]">
-                                            USD $50 {copy.globalNorth} · USD $20 {copy.globalSouth}
-                                        </p>
-                                        {purchaseUrlFor(event.language) ? (
+                                        {event.publicAccess ? (
+                                            <Link
+                                                href={account ? `/session/${event.id}` : `/api/account/login?flow=attendee&next=${encodeURIComponent(`/session/${event.id}`)}`}
+                                                className="event-button event-button--primary mt-3 inline-flex w-full text-center sm:w-auto"
+                                            >
+                                                {locale === 'en' ? 'Enter event' : 'Ingresar al evento'}
+                                            </Link>
+                                        ) : purchaseUrlFor(event.language) ? (
                                             <a
                                                 href={purchaseUrlFor(event.language)}
                                                 className="event-button event-button--primary mt-3 inline-flex w-full text-center sm:w-auto"
@@ -187,6 +210,11 @@ export default async function LandingPage({
                                                 {copy.salesSoon}
                                             </p>
                                         )}
+                                        {!event.publicAccess && (
+                                            <p className="mt-3 text-xs text-[var(--text-secondary)]">
+                                                USD $50 {copy.globalNorth} · USD $20 {copy.globalSouth}
+                                            </p>
+                                        )}
                                     </div>
                                 </li>
                             ))}
@@ -194,8 +222,8 @@ export default async function LandingPage({
                     )}
                 </section>
 
-                {/* Login */}
-                <section className="space-y-5" aria-labelledby="login-heading">
+                {/* Ticket login remains available only when a ticketed event is listed. */}
+                {hasTicketedEvents && <section className="space-y-5" aria-labelledby="login-heading">
                     <h2 id="login-heading" className="hb-section-label">
                         {copy.loginHeading}
                     </h2>
@@ -234,7 +262,7 @@ export default async function LandingPage({
                             </div>
                         )}
                     </div>
-                </section>
+                </section>}
 
                 {/* Footer */}
                 <footer className="mt-auto flex flex-wrap gap-x-5 gap-y-2 text-xs text-[var(--text-muted)]">

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -1308,6 +1308,10 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
                     cache: 'no-store',
                 });
                 const data = await response.json().catch(() => ({})) as Partial<EntryResponse> & { error?: string };
+                if (response.status === 401) {
+                    router.replace(`/?next=${encodeURIComponent(`/session/${sessionId}`)}`);
+                    return;
+                }
                 if (!response.ok || !data.state || !data.session) {
                     throw new Error(data.error || `Entry status unavailable (HTTP ${response.status})`);
                 }
@@ -1341,7 +1345,7 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
             window.removeEventListener('online', checkWhenVisible);
             document.removeEventListener('visibilitychange', checkWhenVisible);
         };
-    }, [sessionId, retryEntry, seedLocale, copy.session.entryUnavailable]);
+    }, [sessionId, retryEntry, seedLocale, copy.session.entryUnavailable, router]);
 
     if (!entry) {
         return (

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -1308,10 +1308,6 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
                     cache: 'no-store',
                 });
                 const data = await response.json().catch(() => ({})) as Partial<EntryResponse> & { error?: string };
-                if (response.status === 401) {
-                    router.replace(`/?next=${encodeURIComponent(`/session/${sessionId}`)}`);
-                    return;
-                }
                 if (!response.ok || !data.state || !data.session) {
                     throw new Error(data.error || `Entry status unavailable (HTTP ${response.status})`);
                 }
@@ -1345,7 +1341,7 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
             window.removeEventListener('online', checkWhenVisible);
             document.removeEventListener('visibilitychange', checkWhenVisible);
         };
-    }, [sessionId, retryEntry, seedLocale, copy.session.entryUnavailable, router]);
+    }, [sessionId, retryEntry, seedLocale, copy.session.entryUnavailable]);
 
     if (!entry) {
         return (

--- a/src/lib/__tests__/public-session-access.test.ts
+++ b/src/lib/__tests__/public-session-access.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { transaction, entitlementUpsert, webSessionUpdateMany } = vi.hoisted(() => ({
+    transaction: vi.fn(),
+    entitlementUpsert: vi.fn(),
+    webSessionUpdateMany: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+    prisma: { $transaction: transaction },
+}));
+
+const account = {
+    issuer: 'https://account.harmonicbeacon.com',
+    subject: 'account-person-1',
+    sessionId: 'central-session-1',
+    displayName: '  Sai  ',
+    validatedAt: new Date('2026-08-18T12:00:00Z'),
+};
+const publicSession = {
+    id: '50000000-0000-4000-8000-202608220001',
+    scheduledAt: new Date('2026-08-22T16:00:00Z'),
+    publicAccess: true,
+};
+
+describe('attachPublicSessionAccess', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        entitlementUpsert.mockResolvedValue({ id: 'free-entitlement-1' });
+        webSessionUpdateMany.mockResolvedValue({ count: 1 });
+        transaction.mockImplementation(async (work) => work({
+            ticketEntitlement: { upsert: entitlementUpsert },
+            webSession: { updateMany: webSessionUpdateMany },
+        }));
+    });
+
+    it('does nothing for a session that is not explicitly public', async () => {
+        const { attachPublicSessionAccess } = await import('../public-session-access');
+        await expect(attachPublicSessionAccess(
+            'opaque-cookie',
+            { ...publicSession, publicAccess: false },
+            account,
+        )).resolves.toBe(false);
+        expect(transaction).not.toHaveBeenCalled();
+    });
+
+    it('creates account-bound complimentary access and attaches only its active web session', async () => {
+        const { attachPublicSessionAccess } = await import('../public-session-access');
+        const now = new Date('2026-08-18T13:00:00Z');
+
+        await expect(attachPublicSessionAccess(
+            'opaque-cookie',
+            publicSession,
+            account,
+            now,
+        )).resolves.toBe(true);
+
+        expect(entitlementUpsert).toHaveBeenCalledWith(expect.objectContaining({
+            create: expect.objectContaining({
+                scheduledSessionId: publicSession.id,
+                codeLastFour: 'FREE',
+                tier: 'COMP',
+                state: 'BOUND',
+                accountId: account.subject,
+                accountIssuer: account.issuer,
+                boundAt: now,
+                expiresAt: new Date('2026-08-23T16:00:00Z'),
+            }),
+        }));
+        expect(webSessionUpdateMany).toHaveBeenCalledWith({
+            where: expect.objectContaining({
+                accountIssuer: account.issuer,
+                accountSubject: account.subject,
+                staffUserId: null,
+                revokedAt: null,
+                expiresAt: { gt: now },
+            }),
+            data: {
+                ticketEntitlementId: 'free-entitlement-1',
+                displayName: 'Sai',
+                lastSeenAt: now,
+            },
+        });
+        expect(webSessionUpdateMany.mock.calls[0][0].where.tokenDigest).not.toContain('opaque-cookie');
+    });
+
+    it('fails closed when the authenticated web session changed concurrently', async () => {
+        webSessionUpdateMany.mockResolvedValue({ count: 0 });
+        const { attachPublicSessionAccess } = await import('../public-session-access');
+        await expect(attachPublicSessionAccess(
+            'opaque-cookie',
+            publicSession,
+            account,
+        )).resolves.toBe(false);
+    });
+});

--- a/src/lib/__tests__/seed-contract.test.ts
+++ b/src/lib/__tests__/seed-contract.test.ts
@@ -125,6 +125,23 @@ describe('weekend seed contract', () => {
         expect(migration).toContain('ADD COLUMN "actor_role" "StaffRole"');
     });
 
+    it('defines the four free Saturdays as public Spanish app sessions', () => {
+        const migration = readFileSync(
+            new URL(
+                '../../../prisma/migrations/20260818030000_four_saturday_public_cycle/migration.sql',
+                import.meta.url,
+            ),
+            'utf8',
+        );
+
+        for (const date of ['2026-08-22', '2026-08-29', '2026-09-05', '2026-09-12']) {
+            expect(migration).toContain(date);
+        }
+        expect(migration).toContain('"public_access" = true');
+        expect(migration).toContain(`'SPANISH'::"SessionLanguage"`);
+        expect(migration).not.toMatch(/ticket.?tailor|purchase/i);
+    });
+
     it('marks production and fixture events explicitly without title inference', () => {
         expect(loadSeedContract(validEnvironment()).events.every((event) => event.isTest === false))
             .toBe(true);

--- a/src/lib/public-session-access.ts
+++ b/src/lib/public-session-access.ts
@@ -1,0 +1,73 @@
+import { createHash } from 'node:crypto';
+
+import type { AccountIdentity } from '@/lib/account-rp';
+import { prisma } from '@/lib/db';
+import { digestSessionToken } from '@/lib/session-auth';
+
+type PublicSession = {
+    id: string;
+    scheduledAt: Date;
+    publicAccess: boolean;
+};
+
+function publicEntitlementDigest(sessionId: string, account: AccountIdentity): string {
+    return createHash('sha256')
+        .update(`public-session\0${sessionId}\0${account.issuer}\0${account.subject}`)
+        .digest('hex');
+}
+
+/**
+ * Attach a free public event to an already authenticated Beacon Account.
+ * This is the registration-free bridge into the existing ticket-shaped room
+ * authorization boundary; it never changes the Account login implementation.
+ */
+export async function attachPublicSessionAccess(
+    cookieValue: string,
+    session: PublicSession,
+    account: AccountIdentity,
+    now = new Date(),
+): Promise<boolean> {
+    if (!session.publicAccess) return false;
+
+    const expiresAt = new Date(Math.max(
+        session.scheduledAt.getTime() + 24 * 60 * 60 * 1000,
+        now.getTime() + 60 * 60 * 1000,
+    ));
+    const codeDigest = publicEntitlementDigest(session.id, account);
+
+    return prisma.$transaction(async (tx) => {
+        const entitlement = await tx.ticketEntitlement.upsert({
+            where: { codeDigest },
+            update: {},
+            create: {
+                scheduledSessionId: session.id,
+                codeDigest,
+                codeLastFour: 'FREE',
+                tier: 'COMP',
+                state: 'BOUND',
+                accountId: account.subject,
+                accountIssuer: account.issuer,
+                boundAt: now,
+                expiresAt,
+            },
+            select: { id: true },
+        });
+
+        const attached = await tx.webSession.updateMany({
+            where: {
+                tokenDigest: digestSessionToken(cookieValue),
+                accountIssuer: account.issuer,
+                accountSubject: account.subject,
+                staffUserId: null,
+                revokedAt: null,
+                expiresAt: { gt: now },
+            },
+            data: {
+                ticketEntitlementId: entitlement.id,
+                displayName: account.displayName?.trim() || 'Participante',
+                lastSeenAt: now,
+            },
+        });
+        return attached.count === 1;
+    });
+}


### PR DESCRIPTION
## Outcome
- creates the four Spanish sessions for Aug 22, Aug 29, Sep 5 and Sep 12, 2026
- marks them free/public in the app and removes commerce from their cards
- grants room access automatically after existing Beacon Account login
- leaves the Beacon Account login implementation untouched

## Verification
- 45 focused tests pass
- ESLint passes
- production Next.js build passes
- git diff check passes