### PR TITLE
fix(account): make signup confirmation durable

### DIFF
--- a/src/app/api/account/auth/[...all]/route.test.ts
+++ b/src/app/api/account/auth/[...all]/route.test.ts
@@ -7,12 +7,21 @@ const revokeAccountSession = vi.hoisted(() => vi.fn());
 const userFindUnique = vi.hoisted(() => vi.fn());
 const sessionFindUnique = vi.hoisted(() => vi.fn());
 const sessionDeleteMany = vi.hoisted(() => vi.fn());
+const ensureVerificationMailQueued = vi.hoisted(() => vi.fn());
+const processVerificationMailOutbox = vi.hoisted(() => vi.fn());
+const after = vi.hoisted(() => vi.fn());
+vi.mock('next/server', () => ({ after }));
 vi.mock('@/lib/account/auth', () => ({
     accountAuth: () => ({ handler: authHandler, api: { getSession } }),
 }));
 vi.mock('@/lib/account/authority-db', () => ({ accountAuthorityDatabaseReady: () => true }));
 vi.mock('@/lib/account/revocation', () => ({ revokeAccountSession }));
 vi.mock('@/lib/account/rate-limit', () => ({ consumeAccountRateLimit: () => true }));
+vi.mock('@/lib/account/mail-outbox', () => ({
+    ensureVerificationMailQueued,
+    processVerificationMailOutbox,
+}));
+vi.mock('@/lib/account/timing', () => ({ enforceAccountCredentialFloor: vi.fn() }));
 vi.mock('@/lib/db', () => ({
     prisma: {
         $transaction: transaction,
@@ -50,6 +59,8 @@ describe('Account catch-all route confidential OAuth boundary', () => {
         transaction.mockImplementation(async (callback) => callback({}));
         revokeAccountSession.mockResolvedValue(undefined);
         sessionDeleteMany.mockResolvedValue({ count: 0 });
+        ensureVerificationMailQueued.mockResolvedValue(undefined);
+        processVerificationMailOutbox.mockResolvedValue(undefined);
     });
     afterEach(() => { vi.unstubAllEnvs(); vi.clearAllMocks(); });
 
@@ -107,6 +118,34 @@ describe('Account catch-all route confidential OAuth boundary', () => {
         expect(response.headers.getSetCookie().join('\n')).not.toContain('__Secure-__Host-');
         expect(getSession.mock.calls[1]?.[0]?.headers.get('cookie'))
             .toBe('__Host-hb_account_session=opaque-session');
+    });
+
+    it.each([
+        ['underlying success', 200],
+        ['underlying rejection', 422],
+    ])('returns the same exact cookie-free signup acceptance for %s', async (_label, status) => {
+        const headers = new Headers({ 'Content-Type': 'application/json' });
+        headers.append('Set-Cookie', '__Host-hb_account_session=must-not-leave-signup; Path=/; HttpOnly; Secure');
+        authHandler.mockResolvedValueOnce(Response.json({ token: 'opaque' }, { status, headers }));
+
+        const response = await POST(new Request(`${origin}/api/account/auth/sign-up/email`, {
+            method: 'POST',
+            headers: {
+                host: 'account.harmonicbeacon.com', origin,
+                'sec-fetch-site': 'same-origin', 'content-type': 'application/json',
+                'x-hb-locale': 'es',
+            },
+            body: JSON.stringify({
+                name: 'Test Listener', email: 'listener@example.invalid', password: '12345678',
+            }),
+        }));
+
+        expect(response.status).toBe(202);
+        expect(await response.json()).toEqual({ status: 'accepted' });
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(response.headers.getSetCookie()).toEqual([]);
+        expect(ensureVerificationMailQueued).toHaveBeenCalledWith('listener@example.invalid', 'es');
+        expect(after).toHaveBeenCalledOnce();
     });
 
     it('rejects an unforwardable successful sign-in and removes only its exact new session token', async () => {

--- a/src/app/api/account/auth/[...all]/route.ts
+++ b/src/app/api/account/auth/[...all]/route.ts
@@ -41,7 +41,7 @@ async function genericCredentialResponse(response: Response, path: string): Prom
     const signup = path === '/api/account/auth/sign-up/email';
     const successful = response.ok;
     const headers = new Headers({ 'Cache-Control': 'private, no-store' });
-    if (successful) {
+    if (successful && !signup) {
         for (const cookie of response.headers.getSetCookie()) {
             headers.append('Set-Cookie', cookie);
         }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,6 +103,31 @@ hb-global-nav:not(:defined) {
 .account-mode { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem; }
 .account-mode button[aria-pressed="true"] { color: #16120d; background: #c9a24e; }
 .account-muted, .account-message { color: rgba(244, 238, 226, .7); line-height: 1.55; }
+.account-signup-confirmation {
+  display: grid;
+  justify-items: center;
+  gap: .75rem;
+  margin-bottom: 1.25rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(201, 162, 78, .45);
+  border-radius: 18px;
+  color: #f4eee2;
+  text-align: center;
+  background: rgba(201, 162, 78, .08);
+}
+.account-signup-confirmation:focus-visible { outline: 2px solid #e0bd69; outline-offset: 3px; }
+.account-signup-confirmation__mark {
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  place-items: center;
+  border: 1px solid rgba(201, 162, 78, .65);
+  border-radius: 999px;
+  color: #e0bd69;
+  font-size: 1.25rem;
+}
+.account-signup-confirmation h2, .account-signup-confirmation p { margin: 0; }
+.account-signup-confirmation p { line-height: 1.55; }
 .account-link { margin-top: 1rem; border: 0 !important; padding-inline: 0 !important; }
 @media (prefers-reduced-motion: reduce) {
   .account-shell *, .account-shell *::before, .account-shell *::after { scroll-behavior: auto !important; transition: none !important; }

--- a/src/components/account/AccountClient.tsx
+++ b/src/components/account/AccountClient.tsx
@@ -84,6 +84,8 @@ export default function AccountClient({
     const [feedbackFocusRevision, setFeedbackFocusRevision] = useState(0);
     const feedbackRef = useRef<HTMLParagraphElement>(null);
     const signupConfirmationRef = useRef<HTMLElement>(null);
+    const signInEmailRef = useRef<HTMLInputElement>(null);
+    const signInFocusRequested = useRef(false);
     const credentialSubmissionInFlight = useRef(false);
 
     useEffect(() => {
@@ -92,6 +94,13 @@ export default function AccountClient({
         target?.focus({ preventScroll: true });
         target?.scrollIntoView?.({ block: 'nearest' });
     }, [feedbackFocusRevision, signupAccepted]);
+
+    useEffect(() => {
+        if (!signInFocusRequested.current || mode !== 'signin' || signupAccepted) return;
+        signInFocusRequested.current = false;
+        signInEmailRef.current?.focus({ preventScroll: true });
+        signInEmailRef.current?.scrollIntoView?.({ block: 'nearest' });
+    }, [mode, signupAccepted]);
 
     function announceCredentialResult(nextMessage: string) {
         setMessage(nextMessage);
@@ -102,6 +111,11 @@ export default function AccountClient({
         setMode(nextMode);
         setMessage('');
         setSignupAccepted(false);
+    }
+
+    function returnToSignIn() {
+        signInFocusRequested.current = true;
+        selectMode('signin');
     }
 
     async function submitCredentials(event: FormEvent<HTMLFormElement>) {
@@ -155,8 +169,8 @@ export default function AccountClient({
                     formElement.reset();
                     setSignupAccepted(true);
                     announceCredentialResult(es
-                        ? 'Te enviamos un correo. Confirmá tu dirección para activar la cuenta y después ingresá.'
-                        : 'We sent you an email. Confirm your address to activate the account, then sign in.');
+                        ? 'Si la solicitud es elegible, revisá tu correo para continuar.'
+                        : 'If the request is eligible, check your email to continue.');
                 } else {
                     announceCredentialResult(credentialFailure);
                 }
@@ -261,10 +275,10 @@ export default function AccountClient({
                 tabIndex={-1}
             >
                 <span className="account-signup-confirmation__mark" aria-hidden="true">&#10003;</span>
-                <h2>{es ? 'Confirmá tu correo' : 'Confirm your email'}</h2>
+                <h2>{es ? 'Revisá tu correo' : 'Check your email'}</h2>
                 <p>{message}</p>
             </section>
-            <button className="account-primary" type="button" onClick={() => selectMode('signin')}>
+            <button className="account-primary" type="button" onClick={returnToSignIn}>
                 {es ? 'Ir al ingreso' : 'Go to sign in'}
             </button>
         </div>
@@ -291,7 +305,13 @@ export default function AccountClient({
                 }
             }}>
                 {mode === 'signup' && <label>{es ? 'Nombre visible' : 'Display name'}<input name="displayName" required minLength={1} maxLength={60} autoComplete="nickname" /></label>}
-                <label>{es ? 'Correo' : 'Email'}<input name="email" type="email" required autoComplete="email" /></label>
+                <label>{es ? 'Correo' : 'Email'}<input
+                    ref={mode === 'signin' ? signInEmailRef : undefined}
+                    name="email"
+                    type="email"
+                    required
+                    autoComplete="email"
+                /></label>
                 {mode !== 'forgot' && <AccountPasswordField
                     label={es ? 'Contraseña' : 'Password'}
                     showLabel={showPassword}

--- a/src/components/account/AccountClient.tsx
+++ b/src/components/account/AccountClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState, type FormEvent } from 'react';
+import { useEffect, useRef, useState, type FormEvent } from 'react';
 
 import {
     ACCOUNT_PASSWORD_MAX_LENGTH,
@@ -80,21 +80,35 @@ export default function AccountClient({
     const [mode, setMode] = useState<'signin' | 'signup' | 'forgot'>('signin');
     const [message, setMessage] = useState('');
     const [busy, setBusy] = useState(false);
+    const [signupAccepted, setSignupAccepted] = useState(false);
+    const [feedbackFocusRevision, setFeedbackFocusRevision] = useState(0);
     const feedbackRef = useRef<HTMLParagraphElement>(null);
+    const signupConfirmationRef = useRef<HTMLElement>(null);
     const credentialSubmissionInFlight = useRef(false);
+
+    useEffect(() => {
+        if (feedbackFocusRevision === 0) return;
+        const target = signupAccepted ? signupConfirmationRef.current : feedbackRef.current;
+        target?.focus({ preventScroll: true });
+        target?.scrollIntoView?.({ block: 'nearest' });
+    }, [feedbackFocusRevision, signupAccepted]);
 
     function announceCredentialResult(nextMessage: string) {
         setMessage(nextMessage);
-        queueMicrotask(() => {
-            feedbackRef.current?.focus({ preventScroll: true });
-            feedbackRef.current?.scrollIntoView?.({ block: 'nearest' });
-        });
+        setFeedbackFocusRevision((revision) => revision + 1);
+    }
+
+    function selectMode(nextMode: 'signin' | 'signup' | 'forgot') {
+        setMode(nextMode);
+        setMessage('');
+        setSignupAccepted(false);
     }
 
     async function submitCredentials(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
         if (credentialSubmissionInFlight.current) return;
-        const form = new FormData(event.currentTarget);
+        const formElement = event.currentTarget;
+        const form = new FormData(formElement);
         const email = String(form.get('email') ?? '');
         const password = String(form.get('password') ?? '');
         if (mode !== 'forgot' && !accountPasswordLengthValid(password)) {
@@ -110,7 +124,10 @@ export default function AccountClient({
             return;
         }
         credentialSubmissionInFlight.current = true;
-        setBusy(true); setMessage('');
+        setBusy(true);
+        setMessage(mode === 'signup'
+            ? (es ? 'Creando tu cuenta…' : 'Creating your account…')
+            : '');
         try {
             if (mode === 'forgot') {
                 const response = await post('/api/account/password/reset/request', locale, { email });
@@ -129,11 +146,20 @@ export default function AccountClient({
                 callbackURL,
                 oauth_query: oauthQuery(),
             });
-            const result = await response.json().catch(() => null) as { redirect?: string } | null;
+            const result = await response.json().catch(() => null) as {
+                redirect?: string;
+                status?: string;
+            } | null;
             if (mode === 'signup') {
-                announceCredentialResult(response.ok
-                    ? (es ? 'Revisá tu correo para verificar la cuenta y después ingresá.' : 'Check your email to verify the account, then sign in.')
-                    : (es ? 'No se pudo crear la cuenta. Revisá los datos e intentá nuevamente.' : 'Account could not be created. Check the details and try again.'));
+                if (response.status === 202 && result?.status === 'accepted') {
+                    formElement.reset();
+                    setSignupAccepted(true);
+                    announceCredentialResult(es
+                        ? 'Te enviamos un correo. Confirmá tu dirección para activar la cuenta y después ingresá.'
+                        : 'We sent you an email. Confirm your address to activate the account, then sign in.');
+                } else {
+                    announceCredentialResult(credentialFailure);
+                }
             } else if (response.ok) {
                 window.location.replace(result?.redirect ?? callbackURL);
             } else {
@@ -225,11 +251,30 @@ export default function AccountClient({
             : 'Sign-out could not be completed. Try again.');
     }
 
+    if (!session && signupAccepted) return (
+        <div className="account-card">
+            <section
+                ref={signupConfirmationRef}
+                className="account-signup-confirmation"
+                role="status"
+                aria-live="polite"
+                tabIndex={-1}
+            >
+                <span className="account-signup-confirmation__mark" aria-hidden="true">&#10003;</span>
+                <h2>{es ? 'Confirmá tu correo' : 'Confirm your email'}</h2>
+                <p>{message}</p>
+            </section>
+            <button className="account-primary" type="button" onClick={() => selectMode('signin')}>
+                {es ? 'Ir al ingreso' : 'Go to sign in'}
+            </button>
+        </div>
+    );
+
     if (!session) return (
         <div className="account-card">
             <div className="account-mode" role="group" aria-label={es ? 'Acción de cuenta' : 'Account action'}>
-                <button type="button" disabled={busy} aria-pressed={mode === 'signin'} onClick={() => setMode('signin')}>{es ? 'Ingresar' : 'Sign in'}</button>
-                <button type="button" disabled={busy} aria-pressed={mode === 'signup'} onClick={() => setMode('signup')}>{es ? 'Crear cuenta' : 'Create account'}</button>
+                <button type="button" disabled={busy} aria-pressed={mode === 'signin'} onClick={() => selectMode('signin')}>{es ? 'Ingresar' : 'Sign in'}</button>
+                <button type="button" disabled={busy} aria-pressed={mode === 'signup'} onClick={() => selectMode('signup')}>{es ? 'Crear cuenta' : 'Create account'}</button>
             </div>
             <div className="account-providers">
                 {providers.google && <button disabled={busy} onClick={() => social('google')}>{es ? 'Continuar con Google' : 'Continue with Google'}</button>}
@@ -270,9 +315,13 @@ export default function AccountClient({
                 />}
                 {mode === 'signup' && <p id="account-password-policy" className="account-muted">{passwordHint}</p>}
                 <p ref={feedbackRef} className="account-message" role="status" aria-live="polite" tabIndex={-1} hidden={!message}>{message}</p>
-                <button className="account-primary" disabled={busy}>{mode === 'signin' ? (es ? 'Ingresar' : 'Sign in') : mode === 'signup' ? (es ? 'Crear cuenta' : 'Create account') : (es ? 'Enviar correo' : 'Send reset email')}</button>
+                <button className="account-primary" disabled={busy}>{mode === 'signin'
+                    ? (es ? 'Ingresar' : 'Sign in')
+                    : mode === 'signup'
+                        ? busy ? (es ? 'Creando…' : 'Creating…') : (es ? 'Crear cuenta' : 'Create account')
+                        : (es ? 'Enviar correo' : 'Send reset email')}</button>
             </form>
-            <button className="account-link" type="button" onClick={() => setMode(mode === 'forgot' ? 'signin' : 'forgot')}>
+            <button className="account-link" type="button" onClick={() => selectMode(mode === 'forgot' ? 'signin' : 'forgot')}>
                 {mode === 'forgot' ? (es ? 'Volver al ingreso' : 'Back to sign in') : (es ? '¿Olvidaste tu contraseña?' : 'Forgot password?')}
             </button>
         </div>

--- a/src/components/account/__tests__/AccountClient.test.ts
+++ b/src/components/account/__tests__/AccountClient.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createElement } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -127,8 +128,8 @@ describe('Account cross-product logout completion', () => {
     });
 
     it.each([
-        ['en' as const, 'Confirm your email', 'We sent you an email. Confirm your address to activate the account, then sign in.', 'Go to sign in'],
-        ['es' as const, 'Confirmá tu correo', 'Te enviamos un correo. Confirmá tu dirección para activar la cuenta y después ingresá.', 'Ir al ingreso'],
+        ['en' as const, 'Check your email', 'If the request is eligible, check your email to continue.', 'Go to sign in'],
+        ['es' as const, 'Revisá tu correo', 'Si la solicitud es elegible, revisá tu correo para continuar.', 'Ir al ingreso'],
     ])('submits an eight-character %s signup and replaces the form with focused confirmation', async (
         locale, heading, copy, returnLabel,
     ) => {
@@ -156,8 +157,16 @@ describe('Account cross-product logout completion', () => {
         expect(feedback).toHaveTextContent(copy);
         await waitFor(() => expect(feedback).toHaveFocus());
         expect(screen.queryByRole('button', { name: createLabel })).toBeNull();
-        expect(screen.getByRole('button', { name: returnLabel })).toBeVisible();
         expect(document.body).not.toHaveTextContent('listener@example.invalid');
+        const returnButton = screen.getByRole('button', { name: returnLabel });
+        expect(returnButton).toBeVisible();
+        const user = userEvent.setup();
+        await user.tab();
+        expect(returnButton).toHaveFocus();
+        await user.keyboard('{Enter}');
+        await waitFor(() => expect(screen.getByRole('textbox', {
+            name: locale === 'es' ? 'Correo' : 'Email',
+        })).toHaveFocus());
     });
 
     it('shows an enumeration-neutral server failure and always restores the submit button', async () => {
@@ -184,7 +193,7 @@ describe('Account cross-product logout completion', () => {
         ));
         expect(feedback).toHaveFocus();
         expect(screen.getAllByRole('button', { name: 'Create account' }).at(-1)).toBeEnabled();
-        expect(screen.queryByText(/We sent you an email/)).toBeNull();
+        expect(screen.queryByText(/request is eligible/)).toBeNull();
     });
 
     it.each([
@@ -209,7 +218,7 @@ describe('Account cross-product logout completion', () => {
         fireEvent.submit(screen.getByLabelText('Password').closest('form')!);
         const feedback = await screen.findByRole('status');
         await waitFor(() => expect(feedback).toHaveTextContent('The request could not be completed.'));
-        expect(screen.queryByRole('heading', { name: 'Confirm your email' })).toBeNull();
+        expect(screen.queryByRole('heading', { name: 'Check your email' })).toBeNull();
     });
 
     it('coalesces duplicate credential submits while the first request is pending', async () => {
@@ -239,7 +248,7 @@ describe('Account cross-product logout completion', () => {
         resolveFetch(new Response('{"status":"accepted"}', {
             status: 202, headers: { 'Content-Type': 'application/json' },
         }));
-        await screen.findByRole('heading', { name: 'Confirm your email' });
+        await screen.findByRole('heading', { name: 'Check your email' });
         expect(screen.queryByRole('button', { name: 'Create account' })).toBeNull();
         expect(fetchMock).toHaveBeenCalledOnce();
         fireEvent.click(screen.getByRole('button', { name: 'Go to sign in' }));

--- a/src/components/account/__tests__/AccountClient.test.ts
+++ b/src/components/account/__tests__/AccountClient.test.ts
@@ -126,28 +126,38 @@ describe('Account cross-product logout completion', () => {
         expect(repeated).toHaveFocus();
     });
 
-    it('submits an eight-character signup and shows check-email only on success', async () => {
-        const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {
+    it.each([
+        ['en' as const, 'Confirm your email', 'We sent you an email. Confirm your address to activate the account, then sign in.', 'Go to sign in'],
+        ['es' as const, 'Confirmá tu correo', 'Te enviamos un correo. Confirmá tu dirección para activar la cuenta y después ingresá.', 'Ir al ingreso'],
+    ])('submits an eight-character %s signup and replaces the form with focused confirmation', async (
+        locale, heading, copy, returnLabel,
+    ) => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response('{"status":"accepted"}', {
             status: 202, headers: { 'Content-Type': 'application/json' },
         }));
         vi.stubGlobal('fetch', fetchMock);
         render(createElement(AccountClient, {
             initialSession: null,
             providers: { google: false, apple: false },
-            locale: 'en',
+            locale,
             returnTo: null,
         }));
-        fireEvent.click(screen.getAllByRole('button', { name: 'Create account' })[0]);
-        fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Test Listener' } });
-        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'listener@example.invalid' } });
-        const password = screen.getByLabelText('Password');
+        const createLabel = locale === 'es' ? 'Crear cuenta' : 'Create account';
+        fireEvent.click(screen.getAllByRole('button', { name: createLabel })[0]);
+        fireEvent.change(screen.getByLabelText(locale === 'es' ? 'Nombre visible' : 'Display name'), { target: { value: 'Test Listener' } });
+        fireEvent.change(screen.getByLabelText(locale === 'es' ? 'Correo' : 'Email'), { target: { value: 'listener@example.invalid' } });
+        const password = screen.getByLabelText(locale === 'es' ? 'Contraseña' : 'Password');
         fireEvent.change(password, { target: { value: '12345678' } });
-        fireEvent.change(screen.getByLabelText('Repeat password'), { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText(locale === 'es' ? 'Repetir contraseña' : 'Repeat password'), { target: { value: '12345678' } });
         fireEvent.submit(password.closest('form')!);
         await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
         const feedback = screen.getByRole('status');
-        expect(feedback).toHaveTextContent('Check your email to verify the account');
+        expect(feedback).toHaveTextContent(heading);
+        expect(feedback).toHaveTextContent(copy);
         await waitFor(() => expect(feedback).toHaveFocus());
+        expect(screen.queryByRole('button', { name: createLabel })).toBeNull();
+        expect(screen.getByRole('button', { name: returnLabel })).toBeVisible();
+        expect(document.body).not.toHaveTextContent('listener@example.invalid');
     });
 
     it('shows an enumeration-neutral server failure and always restores the submit button', async () => {
@@ -170,11 +180,36 @@ describe('Account cross-product logout completion', () => {
         fireEvent.submit(password.closest('form')!);
         const feedback = await screen.findByRole('status');
         await waitFor(() => expect(feedback).toHaveTextContent(
-            'Account could not be created. Check the details and try again.',
+            'The request could not be completed. Check the details and try again.',
         ));
         expect(feedback).toHaveFocus();
         expect(screen.getAllByRole('button', { name: 'Create account' }).at(-1)).toBeEnabled();
-        expect(screen.queryByText(/Check your email to verify/)).toBeNull();
+        expect(screen.queryByText(/We sent you an email/)).toBeNull();
+    });
+
+    it.each([
+        [200, '{"status":"accepted"}'],
+        [202, '{"status":"unexpected"}'],
+    ])('rejects malformed signup success status/body (%s) instead of showing a false confirmation', async (status, body) => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(body, {
+            status, headers: { 'Content-Type': 'application/json' },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(createElement(AccountClient, {
+            initialSession: null,
+            providers: { google: false, apple: false },
+            locale: 'en',
+            returnTo: null,
+        }));
+        fireEvent.click(screen.getAllByRole('button', { name: 'Create account' })[0]);
+        fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Test Listener' } });
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'listener@example.invalid' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText('Repeat password'), { target: { value: '12345678' } });
+        fireEvent.submit(screen.getByLabelText('Password').closest('form')!);
+        const feedback = await screen.findByRole('status');
+        await waitFor(() => expect(feedback).toHaveTextContent('The request could not be completed.'));
+        expect(screen.queryByRole('heading', { name: 'Confirm your email' })).toBeNull();
     });
 
     it('coalesces duplicate credential submits while the first request is pending', async () => {
@@ -199,11 +234,16 @@ describe('Account cross-product logout completion', () => {
         fireEvent.submit(form);
         fireEvent.submit(form);
         expect(fetchMock).toHaveBeenCalledOnce();
-        expect(screen.getAllByRole('button', { name: 'Create account' }).at(-1)).toBeDisabled();
-        resolveFetch(new Response('{}', {
+        expect(screen.getByRole('status')).toHaveTextContent('Creating your account…');
+        expect(screen.getByRole('button', { name: 'Creating…' })).toBeDisabled();
+        resolveFetch(new Response('{"status":"accepted"}', {
             status: 202, headers: { 'Content-Type': 'application/json' },
         }));
-        await waitFor(() => expect(screen.getAllByRole('button', { name: 'Create account' }).at(-1)).toBeEnabled());
+        await screen.findByRole('heading', { name: 'Confirm your email' });
+        expect(screen.queryByRole('button', { name: 'Create account' })).toBeNull();
+        expect(fetchMock).toHaveBeenCalledOnce();
+        fireEvent.click(screen.getByRole('button', { name: 'Go to sign in' }));
+        expect(screen.getAllByRole('button', { name: 'Sign in' })).toHaveLength(2);
     });
 
     it('blocks a signed-in password change when the repeated value differs', () => {


### PR DESCRIPTION
## Outcome

Account signup now has an explicit submitting state and a durable, focused confirmation panel after the exact accepted response. The terminal confirmation replaces the form, so repeated clicks cannot enqueue another request during the same mount. ES/EN copy remains provider- and email-neutral and does not echo the submitted address.

The catch-all route now returns the same exact 202 accepted body without signup cookies for both underlying success and rejection, preserving anti-enumeration.

## Root cause

The prior status was subtle and low in the form. Its queueMicrotask focus ran before React committed the feedback node, leaving focus on BODY. The submit button was then re-enabled, so a user who missed the message could submit repeatedly.

## Evidence

- Focused Account component + route tests: 22 passed
- Full Vitest suite: 1779 passed, 44 skipped
- TypeScript: green
- ESLint: 0 errors; 2 pre-existing warnings in pinned hb-global-nav asset
- Production build: green
- git diff --check: green

No deployment or merge is included.