### PR TITLE
Fix Account production database privilege boundary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/scripts/commerce-media-worker.ts 
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-quiesce-for-free-for-all.ts ./scripts/listener-quiesce-for-free-for-all.ts
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-withdrawal-operator.ts ./scripts/listener-withdrawal-operator.ts
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/check-migrations.mjs ./scripts/beacon-account/check-migrations.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/provision-production-role.mjs ./scripts/beacon-account/provision-production-role.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/validate.mjs ./ops/beacon-account/validate.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/account.production.env.example ./ops/beacon-account/account.production.env.example
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/account.staging.env.example ./ops/beacon-account/account.staging.env.example

--- a/docs/architecture/BEACON_ACCOUNT_AUTHORITY.md
+++ b/docs/architecture/BEACON_ACCOUNT_AUTHORITY.md
@@ -103,6 +103,27 @@ already issued, but new identity/authorization and lease renewal fail closed.
 
 ## Runtime and provider configuration
 
+### Production database boundary
+
+Production shares the canonical `earlybirds_preview` database so existing
+opaque account and product foreign keys survive, but it does not share the
+database owner's credential. The lifecycle derives a short-lived migration
+connection from the already-running PostgreSQL container, confines that
+connection to the internal DB network, and removes it after migration, backup
+or verification. The long-running application and mail worker use the
+non-owner `account_prod` role. Deployment creates or rotates that role only
+after the reviewed migration and grants it CRUD on the explicit Account/auth
+table inventory; it has no role membership, DDL, superuser, membership,
+commerce or event-table access.
+
+The first production authority migration intentionally invalidates legacy
+browser sessions and one-use auth artifacts. It must therefore be deployed as
+the coordinated Account → Listener identity cutover, with the encrypted
+pre-migration backup already verified. Starting an internal Account container
+early is not a harmless preview and is forbidden. A retry may accept the exact
+target migration as already applied, but never an unknown pending/applied
+migration or schema downgrade.
+
 The dedicated Account container requires `BEACON_ACCOUNT_RUNTIME=1` and the
 exact issuer Host; all non-Account routes and direct Docker Host access are 404.
 Readiness uses `BEACON_DATABASE_SCHEMA_VERSION` and returns

--- a/ops/beacon-account/account-mail-worker.production.env.example
+++ b/ops/beacon-account/account-mail-worker.production.env.example
@@ -1,6 +1,6 @@
 # Copy to /etc/harmonic-beacon/account-mail-worker.production.env as root:root 0600.
 # This file deliberately excludes browser auth, OAuth provider and RP secrets.
-DATABASE_URL=postgresql://account_prod:replace@earlybirds-preview-postgres:5432/earlybirds_preview?schema=public
+DATABASE_URL=postgresql://account_prod:replace-production-database-password-32-random@earlybirds-preview-postgres:5432/earlybirds_preview?schema=public
 BEACON_ACCOUNT_BASE_URL=https://account.harmonicbeacon.com
 BEACON_ACCOUNT_MAIL_DELIVERY_TOKEN=replace-production-private-mail-token-32-random
 BEACON_ACCOUNT_MAIL_OUTBOX_KEY=replaceProdOutboxKeyAAAAAAAAAAAAAAAAAAAAAAA

--- a/ops/beacon-account/account.production.env.example
+++ b/ops/beacon-account/account.production.env.example
@@ -1,6 +1,6 @@
 # Copy to /etc/harmonic-beacon/account.production.env as root:root 0600.
 # Never reuse any value from the staging file.
-DATABASE_URL=postgresql://account_prod:replace@earlybirds-preview-postgres:5432/earlybirds_preview?schema=public
+DATABASE_URL=postgresql://account_prod:replace-production-database-password-32-random@earlybirds-preview-postgres:5432/earlybirds_preview?schema=public
 BEACON_ACCOUNT_BASE_URL=https://account.harmonicbeacon.com
 BEACON_ACCOUNT_RUNTIME=1
 BEACON_ACCOUNT_PROVISION_CONFIRM_ISSUER=https://account.harmonicbeacon.com

--- a/ops/beacon-account/test/contract.test.mjs
+++ b/ops/beacon-account/test/contract.test.mjs
@@ -177,6 +177,17 @@ test('validator rejects a shared staging database schema', () => {
   assert.throws(() => validatePair(PROD, bad, STAGING_DB, true), /isolated account-staging-postgres/);
 });
 
+test('validator pins the production runtime role and bounded database password shape', () => {
+  const wrongRole = mutate(PROD, 'postgresql://account_prod:', 'postgresql://earlybirds_preview:');
+  assert.throws(() => validatePair(wrongRole, STAGING, STAGING_DB, true), /dedicated account_prod role/);
+  const unsafePassword = mutate(
+    PROD,
+    'account_prod:replace-production-database-password-32-random@earlybirds-preview-postgres',
+    'account_prod:short@earlybirds-preview-postgres',
+  );
+  assert.throws(() => validatePair(unsafePassword, STAGING, STAGING_DB, true), /32-128 base64url/);
+});
+
 test('validator rejects a production client secret in staging', () => {
   const bad = mutate(STAGING, 'BEACON_ACCOUNT_CLIENT_SECRET_HB_LISTENER=', 'BEACON_ACCOUNT_CLIENT_SECRET_HB_LISTENER=wrong-boundary');
   assert.throws(() => validatePair(PROD, bad, STAGING_DB, true), /must be empty outside its issuer/);
@@ -285,11 +296,18 @@ test('lifecycle verifies immutable provenance and does not downgrade schemas', (
   assert.match(start, /git -C "\$root" rev-parse HEAD/);
   assert.match(start, /docker image inspect "harmonic-beacon\/account:\$BEACON_ACCOUNT_IMAGE_TAG"/);
   assert.match(start, /account_compose build account-production[\s\S]*account_validate/);
-  assert.match(start, /account_compose up -d "account-mail-worker-\$environment" "account-\$environment"/);
+  assert.match(start, /account_compose up -d --no-deps[\s\\]+account-mail-worker-production account-production/);
+  assert.match(start, /account_compose up -d account-mail-worker-staging account-staging/);
   assert.match(start, /health-smoke\.sh"[\s\\]+"\$environment" "\$ACCOUNT_DEPLOY_FILE" "\$BEACON_ACCOUNT_GIT_SHA" 1 1/);
   assert.ok(start.indexOf('health-smoke.sh') < start.lastIndexOf('cutover_started=0'));
   assert.match(start, /account_check_production_migrations before/);
   assert.match(start, /account_check_production_migrations after/);
+  assert.match(start, /account_migrate_production/);
+  assert.match(start, /account_provision_production_role/);
+  assert.match(start, /account_provision_production_authority/);
+  assert.ok(start.indexOf('account_backup_production') < start.indexOf('account_migrate_production'));
+  assert.ok(start.indexOf('account_migrate_production') < start.indexOf('account_provision_production_role'));
+  assert.ok(start.indexOf('account_provision_production_role') < start.indexOf('cutover_started=1', start.indexOf('if [ "$environment" = production ]')));
   assert.match(start, /flock -n 9/);
   assert.match(start, /account_backup_production/);
   assert.match(start, /account_restore_previous_runtime/);
@@ -321,6 +339,11 @@ test('lifecycle verifies immutable provenance and does not downgrade schemas', (
   assert.match(lib, /openssl enc -d -aes-256-cbc/);
   assert.doesNotMatch(lib, /> "\$backup_dir\/\$backup_name"\s*$/m);
   assert.match(lib, /database was not downgraded|account_restore_previous_runtime/);
+  assert.match(lib, /account_write_production_admin_env/);
+  assert.match(lib, /--network none --read-only --cap-drop ALL --user 0:0/);
+  assert.match(lib, /--network earlybirds_preview_db_internal --read-only --tmpfs \/tmp/);
+  assert.match(lib, /provision-production-role\.mjs/);
+  assert.doesNotMatch(lib, /GRANT\s+earlybirds_preview\s+TO\s+account_prod/i);
   assert.match(smoke, /verify-health-json\.sh/);
   assert.match(smoke, /--connect-timeout 3 --max-time 8/);
   assert.match(smoke, /\/assets\/hb-global-nav\.js\?v=\$expected_sha/);
@@ -330,11 +353,13 @@ test('lifecycle verifies immutable provenance and does not downgrade schemas', (
   assert.doesNotMatch(smoke, /\bnode\b/);
   const migrationGuard = fs.readFileSync(path.resolve(ROOT, '../../scripts/beacon-account/check-migrations.mjs'), 'utf8');
   assert.match(migrationGuard, /pending migrations differ from the reviewed Account-only list/);
+  assert.match(migrationGuard, /pending\.length === 0 && applied\.has\(target\)/);
   assert.match(migrationGuard, /unresolved migration/);
   assert.doesNotMatch(`${start}\n${lib}`, /migrate reset|migrate down|docker compose down|volume rm|prune/);
   const dockerfile = fs.readFileSync(path.resolve(ROOT, '../../Dockerfile'), 'utf8');
   assert.match(dockerfile, /BEACON_ACCOUNT_NAV_ASSET=1/);
   assert.match(dockerfile, /ops\/beacon-account\/validate\.mjs/);
+  assert.match(dockerfile, /scripts\/beacon-account\/provision-production-role\.mjs/);
   for (const fixture of [
     'account.production.env.example',
     'account.staging.env.example',
@@ -344,6 +369,23 @@ test('lifecycle verifies immutable provenance and does not downgrade schemas', (
   ]) {
     assert.match(dockerfile, new RegExp(`ops/beacon-account/${fixture.replaceAll('.', '\\\.')}`));
   }
+});
+
+test('production runtime role provisioning is explicit, non-owner and allowlisted', () => {
+  const source = fs.readFileSync(
+    path.resolve(ROOT, '../../scripts/beacon-account/provision-production-role.mjs'),
+    'utf8',
+  );
+  assert.match(source, /RUNTIME_ROLE = 'account_prod'/);
+  assert.match(source, /NOSUPERUSER NOCREATEDB NOCREATEROLE/);
+  assert.match(source, /NOREPLICATION NOBYPASSRLS/);
+  assert.match(source, /runtime database role must not inherit another role/);
+  assert.match(source, /REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM account_prod/);
+  assert.match(source, /GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE/);
+  assert.match(source, /beacon_account_mail_outbox/);
+  assert.match(source, /beacon_oauth_access_tokens/);
+  assert.doesNotMatch(source, /GRANT\s+earlybirds_preview\s+TO\s+account_prod/i);
+  assert.doesNotMatch(source, /GRANT\s+ALL\s+(?:PRIVILEGES\s+)?ON\s+ALL\s+TABLES/i);
 });
 
 test('runtime verification preserves the pre-worker rollback boundary', () => {

--- a/ops/beacon-account/validate.mjs
+++ b/ops/beacon-account/validate.mjs
@@ -41,6 +41,13 @@ function validateDatabase(raw, expected) {
   if (url.hostname !== expected.host || url.pathname.slice(1) !== expected.database) {
     throw new Error(`DATABASE_URL must use isolated ${expected.host}/${expected.database}`);
   }
+  if (decodeURIComponent(url.username) !== expected.user) {
+    throw new Error(`DATABASE_URL must use the dedicated ${expected.user} role`);
+  }
+  const password = decodeURIComponent(url.password);
+  if (!/^[A-Za-z0-9_-]{32,128}$/.test(password)) {
+    throw new Error('DATABASE_URL password must be 32-128 base64url characters');
+  }
   return {
     identity: `${url.hostname}:${url.port || '5432'}${url.pathname}?schema=${expected.schema}`,
     url,
@@ -110,8 +117,8 @@ function validateEnvironment(env, kind, allowPlaceholders, stagingDatabaseEnv) {
     if (env.get(key)) throw new Error(`${key} must be empty outside its issuer`);
   });
   const database = validateDatabase(required(env, 'DATABASE_URL'), production
-    ? { host: 'earlybirds-preview-postgres', database: 'earlybirds_preview', schema: 'public' }
-    : { host: 'account-staging-postgres', database: 'beacon_account_staging', schema: 'public' });
+    ? { host: 'earlybirds-preview-postgres', database: 'earlybirds_preview', schema: 'public', user: 'account_prod' }
+    : { host: 'account-staging-postgres', database: 'beacon_account_staging', schema: 'public', user: 'beacon_account_staging' });
   if (!production) {
     assertRealSecret(required(stagingDatabaseEnv, 'POSTGRES_PASSWORD', 32), 'POSTGRES_PASSWORD', allowPlaceholders);
     if (!stagingDatabaseEnv ||

--- a/scripts/beacon-account/check-migrations.mjs
+++ b/scripts/beacon-account/check-migrations.mjs
@@ -29,8 +29,12 @@ try {
     .filter((row) => row.finished_at !== null && row.rolled_back_at === null)
     .map((row) => row.migration_name));
   const pending = available.filter((name) => !applied.has(name));
-  if (mode === 'before' && JSON.stringify(pending) !== JSON.stringify(expected)) {
-    throw new Error('pending migrations differ from the reviewed Account-only list');
+  if (mode === 'before') {
+    const exactPending = JSON.stringify(pending) === JSON.stringify(expected);
+    const exactAlreadyApplied = pending.length === 0 && applied.has(target);
+    if (!exactPending && !exactAlreadyApplied) {
+      throw new Error('pending migrations differ from the reviewed Account-only list');
+    }
   }
   if (mode === 'after' && pending.length !== 0) throw new Error('migrations remain pending after deploy');
 } finally {

--- a/scripts/beacon-account/lib.sh
+++ b/scripts/beacon-account/lib.sh
@@ -158,10 +158,86 @@ account_verify_running() {
   fi
 }
 
-account_check_production_migrations() {
+account_check_production_migrations() (
   mode=$1
-  account_compose run --rm --no-deps account-production \
-    node scripts/beacon-account/check-migrations.mjs "$mode"
+  work=$(mktemp -d /run/beacon-account-migration-check.XXXXXX)
+  trap 'rm -rf "$work"' EXIT HUP INT TERM
+  account_write_production_admin_env "$work/admin.env"
+  docker run --rm --network earlybirds_preview_db_internal --read-only --tmpfs /tmp \
+    --cap-drop ALL --security-opt no-new-privileges --env-file "$work/admin.env" \
+    -e "BEACON_ACCOUNT_EXPECTED_PENDING_MIGRATIONS=$BEACON_ACCOUNT_EXPECTED_PENDING_MIGRATIONS" \
+    -e "BEACON_ACCOUNT_SCHEMA_VERSION=$BEACON_ACCOUNT_SCHEMA_VERSION" \
+    --entrypoint node "harmonic-beacon/account:$BEACON_ACCOUNT_IMAGE_TAG" \
+    /app/scripts/beacon-account/check-migrations.mjs "$mode"
+  rm -rf "$work"
+  trap - EXIT HUP INT TERM
+)
+
+account_write_production_admin_env() {
+  target=$1
+  container=earlybirds-preview-postgres-1
+  state=$(docker inspect "$container" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>/dev/null || true)
+  test "$state" = healthy || account_fail 'production PostgreSQL is not healthy'
+  networks=$(docker inspect "$container" --format '{{range $name,$value := .NetworkSettings.Networks}}{{println $name}}{{end}}')
+  echo "$networks" | grep -Fxq earlybirds_preview_db_internal ||
+    account_fail 'production PostgreSQL is outside its exact internal network'
+  work=$(dirname -- "$target")
+  inspect_file="$work/postgres-inspect.json"
+  docker inspect "$container" > "$inspect_file"
+  chmod 0600 "$inspect_file"
+  docker run --rm --network none --read-only --cap-drop ALL --user 0:0 \
+    --security-opt no-new-privileges \
+    --mount "type=bind,src=$inspect_file,dst=/run/postgres-inspect.json,readonly" \
+    --entrypoint node "harmonic-beacon/account:$BEACON_ACCOUNT_IMAGE_TAG" -e '
+      const fs = require("node:fs");
+      const inspected = JSON.parse(fs.readFileSync("/run/postgres-inspect.json", "utf8"));
+      if (!Array.isArray(inspected) || inspected.length !== 1) throw new Error("invalid PostgreSQL inspection");
+      const values = new Map((inspected[0].Config?.Env ?? []).map((line) => {
+        const at = line.indexOf("="); return [line.slice(0, at), line.slice(at + 1)];
+      }));
+      const user = values.get("POSTGRES_USER");
+      const password = values.get("POSTGRES_PASSWORD");
+      const database = values.get("POSTGRES_DB");
+      if (user !== "earlybirds_preview" || database !== "earlybirds_preview" ||
+          !password || password.length < 32) throw new Error("unexpected PostgreSQL authority identity");
+      const url = new URL("postgresql://earlybirds-preview-postgres/earlybirds_preview?schema=public");
+      url.username = user; url.password = password;
+      process.stdout.write(`DATABASE_URL=${url.toString()}\n`);
+    ' > "$target"
+  rm -f "$inspect_file"
+  chmod 0600 "$target"
+  test "$(wc -l < "$target")" -eq 1 || account_fail 'migration database environment is invalid'
+}
+
+account_migrate_production() (
+  work=$(mktemp -d /run/beacon-account-migrate.XXXXXX)
+  trap 'rm -rf "$work"' EXIT HUP INT TERM
+  account_write_production_admin_env "$work/admin.env"
+  docker run --rm --network earlybirds_preview_db_internal --read-only --tmpfs /tmp \
+    --cap-drop ALL --security-opt no-new-privileges --env-file "$work/admin.env" \
+    "harmonic-beacon/account:$BEACON_ACCOUNT_IMAGE_TAG" npx prisma migrate deploy
+)
+
+account_provision_production_role() (
+  work=$(mktemp -d /run/beacon-account-role.XXXXXX)
+  trap 'rm -rf "$work"' EXIT HUP INT TERM
+  account_write_production_admin_env "$work/admin.env"
+  sed -n '/^DATABASE_URL=/p' "$BEACON_ACCOUNT_PRODUCTION_ENV_FILE" > "$work/runtime.env"
+  chmod 0600 "$work/runtime.env"
+  test "$(wc -l < "$work/runtime.env")" -eq 1 || account_fail 'production runtime DATABASE_URL is missing or duplicated'
+  docker run --rm --network earlybirds_preview_db_internal --read-only --tmpfs /tmp \
+    --cap-drop ALL --user 0:0 --security-opt no-new-privileges \
+    --env-file "$work/admin.env" \
+    --mount "type=bind,src=$work/runtime.env,dst=/run/account-runtime.env,readonly" \
+    --entrypoint node "harmonic-beacon/account:$BEACON_ACCOUNT_IMAGE_TAG" \
+    /app/scripts/beacon-account/provision-production-role.mjs /run/account-runtime.env
+)
+
+account_provision_production_authority() {
+  docker run --rm --network earlybirds_preview_db_internal --read-only --tmpfs /tmp \
+    --cap-drop ALL --security-opt no-new-privileges \
+    --env-file "$BEACON_ACCOUNT_PRODUCTION_ENV_FILE" \
+    "harmonic-beacon/account:$BEACON_ACCOUNT_IMAGE_TAG" npm run account:provision
 }
 
 account_backup_production() (
@@ -178,8 +254,7 @@ account_backup_production() (
   mkfifo -m 0600 "$dump_fifo"
   chmod 0600 "$database_env"
   trap 'rm -rf "$backup_work"; rm -f "$backup_dir/$backup_name"' EXIT HUP INT TERM
-  sed -n '/^DATABASE_URL=/p' "$BEACON_ACCOUNT_PRODUCTION_ENV_FILE" > "$database_env"
-  test "$(wc -l < "$database_env")" -eq 1 || account_fail 'production DATABASE_URL is missing or duplicated'
+  account_write_production_admin_env "$database_env"
   docker run --rm --network earlybirds_preview_db_internal --env-file "$database_env" \
     postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777 \
     sh -ec 'pg_dump --format=custom --no-owner --no-acl "$DATABASE_URL"' > "$dump_fifo" &

--- a/scripts/beacon-account/provision-production-role.mjs
+++ b/scripts/beacon-account/provision-production-role.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import process from 'node:process';
+
+import pg from 'pg';
+
+const EXPECTED_HOST = 'earlybirds-preview-postgres';
+const EXPECTED_DATABASE = 'earlybirds_preview';
+const RUNTIME_ROLE = 'account_prod';
+const ROLE_LOCK = 7_393_011_842;
+
+const runtimeTables = [
+  'early_bird_users',
+  'early_bird_auth_sessions',
+  'early_bird_identities',
+  'early_bird_verifications',
+  'beacon_account_authority_environment',
+  'beacon_profiles',
+  'beacon_account_action_tokens',
+  'beacon_account_auth_throttles',
+  'beacon_account_mail_outbox',
+  'listener_account_sessions',
+  'beacon_oauth_clients',
+  'beacon_oauth_refresh_tokens',
+  'beacon_oauth_access_tokens',
+  'beacon_oauth_consents',
+  'beacon_jwks',
+];
+
+const triggerFunctions = [
+  'beacon_profile_after_account_insert',
+  'beacon_verification_outbox_after_identity_insert',
+];
+
+function databaseUrlFromEnvFile(file) {
+  const matches = fs.readFileSync(file, 'utf8').split(/\r?\n/)
+    .filter((line) => line.startsWith('DATABASE_URL='));
+  if (matches.length !== 1) throw new Error('runtime database file must contain exactly one DATABASE_URL');
+  return new URL(matches[0].slice('DATABASE_URL='.length));
+}
+
+function validateUrl(url, role, label, expectedHost) {
+  if (!['postgres:', 'postgresql:'].includes(url.protocol) ||
+      url.hostname !== expectedHost ||
+      url.pathname.slice(1) !== EXPECTED_DATABASE ||
+      (url.searchParams.get('schema') ?? 'public') !== 'public') {
+    throw new Error(`${label} database boundary mismatch`);
+  }
+  if (decodeURIComponent(url.username) !== role) throw new Error(`${label} database role mismatch`);
+  const password = decodeURIComponent(url.password);
+  if (!/^[A-Za-z0-9_-]{32,128}$/.test(password)) {
+    throw new Error(`${label} database password must be 32-128 base64url characters`);
+  }
+  return password;
+}
+
+async function formattedRolePassword(client, password) {
+  const result = await client.query(
+    "SELECT format('ALTER ROLE %I LOGIN PASSWORD %L', $1::text, $2::text) AS statement",
+    [RUNTIME_ROLE, password],
+  );
+  return result.rows[0].statement;
+}
+
+export async function provisionProductionRole({
+  adminUrl,
+  runtimeEnvFile,
+  expectedHost = EXPECTED_HOST,
+}) {
+  const runtimeUrl = databaseUrlFromEnvFile(runtimeEnvFile);
+  const runtimePassword = validateUrl(runtimeUrl, RUNTIME_ROLE, 'runtime', expectedHost);
+  const parsedAdminUrl = new URL(adminUrl);
+  validateUrl(parsedAdminUrl, 'earlybirds_preview', 'migration', expectedHost);
+
+  const client = new pg.Client({ connectionString: parsedAdminUrl.toString() });
+  await client.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock($1)', [ROLE_LOCK]);
+    const authority = await client.query(`
+      SELECT current_database() AS database,
+             current_user AS role,
+             (SELECT rolsuper FROM pg_roles WHERE rolname = current_user) AS superuser
+    `);
+    if (authority.rows[0]?.database !== EXPECTED_DATABASE ||
+        authority.rows[0]?.role !== 'earlybirds_preview' ||
+        authority.rows[0]?.superuser !== true) {
+      throw new Error('migration connection is not the exact production database authority');
+    }
+
+    const existing = await client.query(
+      'SELECT rolsuper, rolcreatedb, rolcreaterole, rolreplication, rolbypassrls FROM pg_roles WHERE rolname = $1',
+      [RUNTIME_ROLE],
+    );
+    if (existing.rowCount === 0) await client.query('CREATE ROLE account_prod LOGIN');
+    else if (Object.values(existing.rows[0]).some(Boolean)) {
+      throw new Error('runtime database role has forbidden elevated attributes');
+    }
+    const memberships = await client.query(`
+      SELECT count(*)::integer AS count
+      FROM pg_auth_members membership
+      JOIN pg_roles member ON member.oid = membership.member
+      WHERE member.rolname = $1
+    `, [RUNTIME_ROLE]);
+    if (memberships.rows[0].count !== 0) throw new Error('runtime database role must not inherit another role');
+
+    await client.query(await formattedRolePassword(client, runtimePassword));
+    await client.query(`
+      ALTER ROLE account_prod NOSUPERUSER NOCREATEDB NOCREATEROLE
+        NOREPLICATION NOBYPASSRLS INHERIT;
+      ALTER ROLE account_prod SET search_path = public;
+      GRANT CONNECT ON DATABASE earlybirds_preview TO account_prod;
+      GRANT USAGE ON SCHEMA public TO account_prod;
+      REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM account_prod;
+      REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM account_prod;
+    `);
+
+    const objects = await client.query(
+      'SELECT name FROM unnest($1::text[]) AS expected(name) WHERE to_regclass(format(\'public.%I\', name)) IS NULL',
+      [runtimeTables],
+    );
+    if (objects.rowCount !== 0) throw new Error('required Account runtime table is missing after migration');
+    await client.query(`GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE ${runtimeTables
+      .map((name) => `"${name}"`).join(', ')} TO account_prod`);
+    for (const name of triggerFunctions) {
+      const present = await client.query('SELECT to_regprocedure($1) IS NOT NULL AS present', [`${name}()`]);
+      if (!present.rows[0].present) throw new Error('required Account trigger function is missing after migration');
+      await client.query(`GRANT EXECUTE ON FUNCTION "${name}"() TO account_prod`);
+    }
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  } finally {
+    await client.end();
+  }
+
+  const runtime = new pg.Client({ connectionString: runtimeUrl.toString() });
+  await runtime.connect();
+  try {
+    const check = await runtime.query(`
+      SELECT current_database() AS database, current_user AS role,
+             to_regclass('public.beacon_account_authority_environment') IS NOT NULL AS authority
+    `);
+    if (check.rows[0]?.database !== EXPECTED_DATABASE ||
+        check.rows[0]?.role !== RUNTIME_ROLE || check.rows[0]?.authority !== true) {
+      throw new Error('runtime database role verification failed');
+    }
+  } finally {
+    await runtime.end();
+  }
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  const runtimeEnvFile = process.argv[2];
+  if (!runtimeEnvFile || !process.env.DATABASE_URL) {
+    throw new Error('usage: DATABASE_URL=<migration-url> provision-production-role.mjs runtime-database.env');
+  }
+  provisionProductionRole({ adminUrl: process.env.DATABASE_URL, runtimeEnvFile })
+    .then(() => process.stdout.write('Account production runtime database role is ready.\n'))
+    .catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.message : 'role provisioning failed'}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/beacon-account/start.sh
+++ b/scripts/beacon-account/start.sh
@@ -36,11 +36,20 @@ baked_sha=$(docker image inspect "harmonic-beacon/account:$BEACON_ACCOUNT_IMAGE_
 test "$baked_sha" = "$BEACON_ACCOUNT_GIT_SHA" || account_fail 'built image provenance mismatch'
 account_validate
 
-[ "$environment" != production ] || account_check_production_migrations before
-[ "$environment" != production ] || account_backup_production >/dev/null
-cutover_started=1
-account_compose up -d "account-mail-worker-$environment" "account-$environment"
-[ "$environment" != production ] || account_check_production_migrations after
+if [ "$environment" = production ]; then
+  account_check_production_migrations before
+  account_backup_production >/dev/null
+  account_migrate_production
+  account_check_production_migrations after
+  account_provision_production_role
+  account_provision_production_authority
+  cutover_started=1
+  account_compose up -d --no-deps \
+    account-mail-worker-production account-production
+else
+  cutover_started=1
+  account_compose up -d account-mail-worker-staging account-staging
+fi
 account_verify_running "$environment"
 "$root/scripts/beacon-account/health-smoke.sh" \
   "$environment" "$ACCOUNT_DEPLOY_FILE" "$BEACON_ACCOUNT_GIT_SHA" 1 1


### PR DESCRIPTION
## Outcome

Closes the production preflight failure where the configured `account_prod` role did not exist and the lifecycle implicitly required the long-running Account runtime to own the shared Early Birds schema.

- derives the existing PostgreSQL owner credential only into root-only ephemeral files and only for migration/check/backup;
- creates/rotates non-owner `account_prod` after the reviewed migration;
- grants CRUD only on the explicit Account/auth table inventory, with no role membership, DDL, superuser, membership, commerce or event access;
- starts production app/worker with `--no-deps` only after migration, grants and authority provisioning;
- keeps staging lifecycle unchanged;
- permits a safe deploy retry only when the exact target migration is already applied;
- documents that the first production migration invalidates legacy sessions and therefore must coincide with the Listener identity cutover.

## Evidence

- Account lifecycle contract: 20/20
- full Vitest: 1782 passed, 44 skipped
- PostgreSQL 16 fresh migration + role provision + replay: green
  - `account_prod` non-elevated, no memberships
  - Account table read succeeds
  - membership projection read denied (`42501`)
  - DDL denied (`42501`)
- `npx tsc --noEmit`
- ESLint: 0 errors (2 pre-existing warnings in pinned nav asset)
- production dependency audit gate
- Prisma validate/generate
- Next production build
- shell/Node syntax and `git diff --check`

No runtime, DB, DNS, nginx or secret was changed by this PR. Production deployment remains intentionally gated on coordinated Account → Listener cutover and verified backup.
