### PR TITLE
ops(listener): prepare production Account RP boundary

### DIFF
--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -19,8 +19,10 @@ on:
       - ops/early-birds/**
       - ops/early-birds-preview/**
       - ops/listener-identity-staging/**
+      - ops/listener-account-production/**
       - scripts/early-birds-preview/**
       - scripts/listener-identity-staging/**
+      - scripts/listener-account-production/**
       - scripts/listener_container_observer.py
       - tools/early-birds-hls-load/**
       - docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
@@ -48,8 +50,10 @@ on:
       - ops/early-birds/**
       - ops/early-birds-preview/**
       - ops/listener-identity-staging/**
+      - ops/listener-account-production/**
       - scripts/early-birds-preview/**
       - scripts/listener-identity-staging/**
+      - scripts/listener-account-production/**
       - scripts/listener_container_observer.py
       - tools/early-birds-hls-load/**
       - docs/ops/LISTENER_FIRST_EXTERNAL_HLS_SMOKE.md
@@ -132,3 +136,5 @@ jobs:
       - run: npm --prefix ops/listener-identity-staging run check
       - run: npm --prefix ops/listener-identity-staging test
       - run: npm --prefix ops/listener-identity-staging run validate:example
+      - run: npm --prefix ops/listener-account-production run check
+      - run: npm --prefix ops/listener-account-production test

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-quiesce-for-free
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-withdrawal-operator.ts ./scripts/listener-withdrawal-operator.ts
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/check-migrations.mjs ./scripts/beacon-account/check-migrations.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/provision-production-role.mjs ./scripts/beacon-account/provision-production-role.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-account-production/sync-secret.mjs ./scripts/listener-account-production/sync-secret.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-account-production/preflight.mjs ./scripts/listener-account-production/preflight.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/validate.mjs ./ops/beacon-account/validate.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/account.production.env.example ./ops/beacon-account/account.production.env.example
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/account.staging.env.example ./ops/beacon-account/account.staging.env.example
@@ -61,6 +63,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/account-mail-w
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/account-mail-worker.staging.env.example ./ops/beacon-account/account-mail-worker.staging.env.example
 COPY --from=builder --chown=nextjs:nodejs /app/ops/listener-identity-staging/validate.mjs ./ops/listener-identity-staging/validate.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/ops/listener-identity-staging/intro-artifacts.sha256 ./ops/listener-identity-staging/intro-artifacts.sha256
+COPY --from=builder --chown=nextjs:nodejs /app/ops/listener-account-production/validate.mjs ./ops/listener-account-production/validate.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/provision-account-authority.ts ./scripts/provision-account-authority.ts
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/process-account-mail-outbox.ts ./scripts/process-account-mail-outbox.ts
 COPY --from=builder --chown=nextjs:nodejs /app/src/lib/event-stabilization.ts ./src/lib/event-stabilization.ts

--- a/ops/early-birds-preview/preview.env.synthetic.example
+++ b/ops/early-birds-preview/preview.env.synthetic.example
@@ -30,8 +30,9 @@ EARLY_BIRDS_GOOGLE_CLIENT_SECRET=
 BEACON_LISTENER_APPLE_ENABLED=0
 BEACON_LISTENER_APPLE_CLIENT_ID=
 BEACON_LISTENER_APPLE_CLIENT_SECRET=
-# Central Account RP remains OFF in the disconnected fixture. Real root-owned
-# prod/staging files install four distinct values before enabling it.
+# Central Account RP remains OFF in the disconnected fixture. The production
+# cutover installs only the dedicated production client/state pair; staging
+# secrets never belong in this runtime file or container.
 BEACON_LISTENER_ACCOUNT_ENABLED=0
 BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=
 BEACON_LISTENER_ACCOUNT_CLIENT_SECRET_STAGING=

--- a/ops/early-birds-preview/test/preview-contract.test.mjs
+++ b/ops/early-birds-preview/test/preview-contract.test.mjs
@@ -91,6 +91,38 @@ test('synthetic guard accepts the example and rejects unsafe effective values', 
     assert.equal(runGuard(envFile).status, 0);
   });
 
+  await t.test('guarded production Account handoff uses only production secrets', async () => {
+    const envFile = path.join(temporary, 'production-account.env');
+    await fs.writeFile(envFile, source
+      .replace(
+        'EARLY_BIRDS_AUTH_BASE_URL=https://earlybirds-staging.harmonicbeacon.com',
+        'EARLY_BIRDS_AUTH_BASE_URL=https://listen.harmonicbeacon.com',
+      )
+      .replace(
+        'EARLY_BIRDS_TRUSTED_ORIGINS=https://earlybirds-staging.harmonicbeacon.com',
+        'EARLY_BIRDS_TRUSTED_ORIGINS=https://listen.harmonicbeacon.com,https://earlybirds-staging.harmonicbeacon.com',
+      )
+      .replace('BEACON_LISTENER_ACCOUNT_ENABLED=0', 'BEACON_LISTENER_ACCOUNT_ENABLED=1')
+      .replace('BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=', `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${'c'.repeat(64)}`)
+      .replace('BEACON_LISTENER_ACCOUNT_STATE_SECRET=', `BEACON_LISTENER_ACCOUNT_STATE_SECRET=${'s'.repeat(64)}`), {
+      mode: 0o600,
+    });
+    assert.equal(runGuard(envFile).status, 0);
+
+    await fs.appendFile(envFile, `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET_STAGING=${'x'.repeat(64)}\n`);
+    const result = runGuard(envFile);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /must not contain staging Account secrets/);
+  });
+
+  await t.test('disabled Listener rejects dormant Account secrets in its runtime env', async () => {
+    const envFile = path.join(temporary, 'disabled-account-with-secret.env');
+    await fs.writeFile(envFile, `${source}\nBEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${'c'.repeat(64)}\n`, { mode: 0o600 });
+    const result = runGuard(envFile);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /disabled Listener must not carry Account RP secrets/);
+  });
+
   await t.test('guarded staging Apple OAuth handoff remains on the staging callback host', async () => {
     const envFile = path.join(temporary, 'staging-apple-oauth.env');
     await fs.writeFile(envFile, source

--- a/ops/listener-account-production/README.md
+++ b/ops/listener-account-production/README.md
@@ -1,0 +1,24 @@
+# Listener production Account preparation
+
+This package prepares the production Listener relying-party secret without
+changing the running Listener or enabling Account. It deliberately precedes
+the coordinated Account/Listener cutover.
+
+1. Build the exact reviewed `early-birds` SHA as
+   `harmonic-beacon/earlybirds-preview-listener:<sha40>`.
+2. Run `sudo scripts/listener-account-production/prepare.sh <sha40>` on Mona.
+   It reads the root-only Account and Listener env files in a networkless,
+   read-only candidate container. The resulting two-key bundle is installed at
+   `/etc/harmonic-beacon/listener-account-production.env` as root:root 0600.
+3. Do not copy the bundle into the running Listener env and do not set
+   `BEACON_LISTENER_ACCOUNT_ENABLED=1` yet.
+4. After Account production has a reviewed public TLS edge and is fully ready,
+   run `sudo scripts/listener-account-production/preflight.sh <sha40>`. It
+   exposes only the dedicated RP client secret to a bounded egress probe and
+   proves readiness, discovery, JWKS, Basic authentication and session-status.
+
+The first Account production migration revokes legacy Listener authentication
+sessions. Therefore Account migration, Listener env activation and the public
+edge change belong to one maintenance boundary with fresh backups and rollback.
+This preparatory package does not perform that boundary and does not require a
+DNS record.

--- a/ops/listener-account-production/package.json
+++ b/ops/listener-account-production/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@harmonic-beacon/listener-account-production-ops",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "node --check validate.mjs && node --check ../../scripts/listener-account-production/sync-secret.mjs && node --check ../../scripts/listener-account-production/preflight.mjs && sh -n ../../scripts/listener-account-production/prepare.sh ../../scripts/listener-account-production/preflight.sh",
+    "test": "node --test test/contract.test.mjs"
+  }
+}

--- a/ops/listener-account-production/test/contract.test.mjs
+++ b/ops/listener-account-production/test/contract.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { buildProductionBundle } from '../../../scripts/listener-account-production/sync-secret.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const source = (file) => fs.readFileSync(path.join(ROOT, file), 'utf8');
+const client = 'c'.repeat(64);
+const state = 's'.repeat(64);
+const account = `BEACON_ACCOUNT_BASE_URL=https://account.harmonicbeacon.com\nBEACON_ACCOUNT_CLIENT_SECRET_HB_LISTENER=${client}\n`;
+const listener = 'EARLY_BIRDS_AUTH_BASE_URL=https://listen.harmonicbeacon.com\nBEACON_LISTENER_ACCOUNT_ENABLED=0\n';
+
+test('builds the exact two-key production bundle and preserves state', () => {
+  const bundle = buildProductionBundle({
+    accountContents: account,
+    listenerContents: listener,
+    currentContents: `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\n`,
+  });
+  assert.equal(bundle, `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\n`);
+});
+
+test('refuses enabled, staging and unexpected secret states', () => {
+  assert.throws(() => buildProductionBundle({
+    accountContents: account,
+    listenerContents: listener.replace('=0', '=1'),
+  }), /must remain disabled/);
+  assert.throws(() => buildProductionBundle({
+    accountContents: account,
+    listenerContents: `${listener}BEACON_LISTENER_ACCOUNT_CLIENT_SECRET_STAGING=${state}\n`,
+  }), /STAGING must be absent/);
+  const rotated = buildProductionBundle({
+    accountContents: account,
+    listenerContents: listener,
+    currentContents: `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${'x'.repeat(64)}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\n`,
+  });
+  assert.equal(rotated, `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\n`);
+  assert.throws(() => buildProductionBundle({
+    accountContents: account,
+    listenerContents: listener,
+    currentContents: `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\nEXTRA=value\n`,
+  }), /unexpected keys/);
+});
+
+test('host wrappers constrain secrets, networking, provenance and arguments', () => {
+  const prepare = source('scripts/listener-account-production/prepare.sh');
+  const preflight = source('scripts/listener-account-production/preflight.sh');
+  assert.match(prepare, /--network none/);
+  assert.match(prepare, /--read-only/);
+  assert.match(prepare, /--cap-drop ALL/);
+  assert.match(prepare, /--security-opt no-new-privileges/);
+  assert.match(prepare, /BEACON_GIT_SHA/);
+  assert.match(prepare, /root:root:600/);
+  assert.doesNotMatch(prepare, /docker inspect .*Config\.Env/);
+  assert.match(preflight, /earlybirds_preview_listener_egress/);
+  assert.doesNotMatch(preflight, /account\.production\.env|earlybirds-preview\.env/);
+});
+
+test('preflight pins the production issuer and frozen OIDC contract', () => {
+  const preflight = source('scripts/listener-account-production/preflight.mjs');
+  assert.match(preflight, /https:\/\/account\.harmonicbeacon\.com/);
+  assert.match(preflight, /hb-listener/);
+  assert.match(preflight, /client_secret_basic/);
+  assert.match(preflight, /JSON\.stringify\(\['client_secret_basic'\]\)/);
+  assert.match(preflight, /S256/);
+  assert.match(preflight, /Ed25519/);
+  assert.match(preflight, /session-status/);
+  assert.match(preflight, /AbortSignal\.timeout\(8_000\)/);
+});
+
+test('Docker image contains only the required preparation scripts', () => {
+  const dockerfile = source('Dockerfile');
+  assert.match(dockerfile, /scripts\/listener-account-production\/sync-secret\.mjs/);
+  assert.match(dockerfile, /scripts\/listener-account-production\/preflight\.mjs/);
+  assert.match(dockerfile, /ops\/listener-account-production\/validate\.mjs/);
+});

--- a/ops/listener-account-production/test/contract.test.mjs
+++ b/ops/listener-account-production/test/contract.test.mjs
@@ -47,6 +47,8 @@ test('refuses enabled, staging and unexpected secret states', () => {
 test('host wrappers constrain secrets, networking, provenance and arguments', () => {
   const prepare = source('scripts/listener-account-production/prepare.sh');
   const preflight = source('scripts/listener-account-production/preflight.sh');
+  assert.match(prepare, /id -u/);
+  assert.match(preflight, /id -u/);
   assert.match(prepare, /--network none/);
   assert.match(prepare, /--read-only/);
   assert.match(prepare, /--cap-drop ALL/);

--- a/ops/listener-account-production/validate.mjs
+++ b/ops/listener-account-production/validate.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+const requiredFiles = [
+  '/app/scripts/listener-account-production/sync-secret.mjs',
+  '/app/scripts/listener-account-production/preflight.mjs',
+];
+
+for (const file of requiredFiles) {
+  const metadata = fs.statSync(file);
+  if (!metadata.isFile()) throw new Error('Listener production Account lifecycle file is missing from the image');
+}
+process.stdout.write('Listener production Account image contract is present.\n');

--- a/scripts/early-birds-preview/lib.sh
+++ b/scripts/early-birds-preview/lib.sh
@@ -119,13 +119,25 @@ require_synthetic_env() {
   fi
   case "$account_enabled" in 0|1) ;; *) preview_fail 'BEACON_LISTENER_ACCOUNT_ENABLED must be 0 or 1' ;; esac
   if test "$account_enabled" = 1; then
-    for account_secret in "$account_client_prod" "$account_client_staging" "$account_state_prod" "$account_state_staging"; do
+    for account_secret in "$account_client_prod" "$account_state_prod"; do
       test "${#account_secret}" -ge 32 || preview_fail 'Listener Account RP secrets must contain at least 32 characters'
     done
-    test "$account_client_prod" != "$account_client_staging" || preview_fail 'Listener Account client secrets must differ by environment'
-    test "$account_state_prod" != "$account_state_staging" || preview_fail 'Listener Account state secrets must differ by environment'
+    test "$account_client_prod" != "$account_state_prod" || preview_fail 'Listener Account client and state secrets must differ'
+    test -z "$account_client_staging" && test -z "$account_state_staging" ||
+      preview_fail 'production Listener must not contain staging Account secrets'
+    require_exact_preview_value EARLY_BIRDS_AUTH_BASE_URL https://listen.harmonicbeacon.com "$env_file"
+    require_exact_preview_value EARLY_BIRDS_TRUSTED_ORIGINS \
+      https://listen.harmonicbeacon.com,https://earlybirds-staging.harmonicbeacon.com "$env_file"
+  else
+    for account_secret in "$account_client_prod" "$account_client_staging" "$account_state_prod" "$account_state_staging"; do
+      test -z "$account_secret" || preview_fail 'disabled Listener must not carry Account RP secrets'
+    done
   fi
-  if test -n "$google_client_id" || test -n "$apple_client_id"; then
+  if test "$account_enabled" = 1; then
+    # The exact production Listener origin was already required together with
+    # its production-only RP secret pair above.
+    :
+  elif test -n "$google_client_id" || test -n "$apple_client_id"; then
     oauth_auth_base=$(preview_env_value EARLY_BIRDS_AUTH_BASE_URL "$env_file")
     case "$oauth_auth_base" in
       https://earlybirds-staging.harmonicbeacon.com)

--- a/scripts/listener-account-production/preflight.mjs
+++ b/scripts/listener-account-production/preflight.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { lstat, readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+import { parseEnvironment } from './sync-secret.mjs';
+
+const ISSUER = 'https://account.harmonicbeacon.com';
+const CLIENT_ID = 'hb-listener';
+const BUNDLE = '/run/listener-account-production.env';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function jsonResponse(url, init = {}) {
+  const response = await fetch(url, {
+    ...init,
+    cache: 'no-store',
+    redirect: 'error',
+    signal: AbortSignal.timeout(8_000),
+  });
+  const body = await response.json().catch(() => fail(`${url} did not return JSON`));
+  return { response, body };
+}
+
+export async function productionAccountPreflight({ bundlePath = BUNDLE } = {}) {
+  const metadata = await lstat(bundlePath);
+  if (!metadata.isFile() || metadata.uid !== 0 || metadata.gid !== 0 || (metadata.mode & 0o777) !== 0o600) {
+    fail('Listener production Account bundle must be a root:root mode-0600 regular file');
+  }
+  const bundle = parseEnvironment(await readFile(bundlePath, 'utf8'));
+  const keys = [...bundle.keys()].sort();
+  const expectedKeys = [
+    'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET',
+    'BEACON_LISTENER_ACCOUNT_STATE_SECRET',
+  ].sort();
+  if (keys.join('\n') !== expectedKeys.join('\n')) fail('Listener production Account bundle key inventory mismatch');
+  const clientSecret = bundle.get('BEACON_LISTENER_ACCOUNT_CLIENT_SECRET') ?? '';
+  if (!/^[A-Za-z0-9_-]{32,128}$/.test(clientSecret)) fail('Listener production Account client secret is invalid');
+
+  const { response: readyResponse, body: ready } = await jsonResponse(`${ISSUER}/api/account/health/ready`);
+  if (!readyResponse.ok || ready?.status !== 'ok' || ready?.checks?.database !== 'ok' ||
+      ready?.checks?.mail !== 'ok' || ready?.checks?.issuer !== 'ok' || ready?.checks?.jwks !== 'ok' ||
+      ready?.checks?.clients !== 'ok' || ready?.checks?.providers !== 'ok') {
+    fail('Account production readiness is unavailable or incomplete');
+  }
+
+  const { response: discoveryResponse, body: discovery } = await jsonResponse(
+    `${ISSUER}/.well-known/openid-configuration`,
+    { headers: { Accept: 'application/json' } },
+  );
+  if (!discoveryResponse.ok || discovery.issuer !== ISSUER) fail('Account production discovery mismatch');
+  const endpoints = {
+    authorization_endpoint: '/api/account/auth/oauth2/authorize',
+    token_endpoint: '/api/account/auth/oauth2/token',
+    jwks_uri: '/.well-known/jwks.json',
+    introspection_endpoint: '/api/account/auth/oauth2/introspect',
+    end_session_endpoint: '/api/account/auth/oauth2/end-session',
+  };
+  for (const [name, path] of Object.entries(endpoints)) {
+    if (discovery[name] !== `${ISSUER}${path}`) fail(`Account production discovery ${name} mismatch`);
+  }
+  if (JSON.stringify(discovery.code_challenge_methods_supported) !== JSON.stringify(['S256']) ||
+      JSON.stringify(discovery.token_endpoint_auth_methods_supported) !== JSON.stringify(['client_secret_basic'])) {
+    fail('Account production discovery does not expose the frozen RP contract');
+  }
+
+  const { response: jwksResponse, body: jwks } = await jsonResponse(`${ISSUER}/.well-known/jwks.json`);
+  const keyIds = Array.isArray(jwks.keys) ? jwks.keys.map((key) => key?.kid) : [];
+  if (!jwksResponse.ok || !Array.isArray(jwks.keys) || jwks.keys.length < 1 ||
+      jwks.keys.some((key) => typeof key?.kid !== 'string' || !key.kid || key.kty !== 'OKP' ||
+        key.alg !== 'EdDSA' || key.crv !== 'Ed25519' || !/^[A-Za-z0-9_-]{43}$/.test(key.x ?? '') || key.d ||
+        (key.use !== undefined && key.use !== 'sig') ||
+        (key.key_ops !== undefined && (!Array.isArray(key.key_ops) || !key.key_ops.includes('verify')))) ||
+      new Set(keyIds).size !== keyIds.length) {
+    fail('Account production JWKS is unavailable or invalid');
+  }
+
+  const basic = Buffer.from(`${CLIENT_ID}:${clientSecret}`, 'utf8').toString('base64');
+  const { response: statusResponse, body: status } = await jsonResponse(`${ISSUER}/api/account/session-status`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Basic ${basic}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({ sid: 'listener-production-preflight', sub: 'listener-production-preflight' }),
+  });
+  if (!statusResponse.ok || status.active !== false ||
+      !statusResponse.headers.get('cache-control')?.toLowerCase().includes('no-store')) {
+    fail('Account production Listener client authentication failed');
+  }
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  if (process.getuid?.() !== 0 || process.argv.length !== 2) {
+    throw new Error('run as root without arguments');
+  }
+  productionAccountPreflight()
+    .then(() => process.stdout.write('Listener production Account preflight passed without exposing secrets.\n'))
+    .catch((error) => {
+      process.stderr.write(`Listener production Account preflight failed: ${error instanceof Error ? error.message : 'unknown error'}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/listener-account-production/preflight.sh
+++ b/scripts/listener-account-production/preflight.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+
 expected_sha=${1:?usage: preflight.sh exact-sha40}
 case "$expected_sha" in *[!0-9a-f]*|'') echo 'exact lowercase sha40 required' >&2; exit 2 ;; esac
 test "${#expected_sha}" -eq 40 || { echo 'exact lowercase sha40 required' >&2; exit 2; }

--- a/scripts/listener-account-production/preflight.sh
+++ b/scripts/listener-account-production/preflight.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -eu
+
+expected_sha=${1:?usage: preflight.sh exact-sha40}
+case "$expected_sha" in *[!0-9a-f]*|'') echo 'exact lowercase sha40 required' >&2; exit 2 ;; esac
+test "${#expected_sha}" -eq 40 || { echo 'exact lowercase sha40 required' >&2; exit 2; }
+image="harmonic-beacon/earlybirds-preview-listener:$expected_sha"
+bundle=/etc/harmonic-beacon/listener-account-production.env
+
+test -f "$bundle" && test ! -L "$bundle" || { echo 'Listener production Account bundle is absent' >&2; exit 2; }
+test "$(stat -c '%U:%G:%a' "$bundle")" = root:root:600 || {
+  echo 'Listener production Account bundle must be root:root mode 0600' >&2; exit 2;
+}
+baked_sha=$(docker image inspect "$image" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$baked_sha" = "$expected_sha" || { echo 'candidate image provenance mismatch' >&2; exit 2; }
+network_internal=$(docker network inspect earlybirds_preview_listener_egress --format '{{.Internal}}' 2>/dev/null || true)
+test "$network_internal" = false || { echo 'Listener egress network is unavailable' >&2; exit 2; }
+
+docker run --rm --pull never --network earlybirds_preview_listener_egress --read-only --user 0:0 \
+  --cap-drop ALL --security-opt no-new-privileges \
+  --mount "type=bind,src=$bundle,dst=/run/listener-account-production.env,readonly" \
+  --entrypoint node "$image" /app/scripts/listener-account-production/preflight.mjs

--- a/scripts/listener-account-production/prepare.sh
+++ b/scripts/listener-account-production/prepare.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+
 expected_sha=${1:?usage: prepare.sh exact-sha40}
 case "$expected_sha" in *[!0-9a-f]*|'') echo 'exact lowercase sha40 required' >&2; exit 2 ;; esac
 test "${#expected_sha}" -eq 40 || { echo 'exact lowercase sha40 required' >&2; exit 2; }

--- a/scripts/listener-account-production/prepare.sh
+++ b/scripts/listener-account-production/prepare.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -eu
+
+expected_sha=${1:?usage: prepare.sh exact-sha40}
+case "$expected_sha" in *[!0-9a-f]*|'') echo 'exact lowercase sha40 required' >&2; exit 2 ;; esac
+test "${#expected_sha}" -eq 40 || { echo 'exact lowercase sha40 required' >&2; exit 2; }
+
+image="harmonic-beacon/earlybirds-preview-listener:$expected_sha"
+account_env=/etc/harmonic-beacon/account.production.env
+listener_env=/etc/harmonic-beacon/earlybirds-preview.env
+target=/etc/harmonic-beacon/listener-account-production.env
+target_directory=/etc/harmonic-beacon
+work=$(mktemp -d /run/listener-account-production.XXXXXX)
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+umask 077
+
+test -d "$target_directory" && test ! -L "$target_directory" || {
+  echo 'Harmonic Beacon secret directory is not a regular directory' >&2; exit 2;
+}
+test "$(stat -c '%U:%G:%a' "$target_directory")" = root:root:700 || {
+  echo 'Harmonic Beacon secret directory must be root:root mode 0700' >&2; exit 2;
+}
+
+for source in "$account_env" "$listener_env"; do
+  test -f "$source" && test ! -L "$source" || { echo 'required production env is not a regular file' >&2; exit 2; }
+  test "$(stat -c '%U:%G:%a' "$source")" = root:root:600 || {
+    echo 'required production env must be root:root mode 0600' >&2; exit 2;
+  }
+done
+if test -e "$target"; then
+  test -f "$target" && test ! -L "$target" || { echo 'current Account bundle is not a regular file' >&2; exit 2; }
+  test "$(stat -c '%U:%G:%a' "$target")" = root:root:600 || {
+    echo 'current Account bundle must be root:root mode 0600' >&2; exit 2;
+  }
+  install -o root -g root -m 0600 "$target" "$work/current.env"
+fi
+
+docker image inspect "$image" >/dev/null
+baked_sha=$(docker image inspect "$image" --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$baked_sha" = "$expected_sha" || { echo 'candidate image provenance mismatch' >&2; exit 2; }
+
+docker run --rm --pull never --network none --read-only --user 0:0 --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --mount "type=bind,src=$account_env,dst=/run/account-production.env,readonly" \
+  --mount "type=bind,src=$listener_env,dst=/run/listener-production.env,readonly" \
+  --mount "type=bind,src=$work,dst=/run/work" \
+  --entrypoint node "$image" /app/scripts/listener-account-production/sync-secret.mjs
+
+test -f "$work/candidate.env" && test ! -L "$work/candidate.env" || {
+  echo 'candidate Account bundle was not produced' >&2; exit 2;
+}
+test "$(stat -c '%a' "$work/candidate.env")" = 600 || {
+  echo 'candidate Account bundle mode mismatch' >&2; exit 2;
+}
+temporary="${target}.tmp-$$"
+trap 'rm -f "$temporary"; cleanup' EXIT HUP INT TERM
+install -o root -g root -m 0600 "$work/candidate.env" "$temporary"
+mv -T "$temporary" "$target"
+trap cleanup EXIT HUP INT TERM
+test "$(stat -c '%U:%G:%a' "$target")" = root:root:600 || {
+  echo 'installed Account bundle ownership mismatch' >&2; exit 2;
+}
+echo 'Listener production Account bundle installed dormant; runtime and feature flag were not changed.'

--- a/scripts/listener-account-production/sync-secret.mjs
+++ b/scripts/listener-account-production/sync-secret.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { randomBytes } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import process from 'node:process';
+
+const ACCOUNT_ENV = '/run/account-production.env';
+const LISTENER_ENV = '/run/listener-production.env';
+const CURRENT_BUNDLE = '/run/work/current.env';
+const CANDIDATE_BUNDLE = '/run/work/candidate.env';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+export function parseEnvironment(contents) {
+  const values = new Map();
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const at = line.indexOf('=');
+    if (at < 1) fail('invalid environment file');
+    const key = line.slice(0, at);
+    const value = line.slice(at + 1);
+    if (!/^[A-Z][A-Z0-9_]*$/.test(key) || values.has(key)) {
+      fail('invalid or duplicate environment key');
+    }
+    values.set(key, value);
+  }
+  return values;
+}
+
+function exact(values, key, expected, label) {
+  if (values.get(key) !== expected) fail(`${label} ${key} mismatch`);
+}
+
+function secret(values, key, label) {
+  const value = values.get(key) ?? '';
+  if (!/^[A-Za-z0-9_-]{32,128}$/.test(value)) fail(`${label} ${key} is invalid`);
+  return value;
+}
+
+export function buildProductionBundle({ accountContents, listenerContents, currentContents = '' }) {
+  const account = parseEnvironment(accountContents);
+  const listener = parseEnvironment(listenerContents);
+  const current = parseEnvironment(currentContents);
+
+  exact(account, 'BEACON_ACCOUNT_BASE_URL', 'https://account.harmonicbeacon.com', 'Account production');
+  exact(listener, 'EARLY_BIRDS_AUTH_BASE_URL', 'https://listen.harmonicbeacon.com', 'Listener production');
+  const enabled = listener.get('BEACON_LISTENER_ACCOUNT_ENABLED') ?? '0';
+  if (enabled !== '0') fail('Listener Account must remain disabled while preparing the bundle');
+  for (const key of [
+    'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET',
+    'BEACON_LISTENER_ACCOUNT_STATE_SECRET',
+    'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET_STAGING',
+    'BEACON_LISTENER_ACCOUNT_STATE_SECRET_STAGING',
+  ]) {
+    if (listener.has(key) && listener.get(key) !== '') fail(`Listener runtime ${key} must be absent while disabled`);
+  }
+
+  const clientSecret = secret(account, 'BEACON_ACCOUNT_CLIENT_SECRET_HB_LISTENER', 'Account production');
+  const currentKeys = [...current.keys()].sort();
+  if (currentKeys.length > 0 && currentKeys.join('\n') !== [
+    'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET',
+    'BEACON_LISTENER_ACCOUNT_STATE_SECRET',
+  ].sort().join('\n')) {
+    fail('current Listener Account bundle contains unexpected keys');
+  }
+  const stateSecret = current.has('BEACON_LISTENER_ACCOUNT_STATE_SECRET')
+    ? secret(current, 'BEACON_LISTENER_ACCOUNT_STATE_SECRET', 'current Listener bundle')
+    : randomBytes(32).toString('base64url');
+  if (stateSecret === clientSecret) fail('Listener client and state secrets must differ');
+
+  return [
+    `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${clientSecret}`,
+    `BEACON_LISTENER_ACCOUNT_STATE_SECRET=${stateSecret}`,
+    '',
+  ].join('\n');
+}
+
+async function main() {
+  if (process.getuid?.() !== 0) fail('run as root');
+  if (process.argv.length !== 2) fail('this command accepts no paths or secret values');
+  const currentContents = await readFile(CURRENT_BUNDLE, 'utf8').catch((error) => {
+    if (error?.code === 'ENOENT') return '';
+    throw error;
+  });
+  const bundle = buildProductionBundle({
+    accountContents: await readFile(ACCOUNT_ENV, 'utf8'),
+    listenerContents: await readFile(LISTENER_ENV, 'utf8'),
+    currentContents,
+  });
+  await writeFile(CANDIDATE_BUNDLE, bundle, { flag: 'wx', mode: 0o600 });
+  process.stdout.write('Listener production Account bundle prepared; feature remains OFF.\n');
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  main().catch((error) => {
+    process.stderr.write(`Listener production Account bundle failed: ${error instanceof Error ? error.message : 'unknown error'}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Outcome

Prepares the production Listener RP secret as a separate dormant root-only bundle without changing the running Listener or enabling Account. It also fixes the production guard so staging Account secrets cannot enter the production Listener environment.

## Security boundary

- sync runs inside the exact candidate image with no network, read-only rootfs, root only to read root:root 0600 mounts, all capabilities dropped, and no secret output
- target bundle contains exactly the production client secret and an independent persistent state secret
- disabled runtime rejects Account secrets; enabled production runtime requires the exact listen origin and forbids staging secrets
- bounded egress preflight receives only the two-key RP bundle and verifies Account readiness, exact discovery, Ed25519 JWKS, Basic client authentication and session-status
- no runtime, env, Nginx, DNS or database mutation is performed by this PR

## Gates

- full Vitest: 1782 passed / 44 skipped
- production Next build: pass
- TypeScript + focused ESLint: pass
- preview contract: 53/53 pass
- production RP contract: 5/5 pass
- production dependency audit gate: pass
- shell/node syntax and diff-check: pass
