### PR TITLE
Fix Listener recovery behind canonical proxy origin

### DIFF
--- a/src/app/api/listener/auth/recover/__tests__/route.test.ts
+++ b/src/app/api/listener/auth/recover/__tests__/route.test.ts
@@ -6,12 +6,19 @@ vi.mock('@/lib/db', () => ({ prisma: { listenerAccountSession: db } }));
 
 import { GET, POST } from '../route';
 
-function request(origin = 'https://earlybirds-staging.harmonicbeacon.com') {
-    return new NextRequest('https://earlybirds-staging.harmonicbeacon.com/api/listener/auth/recover', {
+function request(input: {
+    origin?: string;
+    url?: string;
+    host?: string;
+    forwardedHost?: string;
+} = {}) {
+    const origin = input.origin ?? 'https://earlybirds-staging.harmonicbeacon.com';
+    return new NextRequest(input.url ?? 'https://earlybirds-staging.harmonicbeacon.com/api/listener/auth/recover', {
         method: 'POST',
         headers: {
-            host: 'earlybirds-staging.harmonicbeacon.com', origin,
-            'sec-fetch-site': origin.includes('earlybirds-staging') ? 'same-origin' : 'same-site',
+            host: input.host ?? 'earlybirds-staging.harmonicbeacon.com', origin,
+            'x-forwarded-host': input.forwardedHost ?? 'earlybirds-staging.harmonicbeacon.com',
+            'sec-fetch-site': 'same-origin',
             'content-type': 'application/json',
             cookie: '__Host-hb_listener_account=local-cookie',
         },
@@ -61,6 +68,16 @@ describe('Listener same-origin central logout initiation', () => {
         expect(db.deleteMany).not.toHaveBeenCalled();
     });
 
+    it('accepts the canonical browser origin when Next sees the loopback nginx upstream', async () => {
+        db.findUnique.mockResolvedValue(null);
+        const response = await POST(request({
+            url: 'http://127.0.0.1:3000/api/listener/auth/recover',
+            forwardedHost: 'attacker.example',
+        }));
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({ confirmation: true });
+    });
+
     it('treats malformed or duplicate RP cookies as absent without throwing or querying by token', async () => {
         for (const cookie of [
             '__Host-hb_listener_account=%',
@@ -76,7 +93,8 @@ describe('Listener same-origin central logout initiation', () => {
     });
 
     it('rejects sibling-origin POSTs and every GET', async () => {
-        expect((await POST(request('https://listen.harmonicbeacon.com'))).status).toBe(403);
+        expect((await POST(request({ origin: 'https://listen.harmonicbeacon.com' }))).status).toBe(403);
+        expect((await POST(request({ host: '127.0.0.1:3000' }))).status).toBe(403);
         expect(GET().status).toBe(405);
         expect(db.findUnique).not.toHaveBeenCalled();
     });

--- a/src/app/api/listener/auth/recover/route.ts
+++ b/src/app/api/listener/auth/recover/route.ts
@@ -7,13 +7,16 @@ import {
     listenerAccountRPConfig,
     readListenerAccountCookie,
 } from '@/lib/listener/account-rp';
-import { isCanonicalListenerHost, isListenerStagingHost } from '@/lib/listener/public-discovery';
+import {
+    isListenerStagingHost,
+    trustedListenerRequestOrigin,
+} from '@/lib/listener/public-discovery';
 import { digestSessionToken } from '@/lib/session-auth';
 
 export async function POST(request: NextRequest): Promise<Response> {
     const headers = new Headers(request.headers);
-    const listenerHost = isCanonicalListenerHost(headers) || isListenerStagingHost(headers);
-    if (!listenerHost || request.headers.get('origin') !== request.nextUrl.origin ||
+    const listenerOrigin = trustedListenerRequestOrigin(headers);
+    if (!listenerOrigin || request.headers.get('origin') !== listenerOrigin ||
         request.headers.get('sec-fetch-site') !== 'same-origin' ||
         request.headers.get('content-type') !== 'application/json') {
         return new Response(null, { status: 403, headers: { 'Cache-Control': 'private, no-store' } });

--- a/src/lib/listener/__tests__/public-discovery.test.ts
+++ b/src/lib/listener/__tests__/public-discovery.test.ts
@@ -9,6 +9,7 @@ import {
     listenerLocaleForHeaders,
     listenerRobotsText,
     listenerSitemapXml,
+    trustedListenerRequestOrigin,
 } from '../public-discovery';
 
 function requestHeaders(host: string | null): Headers {
@@ -35,6 +36,16 @@ describe('Listener public discovery', () => {
         expect(isListenerStagingHost(requestHeaders('listen.harmonicbeacon.com'))).toBe(false);
         expect(isListenerStagingHost(requestHeaders('live.harmonicbeacon.com'))).toBe(false);
         expect(isListenerStagingHost(requestHeaders('earlybirds-staging.harmonicbeacon.com.evil.test'))).toBe(false);
+    });
+
+    it('derives the browser origin from the exact Host and ignores forwarded hosts', () => {
+        const staging = requestHeaders('earlybirds-staging.harmonicbeacon.com');
+        staging.set('x-forwarded-host', 'attacker.example');
+        expect(trustedListenerRequestOrigin(staging))
+            .toBe('https://earlybirds-staging.harmonicbeacon.com');
+        expect(trustedListenerRequestOrigin(requestHeaders('listen.harmonicbeacon.com')))
+            .toBe('https://listen.harmonicbeacon.com');
+        expect(trustedListenerRequestOrigin(requestHeaders('127.0.0.1:3000'))).toBeNull();
     });
 
     it('uses the same browser-language decision for public content and document metadata', () => {

--- a/src/lib/listener/public-discovery.ts
+++ b/src/lib/listener/public-discovery.ts
@@ -5,6 +5,7 @@ import { localeForBrowserLanguage, type UiLocale } from '@/lib/i18n';
 export const LISTENER_PUBLIC_HOST = 'listen.harmonicbeacon.com';
 export const LISTENER_STAGING_HOST = 'earlybirds-staging.harmonicbeacon.com';
 export const LISTENER_PUBLIC_ORIGIN = `https://${LISTENER_PUBLIC_HOST}`;
+export const LISTENER_STAGING_ORIGIN = `https://${LISTENER_STAGING_HOST}`;
 export const LISTENER_CANONICAL_URL = `${LISTENER_PUBLIC_ORIGIN}/`;
 
 const localizedMetadata: Record<UiLocale, { title: string; description: string }> = {
@@ -39,6 +40,19 @@ export function isCanonicalListenerHost(headers: Pick<Headers, 'get'>): boolean 
 /** Experimental presentation controls exist only on the disposable UI workbench. */
 export function isListenerStagingHost(headers: Pick<Headers, 'get'>): boolean {
     return normalizedHost(headers.get('host')) === LISTENER_STAGING_HOST;
+}
+
+/**
+ * Resolve the browser origin only from the validated public Host contract.
+ * Next's request URL may contain the loopback upstream origin behind nginx;
+ * forwarded host/proto headers are intentionally not trusted here.
+ */
+export function trustedListenerRequestOrigin(
+    headers: Pick<Headers, 'get'>,
+): typeof LISTENER_PUBLIC_ORIGIN | typeof LISTENER_STAGING_ORIGIN | null {
+    if (isCanonicalListenerHost(headers)) return LISTENER_PUBLIC_ORIGIN;
+    if (isListenerStagingHost(headers)) return LISTENER_STAGING_ORIGIN;
+    return null;
 }
 
 export function listenerLocaleForHeaders(headers: Pick<Headers, 'get'>): UiLocale {


### PR DESCRIPTION
Fixes the staging/prod Listener recovery and local sign-out boundary behind nginx.

- derives the expected browser origin from the exact validated Listener Host
- never trusts Next loopback request origin or X-Forwarded-Host
- keeps same-origin, JSON-only, and deny-default host checks
- adds a proxy-realistic 127.0.0.1 request regression plus hostile-origin/host tests

Evidence:
- focal 13/13
- listener/auth focal green
- TypeScript and focused ESLint green
- full Vitest 1784 pass / 44 skip
- production Next build green
- diff-check clean

Observed pre-fix public probe: canonical POST to staging returned 403. No runtime or database changes in this PR.