### PR TITLE
Unify Listener account controls in the global navigation

### DIFF
--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -15,9 +15,7 @@
     { key: 'listen', href: LISTENER_ORIGIN + '/', en: 'Listen', es: 'Escuchar' },
     { key: 'news', href: MAIN_ORIGIN + '/eventos/', en: 'News', es: 'Novedades' },
     { key: 'why', href: MAIN_ORIGIN + '/#porque', en: 'Why it works', es: 'Por qué funciona' },
-    { key: 'team', href: MAIN_ORIGIN + '/#team', en: 'Team', es: 'Equipo' },
-    { key: 'foundation', href: MAIN_ORIGIN + '/#foundation', en: 'HIT', es: 'HIT' },
-    { key: 'contact', href: MAIN_ORIGIN + '/#contact', en: 'Contact', es: 'Contacto' }
+    { key: 'foundation', href: MAIN_ORIGIN + '/#foundation', en: 'HIT', es: 'HIT' }
   ];
 
   function validLanguage(value) {
@@ -88,9 +86,7 @@
     if (host === 'live.harmonicbeacon.com') return 'events';
     if (location.pathname.indexOf('/eventos') === 0) return 'news';
     if (location.hash === '#porque') return 'why';
-    if (location.hash === '#team') return 'team';
     if (location.hash === '#foundation') return 'foundation';
-    if (location.hash === '#contact') return 'contact';
     return null;
   }
 
@@ -161,6 +157,7 @@
     .account-trigger svg { width:22px; height:22px; fill:none; stroke:currentColor; stroke-width:1.65; stroke-linecap:round; stroke-linejoin:round; }
     .account-menu { position:absolute; z-index:4; top:calc(100% + 8px); right:0; min-width:164px; padding:6px; border:1px solid rgba(201,162,78,.34); border-radius:12px; background:#16120D; box-shadow:0 18px 48px rgba(0,0,0,.34); }
     .account-menu[hidden] { display:none; }
+    .account-menu slot { display:block; }
     .account-menu a { display:flex; min-height:44px; align-items:center; padding:10px 12px; border-radius:8px; color:#E9E0D0; font-size:11px; font-weight:600; letter-spacing:.12em; text-transform:uppercase; white-space:nowrap; }
     .account-menu a:hover { color:#F4EEE2; background:rgba(201,162,78,.1); }
     .toggle { display:none; width:44px; height:44px; padding:0 10px; border:0; background:transparent; cursor:pointer; }
@@ -240,7 +237,7 @@
       var accountControl = accountControlAvailable()
         ? '<div class="account-control">' +
             '<button class="account-trigger' + (accountSignedIn ? ' signed-in' : '') + '" type="button" aria-label="' + userMenuLabel + '" aria-haspopup="menu" aria-controls="hb-account-menu" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="12" cy="8" r="3.25"></circle><path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5"></path></svg></button>' +
-            '<div class="account-menu" id="hb-account-menu" role="menu" hidden><a role="menuitem" href="' + accountPageHref(language) + '">' + accountLabel + '</a></div>' +
+            '<div class="account-menu" id="hb-account-menu" role="menu" hidden><slot name="account-menu"><a role="menuitem" href="' + accountPageHref(language) + '">' + accountLabel + '</a></slot></div>' +
           '</div>'
         : '';
       this.shadowRoot.innerHTML = '<style>' + style + '</style>' +
@@ -268,7 +265,15 @@
       var accountTrigger = this.shadowRoot.querySelector('.account-trigger');
       var accountMenu = this.shadowRoot.querySelector('.account-menu');
       if (accountTrigger && accountMenu) {
-        var accountMenuLink = accountMenu.querySelector('a');
+        var accountMenuSlot = accountMenu.querySelector('slot');
+        var accountMenuItems = function () {
+          var assigned = accountMenuSlot.assignedElements({ flatten:true });
+          if (!assigned.length) return Array.from(accountMenu.querySelectorAll('[role="menuitem"]'));
+          return assigned.flatMap(function (element) {
+            var items = element.matches('[role="menuitem"]') ? [element] : [];
+            return items.concat(Array.from(element.querySelectorAll('[role="menuitem"]')));
+          });
+        };
         var setAccountMenuOpen = function (open) {
           accountTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
           accountMenu.hidden = !open;
@@ -280,18 +285,22 @@
           if (event.key !== 'ArrowDown') return;
           event.preventDefault();
           setAccountMenuOpen(true);
-          accountMenuLink.focus();
+          var firstItem = accountMenuItems()[0];
+          if (firstItem) firstItem.focus();
         });
-        [accountTrigger, accountMenuLink].forEach(function (control) {
-          control.addEventListener('keydown', function (event) {
-            if (event.key !== 'Escape') return;
-            setAccountMenuOpen(false);
-            accountTrigger.focus();
-          });
+        accountMenu.addEventListener('keydown', function (event) {
+          if (event.key !== 'Escape') return;
+          setAccountMenuOpen(false);
+          accountTrigger.focus();
+        });
+        accountTrigger.addEventListener('keydown', function (event) {
+          if (event.key !== 'Escape') return;
+          setAccountMenuOpen(false);
+          accountTrigger.focus();
         });
         if (this.outsideClick) document.removeEventListener('click', this.outsideClick);
         this.outsideClick = function (event) {
-          if (event.target !== this) setAccountMenuOpen(false);
+          if (!event.composedPath().includes(this)) setAccountMenuOpen(false);
         }.bind(this);
         document.addEventListener('click', this.outsideClick);
       }

--- a/src/app/__tests__/layout-locale.test.tsx
+++ b/src/app/__tests__/layout-locale.test.tsx
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
     requestLocale: vi.fn(),
     requestBrowserLocale: vi.fn(),
     locallyKnownAccountSession: vi.fn(),
-    locallyKnownListenerAccountSession: vi.fn(),
+    locallyKnownListenerNavigationIdentity: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({ headers: mocks.headers }));
@@ -19,7 +19,7 @@ vi.mock('@/lib/account/auth', () => ({
     locallyKnownAccountSession: mocks.locallyKnownAccountSession,
 }));
 vi.mock('@/lib/listener/account-rp', () => ({
-    locallyKnownListenerAccountSession: mocks.locallyKnownListenerAccountSession,
+    locallyKnownListenerNavigationIdentity: mocks.locallyKnownListenerNavigationIdentity,
 }));
 vi.mock('next/font/local', () => ({
     default: () => ({ variable: 'local-font' }),
@@ -39,7 +39,7 @@ describe('root document locale boundary', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.locallyKnownAccountSession.mockResolvedValue(false);
-        mocks.locallyKnownListenerAccountSession.mockResolvedValue(false);
+        mocks.locallyKnownListenerNavigationIdentity.mockResolvedValue(null);
     });
 
     it('matches the canonical Listener SSR document to browser-language content', async () => {
@@ -102,7 +102,7 @@ describe('root document locale boundary', () => {
         expect(navigation.props.accountHref).toBe('https://account-staging.harmonicbeacon.com/account');
         expect(navigation.props.accountSignedIn).toBe(true);
         expect(mocks.locallyKnownAccountSession).toHaveBeenCalledOnce();
-        expect(mocks.locallyKnownListenerAccountSession).not.toHaveBeenCalled();
+        expect(mocks.locallyKnownListenerNavigationIdentity).not.toHaveBeenCalled();
     });
 
     it('uses only the local Listener projection for the signed-in navigation hint', async () => {
@@ -111,14 +111,15 @@ describe('root document locale boundary', () => {
             'en-US',
         ));
         mocks.requestBrowserLocale.mockResolvedValue('en');
-        mocks.locallyKnownListenerAccountSession.mockResolvedValue(true);
+        mocks.locallyKnownListenerNavigationIdentity.mockResolvedValue({ displayName: 'Nico' });
 
         const result = await RootLayout({ children: <main /> });
         const navigation = result.props.children.props.children[0];
 
         expect(navigation.props.accountHref).toBe('https://account-staging.harmonicbeacon.com/account');
         expect(navigation.props.accountSignedIn).toBe(true);
-        expect(mocks.locallyKnownListenerAccountSession).toHaveBeenCalledOnce();
+        expect(navigation.props.accountMenu.props.displayName).toBe('Nico');
+        expect(mocks.locallyKnownListenerNavigationIdentity).toHaveBeenCalledOnce();
         expect(mocks.locallyKnownAccountSession).not.toHaveBeenCalled();
     });
 
@@ -131,7 +132,7 @@ describe('root document locale boundary', () => {
 
         expect(navigation.props.accountHref).toBeNull();
         expect(navigation.props.accountSignedIn).toBe(false);
-        expect(mocks.locallyKnownListenerAccountSession).not.toHaveBeenCalled();
+        expect(mocks.locallyKnownListenerNavigationIdentity).not.toHaveBeenCalled();
         expect(mocks.locallyKnownAccountSession).not.toHaveBeenCalled();
     });
 

--- a/src/app/account/logout/page.tsx
+++ b/src/app/account/logout/page.tsx
@@ -24,7 +24,7 @@ export default async function AccountLogoutPage({ searchParams }: {
     const rawInitiation = Array.isArray(query.initiation) ? query.initiation[0] : query.initiation;
     const initiation = typeof rawInitiation === 'string' && rawInitiation.length <= 2048
         ? rawInitiation : null;
-    return <main className="account-shell"><AccountLogoutClient
+    return <main className="account-shell account-shell--logout"><AccountLogoutClient
         mode={mode} returnTo={returnTo} locale={locale} initiation={initiation}
     /></main>;
 }

--- a/src/app/early-birds/__tests__/page.test.tsx
+++ b/src/app/early-birds/__tests__/page.test.tsx
@@ -87,7 +87,6 @@ describe('EarlyBird Listener page', () => {
         expect(result.type).toBe(EarlyBirdHome);
         expect(result.props).toMatchObject({
             publicAccess: true,
-            displayName: '',
             membership: { kind: 'none', state: 'none' },
             dropIns: { es: null, en: '/api/early-birds/drop-ins/en' },
         });
@@ -151,7 +150,6 @@ describe('EarlyBird Listener page', () => {
 
         expect(result.type).toBe(EarlyBirdHome);
         expect(result.props).toMatchObject({
-            displayName: 'Nico',
             membership: { kind: 'none', state: 'none' },
             accessKind: 'free-quota',
             quota: expect.objectContaining({ remainingMs: 10_800_000 }),

--- a/src/app/early-birds/page.tsx
+++ b/src/app/early-birds/page.tsx
@@ -80,7 +80,6 @@ export default async function EarlyBirdsPage({
                 publicAccess
                 reactiveVisualizationAvailable={reactiveVisualizationAvailable}
                 reactiveFieldLabAvailable={reactiveFieldLabAvailable}
-                displayName=""
                 membership={listenerMembershipPresentation(null)}
                 dropIns={{
                     es: configuredEarlyBirdDropIn('es'),
@@ -120,7 +119,6 @@ export default async function EarlyBirdsPage({
     if (session && access?.allowed === true) {
         return (
             <EarlyBirdHome
-                displayName={session.user.name}
                 reactiveVisualizationAvailable={reactiveVisualizationAvailable}
                 reactiveFieldLabAvailable={reactiveFieldLabAvailable}
                 membership={listenerMembershipPresentation(access.membership.projection)}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,47 @@ hb-global-nav:not(:defined) {
   font-family: var(--font-hb-inter), Inter, system-ui, sans-serif;
 }
 
+hb-global-nav:not(:defined) > [slot="account-menu"] { display: none; }
+
+.hb-global-navigation-local-account-slot { min-width: 15rem; }
+.hb-listener-account-menu { display: grid; min-width: 15rem; }
+.hb-listener-account-menu__identity {
+  margin: 0;
+  padding: 0.65rem 0.75rem 0.55rem;
+  border-bottom: 1px solid rgba(244, 238, 226, 0.1);
+  color: #f4eee2;
+  font-size: 0.82rem;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.hb-listener-account-menu a,
+.hb-listener-account-menu button {
+  display: flex;
+  width: 100%;
+  min-height: 44px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: 8px;
+  color: #e9e0d0;
+  background: transparent;
+  cursor: pointer;
+  font: 600 11px/1.2 var(--font-hb-inter), Inter, system-ui, sans-serif;
+  letter-spacing: .12em;
+  text-align: left;
+  text-transform: uppercase;
+}
+.hb-listener-account-menu a:hover,
+.hb-listener-account-menu button:hover { color: #f4eee2; background: rgba(201, 162, 78, .1); }
+.hb-listener-account-menu a:focus-visible,
+.hb-listener-account-menu button:focus-visible { outline: 2px solid #c9a24e; outline-offset: -2px; }
+.hb-listener-account-menu small {
+  padding: 0.55rem 0.75rem;
+  color: #e4b8ae;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
 /* Central Account authority. Bound to its own route/host; event and Listener
    product styling remain untouched. */
 .account-shell {
@@ -43,6 +84,20 @@ hb-global-nav:not(:defined) {
   border-radius: 18px;
   background: rgba(30, 24, 18, .92);
   box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, .28);
+}
+.account-shell--logout { display: grid; place-items: center; padding-block: 5rem 2rem; }
+.account-card--logout {
+  width: min(24rem, 100%);
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 0.8rem 2.5rem rgba(0, 0, 0, .2);
+}
+.account-card--logout h1 {
+  margin: 0;
+  font-family: var(--font-hb-inter), Inter, system-ui, sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: .04em;
 }
 .account-grid .account-card { width: 100%; }
 .account-form, .account-providers, .account-actions { display: grid; gap: .75rem; margin-top: 1rem; }
@@ -1632,57 +1687,19 @@ html[data-hb-surface='listener'] body {
   margin-left: auto;
 }
 
-.listener-account {
-  position: relative;
-}
-
-.listener-account > summary {
-  width: 2.75rem;
-  height: 2.75rem;
+.listener-home-membership-status {
   display: grid;
-  place-items: center;
-  border: 1px solid var(--hb-hair);
-  border-radius: 50%;
-  color: var(--hb-bone);
-  background: var(--hb-surface);
-  cursor: pointer;
-  list-style: none;
-}
-
-.listener-account > summary::-webkit-details-marker { display: none; }
-
-.listener-account__menu {
-  position: absolute;
-  top: calc(100% + 0.65rem);
-  right: 0;
-  z-index: 20;
-  min-width: 15rem;
-  padding: 1rem;
+  width: min(100%, 30rem);
+  gap: 0.45rem;
+  margin: 1rem auto 0;
+  padding: 0.85rem 1rem;
   border: 1px solid var(--border-subtle);
   border-radius: var(--hb-radius-card);
-  background: rgba(27, 21, 15, 0.97);
-  box-shadow: var(--hb-shadow-card);
-  backdrop-filter: blur(20px);
-}
-
-.listener-account__menu p { font-size: 0.9rem; }
-.listener-account__menu span,
-.listener-account__menu small {
-  display: block;
-  margin-top: 0.3rem;
-  color: var(--text-muted);
-  font-size: 0.72rem;
-}
-
-.listener-account__menu button {
-  width: 100%;
-  min-height: 2.75rem;
-  margin-top: 0.8rem;
-  border-top: 1px solid var(--border-subtle);
-  color: var(--paper);
+  background: rgba(27, 21, 15, 0.72);
   text-align: left;
-  cursor: pointer;
 }
+.listener-home-membership-status > p { color: var(--hb-bone); font-size: 0.84rem; font-weight: 600; }
+.listener-home-membership-status > small { color: var(--text-muted); font-size: 0.72rem; line-height: 1.45; }
 
 .listener-experience {
   width: 100%;
@@ -2812,9 +2829,6 @@ html[data-hb-surface='listener'] body {
     opacity: 0.48;
   }
 
-  .listener-account__menu {
-    width: min(18rem, calc(100vw - 1.5rem));
-  }
 }
 
 @media (max-width: 360px) {
@@ -2833,9 +2847,6 @@ html[data-hb-surface='listener'] body {
   .listener-control-panel { padding-top: 0.75rem; }
   .listener-details { padding-inline: 0.65rem; }
 
-  .listener-account__menu {
-    width: min(15rem, calc(100vw - 1.1rem));
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import { headers } from "next/headers";
 import { LocaleProvider } from "@/context/LocaleContext";
 import { GlobalNavigation } from "@/components/brand/GlobalNavigation";
+import { ListenerNavigationAccountMenu } from "@/components/brand/ListenerNavigationAccountMenu";
 import {
   globalNavigationAccountHref,
   globalNavigationSurface,
@@ -11,7 +12,7 @@ import { requestBrowserLocale, requestLocale } from "@/lib/i18n-server";
 import { isCanonicalListenerHost, isListenerStagingHost } from "@/lib/listener/public-discovery";
 import { isAccountHost } from "@/lib/account/config";
 import { locallyKnownAccountSession } from "@/lib/account/auth";
-import { locallyKnownListenerAccountSession } from "@/lib/listener/account-rp";
+import { locallyKnownListenerNavigationIdentity } from "@/lib/listener/account-rp";
 import "@/styles/hb-brand.css";
 import "./globals.css";
 import { Toaster } from "sonner";
@@ -120,12 +121,13 @@ export default async function RootLayout({
   const accountHost = isAccountHost(incomingHeaders.get('host'));
   const accountHref = globalNavigationAccountHref(incomingHeaders);
   const localHeaders = new Headers(incomingHeaders);
+  const listenerNavigationIdentity = accountHref && listenerAccountHost
+    ? await locallyKnownListenerNavigationIdentity(localHeaders).catch(() => null)
+    : null;
   const accountSignedIn = accountHref
       ? accountHost
       ? await locallyKnownAccountSession(localHeaders).catch(() => false)
-      : listenerAccountHost
-        ? await locallyKnownListenerAccountSession(localHeaders).catch(() => false)
-        : false
+      : Boolean(listenerNavigationIdentity)
     : false;
   // This application is the Live surface by default. Listener and its staging
   // host opt into their own active item explicitly; local/E2E hosts continue
@@ -152,6 +154,13 @@ export default async function RootLayout({
           locale={locale}
           accountHref={accountHref}
           accountSignedIn={accountSignedIn}
+          accountMenu={listenerNavigationIdentity && accountHref ? (
+            <ListenerNavigationAccountMenu
+              displayName={listenerNavigationIdentity.displayName}
+              accountHref={accountHref}
+              locale={locale}
+            />
+          ) : undefined}
         />
         <LocaleProvider initialLocale={locale}>
           {/* Main content */}

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -28,17 +28,19 @@ manifest and visual-review update together.
 Listener, Live and Account serve a byte-pinned local snapshot of the canonical
 web component rather than executing JavaScript supplied at runtime by another
 origin. The source is `AlterMundi/harmonicbeacon.com` commit
-`ed7421616429681a37836f4698c73cf01799b75e`; the vendored
+`7e2730344e543e6c6ff5abde6d8133fc198214ae`; the vendored
 `public/assets/hb-global-nav.js` SHA-256 is
-`4a8a18fea07e279c0f757abd3be61bd715b0c6e647e6bc389d84c228c312e691`.
+`ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08`.
 The local light-DOM markup remains the accessible, same-destination fallback.
 Both implementations keep Account out of the primary destination list and
 expose it from the user-icon menu. The enhanced navigation renders both the
 Beacon mark and user glyph locally; it does not embed Account in an iframe or
-fetch a cross-origin image. Product layouts may pass only the boolean presence
-of a locally known Account session. That hint changes the icon treatment and
-accessible label, but never carries a name, email, subject, session ID or token
-and is never an authorization decision.
+fetch a cross-origin image. Product layouts may pass the boolean presence of a
+locally known Account session and may fill the canonical menu slot with
+host-local presentation. The static asset never reads cookies or identity and
+the slot must never carry email, subject, session ID or token. Listener uses it
+only for the already-visible display name, Account destination and sign-out
+action. Neither the hint nor slotted presentation is an authorization decision.
 
 ## Font source and license
 

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -11,13 +11,13 @@
   },
   "globalNavigation": {
     "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
-    "commit": "ed7421616429681a37836f4698c73cf01799b75e",
+    "commit": "7e2730344e543e6c6ff5abde6d8133fc198214ae",
     "source": "assets/hb-global-nav.js",
     "path": "public/assets/hb-global-nav.js",
-    "sha256": "4a8a18fea07e279c0f757abd3be61bd715b0c6e647e6bc389d84c228c312e691"
+    "sha256": "ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08"
   },
   "snapshots": {
-    "public/assets/hb-global-nav.js": "4a8a18fea07e279c0f757abd3be61bd715b0c6e647e6bc389d84c228c312e691",
+    "public/assets/hb-global-nav.js": "ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08",
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
   },

--- a/src/components/account/AccountLogoutClient.tsx
+++ b/src/components/account/AccountLogoutClient.tsx
@@ -44,7 +44,7 @@ export default function AccountLogoutClient({
     }, [initiation, mode, returnTo]);
 
     return (
-        <section className="account-card" aria-live="polite">
+        <section className="account-card account-card--logout" aria-live="polite">
             <h1>{es ? 'Cerrando sesión…' : 'Signing out…'}</h1>
             {!initiation && !failed && <button className="account-primary" onClick={perform}>
                 {es ? 'Confirmar cierre de sesión' : 'Confirm sign out'}

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -1,13 +1,13 @@
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 import Script from 'next/script';
 
 import type { UiLocale } from '@/lib/i18n';
 
-// Byte-pinned local snapshot of harmonicbeacon.com@ed74216. Protected product
+// Byte-pinned local snapshot of harmonicbeacon.com@7e27303. Protected product
 // origins never execute remotely supplied JavaScript with their host cookies.
 export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
-export const GLOBAL_NAVIGATION_PROVENANCE = 'ed7421616429681a37836f4698c73cf01799b75e';
-export const GLOBAL_NAVIGATION_SHA256 = '4a8a18fea07e279c0f757abd3be61bd715b0c6e647e6bc389d84c228c312e691';
+export const GLOBAL_NAVIGATION_PROVENANCE = '7e2730344e543e6c6ff5abde6d8133fc198214ae';
+export const GLOBAL_NAVIGATION_SHA256 = 'ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08';
 
 export type GlobalNavigationSurface = 'events' | 'listen' | 'account';
 
@@ -15,10 +15,6 @@ const links = [
     { key: 'events', href: 'https://live.harmonicbeacon.com/', en: 'Events', es: 'Eventos' },
     { key: 'listen', href: 'https://listen.harmonicbeacon.com/', en: 'Listen', es: 'Escuchar' },
     { key: 'news', href: 'https://harmonicbeacon.com/eventos/', en: 'News', es: 'Novedades' },
-    { key: 'why', href: 'https://harmonicbeacon.com/#porque', en: 'Why it works', es: 'Por qué funciona' },
-    { key: 'team', href: 'https://harmonicbeacon.com/#team', en: 'Team', es: 'Equipo' },
-    { key: 'foundation', href: 'https://harmonicbeacon.com/#foundation', en: 'HIT', es: 'HIT' },
-    { key: 'contact', href: 'https://harmonicbeacon.com/#contact', en: 'Contact', es: 'Contacto' },
 ] as const;
 
 function withLanguage(href: string, locale: UiLocale): string {
@@ -33,12 +29,14 @@ export function GlobalNavigation({
     allowRemoteEnhancement = true,
     accountHref,
     accountSignedIn = false,
+    accountMenu,
 }: {
     active: GlobalNavigationSurface;
     locale: UiLocale;
     allowRemoteEnhancement?: boolean;
     accountHref?: 'https://account-staging.harmonicbeacon.com/account' | null;
     accountSignedIn?: boolean;
+    accountMenu?: ReactNode;
 }) {
     const navLabel = locale === 'es' ? 'Navegación principal' : 'Primary navigation';
     const userMenuLabel = locale === 'es'
@@ -46,7 +44,7 @@ export function GlobalNavigation({
         : accountSignedIn ? 'User menu, signed in' : 'User menu';
     const accountLabel = locale === 'es' ? 'Cuenta' : 'Account';
     const fallback = (
-        <nav className="hb-global-navigation-fallback" aria-label={navLabel}>
+        <nav key="fallback" className="hb-global-navigation-fallback" aria-label={navLabel}>
             <a className="hb-global-navigation-fallback__brand" href={withLanguage('https://harmonicbeacon.com/', locale)}>
                 Harmonic Beacon
             </a>
@@ -89,7 +87,11 @@ export function GlobalNavigation({
             {createElement('hb-global-nav', {
                 'data-surface': active,
                 ...(accountSignedIn ? { 'data-account-signed-in': '' } : {}),
-            }, fallback)}
+            }, fallback, accountMenu ? (
+                <div key="account-menu" slot="account-menu" className="hb-global-navigation-local-account-slot">
+                    {accountMenu}
+                </div>
+            ) : null)}
             {allowRemoteEnhancement && (
                 <Script src={`${GLOBAL_NAVIGATION_ASSET}?v=${GLOBAL_NAVIGATION_PROVENANCE}`} strategy="afterInteractive" />
             )}

--- a/src/components/brand/ListenerNavigationAccountMenu.tsx
+++ b/src/components/brand/ListenerNavigationAccountMenu.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+import { recoverListenerIdentity } from '@/lib/early-birds/auth-client';
+import type { UiLocale } from '@/lib/i18n';
+
+export function ListenerNavigationAccountMenu({
+    displayName,
+    accountHref,
+    locale,
+}: {
+    displayName: string;
+    accountHref: 'https://account-staging.harmonicbeacon.com/account';
+    locale: UiLocale;
+}) {
+    const [signOutError, setSignOutError] = useState(false);
+    const es = locale === 'es';
+    const accountURL = new URL(accountHref);
+    accountURL.searchParams.set('lang', locale);
+
+    async function signOut() {
+        setSignOutError(false);
+        if (!await recoverListenerIdentity()) setSignOutError(true);
+    }
+
+    return (
+        <div className="hb-listener-account-menu">
+            <p className="hb-listener-account-menu__identity">{displayName}</p>
+            <a role="menuitem" href={accountURL.toString()}>
+                {es ? 'Cuenta' : 'Account'}
+            </a>
+            <button type="button" role="menuitem" onClick={signOut}>
+                {es ? 'Cerrar sesión' : 'Sign out'}
+            </button>
+            {signOutError && (
+                <small role="alert">
+                    {es
+                        ? 'No pudimos preparar un nuevo ingreso. Intentá de nuevo.'
+                        : 'We could not prepare a new sign-in. Please try again.'}
+                </small>
+            )}
+        </div>
+    );
+}

--- a/src/components/brand/__tests__/ListenerNavigationAccountMenu.test.tsx
+++ b/src/components/brand/__tests__/ListenerNavigationAccountMenu.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const recover = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/early-birds/auth-client', () => ({ recoverListenerIdentity: recover }));
+
+import { ListenerNavigationAccountMenu } from '../ListenerNavigationAccountMenu';
+
+describe('Listener canonical navigation Account menu', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('shows only local presentation and routes sign-out through recovery', async () => {
+        recover.mockResolvedValue(true);
+        render(<ListenerNavigationAccountMenu
+            displayName="Founder Test"
+            accountHref="https://account-staging.harmonicbeacon.com/account"
+            locale="en"
+        />);
+
+        expect(screen.getByText('Founder Test')).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Account' })).toHaveAttribute(
+            'href',
+            'https://account-staging.harmonicbeacon.com/account?lang=en',
+        );
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Sign out' }));
+        expect(recover).toHaveBeenCalledOnce();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('keeps a failed recovery visible inside the one user menu', async () => {
+        recover.mockResolvedValue(false);
+        render(<ListenerNavigationAccountMenu
+            displayName="Nicolás"
+            accountHref="https://account-staging.harmonicbeacon.com/account"
+            locale="es"
+        />);
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Cerrar sesión' }));
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            'No pudimos preparar un nuevo ingreso.',
+        );
+    });
+});

--- a/src/components/early-birds/EarlyBirdHome.tsx
+++ b/src/components/early-birds/EarlyBirdHome.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { useLocale } from '@/context/LocaleContext';
-import {
-    clearListenerOAuthAttempt,
-    recoverListenerIdentity,
-} from '@/lib/early-birds/auth-client';
+import { clearListenerOAuthAttempt } from '@/lib/early-birds/auth-client';
 import { earlyBirdCopy, earlyBirdHomeCopy, listenerMembershipPresentationCopy } from '@/lib/early-birds/copy';
 import type { ListenerMembershipPresentation } from '@/lib/early-birds/membership-presentation';
 
@@ -21,7 +18,6 @@ import type { SerializedEarlyBirdQuotaSnapshot } from './free-quota';
 import ListenerPlayer from './ListenerPlayer';
 
 export default function EarlyBirdHome({
-    displayName,
     membership,
     accessKind = 'membership',
     serverNow = new Date(0).toISOString(),
@@ -34,7 +30,8 @@ export default function EarlyBirdHome({
     checkoutEnvironment = 'staging',
     liveWorkbench = null,
 }: {
-    displayName: string;
+    /** @deprecated Identity presentation now belongs to the canonical navbar. */
+    displayName?: string;
     membership: ListenerMembershipPresentation;
     accessKind?: 'membership' | 'free-quota';
     serverNow?: string;
@@ -50,53 +47,19 @@ export default function EarlyBirdHome({
     const { locale } = useLocale();
     const copy = earlyBirdHomeCopy[locale];
     const membershipCopy = listenerMembershipPresentationCopy(earlyBirdCopy[locale], membership);
-    const [signOutError, setSignOutError] = useState(false);
 
     useEffect(() => clearListenerOAuthAttempt(), []);
-
-    async function signOut() {
-        setSignOutError(false);
-        if (!await recoverListenerIdentity()) setSignOutError(true);
-    }
 
     return (
         <main className="listener-shell">
             <div className="listener-shell__frame listener-shell__frame--home">
-                <header className="listener-rail">
-                    <div className="listener-rail__actions">
-                        {publicAccess && (
+                {publicAccess && (
+                    <header className="listener-rail">
+                        <div className="listener-rail__actions">
                             <FreeQuotaStatus serverNow={serverNow} unlimited="free-for-all" compact />
-                        )}
-                        {!publicAccess && <details
-                            className="listener-account"
-                            // Browsers may restore native disclosure state before React hydrates.
-                            suppressHydrationWarning
-                        >
-                            <summary aria-label={copy.account} title={copy.account}>
-                                {displayName.slice(0, 1).toUpperCase()}
-                            </summary>
-                            <div className="listener-account__menu">
-                                <p>{displayName}</p>
-                                {membershipCopy && (
-                                    <span>{membershipCopy?.title ?? copy.active}</span>
-                                )}
-                                {membership.kind !== 'none' && membershipCopy?.detail && (
-                                    <small>{membershipCopy.detail}</small>
-                                )}
-                                {accessKind === 'membership' && membership.kind === 'founder' && (
-                                    <FreeQuotaStatus serverNow={serverNow} unlimited="membership" compact />
-                                )}
-                                {accessKind === 'membership' && membership.kind === 'founder' && (
-                                    <FoundingListenerMembershipActions membership={membership} />
-                                )}
-                                <button type="button" onClick={signOut}>{copy.signOut}</button>
-                                {signOutError && (
-                                    <small role="alert">{earlyBirdCopy[locale].identityRecoveryFailed}</small>
-                                )}
-                            </div>
-                        </details>}
-                    </div>
-                </header>
+                        </div>
+                    </header>
+                )}
                 <div className="listener-static-field" data-testid="listener-static-field">
                     <BeaconField phase="ready" />
                 </div>
@@ -111,6 +74,20 @@ export default function EarlyBirdHome({
                         reactiveVisualizationInitiallyEnabled={false}
                         reactiveFieldLabAvailable={reactiveFieldLabAvailable}
                     />
+                    {!publicAccess && membershipCopy && (
+                        <footer className="listener-home-membership-status">
+                            <p>{membershipCopy.title ?? copy.active}</p>
+                            {membership.kind !== 'none' && membershipCopy.detail && (
+                                <small>{membershipCopy.detail}</small>
+                            )}
+                            {accessKind === 'membership' && membership.kind === 'founder' && (
+                                <FreeQuotaStatus serverNow={serverNow} unlimited="membership" compact />
+                            )}
+                            {accessKind === 'membership' && membership.kind === 'founder' && (
+                                <FoundingListenerMembershipActions membership={membership} />
+                            )}
+                        </footer>
+                    )}
                     {!publicAccess && accessKind === 'free-quota' && (
                         <footer className="listener-listening-status">
                             <FreeQuotaStatus

--- a/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
+++ b/src/components/early-birds/__tests__/EarlyBirdHome.test.tsx
@@ -1,15 +1,12 @@
 // @vitest-environment jsdom
 import { act, cleanup, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { hydrateRoot } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LocaleProvider } from '@/context/LocaleContext';
 
-const recoverIdentity = vi.hoisted(() => vi.fn());
 vi.mock('@/lib/early-birds/auth-client', () => ({
-    recoverListenerIdentity: recoverIdentity,
     clearListenerOAuthAttempt: vi.fn(),
 }));
 
@@ -38,12 +35,10 @@ import EarlyBirdHome from '../EarlyBirdHome';
 
 afterEach(() => {
     cleanup();
-    recoverIdentity.mockReset();
 });
 
 describe('EarlyBird Listener home access chrome', () => {
-    it('routes logout and account switching through the bounded recovery endpoint', async () => {
-        recoverIdentity.mockResolvedValueOnce(false);
+    it('keeps identity actions in the global navbar and presents membership as page content', () => {
         render(
             <LocaleProvider initialLocale="en">
                 <EarlyBirdHome
@@ -54,14 +49,14 @@ describe('EarlyBird Listener home access chrome', () => {
             </LocaleProvider>,
         );
 
-        await userEvent.click(screen.getByRole('button', { name: 'Sign out' }));
-        expect(recoverIdentity).toHaveBeenCalledOnce();
-        expect(screen.getByRole('alert')).toHaveTextContent(
-            'We could not prepare a new sign-in.',
-        );
+        expect(screen.queryByRole('button', { name: 'Sign out' })).not.toBeInTheDocument();
+        expect(document.querySelector('details.listener-account')).toBeNull();
+        expect(screen.getByText('Invitation access')).toBeInTheDocument();
+        expect(screen.getByText('Invitation access').closest('.listener-home-membership-status'))
+            .toBeTruthy();
     });
 
-    it('tolerates browser-restored profile disclosure state during hydration', async () => {
+    it('hydrates the noninteractive membership status without disclosure state', async () => {
         const tree = (
             <LocaleProvider initialLocale="en">
                 <EarlyBirdHome
@@ -74,9 +69,8 @@ describe('EarlyBird Listener home access chrome', () => {
         const container = document.createElement('div');
         container.innerHTML = renderToString(tree);
         document.body.append(container);
-        const disclosure = container.querySelector('details.listener-account');
-        expect(disclosure).toBeInstanceOf(HTMLDetailsElement);
-        (disclosure as HTMLDetailsElement).open = true;
+        expect(container.querySelector('details.listener-account')).toBeNull();
+        expect(container.querySelector('.listener-home-membership-status')).toBeTruthy();
         const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
         let root!: ReturnType<typeof hydrateRoot>;
@@ -132,7 +126,7 @@ describe('EarlyBird Listener home access chrome', () => {
         expect(screen.queryByText('Preview access')).not.toBeInTheDocument();
     });
 
-    it('keeps account controls for a membership-backed Listener', () => {
+    it('does not duplicate the navbar user control for a membership-backed Listener', () => {
         render(
             <LocaleProvider initialLocale="en">
                 <EarlyBirdHome
@@ -143,8 +137,8 @@ describe('EarlyBird Listener home access chrome', () => {
             </LocaleProvider>,
         );
 
-        expect(screen.getByLabelText('Account')).toBeInTheDocument();
-        expect(screen.getByText('Sign out')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Account')).not.toBeInTheDocument();
+        expect(screen.queryByText('Sign out')).not.toBeInTheDocument();
         expect(screen.getByText('Invitation access')).toBeInTheDocument();
         expect(screen.queryByText('FREE')).not.toBeInTheDocument();
     });
@@ -263,7 +257,8 @@ describe('EarlyBird Listener home access chrome', () => {
         expect(footer).toHaveTextContent('Membership is not available for purchase right now.');
         expect(footer?.querySelector('a')).toBeNull();
         expect(document.querySelector('a[href^="mailto:"]')).toBeNull();
-        expect(screen.getByLabelText('Account').closest('header')).not.toContainElement(footer);
+        expect(screen.queryByLabelText('Account')).toBeNull();
+        expect(document.querySelector('details.listener-account')).toBeNull();
     });
 
     it('replaces the mail contact fallback with the private checkout action', () => {

--- a/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
+++ b/src/components/early-birds/__tests__/listener-visual-isolation.test.tsx
@@ -188,10 +188,10 @@ describe('Listener visual isolation from event surfaces (issues #213, #198)', ()
         expect(css).toContain('width: min(100%, 46rem);');
         expect(css).toContain('width: min(100%, 42rem);');
         expect(mobile).toContain('min-height: 48px;');
-        expect(mobile).toContain('width: min(18rem, calc(100vw - 1.5rem));');
         expect(mobile).not.toContain('position: sticky;');
-        expect(narrow).toContain('width: min(15rem, calc(100vw - 1.1rem));');
         expect(narrow).toContain('padding-inline: 0.65rem;');
+        expect(css).not.toContain('.listener-account__menu');
+        expect(css).not.toContain('.listener-account > summary');
         expect(css).toMatch(/\.listener-details input\[type='range'\][\s\S]*?min-height: 2\.75rem;/);
         expect(css).toMatch(/\.listener-quota a[\s\S]*?min-height: 2\.75rem;/);
     });

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -54,7 +54,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
     });
 
     it('loads a byte-pinned local canonical asset instead of remote same-origin code', () => {
-        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('ed7421616429681a37836f4698c73cf01799b75e');
+        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('7e2730344e543e6c6ff5abde6d8133fc198214ae');
         const bytes = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'));
         expect(createHash('sha256').update(bytes).digest('hex')).toBe(GLOBAL_NAVIGATION_SHA256);
         expect(manifest.globalNavigation.commit).toBe(GLOBAL_NAVIGATION_PROVENANCE);
@@ -76,9 +76,28 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(source).toContain('<circle cx="12" cy="8" r="3.25">');
         expect(source).toContain('aria-haspopup="menu"');
         expect(source).toContain('class="account-menu"');
+        expect(source).toContain('<slot name="account-menu">');
+        expect(source).toContain('assignedElements({ flatten:true })');
         expect(source).not.toContain('class="account-link"');
         expect(source).not.toContain('<iframe');
         expect(source).not.toContain('/favicon.svg');
+    });
+
+    it('offers one host-local menu through the canonical user control', () => {
+        const view = render(<GlobalNavigation
+            active="listen"
+            locale="en"
+            accountHref="https://account-staging.harmonicbeacon.com/account"
+            accountSignedIn
+            accountMenu={<div><p>Nico</p><button role="menuitem">Sign out</button></div>}
+        />);
+
+        const slot = view.container.querySelector('[slot="account-menu"]');
+        expect(slot).toBeTruthy();
+        expect(slot?.parentElement?.tagName.toLowerCase()).toBe('hb-global-nav');
+        expect(within(slot as HTMLElement).getByText('Nico')).toBeInTheDocument();
+        expect(within(slot as HTMLElement).getByRole('menuitem', { name: 'Sign out' }))
+            .toBeInTheDocument();
     });
 
     it('renders the same destinations in Spanish', () => {

--- a/src/lib/listener/__tests__/account-rp.test.ts
+++ b/src/lib/listener/__tests__/account-rp.test.ts
@@ -9,6 +9,7 @@ import {
     currentListenerAccountSession,
     LISTENER_ACCOUNT_COOKIE,
     listenerAccountRPConfig,
+    locallyKnownListenerNavigationIdentity,
     locallyKnownListenerAccountSession,
     localListenerAccountId,
     readListenerAccountCookie,
@@ -103,12 +104,16 @@ describe('Listener Account RP subject namespace', () => {
             sid: 'central-sid',
             synthetic: false,
             expiresAt: new Date('2026-08-18T12:05:00.000Z'),
+            account: { name: 'Fallback name', beaconProfile: { displayName: 'Nico' } },
         });
         const headers = new Headers({
             host: 'earlybirds-staging.harmonicbeacon.com',
             cookie: `${LISTENER_ACCOUNT_COOKIE}=opaque-session-token`,
         });
 
+        await expect(locallyKnownListenerNavigationIdentity(headers, now)).resolves.toEqual({
+            displayName: 'Nico',
+        });
         await expect(locallyKnownListenerAccountSession(headers, now)).resolves.toBe(true);
         expect(fetchMock).not.toHaveBeenCalled();
         expect(sessions.update).not.toHaveBeenCalled();

--- a/src/lib/listener/account-rp.ts
+++ b/src/lib/listener/account-rp.ts
@@ -322,24 +322,54 @@ export async function currentListenerAccountSession(
     return listenerSessionView(session);
 }
 
+export type LocalListenerNavigationIdentity = {
+    displayName: string;
+};
+
 /**
- * A boolean-only navigation hint derived from the host-local RP session.
- * It never revalidates with Account, mutates the session, or exposes identity.
+ * Host-local presentation for the canonical navigation control. It never
+ * revalidates with Account or mutates the session, and it returns no email,
+ * subject, sid, token or authorization state.
  */
+export async function locallyKnownListenerNavigationIdentity(
+    headers: Headers,
+    now = new Date(),
+): Promise<LocalListenerNavigationIdentity | null> {
+    const raw = readListenerAccountCookie(headers);
+    if (!raw) return null;
+    let config: RPConfig;
+    try { config = listenerAccountRPConfig(headers); } catch { return null; }
+    const session = await prisma.listenerAccountSession.findUnique({
+        where: { tokenDigest: digestSessionToken(raw) },
+        select: {
+            issuer: true,
+            subject: true,
+            sid: true,
+            synthetic: true,
+            expiresAt: true,
+            account: {
+                select: {
+                    name: true,
+                    beaconProfile: { select: { displayName: true } },
+                },
+            },
+        },
+    });
+    if (!session || session.synthetic || session.issuer !== config.issuer ||
+        session.subject.length === 0 || session.sid.length === 0 || session.expiresAt <= now) {
+        return null;
+    }
+    return {
+        displayName: session.account.beaconProfile?.displayName ?? session.account.name,
+    };
+}
+
+/** Boolean-only compatibility wrapper for callers that need no presentation. */
 export async function locallyKnownListenerAccountSession(
     headers: Headers,
     now = new Date(),
 ): Promise<boolean> {
-    const raw = readListenerAccountCookie(headers);
-    if (!raw) return false;
-    let config: RPConfig;
-    try { config = listenerAccountRPConfig(headers); } catch { return false; }
-    const session = await prisma.listenerAccountSession.findUnique({
-        where: { tokenDigest: digestSessionToken(raw) },
-        select: { issuer: true, subject: true, sid: true, synthetic: true, expiresAt: true },
-    });
-    return Boolean(session && !session.synthetic && session.issuer === config.issuer &&
-        session.subject.length > 0 && session.sid.length > 0 && session.expiresAt > now);
+    return Boolean(await locallyKnownListenerNavigationIdentity(headers, now));
 }
 
 type ListenerSessionWithAccount = Prisma.ListenerAccountSessionGetPayload<{


### PR DESCRIPTION
## Outcome

- removes the duplicate Listener user-circle/disclosure
- presents display name, Account, and sign out through the single canonical navbar user control
- keeps Founder/membership status as ordinary content below the player
- derives the navbar name from the host-local Listener session without backchannel calls or writes
- makes the Account logout transition compact instead of a full-size card
- pins the merged canonical navigation source from harmonicbeacon.com#74 byte-for-byte

## Safety

- staging Account link remains exact and production Account remains absent
- no email, subject, sid, token, membership authority, or provider credential reaches the navbar
- no audio, LiveKit, event, payment, membership authority, schema, or migration behavior changed

## Verification

- 1787 Vitest tests passed, 44 skipped
- TypeScript, focused ESLint, production Next build, and diff-check passed
- canonical asset byte-exact SHA-256 ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08
- Chromium at 320/390/1440: exactly one 44x44 user control, no overflow, ArrowDown/Escape focus contract, local identity visible
