### PR TITLE
docs(account): define central Google and Apple rollout

### DIFF
--- a/docs/architecture/BEACON_ACCOUNT_AUTHORITY.md
+++ b/docs/architecture/BEACON_ACCOUNT_AUTHORITY.md
@@ -154,6 +154,10 @@ never the `.p8`; generate/rotate it outside Git from Team ID, Key ID, Services
 ID and `.p8`. Exact callbacks are
 `https://account.harmonicbeacon.com/api/account/auth/callback/apple` and
 `https://account-staging.harmonicbeacon.com/api/account/auth/callback/apple`.
+The exact Google/Apple registration, staging activation, human acceptance,
+rollback, and rotation procedure is
+`docs/operations/BEACON_ACCOUNT_SOCIAL_PROVIDERS.md`. The older direct-Listener
+provider runbook is not the central Account contract.
 The raw one-use Account action token exists only in its exact HTTPS mail action
 URL; that surface is `no-referrer` and scrubs the query client-side before any
 submission. Secrets, provider tokens and raw action tokens never enter Git,

--- a/docs/operations/BEACON_ACCOUNT_SOCIAL_PROVIDERS.md
+++ b/docs/operations/BEACON_ACCOUNT_SOCIAL_PROVIDERS.md
@@ -1,0 +1,152 @@
+# Beacon Account social providers
+
+Google and Apple belong only to the central Beacon Account authority. Listener
+and Live are confidential OIDC relying parties; they must not receive provider
+client secrets, provider tokens, or direct social callbacks.
+
+Both providers are independently default-off. A disabled provider is absent
+from the Account UI. A readiness result of `providers: ok` means that the
+configured enabled/disabled state is internally valid; it is not evidence that
+a disabled provider has completed human acceptance.
+
+## Fixed security contract
+
+- Staging authority: `https://account-staging.harmonicbeacon.com`.
+- Production authority: `https://account.harmonicbeacon.com`.
+- Google uses Authorization Code, the Account-owned state cookie, and
+  `prompt=select_account` with online access. Account switching must remain
+  explicit.
+- Apple uses its Services ID as the OAuth client ID and a current ES256
+  client-secret JWT. Raw `.p8` material is never installed in the application.
+- An Account has exactly one access method: verified email/password, Google,
+  or Apple. Matching email never links or merges accounts.
+- Provider access, refresh, and ID tokens are not authorization keys for
+  Listener, Live, membership, staff, tickets, or events.
+- Provider secrets and account identifiers never belong in Git, GitHub, chat,
+  screenshots, shell arguments, browser storage, metrics, or logs.
+
+## Google Cloud setup
+
+Create separate **Web application** OAuth clients for staging and production.
+Do not reuse the legacy direct-Listener client.
+
+Register exactly one callback on each client:
+
+- staging:
+  `https://account-staging.harmonicbeacon.com/api/account/auth/callback/google`
+- production:
+  `https://account.harmonicbeacon.com/api/account/auth/callback/google`
+
+The Account flow does not require a sibling product origin or callback. If the
+Google consent screen remains in Testing, add only the intended human testers.
+The application requests the provider's ordinary identity scopes; Google email
+is profile data, never membership or linking authority.
+
+Install the client ID and secret only in the corresponding root-owned Account
+environment:
+
+```text
+BEACON_ACCOUNT_GOOGLE_ENABLED=0
+BEACON_ACCOUNT_GOOGLE_CLIENT_ID=<web-client-id>.apps.googleusercontent.com
+BEACON_ACCOUNT_GOOGLE_CLIENT_SECRET=<secret>
+```
+
+Keep the switch at `0` while installing and validating the bundle. Never place
+staging and production credentials in the same runtime.
+
+## Apple Developer setup
+
+An Apple Developer Program Account Holder or Admin with 2FA must create or
+confirm:
+
+1. a primary App ID with Sign in with Apple enabled;
+2. a Services ID for Beacon Account;
+3. the exact Account web domain and return URL for the target environment;
+4. Team ID, Key ID, and a Sign in with Apple private `.p8` key;
+5. an ES256 client-secret JWT with:
+   - header `alg=ES256` and `kid=<Key ID>`;
+   - `iss=<Team ID>`;
+   - `sub=<Services ID>`;
+   - `aud=https://appleid.apple.com`;
+   - a valid `iat` and an `exp` no more than six months later.
+
+The exact Apple callbacks are:
+
+- staging:
+  `https://account-staging.harmonicbeacon.com/api/account/auth/callback/apple`
+- production:
+  `https://account.harmonicbeacon.com/api/account/auth/callback/apple`
+
+Generate the JWT offline from the protected `.p8`. Install only the Services
+ID and generated JWT:
+
+```text
+BEACON_ACCOUNT_APPLE_ENABLED=0
+BEACON_ACCOUNT_APPLE_CLIENT_ID=<services-id>
+BEACON_ACCOUNT_APPLE_CLIENT_SECRET=<current-es256-jwt>
+```
+
+The application rejects a raw `.p8`, a malformed JWT, the wrong audience or
+subject, and an expired JWT. Apple may provide name and email only on first
+consent. Later callbacks without them remain bound by Apple subject and use a
+neutral provider-independent Beacon profile; they never trigger email linking.
+
+## Safe staging activation
+
+Do one provider at a time.
+
+1. Confirm the exact reviewed release and a clean checkout.
+2. Create a fresh encrypted Account staging database backup and verify it with
+   `pg_restore --list`. Back up the current root-owned environment separately.
+3. Confirm the target environment file is a regular, non-symlink
+   `root:root 0600` file. Install the complete provider bundle atomically while
+   its enable flag remains `0`.
+4. Run the containerized Account environment validator with network disabled.
+   It must accept both production and staging files without printing values.
+5. Change only the target provider switch from `0` to `1`, recreate Account
+   staging app only through the reviewed lifecycle, and keep rollback active
+   through the external smoke.
+6. Require Account readiness at the exact candidate SHA with
+   `checks.providers=ok`. Confirm the Account page shows only the provider just
+   enabled and email/password remains available.
+7. Complete supervised human acceptance before enabling the other provider or
+   touching production.
+
+Rollback is the backed-up environment with that provider switch restored to
+`0`, followed by recreating only the Account app. Disabling a provider hides
+new sign-in without deleting accounts, profiles, sessions, or product data.
+Do not delete provider identities as rollback.
+
+## Human acceptance
+
+For each provider, use two distinct disposable staging identities and record
+only sanitized pass/fail evidence.
+
+- Complete first consent and the exact Account callback.
+- Confirm the canonical Beacon display name can be edited and survives reload.
+- Enter Listener through Account SSO without another provider prompt.
+- Sign out the current device and sign in again.
+- Deliberately switch A to B and back to A. The first Listener render, reload,
+  back/forward, bfcache restoration, and duplicate tab must never retain the
+  previous account's profile, Founder state, or authorization.
+- Exercise a delayed callback, back-button callback, replay, and state mismatch.
+  They must fail closed without weakening state or creating a redirect loop.
+- For Apple, cover private relay, first-consent name/email, and a repeat callback
+  where name/email may be absent.
+- Confirm no email-based merge, provider-token persistence in product sessions,
+  membership mutation, payment call, event capability, or audio change.
+
+## Production promotion and rotation
+
+Production remains off until staging acceptance is complete and the production
+Account DNS/TLS edge, backup, migration, static-client inventory, mail path,
+Listener/Live RP cutover, and rollback are independently ready. Promote Google
+and Apple separately; staging success for one provider does not authorize the
+other.
+
+Rotate a Google secret by installing the replacement with the provider still
+enabled, recreating only Account, completing readiness and a real sign-in, and
+then revoking the old secret in Google Cloud. Rotate an Apple client-secret JWT
+before expiry using the same reviewed Team ID, Key ID, Services ID, and
+protected `.p8`; verify readiness and a real sign-in before retiring the old
+JWT. Key revocation and ordinary JWT rotation are separate operations.

--- a/docs/operations/LISTENER_APPLE_IDENTITY.md
+++ b/docs/operations/LISTENER_APPLE_IDENTITY.md
@@ -1,5 +1,12 @@
 # Listener Sign in with Apple
 
+> **Legacy cutover note:** this document describes the direct Listener provider
+> runtime that remains relevant only until the central Account production
+> cutover or for its rollback. Do not create new direct-Listener Apple clients
+> from it. New staging and production provider setup belongs to the central
+> Account authority and must follow
+> `docs/operations/BEACON_ACCOUNT_SOCIAL_PROVIDERS.md`.
+
 Apple identity is provider-neutral, fail-closed and default-off. Google keeps
 its explicit account chooser. No provider may implicitly link itself to an
 existing Listener account merely because an email address matches.

--- a/ops/beacon-account/test/contract.test.mjs
+++ b/ops/beacon-account/test/contract.test.mjs
@@ -483,3 +483,31 @@ test('Account staging ACME bootstrap exposes only the certificate challenge', ()
   assert.match(nginx, /location \/ \{ return 503; \}/);
   assert.doesNotMatch(nginx, /listen 443|ssl_certificate|proxy_pass|1300[0-9]/);
 });
+
+test('social-provider runbook uses only central Account callbacks and default-off activation', () => {
+  const runbook = fs.readFileSync(
+    path.resolve(ROOT, '../../docs/operations/BEACON_ACCOUNT_SOCIAL_PROVIDERS.md'),
+    'utf8',
+  );
+  for (const environment of ['account-staging', 'account']) {
+    for (const provider of ['google', 'apple']) {
+      assert.match(runbook, new RegExp(
+        `https://${environment}\\.harmonicbeacon\\.com/api/account/auth/callback/${provider}`,
+      ));
+    }
+  }
+  for (const provider of ['GOOGLE', 'APPLE']) {
+    assert.match(runbook, new RegExp(`BEACON_ACCOUNT_${provider}_ENABLED=0`));
+    assert.match(runbook, new RegExp(`BEACON_ACCOUNT_${provider}_CLIENT_ID`));
+    assert.match(runbook, new RegExp(`BEACON_ACCOUNT_${provider}_CLIENT_SECRET`));
+  }
+  assert.doesNotMatch(runbook, /api\/early-birds\/auth\/callback\/(?:google|apple)/);
+  assert.match(runbook, /Matching email never links or merges accounts/);
+
+  const legacy = fs.readFileSync(
+    path.resolve(ROOT, '../../docs/operations/LISTENER_APPLE_IDENTITY.md'),
+    'utf8',
+  );
+  assert.match(legacy, /Legacy cutover note/);
+  assert.match(legacy, /BEACON_ACCOUNT_SOCIAL_PROVIDERS\.md/);
+});


### PR DESCRIPTION
## Outcome

Defines the canonical Google/Apple activation, acceptance, rollback, and rotation procedure for the central Beacon Account authority.

## Scope

- exact staging/production Account callbacks for Google and Apple;
- default-off, issuer-separated root-owned bundles;
- Google account-selection and Apple ES256/private-relay contracts;
- one-provider-at-a-time staging and production promotion;
- A→B→A browser acceptance without email linking;
- explicit legacy warning on the old direct-Listener Apple runbook;
- contract test preventing callback/runbook drift.

No credentials, runtime flags, provider clients, DNS, payments, audio, sessions, membership, or event behavior are changed.

## Evidence

- `node --test ops/beacon-account/test/contract.test.mjs` — 21/21 pass
- focused ESLint — pass
- `git diff --check` — pass
