### PR TITLE
LISTENER-IDENTITY: lock Founder/Free cache boundary

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -146,6 +146,14 @@ jobs:
       - name: Run Firefox functional and accessibility gates
         run: npx playwright test --project=firefox
 
+      - name: Verify Listener Founder and Free account-switch cache boundary
+        run: >-
+          npx playwright test e2e/tests/listener-account-switch.spec.ts
+          --project=chromium
+          --project=firefox
+        env:
+          E2E_LISTENER_ACCOUNT_SWITCH_GATE: '1'
+
       - name: Install WebKit after Chromium screenshot gates
         run: npx playwright install --with-deps webkit
 

--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -15,6 +15,13 @@ on:
       - src/components/early-birds/**
       - src/lib/early-birds/**
       - src/lib/listener/**
+      - e2e/fixtures/listener-account-switch.ts
+      - e2e/tests/listener-account-switch.spec.ts
+      - playwright.config.ts
+      - src/app/layout.tsx
+      - src/app/globals.css
+      - src/components/brand/ListenerIdentityCacheBoundary.tsx
+      - src/components/brand/__tests__/ListenerIdentityCacheBoundary.test.tsx
       - services/beacon-stream/**
       - ops/early-birds/**
       - ops/early-birds-preview/**
@@ -46,6 +53,13 @@ on:
       - src/components/early-birds/**
       - src/lib/early-birds/**
       - src/lib/listener/**
+      - e2e/fixtures/listener-account-switch.ts
+      - e2e/tests/listener-account-switch.spec.ts
+      - playwright.config.ts
+      - src/app/layout.tsx
+      - src/app/globals.css
+      - src/components/brand/ListenerIdentityCacheBoundary.tsx
+      - src/components/brand/__tests__/ListenerIdentityCacheBoundary.test.tsx
       - services/beacon-stream/**
       - ops/early-birds/**
       - ops/early-birds-preview/**
@@ -138,3 +152,35 @@ jobs:
       - run: npm --prefix ops/listener-identity-staging run validate:example
       - run: npm --prefix ops/listener-account-production run check
       - run: npm --prefix ops/listener-account-production test
+
+  identity-cache:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: e2e
+          POSTGRES_DB: beacon_test
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d beacon_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      E2E_DATABASE_URL: postgresql://postgres:e2e@localhost:55432/beacon_test
+      E2E_LISTENER_ACCOUNT_SWITCH_GATE: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.22'
+          cache: 'npm'
+      - run: npm ci
+      - run: DATABASE_URL="$E2E_DATABASE_URL" npx prisma migrate deploy
+      - run: npx playwright install --with-deps chromium firefox
+      - run: >-
+          npx playwright test e2e/tests/listener-account-switch.spec.ts
+          --project=chromium
+          --project=firefox

--- a/e2e/fixtures/listener-account-switch.ts
+++ b/e2e/fixtures/listener-account-switch.ts
@@ -1,0 +1,209 @@
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+
+import type { BrowserContext, TestInfo } from '@playwright/test';
+import pg from 'pg';
+
+import { requireDirectDb } from './db';
+
+export const LISTENER_ACCOUNT_COOKIE = '__Host-hb_listener_account';
+const ACCOUNT_ISSUER = 'https://account.harmonicbeacon.com';
+
+export type ListenerAccountSwitchFixture = {
+    accountId: string;
+    token: string;
+};
+
+export type ListenerAccountSwitchPair = {
+    founder: ListenerAccountSwitchFixture;
+    free: ListenerAccountSwitchFixture;
+    accountIds: readonly [string, string];
+};
+
+export type ListenerAccountSwitchSessionState = {
+    present: boolean;
+    accountId: string | null;
+    issuer: string | null;
+    expired: boolean | null;
+    remainingSeconds: number | null;
+    synthetic: boolean | null;
+};
+
+function digest(value: string): string {
+    return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Seed two non-synthetic RP sessions directly into the throwaway E2E database.
+ * No public login hook is added: the fixture can run only with the local
+ * direct-database guard already shared by the browser suite.
+ */
+export async function createListenerAccountSwitchPair(
+    testInfo: TestInfo,
+): Promise<ListenerAccountSwitchPair> {
+    const databaseUrl = requireDirectDb(testInfo);
+    const client = new pg.Client({ connectionString: databaseUrl });
+    const nonce = `${Date.now()}-${randomUUID()}`;
+    const founderAccountId = `account-switch-founder-${nonce}`;
+    const freeAccountId = `account-switch-free-${nonce}`;
+    const founderSubject = `account-switch-founder-sub-${nonce}`;
+    const freeSubject = `account-switch-free-sub-${nonce}`;
+    const founderToken = randomBytes(32).toString('base64url');
+    const freeToken = randomBytes(32).toString('base64url');
+    await client.connect();
+    try {
+        await client.query('BEGIN');
+        for (const [accountId, subject, token, name] of [
+            [founderAccountId, founderSubject, founderToken, 'Founder A'],
+            [freeAccountId, freeSubject, freeToken, 'Free B'],
+        ] as const) {
+            await client.query(
+                `insert into early_bird_users
+                    (id, name, email, email_verified, security_revision, created_at, updated_at)
+                 values ($1, $2, $3, true, 1, now(), now())`,
+                [accountId, name, `${digest(accountId)}@e2e.invalid`],
+            );
+            await client.query(
+                `insert into beacon_profiles
+                    (account_id, display_name, revision, created_at, updated_at)
+                 values ($1, $2, 1, now(), now())
+                 on conflict (account_id) do update set
+                    display_name = excluded.display_name,
+                    revision = greatest(beacon_profiles.revision, excluded.revision),
+                    updated_at = excluded.updated_at`,
+                [accountId, name],
+            );
+            await client.query(
+                `insert into listener_account_subjects
+                    (account_id, issuer, subject, created_at)
+                 values ($1, $2, $3, now())`,
+                [accountId, ACCOUNT_ISSUER, subject],
+            );
+            await client.query(
+                `insert into listener_account_sessions
+                    (id, token_digest, account_id, issuer, subject, sid, expires_at,
+                     last_checked_at, synthetic, created_at)
+                 values ($1, $2, $3, $4, $5, $6,
+                         now() + interval '1 hour', now(), false, now())`,
+                [
+                    randomUUID(), digest(token), accountId, ACCOUNT_ISSUER, subject,
+                    `account-switch-sid-${randomUUID()}`,
+                ],
+            );
+        }
+
+        await client.query(
+            `insert into early_bird_membership_projections (
+                id, account_id, revision, command_hash, state, source, offer_code,
+                offer_revision, effective_at, paid_through, provider, amount_minor,
+                currency, reason_code, synthetic, founder_continuity_episode_id,
+                founder_continuity_revision, founder_continuity_state,
+                founder_continuity_offer_code, founder_continuity_offer_revision,
+                founder_continuity_currency, founder_continuity_amount_minor,
+                founder_continuity_billing_period, founder_continuity_activated_at,
+                founder_continuity_service_through, created_at, updated_at
+             ) values (
+                $1, $2, 1, $3, 'ACTIVE', 'PAYPAL', 'EARLY_BIRDS_FOUNDERS_V1',
+                1, now(), now() + interval '31 days', 'paypal', 500, 'USD',
+                'SUBSCRIPTION_ACTIVATED', false,
+                $4, 1, 'ACTIVE', 'EARLY_BIRDS_FOUNDERS_V1', 1, 'USD', 500,
+                'MONTHLY', now(), now() + interval '31 days', now(), now()
+             )`,
+            [randomUUID(), founderAccountId, digest(`command-${nonce}`), randomUUID()],
+        );
+        await client.query('COMMIT');
+    } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+    } finally {
+        await client.end();
+    }
+
+    return {
+        founder: { accountId: founderAccountId, token: founderToken },
+        free: { accountId: freeAccountId, token: freeToken },
+        accountIds: [founderAccountId, freeAccountId],
+    };
+}
+
+export async function useListenerAccount(
+    context: BrowserContext,
+    baseURL: string,
+    fixture: ListenerAccountSwitchFixture,
+): Promise<void> {
+    const host = new URL(baseURL).hostname;
+    // The production cookie is Secure+__Host and browsers correctly refuse to
+    // store it from an http response. Seed the exact cookie against the secure
+    // localhost origin; Chromium sends Secure cookies to trustworthy localhost
+    // while every request still reaches Playwright's plain-http local server.
+    await context.clearCookies();
+    await context.addCookies([{
+        name: LISTENER_ACCOUNT_COOKIE,
+        value: fixture.token,
+        url: `https://${host}`,
+        expires: Math.floor(Date.now() / 1_000) + 3_600,
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Lax',
+    }]);
+}
+
+export async function listenerAccountSwitchSessionState(
+    testInfo: TestInfo,
+    fixture: ListenerAccountSwitchFixture,
+): Promise<ListenerAccountSwitchSessionState> {
+    const databaseUrl = requireDirectDb(testInfo);
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        const result = await client.query<{
+            account_id: string;
+            issuer: string;
+            expired: boolean;
+            remaining_seconds: string;
+            synthetic: boolean;
+        }>(
+            `select account_id, issuer, expires_at <= now() as expired, synthetic,
+                    extract(epoch from (expires_at - now()))::text as remaining_seconds
+               from listener_account_sessions
+              where token_digest = $1`,
+            [digest(fixture.token)],
+        );
+        const row = result.rows[0];
+        return row ? {
+            present: true,
+            accountId: row.account_id,
+            issuer: row.issuer,
+            expired: row.expired,
+            remainingSeconds: Math.round(Number(row.remaining_seconds)),
+            synthetic: row.synthetic,
+        } : {
+            present: false,
+            accountId: null,
+            issuer: null,
+            expired: null,
+            remainingSeconds: null,
+            synthetic: null,
+        };
+    } finally {
+        await client.end();
+    }
+}
+
+export async function deleteListenerAccountSwitchPair(
+    testInfo: TestInfo,
+    accountIds: readonly string[],
+): Promise<void> {
+    const databaseUrl = requireDirectDb(testInfo);
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        for (const accountId of accountIds) {
+            if (!/^account-switch-(founder|free)-/.test(accountId)) {
+                throw new Error('refusing to delete a non-fixture Listener account');
+            }
+            await client.query('delete from early_bird_users where id = $1', [accountId]);
+        }
+    } finally {
+        await client.end();
+    }
+}

--- a/e2e/tests/listener-account-switch.spec.ts
+++ b/e2e/tests/listener-account-switch.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+import { requireDirectDb } from '../fixtures/db';
+import {
+    createListenerAccountSwitchPair,
+    deleteListenerAccountSwitchPair,
+    LISTENER_ACCOUNT_COOKIE,
+    listenerAccountSwitchSessionState,
+    useListenerAccount,
+} from '../fixtures/listener-account-switch';
+
+async function accessKind(page: Page): Promise<string> {
+    try {
+        return await page.evaluate(async () => {
+            const response = await fetch('/api/listener/access-state', {
+                credentials: 'same-origin', cache: 'no-store',
+            });
+            if (response.status !== 200) return `status-${response.status}`;
+            const payload = await response.json() as { access?: { kind?: unknown } };
+            return String(payload.access?.kind ?? 'missing');
+        });
+    } catch (error) {
+        if (error instanceof Error && /execution context was destroyed|because of a navigation/i
+            .test(error.message)) return 'navigation-in-progress';
+        throw error;
+    }
+}
+
+async function expectFounder(page: Page): Promise<void> {
+    await expect.poll(() => accessKind(page)).toBe('membership');
+    await expect(page.locator('.listener-experience')).toBeVisible();
+    await expect(page.locator('.listener-listening-status')).toHaveCount(0);
+}
+
+async function expectFree(page: Page): Promise<void> {
+    await expect.poll(() => accessKind(page)).toBe('free-quota');
+    await expect(page.locator('.listener-experience')).toBeVisible();
+    await expect(page.locator('.listener-listening-status')).toBeVisible();
+}
+
+// The fixture tokens and direct-database URL must never enter a retained trace.
+test.use({ trace: 'off' });
+
+test.describe('Listener Account A/B cache boundary', () => {
+    test.skip(
+        process.env.E2E_LISTENER_ACCOUNT_SWITCH_GATE !== '1',
+        'requires the isolated Account-on E2E server',
+    );
+
+    test('never restores Founder presentation or authorization for Free B', async ({ browser }, testInfo) => {
+        test.setTimeout(90_000);
+        requireDirectDb(testInfo);
+        const baseURL = String(testInfo.project.use.baseURL);
+        const parsedBaseURL = new URL(baseURL);
+        if (!['localhost', '127.0.0.1', '[::1]'].includes(parsedBaseURL.hostname)) {
+            throw new Error('refusing to run the Account switch fixture against a non-local app');
+        }
+
+        const pair = await createListenerAccountSwitchPair(testInfo);
+        const contexts: BrowserContext[] = [];
+        try {
+            const context = await browser.newContext();
+            contexts.push(context);
+            await useListenerAccount(context, baseURL, pair.founder);
+            const founderState = await listenerAccountSwitchSessionState(testInfo, pair.founder);
+            expect(founderState).toEqual({
+                present: true,
+                accountId: pair.founder.accountId,
+                issuer: 'https://account.harmonicbeacon.com',
+                expired: expect.any(Boolean),
+                remainingSeconds: expect.any(Number),
+                synthetic: false,
+            });
+            expect(founderState.remainingSeconds).toBeGreaterThan(3_000);
+            expect(founderState.expired).toBe(false);
+            expect((await context.cookies(baseURL)).some((cookie) =>
+                cookie.name === LISTENER_ACCOUNT_COOKIE)).toBe(true);
+            const page = await context.newPage();
+            await page.addInitScript(() => {
+                window.addEventListener('pageshow', (event) => {
+                    (window as typeof window & { __hbPageShowPersisted?: boolean })
+                        .__hbPageShowPersisted = event.persisted;
+                });
+            });
+
+            const founderResponse = await page.goto('/listener');
+            expect(founderResponse?.headers()['cache-control']).toContain('no-store');
+            expect((await context.cookies(page.url())).some((cookie) =>
+                cookie.name === LISTENER_ACCOUNT_COOKIE)).toBe(true);
+            const accessRequest = page.waitForRequest('**/api/listener/access-state');
+            const initialKind = await accessKind(page);
+            const initialHeaders = await (await accessRequest).allHeaders();
+            expect(Boolean(initialHeaders.cookie?.startsWith(
+                `${LISTENER_ACCOUNT_COOKIE}=`,
+            ))).toBe(true);
+            await expect(listenerAccountSwitchSessionState(testInfo, pair.founder)).resolves.toEqual({
+                present: true,
+                accountId: pair.founder.accountId,
+                issuer: 'https://account.harmonicbeacon.com',
+                expired: false,
+                remainingSeconds: expect.any(Number),
+                synthetic: false,
+            });
+            expect(initialKind).toBe('membership');
+            await expectFounder(page);
+
+            // Leave A in browser history, switch the host-only RP cookie to B,
+            // and go back. A bfcache restoration must not revive A's Founder UI.
+            await page.goto('/listener/privacy');
+            await useListenerAccount(context, baseURL, pair.free);
+            await page.goBack({ waitUntil: 'domcontentloaded' });
+            // The Account-derived response is deliberately not bfcacheable in
+            // current engines, so this history traversal must fetch B anew.
+            expect(await page.evaluate(() => Boolean(
+                (window as typeof window & { __hbPageShowPersisted?: boolean })
+                    .__hbPageShowPersisted,
+            ))).toBe(false);
+            await expectFree(page);
+
+            await page.goForward({ waitUntil: 'domcontentloaded' });
+            await expect(page).toHaveURL(/\/listener\/privacy$/);
+            await page.goBack({ waitUntil: 'domcontentloaded' });
+            await expectFree(page);
+
+            // Reload and a second tab must both derive only B's server session.
+            await page.reload({ waitUntil: 'domcontentloaded' });
+            await expectFree(page);
+            const duplicate = await context.newPage();
+            await duplicate.goto('/listener');
+            await expectFree(duplicate);
+
+            // Switching back to A restores Founder only after A's cookie is
+            // authoritative again; B's page cannot grant it by itself.
+            await useListenerAccount(context, baseURL, pair.founder);
+            await duplicate.reload({ waitUntil: 'domcontentloaded' });
+            await expectFounder(duplicate);
+        } finally {
+            await Promise.allSettled(contexts.map((context) => context.close()));
+            await deleteListenerAccountSwitchPair(testInfo, pair.accountIds);
+        }
+    });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,7 @@ const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
 // talk to the same throwaway database.
 const DATABASE_URL =
     process.env.E2E_DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5432/beacon_test';
+const LISTENER_ACCOUNT_SWITCH_GATE = process.env.E2E_LISTENER_ACCOUNT_SWITCH_GATE === '1';
 assertSafeFixtureDatabaseUrl(DATABASE_URL);
 if (!process.env.E2E_BASE_URL) {
     process.env.E2E_DATABASE_URL = DATABASE_URL;
@@ -174,6 +175,16 @@ export default defineConfig({
                   EARLY_BIRDS_TEST_LOGIN_SECRET: 'early-birds-e2e-login-secret-not-for-production',
                   EARLY_BIRDS_STAGING_TEAM_ENTRY_ENABLED: '1',
                   EARLY_BIRDS_STAGING_TEAM_ENTRY_HOSTS: `localhost:${PORT}`,
+                  // This opt-in gate gets a separate server process so the
+                  // regular visual suite keeps its existing Account-off UI.
+                  ...(LISTENER_ACCOUNT_SWITCH_GATE ? {
+                      BEACON_LISTENER_ACCOUNT_ENABLED: '1',
+                      BEACON_LISTENER_ACCOUNT_ENVIRONMENT: 'production',
+                      BEACON_LISTENER_ACCOUNT_CLIENT_SECRET:
+                          'listener-account-e2e-client-secret-not-for-production',
+                      BEACON_LISTENER_ACCOUNT_STATE_SECRET:
+                          'listener-account-e2e-state-secret-not-for-production',
+                  } : {}),
               },
           },
 });

--- a/src/app/__tests__/layout-locale.test.tsx
+++ b/src/app/__tests__/layout-locale.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@/context/LocaleContext', () => ({
 vi.mock('sonner', () => ({ Toaster: () => null }));
 
 import RootLayout, { generateMetadata, generateViewport } from '../layout';
+import { ListenerIdentityCacheBoundary } from '@/components/brand/ListenerIdentityCacheBoundary';
 
 function requestHeaders(host: string, acceptLanguage: string): Headers {
     return new Headers({ host, 'accept-language': acceptLanguage });
@@ -114,11 +115,13 @@ describe('root document locale boundary', () => {
         mocks.locallyKnownListenerNavigationIdentity.mockResolvedValue({ displayName: 'Nico' });
 
         const result = await RootLayout({ children: <main /> });
-        const navigation = result.props.children.props.children[0];
+        const bodyChildren = result.props.children.props.children;
+        const navigation = bodyChildren[0];
 
         expect(navigation.props.accountHref).toBe('https://account-staging.harmonicbeacon.com/account');
         expect(navigation.props.accountSignedIn).toBe(true);
         expect(navigation.props.accountMenu.props.displayName).toBe('Nico');
+        expect(bodyChildren[1].type).toBe(ListenerIdentityCacheBoundary);
         expect(mocks.locallyKnownListenerNavigationIdentity).toHaveBeenCalledOnce();
         expect(mocks.locallyKnownAccountSession).not.toHaveBeenCalled();
     });
@@ -128,10 +131,12 @@ describe('root document locale boundary', () => {
         mocks.requestBrowserLocale.mockResolvedValue('en');
 
         const result = await RootLayout({ children: <main /> });
-        const navigation = result.props.children.props.children[0];
+        const bodyChildren = result.props.children.props.children;
+        const navigation = bodyChildren[0];
 
         expect(navigation.props.accountHref).toBeNull();
         expect(navigation.props.accountSignedIn).toBe(false);
+        expect(bodyChildren[1]).toBeNull();
         expect(mocks.locallyKnownListenerNavigationIdentity).not.toHaveBeenCalled();
         expect(mocks.locallyKnownAccountSession).not.toHaveBeenCalled();
     });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1511,6 +1511,12 @@ html[data-hb-surface='listener'] body {
   font-family: var(--hb-font-sans);
 }
 
+/* A host-local Account document is hidden before a possible bfcache snapshot.
+   A persisted restoration reloads authoritatively before removing this flag. */
+html[data-hb-listener-identity-stale='1'] body {
+  visibility: hidden;
+}
+
 .listener-shell :where(button, input, select, textarea),
 .listener-page-shell :where(button, input, select, textarea) {
   font: inherit;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { LocaleProvider } from "@/context/LocaleContext";
 import { GlobalNavigation } from "@/components/brand/GlobalNavigation";
 import { ListenerNavigationAccountMenu } from "@/components/brand/ListenerNavigationAccountMenu";
+import { ListenerIdentityCacheBoundary } from "@/components/brand/ListenerIdentityCacheBoundary";
 import {
   globalNavigationAccountHref,
   globalNavigationSurface,
@@ -162,6 +163,7 @@ export default async function RootLayout({
             />
           ) : undefined}
         />
+        {listenerNavigationIdentity && <ListenerIdentityCacheBoundary />}
         <LocaleProvider initialLocale={locale}>
           {/* Main content */}
           <div className="relative z-10">{children}</div>

--- a/src/components/brand/ListenerIdentityCacheBoundary.tsx
+++ b/src/components/brand/ListenerIdentityCacheBoundary.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { reloadListenerIdentityDocument } from '@/lib/listener/identity-cache-boundary';
+
+export const LISTENER_IDENTITY_STALE_ATTRIBUTE = 'data-hb-listener-identity-stale';
+
+/**
+ * Keep an Account-derived Listener document out of a stale visual state.
+ *
+ * The server response is already private/no-store. This boundary also covers
+ * browsers that elect to retain such a page in their back-forward cache: the
+ * outgoing document is made neutral before its snapshot, and a persisted
+ * restoration is reloaded before any prior profile or entitlement is shown.
+ */
+export function ListenerIdentityCacheBoundary() {
+    useEffect(() => {
+        const root = document.documentElement;
+        root.removeAttribute(LISTENER_IDENTITY_STALE_ATTRIBUTE);
+
+        const onPageHide = () => {
+            root.setAttribute(LISTENER_IDENTITY_STALE_ATTRIBUTE, '1');
+        };
+        const onPageShow = (event: PageTransitionEvent) => {
+            if (event.persisted || root.hasAttribute(LISTENER_IDENTITY_STALE_ATTRIBUTE)) {
+                reloadListenerIdentityDocument();
+            }
+        };
+
+        window.addEventListener('pagehide', onPageHide);
+        window.addEventListener('pageshow', onPageShow);
+        return () => {
+            window.removeEventListener('pagehide', onPageHide);
+            window.removeEventListener('pageshow', onPageShow);
+            root.removeAttribute(LISTENER_IDENTITY_STALE_ATTRIBUTE);
+        };
+    }, []);
+
+    return null;
+}

--- a/src/components/brand/__tests__/ListenerIdentityCacheBoundary.test.tsx
+++ b/src/components/brand/__tests__/ListenerIdentityCacheBoundary.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reloadListenerIdentityDocument = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/listener/identity-cache-boundary', () => ({
+    reloadListenerIdentityDocument,
+}));
+
+import {
+    LISTENER_IDENTITY_STALE_ATTRIBUTE,
+    ListenerIdentityCacheBoundary,
+} from '../ListenerIdentityCacheBoundary';
+
+function transition(type: 'pagehide' | 'pageshow', persisted: boolean): PageTransitionEvent {
+    return new PageTransitionEvent(type, { persisted });
+}
+
+describe('Listener Account browser-cache boundary', () => {
+    beforeEach(() => {
+        document.documentElement.removeAttribute(LISTENER_IDENTITY_STALE_ATTRIBUTE);
+        reloadListenerIdentityDocument.mockReset();
+    });
+
+    afterEach(() => cleanup());
+
+    it('neutralizes the outgoing Account-derived document before a history snapshot', () => {
+        render(<ListenerIdentityCacheBoundary />);
+
+        act(() => window.dispatchEvent(transition('pagehide', true)));
+
+        expect(document.documentElement).toHaveAttribute(
+            LISTENER_IDENTITY_STALE_ATTRIBUTE,
+            '1',
+        );
+        expect(reloadListenerIdentityDocument).not.toHaveBeenCalled();
+    });
+
+    it('reloads a persisted restoration without first exposing the old identity', () => {
+        render(<ListenerIdentityCacheBoundary />);
+        act(() => window.dispatchEvent(transition('pagehide', true)));
+        act(() => window.dispatchEvent(transition('pageshow', true)));
+
+        expect(document.documentElement).toHaveAttribute(
+            LISTENER_IDENTITY_STALE_ATTRIBUTE,
+            '1',
+        );
+        expect(reloadListenerIdentityDocument).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reload a fresh, non-persisted document', () => {
+        render(<ListenerIdentityCacheBoundary />);
+        act(() => window.dispatchEvent(transition('pageshow', false)));
+
+        expect(document.documentElement).not.toHaveAttribute(
+            LISTENER_IDENTITY_STALE_ATTRIBUTE,
+        );
+        expect(reloadListenerIdentityDocument).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/listener/identity-cache-boundary.ts
+++ b/src/lib/listener/identity-cache-boundary.ts
@@ -1,0 +1,4 @@
+/** Reload the host-local Listener document after a browser cache restoration. */
+export function reloadListenerIdentityDocument(): void {
+    window.location.reload();
+}


### PR DESCRIPTION
Closes the remaining automated portion of #385.

What changes:
- adds a direct-PostgreSQL, local-only Playwright fixture for distinct Founder A and Free B Account RP sessions;
- proves server authorization and presentation across A to B first render, browser back and forward, reload, duplicated tab, and B to A in Chromium and Firefox;
- keeps the ordinary E2E server Account-off and enables this isolated gate only in its dedicated CI step;
- keeps Account-derived Listener responses private/no-store and adds a neutral-before-snapshot plus authoritative-reload boundary for browsers that restore a signed-in page from bfcache;
- persists no email, cookie, token, subject, or provider identifier in traces or artifacts.

Local evidence:
- production build green;
- Chromium and Firefox gate 2/2 green against PostgreSQL 16 and the production server;
- full Vitest 1792 pass / 44 skip;
- TypeScript green;
- ESLint 0 errors (2 pre-existing warnings in the byte-pinned nav asset);
- production dependency audit green;
- diff-check green;
- no audio, stream, LiveKit, event, payment, commerce, quota, or membership runtime path changed.