### PR TITLE
ops: add production Account cutover lifecycle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/check-migr
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/provision-production-role.mjs ./scripts/beacon-account/provision-production-role.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-account-production/sync-secret.mjs ./scripts/listener-account-production/sync-secret.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-account-production/preflight.mjs ./scripts/listener-account-production/preflight.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-account-production/activate-env.mjs ./scripts/listener-account-production/activate-env.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/validate.mjs ./ops/beacon-account/validate.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/account.production.env.example ./ops/beacon-account/account.production.env.example
 COPY --from=builder --chown=nextjs:nodejs /app/ops/beacon-account/account.staging.env.example ./ops/beacon-account/account.staging.env.example

--- a/ops/beacon-account/README.md
+++ b/ops/beacon-account/README.md
@@ -1,0 +1,63 @@
+# Beacon Account deployment
+
+The Account authority uses one immutable application image with separate,
+root-owned production and staging configuration. The production lifecycle is a
+deliberate maintenance boundary: the first migration installs the Account
+authority in the protected Listener database and revokes legacy Listener auth
+sessions. It never changes DNS.
+
+## Production preparation
+
+Before requesting DNS, all of these gates must be green:
+
+1. the exact reviewed SHA is checked out cleanly on the host;
+2. `harmonic-beacon/account:<sha40>` and
+   `harmonic-beacon/earlybirds-preview-listener:<sha40>` have baked provenance
+   matching that SHA;
+3. `ops/beacon-account/validate.mjs` accepts the five root-owned env files in a
+   networkless candidate container;
+4. `scripts/listener-account-production/prepare.sh <sha40>` produces the dormant
+   two-key Listener RP bundle while the active Listener remains Account-off;
+5. `account_check_production_migrations before` reports exactly the reviewed
+   pending migration list;
+6. staging email/password, provider, profile, switching and RP acceptance gates
+   required for the release are recorded.
+
+## DNS and certificate boundary
+
+DNSExit is a human-operated critical system. Repository scripts must not change
+it. Only after the operator is explicitly asked, create exact A/AAAA records for
+`account.harmonicbeacon.com` pointing at the reviewed Mona addresses. Do not add
+a CNAME or wildcard.
+
+While the certificate is absent, install only
+`nginx/account-acme-bootstrap.conf.template`. It serves the ACME webroot and
+returns 503 everywhere else; it contains no proxy or TLS listener. Run
+`nginx -t`, reload, obtain the certificate through the existing certbot webroot,
+and verify the certificate SAN is exactly `account.harmonicbeacon.com`.
+
+Then install `nginx/account.harmonicbeacon.com.conf.template`, run `nginx -t`
+and reload. Until the application starts, upstream failures are normalized to
+503. The new hostname therefore never routes to another product and never
+becomes a partially working sign-in authority.
+
+## Coordinated activation
+
+1. Capture protected runtime fingerprints and fresh, verified database/env/nginx
+   backups.
+2. Run `scripts/beacon-account/start.sh production /secure/deploy.env`. It
+   checks migrations, creates and verifies the encrypted backup, migrates,
+   provisions the least-privilege database role and static clients, then starts
+   Account and its mail worker with rollback on failure.
+3. Require Account readiness, exact issuer/discovery/JWKS, Basic-only clients,
+   mail-sidecar readiness, navigation asset hash and negative-route smokes.
+4. Run `scripts/listener-account-production/preflight.sh <sha40>` against the
+   public Account authority.
+5. Activate only the production Listener RP through its reviewed lifecycle.
+   Do not re-enable direct Listener Google, Apple or magic-link identity.
+6. Run human Account-to-Listener acceptance before exposing the production
+   Account control in the shared navigation or enabling Live/Ops consumers.
+
+Rollback never downgrades the database. Restore the previous application/env
+state, leave the Account edge at a truthful 503 if the authority is unavailable,
+and keep all RP feature flags off until readiness and acceptance pass again.

--- a/ops/beacon-account/nginx/account-acme-bootstrap.conf.template
+++ b/ops/beacon-account/nginx/account-acme-bootstrap.conf.template
@@ -1,0 +1,16 @@
+# Temporary HTTP-only bootstrap for the Account production certificate.
+# Install this file only while the certificate is absent. It never proxies
+# Account, Listener, Live, event, media or internal application traffic.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name account.harmonicbeacon.com;
+    access_log off;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/letsencrypt;
+        default_type text/plain;
+    }
+
+    location / { return 503; }
+}

--- a/ops/beacon-account/nginx/account.harmonicbeacon.com.conf.template
+++ b/ops/beacon-account/nginx/account.harmonicbeacon.com.conf.template
@@ -30,6 +30,17 @@ server {
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto https;
     proxy_http_version 1.1;
+    proxy_intercept_errors on;
+    error_page 502 503 504 = @account_unavailable;
+
+    location @account_unavailable {
+        access_log off;
+        add_header Cache-Control "no-store" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer" always;
+        return 503;
+    }
 
     location = /.well-known/openid-configuration {
         if ($request_method !~ ^(GET|HEAD)$) { return 405; }

--- a/ops/beacon-account/test/contract.test.mjs
+++ b/ops/beacon-account/test/contract.test.mjs
@@ -471,17 +471,32 @@ test('nginx keeps Account hosts isolated and never logs token-bearing routes', (
   }
 });
 
-test('Account staging ACME bootstrap exposes only the certificate challenge', () => {
+test('Account ACME bootstraps expose only the exact certificate challenge', () => {
+  for (const [name, host] of [
+    ['account-acme-bootstrap.conf.template', 'account.harmonicbeacon.com'],
+    ['account-staging-acme-bootstrap.conf.template', 'account-staging.harmonicbeacon.com'],
+  ]) {
+    const nginx = fs.readFileSync(path.join(ROOT, 'nginx', name), 'utf8');
+    assert.match(nginx, new RegExp(`server_name ${host.replaceAll('.', '\\.')};`));
+    assert.match(nginx, /access_log off;/);
+    assert.match(nginx, /location \^~ \/\.well-known\/acme-challenge\/ \{/);
+    assert.match(nginx, /root \/var\/www\/letsencrypt;/);
+    assert.match(nginx, /location \/ \{ return 503; \}/);
+    assert.doesNotMatch(nginx, /listen 443|ssl_certificate|proxy_pass|1300[0-9]/);
+  }
+});
+
+test('Account production edge stays truthful while its upstream is unavailable', () => {
   const nginx = fs.readFileSync(
-    path.join(ROOT, 'nginx/account-staging-acme-bootstrap.conf.template'),
+    path.join(ROOT, 'nginx/account.harmonicbeacon.com.conf.template'),
     'utf8',
   );
-  assert.match(nginx, /server_name account-staging\.harmonicbeacon\.com;/);
-  assert.match(nginx, /access_log off;/);
-  assert.match(nginx, /location \^~ \/\.well-known\/acme-challenge\/ \{/);
-  assert.match(nginx, /root \/var\/www\/letsencrypt;/);
-  assert.match(nginx, /location \/ \{ return 503; \}/);
-  assert.doesNotMatch(nginx, /listen 443|ssl_certificate|proxy_pass|1300[0-9]/);
+  assert.match(nginx, /proxy_intercept_errors on;/);
+  assert.match(nginx, /error_page 502 503 504 = @account_unavailable;/);
+  const unavailable = nginx.slice(nginx.indexOf('location @account_unavailable'));
+  assert.match(unavailable, /access_log off;/);
+  assert.match(unavailable, /Cache-Control "no-store" always;/);
+  assert.match(unavailable, /return 503;/);
 });
 
 test('social-provider runbook uses only central Account callbacks and default-off activation', () => {

--- a/ops/listener-account-production/README.md
+++ b/ops/listener-account-production/README.md
@@ -5,7 +5,10 @@ changing the running Listener or enabling Account. It deliberately precedes
 the coordinated Account/Listener cutover.
 
 1. Build the exact reviewed `early-birds` SHA as
-   `harmonic-beacon/earlybirds-preview-listener:<sha40>`.
+   `harmonic-beacon/earlybirds-preview-listener:<sha40>`, with
+   `EARLYBIRDS_PREVIEW_SCHEMA_VERSION` equal to the exact
+   `BEACON_ACCOUNT_SCHEMA_VERSION` production coordinate. Activation rejects a
+   correctly tagged image carrying an older schema label.
 2. Run `sudo scripts/listener-account-production/prepare.sh <sha40>` on Mona.
    It reads the root-only Account and Listener env files in a networkless,
    read-only candidate container. The resulting two-key bundle is installed at
@@ -16,6 +19,15 @@ the coordinated Account/Listener cutover.
    run `sudo scripts/listener-account-production/preflight.sh <sha40>`. It
    exposes only the dedicated RP client secret to a bounded egress probe and
    proves readiness, discovery, JWKS, Basic authentication and session-status.
+5. After fresh Listener DB/env backups, run
+   `sudo scripts/listener-account-production/activate.sh <sha40>`. It generates
+   the Account-on env inside the exact networkless image, atomically installs
+   it, recreates only the Listener app, and keeps rollback active through local
+   and public login smokes. It does not rebuild/restart the stream origin,
+   PostgreSQL, withdrawal worker, payments, LiveKit or event services.
+6. The printed root-only activation directory is the only accepted argument to
+   `rollback.sh`. Rollback restores the Account-off env and exact prior image;
+   it never downgrades the shared database.
 
 The first Account production migration revokes legacy Listener authentication
 sessions. Therefore Account migration, Listener env activation and the public

--- a/ops/listener-account-production/package.json
+++ b/ops/listener-account-production/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "node --check validate.mjs && node --check ../../scripts/listener-account-production/sync-secret.mjs && node --check ../../scripts/listener-account-production/preflight.mjs && sh -n ../../scripts/listener-account-production/prepare.sh ../../scripts/listener-account-production/preflight.sh",
+    "check": "node --check validate.mjs && node --check ../../scripts/listener-account-production/sync-secret.mjs && node --check ../../scripts/listener-account-production/preflight.mjs && node --check ../../scripts/listener-account-production/activate-env.mjs && sh -n ../../scripts/listener-account-production/prepare.sh ../../scripts/listener-account-production/preflight.sh ../../scripts/listener-account-production/activate.sh ../../scripts/listener-account-production/rollback.sh ../../scripts/listener-account-production/health-smoke.sh",
     "test": "node --test test/contract.test.mjs"
   }
 }

--- a/ops/listener-account-production/test/contract.test.mjs
+++ b/ops/listener-account-production/test/contract.test.mjs
@@ -5,6 +5,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { buildProductionBundle } from '../../../scripts/listener-account-production/sync-secret.mjs';
+import { buildProductionActivation } from '../../../scripts/listener-account-production/activate-env.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const source = (file) => fs.readFileSync(path.join(ROOT, file), 'utf8');
@@ -12,6 +13,26 @@ const client = 'c'.repeat(64);
 const state = 's'.repeat(64);
 const account = `BEACON_ACCOUNT_BASE_URL=https://account.harmonicbeacon.com\nBEACON_ACCOUNT_CLIENT_SECRET_HB_LISTENER=${client}\n`;
 const listener = 'EARLY_BIRDS_AUTH_BASE_URL=https://listen.harmonicbeacon.com\nBEACON_LISTENER_ACCOUNT_ENABLED=0\n';
+
+const activationListener = [
+  'EARLYBIRDS_PREVIEW_IMAGE_TAG=old',
+  'EARLYBIRDS_PREVIEW_GIT_SHA=old',
+  'EARLYBIRDS_PREVIEW_BUILD_TIME=old',
+  'EARLYBIRDS_PREVIEW_SCHEMA_VERSION=20260813190000_listener_withdrawal_request',
+  'EARLY_BIRDS_AUTH_BASE_URL=https://listen.harmonicbeacon.com',
+  'EARLY_BIRDS_TRUSTED_ORIGINS=https://listen.harmonicbeacon.com,https://earlybirds-staging.harmonicbeacon.com',
+  'EARLY_BIRDS_GOOGLE_CLIENT_ID=legacy-google',
+  'EARLY_BIRDS_GOOGLE_CLIENT_SECRET=legacy-google-secret',
+  'EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL=https://legacy.example.invalid',
+  'EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN=legacy-mail-token',
+  'EARLY_BIRDS_MAGIC_LINK_RATE_SECRET=legacy-rate-secret',
+  'BEACON_LISTENER_PAYPAL_LIVE_CHECKOUT_ENABLED=1',
+  'BEACON_LISTENER_MERCADO_PAGO_LIVE_CHECKOUT_ENABLED=1',
+  'BEACON_LISTENER_ACCOUNT_ENABLED=0',
+  'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=',
+  'BEACON_LISTENER_ACCOUNT_STATE_SECRET=',
+  '',
+].join('\n');
 
 test('builds the exact two-key production bundle and preserves state', () => {
   const bundle = buildProductionBundle({
@@ -44,9 +65,74 @@ test('refuses enabled, staging and unexpected secret states', () => {
   }), /unexpected keys/);
 });
 
+test('builds a production-only Listener activation without changing unrelated values', () => {
+  const sha = 'a'.repeat(40);
+  const activated = buildProductionActivation({
+    listenerContents: `${activationListener}UNRELATED=preserved\n`,
+    bundleContents: `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\n`,
+    expectedSha: sha,
+    buildTime: '2026-08-19T06:00:00Z',
+    expectedSchema: '20260818010000_beacon_account_authority',
+  });
+  assert.match(activated, new RegExp(`EARLYBIRDS_PREVIEW_IMAGE_TAG=${sha}`));
+  assert.match(activated, new RegExp(`EARLYBIRDS_PREVIEW_GIT_SHA=${sha}`));
+  assert.match(activated, /EARLYBIRDS_PREVIEW_BUILD_TIME=2026-08-19T06:00:00Z/);
+  assert.match(activated, /EARLYBIRDS_PREVIEW_SCHEMA_VERSION=20260818010000_beacon_account_authority/);
+  assert.match(activated, /BEACON_LISTENER_ACCOUNT_ENABLED=1/);
+  assert.match(activated, new RegExp(`BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}`));
+  assert.match(activated, new RegExp(`BEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}`));
+  assert.match(activated, /EARLY_BIRDS_GOOGLE_CLIENT_ID=\n/);
+  assert.match(activated, /EARLY_BIRDS_GOOGLE_CLIENT_SECRET=\n/);
+  assert.match(activated, /BEACON_LISTENER_APPLE_ENABLED=0/);
+  assert.match(activated, /BEACON_LISTENER_APPLE_CLIENT_ID=\n/);
+  assert.match(activated, /BEACON_LISTENER_APPLE_CLIENT_SECRET=\n/);
+  assert.match(activated, /EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL=\n/);
+  assert.match(activated, /EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN=\n/);
+  assert.match(activated, /EARLY_BIRDS_MAGIC_LINK_RATE_SECRET=\n/);
+  assert.match(activated, /BEACON_LISTENER_PAYPAL_LIVE_CHECKOUT_ENABLED=1/);
+  assert.match(activated, /BEACON_LISTENER_MERCADO_PAGO_LIVE_CHECKOUT_ENABLED=1/);
+  assert.match(activated, /UNRELATED=preserved/);
+});
+
+test('activation refuses enabled, cross-environment, ambiguous and invalid input', () => {
+  const input = {
+    listenerContents: activationListener,
+    bundleContents: `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\n`,
+    expectedSha: 'a'.repeat(40),
+    buildTime: '2026-08-19T06:00:00Z',
+    expectedSchema: '20260818010000_beacon_account_authority',
+  };
+  assert.throws(() => buildProductionActivation({
+    ...input,
+    listenerContents: activationListener.replace('ENABLED=0', 'ENABLED=1'),
+  }), /absent or 0/);
+  const withoutFlag = buildProductionActivation({
+    ...input,
+    listenerContents: activationListener.replace('BEACON_LISTENER_ACCOUNT_ENABLED=0\n', ''),
+  });
+  assert.match(withoutFlag, /BEACON_LISTENER_ACCOUNT_ENABLED=1/);
+  assert.throws(() => buildProductionActivation({
+    ...input,
+    listenerContents: `${activationListener}BEACON_LISTENER_ACCOUNT_STATE_SECRET_STAGING=${state}\n`,
+  }), /STAGING must be empty/);
+  assert.throws(() => buildProductionActivation({
+    ...input,
+    bundleContents: `${input.bundleContents}EXTRA=value\n`,
+  }), /unexpected keys/);
+  assert.throws(() => buildProductionActivation({
+    ...input,
+    bundleContents: `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${client}\n`,
+  }), /must differ/);
+  assert.throws(() => buildProductionActivation({ ...input, expectedSha: 'latest' }), /sha40/);
+  assert.throws(() => buildProductionActivation({ ...input, expectedSchema: 'latest' }), /schema migration/);
+});
+
 test('host wrappers constrain secrets, networking, provenance and arguments', () => {
   const prepare = source('scripts/listener-account-production/prepare.sh');
   const preflight = source('scripts/listener-account-production/preflight.sh');
+  const activate = source('scripts/listener-account-production/activate.sh');
+  const rollback = source('scripts/listener-account-production/rollback.sh');
+  const health = source('scripts/listener-account-production/health-smoke.sh');
   assert.match(prepare, /id -u/);
   assert.match(preflight, /id -u/);
   assert.match(prepare, /--network none/);
@@ -58,6 +144,50 @@ test('host wrappers constrain secrets, networking, provenance and arguments', ()
   assert.doesNotMatch(prepare, /docker inspect .*Config\.Env/);
   assert.match(preflight, /earlybirds_preview_listener_egress/);
   assert.doesNotMatch(preflight, /account\.production\.env|earlybirds-preview\.env/);
+  assert.match(activate, /--network none/);
+  assert.match(activate, /--read-only/);
+  assert.match(activate, /--cap-drop ALL/);
+  assert.match(activate, /--security-opt no-new-privileges/);
+  assert.match(activate, /preflight\.sh["']? "?\$expected_sha/);
+  assert.ok(
+    activate.indexOf('preflight.sh" "$expected_sha"') < activate.indexOf('install -d -o root -g root -m 0700 "$state"'),
+    'public Account preflight must precede persistent activation state',
+  );
+  assert.match(activate, /previous\.env/);
+  assert.match(activate, /--no-deps --force-recreate --no-build listener/);
+  assert.match(activate, /health-smoke\.sh"[\s\\\n]+"\$expected_sha" 1 "\$expected_schema"/);
+  assert.match(activate, /candidate image schema provenance mismatch/);
+  assert.match(activate, /previous-schema\.txt/);
+  assert.match(activate, /BEACON_LISTENER_PAYPAL_LIVE_CHECKOUT_ENABLED/);
+  assert.match(activate, /protected-containers\.before/);
+  assert.match(activate, /protected-containers\.after/);
+  assert.match(activate, /cmp -s "\$state\/protected-env\.before" "\$state\/protected-env\.after"/);
+  assert.ok(
+    activate.indexOf('\ncutover_started=1\n') < activate.lastIndexOf('mv -T "$temporary" "$listener_env"'),
+    'rollback must become active before replacing the production env',
+  );
+  assert.ok(
+    activate.lastIndexOf('health-smoke.sh"') < activate.lastIndexOf('cutover_started=0'),
+    'rollback must stay active through the external acceptance smoke',
+  );
+  assert.match(activate, /trap 'exit 130' HUP INT TERM/);
+  assert.match(activate, /rm -rf "\$state"/);
+  assert.doesNotMatch(activate, /require_synthetic_env/);
+  assert.doesNotMatch(activate, /cat [^\n]*(?:account|listener).*\.env/);
+  assert.match(rollback, /listener-account-production\/activation-/);
+  assert.match(rollback, /running Listener does not match this rollback candidate/);
+  assert.match(rollback, /--no-deps --force-recreate --no-build listener/);
+  assert.match(rollback, /database was not downgraded/);
+  assert.match(rollback, /trap '' HUP INT TERM/);
+  assert.doesNotMatch(rollback, /require_synthetic_env/);
+  assert.match(health, /--connect-timeout 3 --max-time 8/);
+  assert.match(health, /--proto '=https'/);
+  assert.match(health, /api\/account\/login\/extra/);
+  assert.match(health, /EARLY_BIRDS_GOOGLE_CLIENT_SECRET/);
+  assert.match(health, /EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN/);
+  assert.match(health, /checks\.listenerAccount == "ok"/);
+  assert.match(health, /databaseSchemaVersion == \$schema/);
+  assert.match(health, /trap 'exit 130' HUP INT TERM/);
 });
 
 test('preflight pins the production issuer and frozen OIDC contract', () => {
@@ -76,5 +206,6 @@ test('Docker image contains only the required preparation scripts', () => {
   const dockerfile = source('Dockerfile');
   assert.match(dockerfile, /scripts\/listener-account-production\/sync-secret\.mjs/);
   assert.match(dockerfile, /scripts\/listener-account-production\/preflight\.mjs/);
+  assert.match(dockerfile, /scripts\/listener-account-production\/activate-env\.mjs/);
   assert.match(dockerfile, /ops\/listener-account-production\/validate\.mjs/);
 });

--- a/ops/listener-account-production/validate.mjs
+++ b/ops/listener-account-production/validate.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 const requiredFiles = [
   '/app/scripts/listener-account-production/sync-secret.mjs',
   '/app/scripts/listener-account-production/preflight.mjs',
+  '/app/scripts/listener-account-production/activate-env.mjs',
 ];
 
 for (const file of requiredFiles) {

--- a/scripts/listener-account-production/activate-env.mjs
+++ b/scripts/listener-account-production/activate-env.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SHA40 = /^[0-9a-f]{40}$/;
+const BUILD_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+const SCHEMA = /^\d{14}_[a-z0-9_]+$/;
+const SECRET = /^[A-Za-z0-9_-]{32,256}$/;
+
+function assignments(contents, label) {
+  const values = new Map();
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const at = line.indexOf('=');
+    if (at <= 0) throw new Error(`${label} contains an invalid assignment`);
+    const key = line.slice(0, at);
+    if (!/^[A-Z][A-Z0-9_]*$/.test(key)) throw new Error(`${label} contains an invalid key`);
+    if (values.has(key)) throw new Error(`${label} contains a duplicate key`);
+    values.set(key, line.slice(at + 1));
+  }
+  return values;
+}
+
+function exact(values, key, expected, label) {
+  if (values.get(key) !== expected) throw new Error(`${label} ${key} mismatch`);
+}
+
+function replaceAssignment(contents, key, value) {
+  const lines = contents.replace(/\r\n/g, '\n').split('\n');
+  let replacements = 0;
+  const updated = lines.map((line) => {
+    if (!line.startsWith(`${key}=`)) return line;
+    replacements += 1;
+    return `${key}=${value}`;
+  });
+  if (replacements > 1) throw new Error(`Listener environment contains duplicate ${key}`);
+  if (replacements === 0) {
+    if (updated.at(-1) !== '') updated.push('');
+    updated.splice(updated.length - 1, 0, `${key}=${value}`);
+  }
+  return updated.join('\n');
+}
+
+export function buildProductionActivation({
+  listenerContents,
+  bundleContents,
+  expectedSha,
+  buildTime,
+  expectedSchema,
+}) {
+  if (!SHA40.test(expectedSha)) throw new Error('exact lowercase sha40 required');
+  if (!BUILD_TIME.test(buildTime)) throw new Error('exact UTC build time required');
+  if (!SCHEMA.test(expectedSchema)) throw new Error('exact schema migration required');
+  const listener = assignments(listenerContents, 'Listener environment');
+  const bundle = assignments(bundleContents, 'Listener Account bundle');
+
+  if ((listener.get('BEACON_LISTENER_ACCOUNT_ENABLED') ?? '0') !== '0') {
+    throw new Error('Listener environment BEACON_LISTENER_ACCOUNT_ENABLED must be absent or 0');
+  }
+  exact(listener, 'EARLY_BIRDS_AUTH_BASE_URL', 'https://listen.harmonicbeacon.com', 'Listener environment');
+  exact(
+    listener,
+    'EARLY_BIRDS_TRUSTED_ORIGINS',
+    'https://listen.harmonicbeacon.com,https://earlybirds-staging.harmonicbeacon.com',
+    'Listener environment',
+  );
+  for (const key of [
+    'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET',
+    'BEACON_LISTENER_ACCOUNT_STATE_SECRET',
+    'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET_STAGING',
+    'BEACON_LISTENER_ACCOUNT_STATE_SECRET_STAGING',
+  ]) {
+    if ((listener.get(key) ?? '') !== '') throw new Error(`Listener environment ${key} must be empty`);
+  }
+
+  const allowedBundle = new Set([
+    'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET',
+    'BEACON_LISTENER_ACCOUNT_STATE_SECRET',
+  ]);
+  for (const key of bundle.keys()) {
+    if (!allowedBundle.has(key)) throw new Error('Listener Account bundle contains unexpected keys');
+  }
+  if (bundle.size !== allowedBundle.size) throw new Error('Listener Account bundle is incomplete');
+  const clientSecret = bundle.get('BEACON_LISTENER_ACCOUNT_CLIENT_SECRET');
+  const stateSecret = bundle.get('BEACON_LISTENER_ACCOUNT_STATE_SECRET');
+  if (!SECRET.test(clientSecret ?? '') || !SECRET.test(stateSecret ?? '')) {
+    throw new Error('Listener Account bundle contains an invalid secret');
+  }
+  if (clientSecret === stateSecret) throw new Error('Listener Account secrets must differ');
+
+  let result = listenerContents;
+  for (const [key, value] of [
+    ['EARLYBIRDS_PREVIEW_IMAGE_TAG', expectedSha],
+    ['EARLYBIRDS_PREVIEW_GIT_SHA', expectedSha],
+    ['EARLYBIRDS_PREVIEW_BUILD_TIME', buildTime],
+    ['EARLYBIRDS_PREVIEW_SCHEMA_VERSION', expectedSchema],
+    // Central Account is the sole identity provider after this cutover. Keep
+    // the old direct-provider and magic-link credentials out of the process;
+    // the root-only previous env retains them only for bounded rollback.
+    ['EARLY_BIRDS_GOOGLE_CLIENT_ID', ''],
+    ['EARLY_BIRDS_GOOGLE_CLIENT_SECRET', ''],
+    ['BEACON_LISTENER_APPLE_ENABLED', '0'],
+    ['BEACON_LISTENER_APPLE_CLIENT_ID', ''],
+    ['BEACON_LISTENER_APPLE_CLIENT_SECRET', ''],
+    ['EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL', ''],
+    ['EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN', ''],
+    ['EARLY_BIRDS_MAGIC_LINK_RATE_SECRET', ''],
+    ['BEACON_LISTENER_ACCOUNT_ENABLED', '1'],
+    ['BEACON_LISTENER_ACCOUNT_CLIENT_SECRET', clientSecret],
+    ['BEACON_LISTENER_ACCOUNT_STATE_SECRET', stateSecret],
+  ]) {
+    result = replaceAssignment(result, key, value);
+  }
+  const effective = assignments(result, 'activated Listener environment');
+  exact(effective, 'BEACON_LISTENER_ACCOUNT_ENABLED', '1', 'activated Listener environment');
+  exact(effective, 'EARLYBIRDS_PREVIEW_IMAGE_TAG', expectedSha, 'activated Listener environment');
+  exact(effective, 'EARLYBIRDS_PREVIEW_GIT_SHA', expectedSha, 'activated Listener environment');
+  exact(effective, 'EARLYBIRDS_PREVIEW_SCHEMA_VERSION', expectedSchema, 'activated Listener environment');
+  exact(effective, 'EARLY_BIRDS_GOOGLE_CLIENT_ID', '', 'activated Listener environment');
+  exact(effective, 'EARLY_BIRDS_GOOGLE_CLIENT_SECRET', '', 'activated Listener environment');
+  exact(effective, 'BEACON_LISTENER_APPLE_ENABLED', '0', 'activated Listener environment');
+  exact(effective, 'BEACON_LISTENER_APPLE_CLIENT_ID', '', 'activated Listener environment');
+  exact(effective, 'BEACON_LISTENER_APPLE_CLIENT_SECRET', '', 'activated Listener environment');
+  exact(effective, 'EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL', '', 'activated Listener environment');
+  exact(effective, 'EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN', '', 'activated Listener environment');
+  exact(effective, 'EARLY_BIRDS_MAGIC_LINK_RATE_SECRET', '', 'activated Listener environment');
+  return result.endsWith('\n') ? result : `${result}\n`;
+}
+
+function requireRootPrivateFile(file, label) {
+  const metadata = fs.lstatSync(file);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) throw new Error(`${label} must be a regular file`);
+  if (metadata.uid !== 0 || metadata.gid !== 0 || (metadata.mode & 0o777) !== 0o600) {
+    throw new Error(`${label} must be root:root mode 0600`);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  const [listenerFile, bundleFile, outputFile, expectedSha, buildTime, expectedSchema] = process.argv.slice(2);
+  if (!listenerFile || !bundleFile || !outputFile || !expectedSha || !buildTime || !expectedSchema) {
+    throw new Error('usage: activate-env.mjs listener.env account.env output.env sha40 build-time schema');
+  }
+  requireRootPrivateFile(listenerFile, 'Listener environment');
+  requireRootPrivateFile(bundleFile, 'Listener Account bundle');
+  if (fs.existsSync(outputFile)) throw new Error('activation output already exists');
+  const outputDirectory = fs.lstatSync(path.dirname(outputFile));
+  if (!outputDirectory.isDirectory() || outputDirectory.isSymbolicLink()) {
+    throw new Error('activation output directory must be regular');
+  }
+  if (outputDirectory.uid !== 0 || outputDirectory.gid !== 0 || (outputDirectory.mode & 0o777) !== 0o700) {
+    throw new Error('activation output directory must be root:root mode 0700');
+  }
+  const candidate = buildProductionActivation({
+    listenerContents: fs.readFileSync(listenerFile, 'utf8'),
+    bundleContents: fs.readFileSync(bundleFile, 'utf8'),
+    expectedSha,
+    buildTime,
+    expectedSchema,
+  });
+  fs.writeFileSync(outputFile, candidate, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+  process.stdout.write('Listener production Account activation environment prepared.\n');
+}

--- a/scripts/listener-account-production/activate.sh
+++ b/scripts/listener-account-production/activate.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env sh
+set -eu
+
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+
+expected_sha=${1:?usage: activate.sh exact-sha40}
+case "$expected_sha" in *[!0-9a-f]*|'') echo 'exact lowercase sha40 required' >&2; exit 2 ;; esac
+test "${#expected_sha}" -eq 40 || { echo 'exact lowercase sha40 required' >&2; exit 2; }
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+image="harmonic-beacon/earlybirds-preview-listener:$expected_sha"
+listener_env=/etc/harmonic-beacon/earlybirds-preview.env
+bundle=/etc/harmonic-beacon/listener-account-production.env
+account_deploy=/etc/harmonic-beacon/beacon-account-deploy.env
+state_root=/var/lib/harmonic-beacon/listener-account-production
+build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+state="$state_root/activation-$expected_sha-$stamp"
+cleanup_preflight() { test ! -d "$state" || rm -rf "$state"; }
+trap cleanup_preflight EXIT
+trap 'exit 130' HUP INT TERM
+umask 077
+
+fail() { echo "Listener production Account activation: $*" >&2; exit 2; }
+private_file() {
+  test -f "$1" && test ! -L "$1" || fail "$2 must be a regular file"
+  test "$(stat -c '%U:%G:%a' "$1")" = root:root:600 || fail "$2 must be root:root mode 0600"
+}
+write_protected_environment() {
+  protected_source=$1
+  protected_target=$2
+  grep -E '^(EARLY_BIRDS_ENABLED|EARLY_BIRDS_FREE_FOR_ALL|BEACON_LISTENER_PAYPAL_SANDBOX_CHECKOUT_ENABLED|BEACON_LISTENER_MERCADO_PAGO_TEST_CHECKOUT_ENABLED|BEACON_LISTENER_PAYPAL_LIVE_CHECKOUT_ENABLED|BEACON_LISTENER_MERCADO_PAGO_LIVE_CHECKOUT_ENABLED|BEACON_LISTENER_STAGING_LIVE_WORKBENCH_ENABLED|LISTENER_WITHDRAWAL_ENABLED|EARLY_BIRDS_STREAM_ORIGIN|EARLY_BIRDS_STREAM_ARTIFACT_ID|EARLY_BIRDS_AUTHORITY_BASE_URL)=' \
+    "$protected_source" | sort > "$protected_target"
+  test "$(wc -l < "$protected_target")" -eq 11 || fail 'protected Listener environment inventory is incomplete'
+  chmod 0600 "$protected_target"
+}
+write_protected_containers() {
+  protected_target=$1
+  : > "$protected_target"
+  for protected_container in \
+    earlybirds-preview-postgres-1 \
+    earlybirds-preview-beacon-stream-1 \
+    earlybirds-preview-withdrawal-operator-1; do
+    docker inspect "$protected_container" \
+      --format '{{.Name}}|{{.Id}}|{{.Config.Image}}|{{.State.Running}}|{{.RestartCount}}' \
+      >> "$protected_target"
+  done
+  chmod 0600 "$protected_target"
+}
+wait_healthy() {
+  wait_attempt=0
+  while test "$wait_attempt" -lt 60; do
+    wait_state=$(docker inspect earlybirds-preview-listener-1 \
+      --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>/dev/null || true)
+    test "$wait_state" != healthy || return 0
+    test "$wait_state" != exited || return 1
+    wait_attempt=$((wait_attempt + 1))
+    sleep 2
+  done
+  return 1
+}
+
+exec 9>/run/lock/listener-account-production.lock
+flock -n 9 || fail 'another Listener Account production activation is active'
+private_file "$listener_env" 'Listener production environment'
+private_file "$bundle" 'Listener Account production bundle'
+private_file "$account_deploy" 'Account deployment coordinates'
+expected_schema=$(sed -n 's/^BEACON_ACCOUNT_SCHEMA_VERSION=//p' "$account_deploy" | tail -n 1 | tr -d '\r')
+printf '%s\n' "$expected_schema" | grep -Eq '^[0-9]{14}_[a-z0-9_]+$' ||
+  fail 'Account schema coordinate is invalid'
+test "$(git -C "$root" rev-parse HEAD)" = "$expected_sha" || fail 'release checkout SHA mismatch'
+test -z "$(git -C "$root" status --porcelain)" || fail 'release checkout is dirty'
+docker image inspect "$image" >/dev/null 2>&1 || fail 'exact candidate image is missing'
+baked_sha=$(docker image inspect "$image" --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$baked_sha" = "$expected_sha" || fail 'candidate image provenance mismatch'
+baked_schema=$(docker image inspect "$image" --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_DATABASE_SCHEMA_VERSION=//p' | tail -n 1)
+test "$baked_schema" = "$expected_schema" || fail 'candidate image schema provenance mismatch'
+
+current_state=$(docker inspect earlybirds-preview-listener-1 \
+  --format '{{.State.Running}}|{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null || true)
+test "$current_state" = 'true|healthy' || fail 'current production Listener is not healthy'
+previous_image=$(docker inspect earlybirds-preview-listener-1 --format '{{.Config.Image}}')
+case "$previous_image" in
+  harmonic-beacon/earlybirds-preview-listener:[0-9a-f][0-9a-f]*) ;;
+  *) fail 'previous Listener image reference is invalid' ;;
+esac
+docker image inspect "$previous_image" >/dev/null 2>&1 || fail 'previous Listener image is missing'
+previous_sha=$(docker inspect earlybirds-preview-listener-1 \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+printf '%s\n' "$previous_sha" | grep -Eq '^[0-9a-f]{40}$' || fail 'previous Listener provenance is invalid'
+test "$previous_image" = "harmonic-beacon/earlybirds-preview-listener:$previous_sha" ||
+  fail 'previous Listener image tag and provenance differ'
+previous_schema=$(sed -n 's/^EARLYBIRDS_PREVIEW_SCHEMA_VERSION=//p' "$listener_env" | tail -n 1 | tr -d '\r')
+printf '%s\n' "$previous_schema" | grep -Eq '^[0-9]{14}_[a-z0-9_]+$' ||
+  fail 'previous Listener schema provenance is invalid'
+test "$previous_image" != "$image" || fail 'candidate is already running'
+
+# This is intentionally before every persistent write and runtime mutation.
+# It proves the public Account issuer and the exact dedicated RP credential.
+"$root/scripts/listener-account-production/preflight.sh" "$expected_sha"
+
+if test -e "$state_root"; then
+  test -d "$state_root" && test ! -L "$state_root" || fail 'state root must be a regular directory'
+  test "$(stat -c '%U:%G:%a' "$state_root")" = root:root:700 ||
+    fail 'state root must be root:root mode 0700'
+else
+  install -d -o root -g root -m 0700 "$state_root"
+fi
+test ! -e "$state" || fail 'activation state already exists'
+install -d -o root -g root -m 0700 "$state"
+install -o root -g root -m 0600 "$listener_env" "$state/previous.env"
+printf '%s\n' "$previous_image" > "$state/previous-image.txt"
+printf '%s\n' "$previous_sha" > "$state/previous-sha.txt"
+printf '%s\n' "$previous_schema" > "$state/previous-schema.txt"
+printf '%s\n' "$image" > "$state/candidate-image.txt"
+chmod 0600 "$state/previous-image.txt" "$state/previous-sha.txt" \
+  "$state/previous-schema.txt" "$state/candidate-image.txt"
+write_protected_environment "$listener_env" "$state/protected-env.before"
+write_protected_containers "$state/protected-containers.before"
+
+docker run --rm --pull never --network none --read-only --user 0:0 --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --mount "type=bind,src=$listener_env,dst=/run/listener.env,readonly" \
+  --mount "type=bind,src=$bundle,dst=/run/account.env,readonly" \
+  --mount "type=bind,src=$state,dst=/run/state" \
+  --entrypoint node "$image" /app/scripts/listener-account-production/activate-env.mjs \
+  /run/listener.env /run/account.env /run/state/candidate.env \
+  "$expected_sha" "$build_time" "$expected_schema"
+private_file "$state/candidate.env" 'candidate Listener environment'
+
+. "$root/scripts/early-birds-preview/lib.sh"
+candidate_images=$(preview_compose_command "$state/candidate.env" config --images)
+printf '%s\n' "$candidate_images" | grep -Fxq "$image" || fail 'Compose does not select the exact candidate image'
+
+cutover_started=0
+rollback_on_failure() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if test "$status" -ne 0 && test "$cutover_started" -eq 1; then
+    echo 'Listener production Account activation failed; restoring prior env and image.' >&2
+    temporary="${listener_env}.rollback-$$"
+    install -o root -g root -m 0600 "$state/previous.env" "$temporary" || true
+    mv -T "$temporary" "$listener_env" || true
+    preview_compose_command "$listener_env" up -d --no-deps --force-recreate --no-build listener || true
+    wait_healthy || true
+    "$root/scripts/listener-account-production/health-smoke.sh" \
+      "$previous_sha" 0 "$previous_schema" || true
+  elif test "$status" -ne 0; then
+    rm -rf "$state"
+  fi
+  exit "$status"
+}
+trap rollback_on_failure EXIT
+trap 'exit 130' HUP INT TERM
+
+temporary="${listener_env}.activate-$$"
+cutover_started=1
+install -o root -g root -m 0600 "$state/candidate.env" "$temporary"
+mv -T "$temporary" "$listener_env"
+rm -f "$state/candidate.env"
+preview_compose_command "$listener_env" up -d --no-deps --force-recreate --no-build listener
+wait_healthy || fail 'Listener did not become healthy'
+
+running_image=$(docker inspect earlybirds-preview-listener-1 --format '{{.Config.Image}}')
+test "$running_image" = "$image" || fail 'running Listener image mismatch'
+running_sha=$(docker inspect earlybirds-preview-listener-1 \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$running_sha" = "$expected_sha" || fail 'running Listener SHA mismatch'
+"$root/scripts/listener-account-production/health-smoke.sh" \
+  "$expected_sha" 1 "$expected_schema"
+docker inspect earlybirds-preview-listener-1 \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' > "$state/runtime-after.env"
+chmod 0600 "$state/runtime-after.env"
+write_protected_environment "$state/runtime-after.env" "$state/protected-env.after"
+rm -f "$state/runtime-after.env"
+cmp -s "$state/protected-env.before" "$state/protected-env.after" ||
+  fail 'payments, stream or authority environment changed during Account activation'
+write_protected_containers "$state/protected-containers.after"
+cmp -s "$state/protected-containers.before" "$state/protected-containers.after" ||
+  fail 'protected Listener dependencies changed during Account activation'
+
+{
+  printf 'activated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'candidate_sha=%s\n' "$expected_sha"
+  printf 'candidate_schema=%s\n' "$expected_schema"
+  printf 'previous_sha=%s\n' "$previous_sha"
+  printf 'listener_health=pass\n'
+  printf 'account_preflight=pass\n'
+  printf 'public_login=pass\n'
+  printf 'protected_runtime=unchanged\n'
+} > "$state/result.txt"
+chmod 0600 "$state/result.txt"
+(cd "$state" && sha256sum previous.env previous-image.txt previous-sha.txt previous-schema.txt \
+  candidate-image.txt protected-env.before protected-env.after protected-containers.before \
+  protected-containers.after result.txt > SHA256SUMS)
+chmod 0600 "$state/SHA256SUMS"
+last_activation_temporary="$state_root/last-activation.tmp-$$"
+printf '%s\n' "$state" > "$last_activation_temporary"
+chmod 0600 "$last_activation_temporary"
+mv -T "$last_activation_temporary" "$state_root/last-activation"
+
+cutover_started=0
+trap - EXIT HUP INT TERM
+echo "Listener production Account RP is healthy at exact SHA $expected_sha."
+echo "Rollback state: $state"

--- a/scripts/listener-account-production/health-smoke.sh
+++ b/scripts/listener-account-production/health-smoke.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env sh
+set -eu
+
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+expected_sha=${1:?usage: health-smoke.sh expected-sha40 account-mode expected-schema}
+account_mode=${2:?usage: health-smoke.sh expected-sha40 account-mode expected-schema}
+expected_schema=${3:?usage: health-smoke.sh expected-sha40 account-mode expected-schema}
+printf '%s\n' "$expected_sha" | grep -Eq '^[0-9a-f]{40}$' || {
+  echo 'exact lowercase sha40 required' >&2; exit 2;
+}
+case "$account_mode" in 0|1) ;; *) echo 'account mode must be 0 or 1' >&2; exit 2 ;; esac
+printf '%s\n' "$expected_schema" | grep -Eq '^[0-9]{14}_[a-z0-9_]+$' || {
+  echo 'exact schema migration required' >&2; exit 2;
+}
+
+container=earlybirds-preview-listener-1
+expected_image="harmonic-beacon/earlybirds-preview-listener:$expected_sha"
+test "$(docker inspect "$container" --format '{{.Config.Image}}')" = "$expected_image" || {
+  echo 'Listener image mismatch' >&2; exit 2;
+}
+test "$(docker inspect "$container" --format '{{.State.Health.Status}}')" = healthy || {
+  echo 'Listener is not healthy' >&2; exit 2;
+}
+test "$(docker inspect "$container" --format '{{.RestartCount}}')" = 0 || {
+  echo 'Listener restarted during the cutover' >&2; exit 2;
+}
+
+work=$(mktemp -d /run/listener-account-production-health.XXXXXX)
+trap 'rm -rf "$work"' EXIT
+trap 'exit 130' HUP INT TERM
+docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}' > "$work/runtime.env"
+chmod 0600 "$work/runtime.env"
+env_value() { sed -n "s/^$1=//p" "$work/runtime.env" | tail -n 1 | tr -d '\r'; }
+test "$(env_value BEACON_GIT_SHA)" = "$expected_sha" || { echo 'Listener SHA mismatch' >&2; exit 2; }
+test "$(env_value BEACON_DATABASE_SCHEMA_VERSION)" = "$expected_schema" || {
+  echo 'Listener schema provenance mismatch' >&2; exit 2;
+}
+runtime_account_mode=$(env_value BEACON_LISTENER_ACCOUNT_ENABLED)
+if test "$account_mode" -eq 1; then
+  test "$runtime_account_mode" = 1 || { echo 'Listener Account mode mismatch' >&2; exit 2; }
+else
+  case "$runtime_account_mode" in ''|0) ;; *) echo 'Listener Account mode mismatch' >&2; exit 2 ;; esac
+fi
+
+if test "$account_mode" -eq 1; then
+  test "$(env_value BEACON_LISTENER_ACCOUNT_ENVIRONMENT)" = production || {
+    echo 'Listener Account environment mismatch' >&2; exit 2;
+  }
+  client_secret=$(env_value BEACON_LISTENER_ACCOUNT_CLIENT_SECRET)
+  state_secret=$(env_value BEACON_LISTENER_ACCOUNT_STATE_SECRET)
+  test "${#client_secret}" -ge 32 && test "${#state_secret}" -ge 32 || {
+    echo 'Listener Account credentials are missing' >&2; exit 2;
+  }
+  test "$client_secret" != "$state_secret" || { echo 'Listener Account credentials are reused' >&2; exit 2; }
+  for key in \
+    BEACON_LISTENER_ACCOUNT_CLIENT_SECRET_STAGING \
+    BEACON_LISTENER_ACCOUNT_STATE_SECRET_STAGING \
+    EARLY_BIRDS_GOOGLE_CLIENT_ID \
+    EARLY_BIRDS_GOOGLE_CLIENT_SECRET \
+    BEACON_LISTENER_APPLE_CLIENT_ID \
+    BEACON_LISTENER_APPLE_CLIENT_SECRET \
+    EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL \
+    EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN \
+    EARLY_BIRDS_MAGIC_LINK_RATE_SECRET; do
+    test -z "$(env_value "$key")" || {
+      echo 'legacy or cross-environment identity material is active' >&2; exit 2;
+    }
+  done
+  test "$(env_value BEACON_LISTENER_APPLE_ENABLED)" = 0 || {
+    echo 'direct Listener Apple identity is active' >&2; exit 2;
+  }
+else
+  test -z "$(env_value BEACON_LISTENER_ACCOUNT_CLIENT_SECRET)" || {
+    echo 'Account-off Listener contains an Account credential' >&2; exit 2;
+  }
+  test -z "$(env_value BEACON_LISTENER_ACCOUNT_STATE_SECRET)" || {
+    echo 'Account-off Listener contains an Account state secret' >&2; exit 2;
+  }
+fi
+
+curl --fail --silent --show-error --connect-timeout 3 --max-time 8 \
+  http://127.0.0.1:13000/api/health > "$work/local-health.json"
+curl --fail --silent --show-error --connect-timeout 3 --max-time 8 \
+  http://127.0.0.1:13000/api/health/ready > "$work/local-ready.json"
+curl --fail --silent --show-error --connect-timeout 3 --max-time 8 \
+  http://127.0.0.1:18080/healthz >/dev/null
+curl --fail --silent --show-error --proto '=https' --connect-timeout 3 --max-time 8 \
+  https://listen.harmonicbeacon.com/api/health > "$work/public-health.json"
+jq --exit-status --arg sha "$expected_sha" --arg schema "$expected_schema" \
+  '.status == "ok" and .gitSha == $sha and .databaseSchemaVersion == $schema' \
+  "$work/local-health.json" >/dev/null
+jq --exit-status --arg sha "$expected_sha" --arg schema "$expected_schema" \
+  '.status == "ok" and .gitSha == $sha and .databaseSchemaVersion == $schema' \
+  "$work/public-health.json" >/dev/null
+jq --exit-status '.status == "ok" and .checks.database == "ok" and .checks.listenerRuntime == "ok"' \
+  "$work/local-ready.json" >/dev/null
+
+login_code=$(curl --silent --show-error --proto '=https' --connect-timeout 3 --max-time 8 \
+  --dump-header "$work/login.headers" --output /dev/null --write-out '%{http_code}' \
+  https://listen.harmonicbeacon.com/api/account/login)
+if test "$account_mode" -eq 1; then
+  case "$login_code" in 302|303) ;; *) echo 'public Account login did not redirect' >&2; exit 2 ;; esac
+  grep -Eiq '^location: https://account\.harmonicbeacon\.com/api/account/auth/oauth2/authorize\?' \
+    "$work/login.headers" || { echo 'public Account login targets the wrong issuer' >&2; exit 2; }
+  grep -Eiq '^set-cookie: __Host-hb_listener_account_attempt=' "$work/login.headers" || {
+    echo 'public Account login did not set its host-only attempt cookie' >&2; exit 2;
+  }
+  jq --exit-status '.checks.listenerAccount == "ok"' "$work/local-ready.json" >/dev/null
+else
+  test "$login_code" = 404 || { echo 'Account-off Listener exposes Account login' >&2; exit 2; }
+fi
+
+suffix_code=$(curl --silent --show-error --proto '=https' --connect-timeout 3 --max-time 8 \
+  --output /dev/null --write-out '%{http_code}' \
+  https://listen.harmonicbeacon.com/api/account/login/extra)
+test "$suffix_code" = 404 || { echo 'public Listener Account suffix is exposed' >&2; exit 2; }
+echo "Listener production health and Account mode $account_mode are exact at SHA $expected_sha."

--- a/scripts/listener-account-production/rollback.sh
+++ b/scripts/listener-account-production/rollback.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env sh
+set -eu
+
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+state=${1:?usage: rollback.sh /var/lib/harmonic-beacon/listener-account-production/activation-*}
+case "$state" in
+  /var/lib/harmonic-beacon/listener-account-production/activation-*) ;;
+  *) echo 'unexpected rollback state path' >&2; exit 2 ;;
+esac
+test -d "$state" && test ! -L "$state" || { echo 'rollback state must be a regular directory' >&2; exit 2; }
+test "$(stat -c '%U:%G:%a' "$state")" = root:root:700 || {
+  echo 'rollback state must be root:root mode 0700' >&2; exit 2;
+}
+for file in previous.env previous-image.txt previous-sha.txt previous-schema.txt \
+  candidate-image.txt protected-env.before protected-env.after \
+  protected-containers.before protected-containers.after result.txt SHA256SUMS; do
+  test -f "$state/$file" && test ! -L "$state/$file" || { echo 'rollback state is incomplete' >&2; exit 2; }
+  test "$(stat -c '%U:%G:%a' "$state/$file")" = root:root:600 || {
+    echo 'rollback state file must be root:root mode 0600' >&2; exit 2;
+  }
+done
+(cd "$state" && sha256sum -c SHA256SUMS >/dev/null)
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+listener_env=/etc/harmonic-beacon/earlybirds-preview.env
+previous_image=$(sed -n '1p' "$state/previous-image.txt")
+previous_sha=$(sed -n '1p' "$state/previous-sha.txt")
+previous_schema=$(sed -n '1p' "$state/previous-schema.txt")
+candidate_image=$(sed -n '1p' "$state/candidate-image.txt")
+test "$previous_image" = "harmonic-beacon/earlybirds-preview-listener:$previous_sha" || {
+  echo 'previous image provenance is inconsistent' >&2; exit 2;
+}
+case "$candidate_image" in
+  harmonic-beacon/earlybirds-preview-listener:[0-9a-f][0-9a-f]*) ;;
+  *) echo 'candidate image reference is invalid' >&2; exit 2 ;;
+esac
+candidate_sha=${candidate_image#harmonic-beacon/earlybirds-preview-listener:}
+printf '%s\n' "$candidate_sha" | grep -Eq '^[0-9a-f]{40}$' || {
+  echo 'candidate image SHA is invalid' >&2; exit 2;
+}
+printf '%s\n' "$previous_schema" | grep -Eq '^[0-9]{14}_[a-z0-9_]+$' || {
+  echo 'previous schema provenance is invalid' >&2; exit 2;
+}
+test "$(docker inspect earlybirds-preview-listener-1 --format '{{.Config.Image}}')" = "$candidate_image" || {
+  echo 'running Listener does not match this rollback candidate' >&2; exit 2;
+}
+docker image inspect "$previous_image" >/dev/null 2>&1 || { echo 'previous image is missing' >&2; exit 2; }
+
+exec 9>/run/lock/listener-account-production.lock
+flock -n 9 || { echo 'another Listener Account production operation is active' >&2; exit 2; }
+temporary="${listener_env}.rollback-$$"
+trap 'rm -f "$temporary"' EXIT
+# Once the rollback env replacement begins, finish restoring the exact prior
+# app instead of accepting a half-applied operator interrupt.
+trap '' HUP INT TERM
+install -o root -g root -m 0600 "$state/previous.env" "$temporary"
+mv -T "$temporary" "$listener_env"
+
+. "$root/scripts/early-birds-preview/lib.sh"
+test "$(preview_env_value EARLYBIRDS_PREVIEW_IMAGE_TAG "$listener_env")" = "$previous_sha" || {
+  echo 'restored env image tag mismatch' >&2; exit 2;
+}
+test "$(preview_env_value EARLYBIRDS_PREVIEW_GIT_SHA "$listener_env")" = "$previous_sha" || {
+  echo 'restored env SHA mismatch' >&2; exit 2;
+}
+test "$(preview_env_value EARLYBIRDS_PREVIEW_SCHEMA_VERSION "$listener_env")" = "$previous_schema" || {
+  echo 'restored env schema mismatch' >&2; exit 2;
+}
+preview_compose_command "$listener_env" up -d --no-deps --force-recreate --no-build listener
+attempt=0
+while test "$attempt" -lt 60; do
+  health=$(docker inspect earlybirds-preview-listener-1 \
+    --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>/dev/null || true)
+  test "$health" != healthy || break
+  attempt=$((attempt + 1))
+  sleep 2
+done
+test "$health" = healthy || { echo 'restored Listener did not become healthy' >&2; exit 2; }
+test "$(docker inspect earlybirds-preview-listener-1 --format '{{.Config.Image}}')" = "$previous_image" || {
+  echo 'restored Listener image mismatch' >&2; exit 2;
+}
+running_sha=$(docker inspect earlybirds-preview-listener-1 \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$running_sha" = "$previous_sha" || { echo 'restored Listener SHA mismatch' >&2; exit 2; }
+"$root/scripts/listener-account-production/health-smoke.sh" \
+  "$previous_sha" 0 "$previous_schema"
+trap - EXIT HUP INT TERM
+echo "Listener production restored to exact SHA $previous_sha; database was not downgraded."


### PR DESCRIPTION
## Outcome

Adds the missing production Account edge bootstrap and a fail-closed, reversible Listener Account activation lifecycle. No runtime, DNS, database, media, event, payment, or provider state is changed by this PR.

## Safety boundary

- DNSExit remains human-operated; repository scripts never mutate DNS.
- Account hostname returns ACME-only/503 before TLS, then normalizes unavailable upstreams to no-store 503.
- Listener activation validates exact image/SHA/schema, runs Account preflight before persistent writes, preserves payments/stream/authority settings, and recreates only the Listener app.
- Automatic and manual rollback restore the exact prior root-owned env and image without schema downgrade.
- Direct Listener Google/Apple/magic-link material is removed only in the Account-on candidate and retained in the protected rollback snapshot.

## Evidence

- Full hook: 209 test files passed, 9 skipped; 1792 tests passed, 44 skipped.
- Listener production contract: 7/7.
- Account infra contract: 22/22.
- TypeScript, focused ESLint, production build, dependency audit, shell/Node syntax, diff-check: green.
- Real Mona Nginx syntax for bootstrap/final templates: green.
- Real production Listener Account-OFF health smoke: green at current immutable SHA; runtime unchanged.
- Real root-only candidate-env dry run preserved PayPal/Mercado Pago Live flags and selected the exact Account schema.
