### PR TITLE
Add safe Account social-provider activation lifecycle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-quiesce-for-free
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-withdrawal-operator.ts ./scripts/listener-withdrawal-operator.ts
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/check-migrations.mjs ./scripts/beacon-account/check-migrations.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/provision-production-role.mjs ./scripts/beacon-account/provision-production-role.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/beacon-account/social-provider-env.mjs ./scripts/beacon-account/social-provider-env.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-account-production/sync-secret.mjs ./scripts/listener-account-production/sync-secret.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-account-production/preflight.mjs ./scripts/listener-account-production/preflight.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/listener-account-production/activate-env.mjs ./scripts/listener-account-production/activate-env.mjs

--- a/docs/operations/BEACON_ACCOUNT_SOCIAL_PROVIDERS.md
+++ b/docs/operations/BEACON_ACCOUNT_SOCIAL_PROVIDERS.md
@@ -42,17 +42,21 @@ Google consent screen remains in Testing, add only the intended human testers.
 The application requests the provider's ordinary identity scopes; Google email
 is profile data, never membership or linking authority.
 
-Install the client ID and secret only in the corresponding root-owned Account
-environment:
+Prepare the client ID and secret only in the corresponding root-owned provider
+bundle. The activation lifecycle, rather than a manual edit, installs them in
+the Account environment:
 
 ```text
-BEACON_ACCOUNT_GOOGLE_ENABLED=0
 BEACON_ACCOUNT_GOOGLE_CLIENT_ID=<web-client-id>.apps.googleusercontent.com
 BEACON_ACCOUNT_GOOGLE_CLIENT_SECRET=<secret>
 ```
 
-Keep the switch at `0` while installing and validating the bundle. Never place
-staging and production credentials in the same runtime.
+Use exactly one of these fixed files, owned by `root:root` with mode `0600`:
+
+- `/etc/harmonic-beacon/account-provider-staging-google.env`
+- `/etc/harmonic-beacon/account-provider-production-google.env`
+
+Never place staging and production credentials in the same bundle or runtime.
 
 ## Apple Developer setup
 
@@ -77,14 +81,18 @@ The exact Apple callbacks are:
 - production:
   `https://account.harmonicbeacon.com/api/account/auth/callback/apple`
 
-Generate the JWT offline from the protected `.p8`. Install only the Services
-ID and generated JWT:
+Generate the JWT offline from the protected `.p8`. Put only the Services ID and
+generated JWT in the target provider bundle:
 
 ```text
-BEACON_ACCOUNT_APPLE_ENABLED=0
 BEACON_ACCOUNT_APPLE_CLIENT_ID=<services-id>
 BEACON_ACCOUNT_APPLE_CLIENT_SECRET=<current-es256-jwt>
 ```
+
+Use exactly one of these fixed files, owned by `root:root` with mode `0600`:
+
+- `/etc/harmonic-beacon/account-provider-staging-apple.env`
+- `/etc/harmonic-beacon/account-provider-production-apple.env`
 
 The application rejects a raw `.p8`, a malformed JWT, the wrong audience or
 subject, and an expired JWT. Apple may provide name and email only on first
@@ -95,27 +103,46 @@ neutral provider-independent Beacon profile; they never trigger email linking.
 
 Do one provider at a time.
 
-1. Confirm the exact reviewed release and a clean checkout.
-2. Create a fresh encrypted Account staging database backup and verify it with
-   `pg_restore --list`. Back up the current root-owned environment separately.
-3. Confirm the target environment file is a regular, non-symlink
-   `root:root 0600` file. Install the complete provider bundle atomically while
-   its enable flag remains `0`.
-4. Run the containerized Account environment validator with network disabled.
-   It must accept both production and staging files without printing values.
-5. Change only the target provider switch from `0` to `1`, recreate Account
-   staging app only through the reviewed lifecycle, and keep rollback active
-   through the external smoke.
-6. Require Account readiness at the exact candidate SHA with
+1. Confirm the exact reviewed release, clean checkout, exact running image and
+   root-owned deployment coordinates.
+2. Create the exact two-line provider bundle at the fixed path above. Do not
+   pass either value on a command line and do not print the file.
+3. Run, for example:
+
+   ```sh
+   sudo scripts/beacon-account/activate-social-provider.sh \
+     staging google /etc/harmonic-beacon/beacon-account-deploy.env
+   ```
+
+   The lifecycle creates and verifies a fresh encrypted database backup,
+   stores the prior Account environment in a root-only rollback directory,
+   builds a complete candidate environment inside the exact image with no
+   network, and validates the complete production/staging pair before any
+   cutover. There is no installed-but-disabled intermediate state.
+4. The lifecycle atomically replaces only the target Account environment and
+   recreates only the target Account app. It does not recreate the mail worker,
+   database, Listener, Live, event, stream, or payment services. Any readiness,
+   discovery, JWKS, or provider-visibility failure automatically restores the
+   previous environment and app.
+5. Require Account readiness at the exact candidate SHA with
    `checks.providers=ok`. Confirm the Account page shows only the provider just
    enabled and email/password remains available.
-7. Complete supervised human acceptance before enabling the other provider or
+6. Complete supervised human acceptance before enabling the other provider or
    touching production.
 
-Rollback is the backed-up environment with that provider switch restored to
-`0`, followed by recreating only the Account app. Disabling a provider hides
-new sign-in without deleting accounts, profiles, sessions, or product data.
-Do not delete provider identities as rollback.
+The successful command prints a root-only rollback-state path. Manual rollback
+uses that exact state and the same deployment coordinates:
+
+```sh
+sudo scripts/beacon-account/rollback-social-provider.sh \
+  /var/lib/harmonic-beacon/account-social-providers/<exact-state> \
+  /etc/harmonic-beacon/beacon-account-deploy.env
+```
+
+Rollback restores the complete prior environment and recreates only the
+Account app. Disabling a provider hides new sign-in without deleting accounts,
+profiles, sessions, or product data. Do not delete provider identities as
+rollback.
 
 ## Human acceptance
 

--- a/ops/beacon-account/test/contract.test.mjs
+++ b/ops/beacon-account/test/contract.test.mjs
@@ -512,10 +512,12 @@ test('social-provider runbook uses only central Account callbacks and default-of
     }
   }
   for (const provider of ['GOOGLE', 'APPLE']) {
-    assert.match(runbook, new RegExp(`BEACON_ACCOUNT_${provider}_ENABLED=0`));
     assert.match(runbook, new RegExp(`BEACON_ACCOUNT_${provider}_CLIENT_ID`));
     assert.match(runbook, new RegExp(`BEACON_ACCOUNT_${provider}_CLIENT_SECRET`));
   }
+  assert.match(runbook, /activate-social-provider\.sh/);
+  assert.match(runbook, /rollback-social-provider\.sh/);
+  assert.match(runbook, /There is no installed-but-disabled intermediate state/);
   assert.doesNotMatch(runbook, /api\/early-birds\/auth\/callback\/(?:google|apple)/);
   assert.match(runbook, /Matching email never links or merges accounts/);
 
@@ -525,4 +527,42 @@ test('social-provider runbook uses only central Account callbacks and default-of
   );
   assert.match(legacy, /Legacy cutover note/);
   assert.match(legacy, /BEACON_ACCOUNT_SOCIAL_PROVIDERS\.md/);
+});
+
+test('social-provider activation is exact-image, offline, backed up and app-only', () => {
+  const activate = fs.readFileSync(
+    path.resolve(ROOT, '../../scripts/beacon-account/activate-social-provider.sh'),
+    'utf8',
+  );
+  const rollback = fs.readFileSync(
+    path.resolve(ROOT, '../../scripts/beacon-account/rollback-social-provider.sh'),
+    'utf8',
+  );
+  const transformer = fs.readFileSync(
+    path.resolve(ROOT, '../../scripts/beacon-account/social-provider-env.mjs'),
+    'utf8',
+  );
+  const dockerfile = fs.readFileSync(path.resolve(ROOT, '../../Dockerfile'), 'utf8');
+  assert.match(activate, /account-provider-\$environment-\$provider\.env/);
+  assert.match(activate, /account_backup_(?:production|staging)/);
+  assert.match(activate, /--network none --read-only --user 0:0 --cap-drop ALL/);
+  assert.match(activate, /social-provider-env\.mjs/);
+  assert.match(activate, /validate\.mjs/);
+  assert.match(activate, /up -d --no-deps --force-recreate --no-build "account-\$environment"/);
+  assert.match(activate, /mail worker changed during provider activation/);
+  assert.doesNotMatch(activate, /account-mail-worker-\$environment"/);
+  assert.doesNotMatch(activate, /^state=/m);
+  assert.doesNotMatch(rollback, /^state=/m);
+  assert.match(rollback, /identities and sessions were retained/);
+  assert.match(transformer, /bundle must contain only the exact provider client ID and secret/);
+  assert.match(dockerfile, /scripts\/beacon-account\/social-provider-env\.mjs/);
+  for (const script of [
+    'activate-social-provider.sh',
+    'rollback-social-provider.sh',
+  ]) {
+    const checked = spawnSync('sh', ['-n', path.resolve(ROOT, `../../scripts/beacon-account/${script}`)], {
+      encoding: 'utf8',
+    });
+    assert.equal(checked.status, 0, checked.stderr);
+  }
 });

--- a/ops/beacon-account/test/fixtures/google-provider.env
+++ b/ops/beacon-account/test/fixtures/google-provider.env
@@ -1,0 +1,2 @@
+BEACON_ACCOUNT_GOOGLE_CLIENT_ID=staging-client.apps.googleusercontent.com
+BEACON_ACCOUNT_GOOGLE_CLIENT_SECRET=synthetic_google_secret_1234567890

--- a/ops/beacon-account/test/social-provider-env.test.mjs
+++ b/ops/beacon-account/test/social-provider-env.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { buildSocialProviderActivation } from '../../../scripts/beacon-account/social-provider-env.mjs';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const staging = fs.readFileSync(path.join(ROOT, 'account.staging.env.example'), 'utf8');
+const production = fs.readFileSync(path.join(ROOT, 'account.production.env.example'), 'utf8');
+
+function jwt(payload = {}, header = {}) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${encode({ alg: 'ES256', kid: 'KEY1234567', ...header })}.${encode({
+    iss: 'TEAM123456',
+    sub: 'com.harmonicbeacon.account.staging',
+    aud: 'https://appleid.apple.com',
+    iat: 2_000_000_000,
+    exp: 2_000_086_400,
+    ...payload,
+  })}.${Buffer.alloc(64, 1).toString('base64url')}`;
+}
+
+test('prepares an exact Google activation without changing unrelated Account values', () => {
+  const bundle = [
+    'BEACON_ACCOUNT_GOOGLE_CLIENT_ID=staging-client.apps.googleusercontent.com',
+    'BEACON_ACCOUNT_GOOGLE_CLIENT_SECRET=google_secret_1234567890',
+    '',
+  ].join('\n');
+  const result = buildSocialProviderActivation({
+    accountContents: staging,
+    bundleContents: bundle,
+    environment: 'staging',
+    provider: 'google',
+  });
+  assert.match(result, /^BEACON_ACCOUNT_GOOGLE_ENABLED=1$/m);
+  assert.match(result, /^BEACON_ACCOUNT_GOOGLE_CLIENT_ID=staging-client\.apps\.googleusercontent\.com$/m);
+  assert.match(result, /^BEACON_ACCOUNT_GOOGLE_CLIENT_SECRET=google_secret_1234567890$/m);
+  assert.match(result, /^BEACON_ACCOUNT_APPLE_ENABLED=0$/m);
+  assert.equal(
+    result.replace(/^BEACON_ACCOUNT_GOOGLE_(?:ENABLED|CLIENT_ID|CLIENT_SECRET)=.*$/gm, ''),
+    staging.replace(/^BEACON_ACCOUNT_GOOGLE_(?:ENABLED|CLIENT_ID|CLIENT_SECRET)=.*$/gm, ''),
+  );
+});
+
+test('accepts a current bounded Apple JWT and preserves production isolation', () => {
+  const secret = jwt();
+  const result = buildSocialProviderActivation({
+    accountContents: production,
+    bundleContents: `BEACON_ACCOUNT_APPLE_CLIENT_ID=com.harmonicbeacon.account.staging\nBEACON_ACCOUNT_APPLE_CLIENT_SECRET=${secret}\n`,
+    environment: 'production',
+    provider: 'apple',
+    nowSeconds: 2_000_000_100,
+  });
+  assert.match(result, /^BEACON_ACCOUNT_APPLE_ENABLED=1$/m);
+  assert.match(result, /^BEACON_ACCOUNT_GOOGLE_ENABLED=0$/m);
+});
+
+test('rejects issuer mismatch, extra keys, enabled targets and invalid provider material', () => {
+  const google = 'BEACON_ACCOUNT_GOOGLE_CLIENT_ID=x.apps.googleusercontent.com\nBEACON_ACCOUNT_GOOGLE_CLIENT_SECRET=google_secret_1234567890\n';
+  const base = { accountContents: staging, environment: 'staging', provider: 'google' };
+  assert.throws(() => buildSocialProviderActivation({ ...base, environment: 'production', bundleContents: google }), /issuer mismatch/);
+  assert.throws(() => buildSocialProviderActivation({ ...base, bundleContents: `${google}UNEXPECTED=1\n` }), /only the exact/);
+  assert.throws(() => buildSocialProviderActivation({
+    ...base,
+    accountContents: staging.replace('BEACON_ACCOUNT_GOOGLE_ENABLED=0', 'BEACON_ACCOUNT_GOOGLE_ENABLED=1'),
+    bundleContents: google,
+  }), /fully disabled/);
+  assert.throws(() => buildSocialProviderActivation({
+    ...base,
+    bundleContents: 'BEACON_ACCOUNT_GOOGLE_CLIENT_ID=not-google\nBEACON_ACCOUNT_GOOGLE_CLIENT_SECRET=google_secret_1234567890\n',
+  }), /client ID/);
+});
+
+test('rejects raw, expired, overlong, wrong-subject and noncanonical Apple secrets', () => {
+  const make = (secret) => `BEACON_ACCOUNT_APPLE_CLIENT_ID=com.harmonicbeacon.account.staging\nBEACON_ACCOUNT_APPLE_CLIENT_SECRET=${secret}\n`;
+  const base = {
+    accountContents: staging,
+    environment: 'staging',
+    provider: 'apple',
+    nowSeconds: 2_000_000_100,
+  };
+  assert.throws(() => buildSocialProviderActivation({ ...base, bundleContents: make('-----BEGIN PRIVATE KEY-----') }), /invalid/);
+  assert.throws(() => buildSocialProviderActivation({ ...base, bundleContents: make(jwt({ exp: 2_000_000_099 })) }), /claims/);
+  assert.throws(() => buildSocialProviderActivation({ ...base, bundleContents: make(jwt({ exp: 2_020_000_000 })) }), /claims/);
+  assert.throws(() => buildSocialProviderActivation({ ...base, bundleContents: make(jwt({ sub: 'wrong' })) }), /claims/);
+  assert.throws(() => buildSocialProviderActivation({ ...base, bundleContents: make(`${jwt()}=`) }), /invalid/);
+});

--- a/scripts/beacon-account/activate-social-provider.sh
+++ b/scripts/beacon-account/activate-social-provider.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env sh
+set -eu
+. "$(dirname -- "$0")/lib.sh"
+
+test "$(id -u)" -eq 0 || account_fail 'run as root'
+environment=${1:?usage: activate-social-provider.sh staging|production google|apple /secure/deploy.env}
+provider=${2:?usage: activate-social-provider.sh staging|production google|apple /secure/deploy.env}
+ACCOUNT_DEPLOY_FILE=${3:?usage: activate-social-provider.sh staging|production google|apple /secure/deploy.env}
+export ACCOUNT_DEPLOY_FILE
+case "$environment" in staging|production) ;; *) account_fail 'environment must be staging or production' ;; esac
+case "$provider" in google|apple) ;; *) account_fail 'provider must be google or apple' ;; esac
+
+account_load_deploy_env "$ACCOUNT_DEPLOY_FILE"
+root=$(account_repo_root)
+image="harmonic-beacon/account:$BEACON_ACCOUNT_GIT_SHA"
+account_env=$BEACON_ACCOUNT_STAGING_ENV_FILE
+test "$environment" != production || account_env=$BEACON_ACCOUNT_PRODUCTION_ENV_FILE
+bundle="/etc/harmonic-beacon/account-provider-$environment-$provider.env"
+state_root=/var/lib/harmonic-beacon/account-social-providers
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+activation_state="$state_root/$environment-$provider-$BEACON_ACCOUNT_GIT_SHA-$stamp"
+container=$(account_container_name "$environment")
+worker=$(account_mail_worker_container_name "$environment")
+database_container=beacon-account-account-staging-postgres-1
+test "$environment" != production || database_container=earlybirds-preview-postgres-1
+
+exec 9>"/run/lock/beacon-account-$environment.lock"
+flock -n 9 || account_fail "another $environment Account operation is active"
+account_require_private_file "$bundle"
+test "$(git -C "$root" rev-parse HEAD)" = "$BEACON_ACCOUNT_GIT_SHA" || account_fail 'release checkout SHA mismatch'
+test -z "$(git -C "$root" status --porcelain)" || account_fail 'release checkout is dirty'
+docker image inspect "$image" >/dev/null 2>&1 || account_fail 'exact Account image is missing'
+baked_sha=$(docker image inspect "$image" --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$baked_sha" = "$BEACON_ACCOUNT_GIT_SHA" || account_fail 'Account image provenance mismatch'
+account_verify_running "$environment" "$BEACON_ACCOUNT_GIT_SHA" "$BEACON_ACCOUNT_IMAGE_TAG" 1
+test "$(docker inspect "$container" --format '{{.Config.Image}}')" = "$image" || account_fail 'running Account image mismatch'
+
+if test -e "$state_root"; then
+  test -d "$state_root" && test ! -L "$state_root" || account_fail 'provider state root must be a regular directory'
+  test "$(stat -c '%U:%G:%a' "$state_root")" = root:root:700 || account_fail 'provider state root must be root:root 0700'
+else
+  install -d -o root -g root -m 0700 "$state_root"
+fi
+test ! -e "$activation_state" || account_fail 'provider activation state already exists'
+install -d -o root -g root -m 0700 "$activation_state"
+install -o root -g root -m 0600 "$account_env" "$activation_state/previous.env"
+printf '%s\n' "$environment" > "$activation_state/environment.txt"
+printf '%s\n' "$provider" > "$activation_state/provider.txt"
+printf '%s\n' "$BEACON_ACCOUNT_GIT_SHA" > "$activation_state/sha.txt"
+docker inspect "$container" --format '{{.Id}}' > "$activation_state/app-id.before"
+docker inspect "$worker" --format '{{.Id}}' > "$activation_state/worker-id.before"
+docker inspect "$database_container" --format '{{.Id}}' > "$activation_state/database-id.before"
+chmod 0600 "$activation_state"/*.txt "$activation_state"/*.before
+
+cleanup_before_cutover() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if test "$status" -ne 0; then rm -rf "$activation_state"; fi
+  exit "$status"
+}
+trap cleanup_before_cutover EXIT HUP INT TERM
+
+if test "$environment" = production; then
+  backup=$(account_backup_production)
+else
+  backup=$(account_backup_staging)
+fi
+printf '%s\n' "$backup" > "$activation_state/database-backup.txt"
+sha256sum "$backup" | awk '{print $1}' > "$activation_state/database-backup.sha256"
+chmod 0600 "$activation_state/database-backup.txt"
+chmod 0600 "$activation_state/database-backup.sha256"
+
+docker run --rm --pull never --network none --read-only --user 0:0 --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --mount "type=bind,src=$account_env,dst=/run/account.env,readonly" \
+  --mount "type=bind,src=$bundle,dst=/run/provider.env,readonly" \
+  --mount "type=bind,src=$activation_state,dst=/run/state" \
+  --entrypoint node "$image" /app/scripts/beacon-account/social-provider-env.mjs \
+    /run/account.env /run/provider.env /run/state/candidate.env "$environment" "$provider"
+account_require_private_file "$activation_state/candidate.env"
+
+production_candidate=$BEACON_ACCOUNT_PRODUCTION_ENV_FILE
+staging_candidate=$BEACON_ACCOUNT_STAGING_ENV_FILE
+test "$environment" != production || production_candidate=$activation_state/candidate.env
+test "$environment" != staging || staging_candidate=$activation_state/candidate.env
+docker run --rm --pull never --network none --read-only --cap-drop ALL --user 0:0 \
+  --security-opt no-new-privileges \
+  --mount "type=bind,src=$production_candidate,dst=/run/account-production.env,readonly" \
+  --mount "type=bind,src=$staging_candidate,dst=/run/account-staging.env,readonly" \
+  --mount "type=bind,src=$BEACON_ACCOUNT_STAGING_DB_ENV_FILE,dst=/run/account-staging-database.env,readonly" \
+  --mount "type=bind,src=$BEACON_ACCOUNT_MAIL_WORKER_PRODUCTION_ENV_FILE,dst=/run/account-mail-worker-production.env,readonly" \
+  --mount "type=bind,src=$BEACON_ACCOUNT_MAIL_WORKER_STAGING_ENV_FILE,dst=/run/account-mail-worker-staging.env,readonly" \
+  --entrypoint node "$image" /app/ops/beacon-account/validate.mjs \
+    /run/account-production.env /run/account-staging.env /run/account-staging-database.env \
+    /run/account-mail-worker-production.env /run/account-mail-worker-staging.env
+
+cutover_started=0
+rollback_on_failure() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if test "$status" -ne 0 && test "$cutover_started" -eq 1; then
+    echo 'Beacon Account provider activation failed; restoring the previous environment.' >&2
+    temporary="${account_env}.rollback-$$"
+    install -o root -g root -m 0600 "$activation_state/previous.env" "$temporary" || true
+    mv -T "$temporary" "$account_env" || true
+    account_compose up -d --no-deps --force-recreate --no-build "account-$environment" || true
+    account_wait_healthy "$container" || true
+  elif test "$status" -ne 0; then
+    rm -rf "$activation_state"
+  fi
+  exit "$status"
+}
+trap rollback_on_failure EXIT
+trap 'exit 130' HUP INT TERM
+
+temporary="${account_env}.provider-$$"
+cutover_started=1
+install -o root -g root -m 0600 "$activation_state/candidate.env" "$temporary"
+mv -T "$temporary" "$account_env"
+rm -f "$activation_state/candidate.env"
+account_compose up -d --no-deps --force-recreate --no-build "account-$environment"
+account_wait_healthy "$container"
+account_verify_running "$environment" "$BEACON_ACCOUNT_GIT_SHA" "$BEACON_ACCOUNT_IMAGE_TAG" 1
+"$root/scripts/beacon-account/health-smoke.sh" \
+  "$environment" "$ACCOUNT_DEPLOY_FILE" "$BEACON_ACCOUNT_GIT_SHA" 1 1
+test "$(docker inspect "$worker" --format '{{.Id}}')" = "$(cat "$activation_state/worker-id.before")" ||
+  account_fail 'mail worker changed during provider activation'
+test "$(docker inspect "$database_container" --format '{{.Id}}')" = "$(cat "$activation_state/database-id.before")" ||
+  account_fail 'database changed during provider activation'
+
+origin=https://account.harmonicbeacon.com
+test "$environment" != staging || origin=https://account-staging.harmonicbeacon.com
+page="$activation_state/account-page.html"
+curl --fail --silent --show-error --proto '=https' --connect-timeout 3 --max-time 8 \
+  -H 'Accept-Language: en' "$origin/account?lang=en" > "$page"
+label='Continue with Google'
+test "$provider" != apple || label='Continue with Apple'
+grep -Fq "$label" "$page" || account_fail 'enabled provider is absent from the Account page'
+grep -Fq 'Sign in' "$page" || account_fail 'email and password sign-in is absent from the Account page'
+rm -f "$page"
+
+{
+  printf 'activated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'environment=%s\n' "$environment"
+  printf 'provider=%s\n' "$provider"
+  printf 'sha=%s\n' "$BEACON_ACCOUNT_GIT_SHA"
+  printf 'database_backup=%s\n' "$backup"
+  printf 'readiness=pass\nprovider_ui=pass\nmail_worker=unchanged\n'
+} > "$activation_state/result.txt"
+chmod 0600 "$activation_state/result.txt"
+(cd "$activation_state" && sha256sum previous.env environment.txt provider.txt sha.txt app-id.before \
+  worker-id.before database-id.before database-backup.txt database-backup.sha256 result.txt > SHA256SUMS)
+chmod 0600 "$activation_state/SHA256SUMS"
+last_tmp="$state_root/last-activation.tmp-$$"
+printf '%s\n' "$activation_state" > "$last_tmp"
+chmod 0600 "$last_tmp"
+mv -T "$last_tmp" "$state_root/last-activation"
+
+cutover_started=0
+trap - EXIT HUP INT TERM
+echo "Beacon Account $provider is enabled and healthy in $environment at exact SHA $BEACON_ACCOUNT_GIT_SHA."
+echo "Rollback state: $activation_state"

--- a/scripts/beacon-account/lib.sh
+++ b/scripts/beacon-account/lib.sh
@@ -246,6 +246,7 @@ account_backup_production() (
   test "$(stat -c '%U:%G:%a' "$backup_dir")" = root:root:700 ||
     account_fail "$backup_dir must be root:root 0700"
   backup_name="account-pre-${BEACON_ACCOUNT_GIT_SHA}-$(date -u +%Y%m%dT%H%M%SZ).dump.enc"
+  test ! -e "$backup_dir/$backup_name" || account_fail 'production backup target already exists'
   backup_work=$(mktemp -d /run/beacon-account-backup.XXXXXX)
   chmod 0700 "$backup_work"
   database_env="$backup_work/database.env"
@@ -273,6 +274,43 @@ account_backup_production() (
       pg_restore --list >/dev/null || account_fail 'encrypted backup verification failed'
   trap - EXIT HUP INT TERM
   test -s "$backup_dir/$backup_name" || account_fail 'production backup is empty'
+  chmod 0600 "$backup_dir/$backup_name"
+  printf '%s\n' "$backup_dir/$backup_name"
+)
+
+account_backup_staging() (
+  backup_dir=$BEACON_ACCOUNT_BACKUP_DIR
+  test -d "$backup_dir" || account_fail "missing backup directory: $backup_dir"
+  test "$(stat -c '%U:%G:%a' "$backup_dir")" = root:root:700 ||
+    account_fail "$backup_dir must be root:root 0700"
+  container=beacon-account-account-staging-postgres-1
+  state=$(docker inspect "$container" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>/dev/null || true)
+  test "$state" = healthy || account_fail 'staging PostgreSQL is not healthy'
+  backup_name="account-staging-pre-provider-${BEACON_ACCOUNT_GIT_SHA}-$(date -u +%Y%m%dT%H%M%SZ).dump.enc"
+  test ! -e "$backup_dir/$backup_name" || account_fail 'staging backup target already exists'
+  backup_work=$(mktemp -d /run/beacon-account-staging-backup.XXXXXX)
+  chmod 0700 "$backup_work"
+  dump_fifo="$backup_work/dump.fifo"
+  mkfifo -m 0600 "$dump_fifo"
+  trap 'rm -rf "$backup_work"; rm -f "$backup_dir/$backup_name"' EXIT HUP INT TERM
+  docker exec "$container" sh -ec \
+    'exec pg_dump --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" --format=custom --no-owner --no-acl' \
+    > "$dump_fifo" &
+  dump_pid=$!
+  if ! openssl enc -aes-256-cbc -salt -pbkdf2 -iter 200000 \
+      -pass "file:$BEACON_ACCOUNT_BACKUP_KEY_FILE" -in "$dump_fifo" -out "$backup_dir/$backup_name"; then
+    kill "$dump_pid" >/dev/null 2>&1 || true
+    wait "$dump_pid" >/dev/null 2>&1 || true
+    account_fail 'staging backup encryption failed'
+  fi
+  wait "$dump_pid" || account_fail 'staging pg_dump failed'
+  rm -rf "$backup_work"
+  openssl enc -d -aes-256-cbc -pbkdf2 -iter 200000 \
+    -pass "file:$BEACON_ACCOUNT_BACKUP_KEY_FILE" -in "$backup_dir/$backup_name" |
+    docker run --rm -i postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777 \
+      pg_restore --list >/dev/null || account_fail 'encrypted staging backup verification failed'
+  trap - EXIT HUP INT TERM
+  test -s "$backup_dir/$backup_name" || account_fail 'staging backup is empty'
   chmod 0600 "$backup_dir/$backup_name"
   printf '%s\n' "$backup_dir/$backup_name"
 )

--- a/scripts/beacon-account/rollback-social-provider.sh
+++ b/scripts/beacon-account/rollback-social-provider.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+set -eu
+. "$(dirname -- "$0")/lib.sh"
+
+test "$(id -u)" -eq 0 || account_fail 'run as root'
+rollback_state=${1:?usage: rollback-social-provider.sh /var/lib/harmonic-beacon/account-social-providers/environment-provider-sha-timestamp /secure/deploy.env}
+ACCOUNT_DEPLOY_FILE=${2:?usage: rollback-social-provider.sh state /secure/deploy.env}
+export ACCOUNT_DEPLOY_FILE
+case "$rollback_state" in /var/lib/harmonic-beacon/account-social-providers/*) ;; *) account_fail 'unexpected provider rollback state path' ;; esac
+test -d "$rollback_state" && test ! -L "$rollback_state" || account_fail 'provider rollback state must be a regular directory'
+test "$(stat -c '%U:%G:%a' "$rollback_state")" = root:root:700 || account_fail 'provider rollback state must be root:root 0700'
+for file in previous.env environment.txt provider.txt sha.txt app-id.before worker-id.before \
+  database-id.before database-backup.txt database-backup.sha256 result.txt SHA256SUMS; do
+  test -f "$rollback_state/$file" && test ! -L "$rollback_state/$file" || account_fail 'provider rollback state is incomplete'
+  test "$(stat -c '%U:%G:%a' "$rollback_state/$file")" = root:root:600 || account_fail 'provider rollback state file must be root:root 0600'
+done
+(cd "$rollback_state" && sha256sum -c SHA256SUMS >/dev/null)
+
+environment=$(cat "$rollback_state/environment.txt")
+provider=$(cat "$rollback_state/provider.txt")
+expected_sha=$(cat "$rollback_state/sha.txt")
+case "$environment" in staging|production) ;; *) account_fail 'rollback environment is invalid' ;; esac
+case "$provider" in google|apple) ;; *) account_fail 'rollback provider is invalid' ;; esac
+echo "$expected_sha" | grep -Eq '^[0-9a-f]{40}$' || account_fail 'rollback SHA is invalid'
+account_load_deploy_env "$ACCOUNT_DEPLOY_FILE"
+test "$BEACON_ACCOUNT_GIT_SHA" = "$expected_sha" || account_fail 'deploy coordinates differ from rollback SHA'
+account_env=$BEACON_ACCOUNT_STAGING_ENV_FILE
+test "$environment" != production || account_env=$BEACON_ACCOUNT_PRODUCTION_ENV_FILE
+container=$(account_container_name "$environment")
+worker=$(account_mail_worker_container_name "$environment")
+test "$(docker inspect "$container" --format '{{.Config.Image}}')" = "harmonic-beacon/account:$expected_sha" ||
+  account_fail 'running Account image differs from rollback state'
+upper=$(printf '%s' "$provider" | tr '[:lower:]' '[:upper:]')
+grep -Fxq "BEACON_ACCOUNT_${upper}_ENABLED=1" "$account_env" || account_fail 'target provider is not currently enabled'
+
+exec 9>"/run/lock/beacon-account-$environment.lock"
+flock -n 9 || account_fail "another $environment Account operation is active"
+temporary="${account_env}.rollback-$$"
+trap 'rm -f "$temporary"' EXIT
+trap '' HUP INT TERM
+install -o root -g root -m 0600 "$rollback_state/previous.env" "$temporary"
+mv -T "$temporary" "$account_env"
+account_compose up -d --no-deps --force-recreate --no-build "account-$environment"
+account_wait_healthy "$container"
+account_verify_running "$environment" "$expected_sha" "$expected_sha" 1
+"$(account_repo_root)/scripts/beacon-account/health-smoke.sh" \
+  "$environment" "$ACCOUNT_DEPLOY_FILE" "$expected_sha" 1 1
+test "$(docker inspect "$worker" --format '{{.Id}}')" = "$(cat "$rollback_state/worker-id.before")" ||
+  account_fail 'mail worker changed during provider rollback'
+trap - EXIT HUP INT TERM
+echo "Beacon Account $provider in $environment was restored to its pre-activation state; identities and sessions were retained."

--- a/scripts/beacon-account/social-provider-env.mjs
+++ b/scripts/beacon-account/social-provider-env.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PROVIDERS = new Set(['google', 'apple']);
+const ENVIRONMENTS = new Set(['staging', 'production']);
+const MAX_APPLE_LIFETIME_SECONDS = 183 * 24 * 60 * 60;
+
+function assignments(contents, label) {
+  const values = new Map();
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const at = line.indexOf('=');
+    if (at <= 0) throw new Error(`${label} contains an invalid assignment`);
+    const key = line.slice(0, at);
+    if (!/^[A-Z][A-Z0-9_]*$/.test(key) || values.has(key)) {
+      throw new Error(`${label} contains an invalid or duplicate key`);
+    }
+    values.set(key, line.slice(at + 1));
+  }
+  return values;
+}
+
+function decodeCanonicalBase64UrlJSON(value, label) {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error(`${label} is invalid`);
+  const decoded = Buffer.from(value, 'base64url');
+  if (decoded.toString('base64url') !== value) throw new Error(`${label} is not canonical`);
+  return JSON.parse(decoded.toString('utf8'));
+}
+
+function validateGoogle(clientId, clientSecret) {
+  if (!/^[A-Za-z0-9._-]{8,480}\.apps\.googleusercontent\.com$/.test(clientId)) {
+    throw new Error('Google client ID is invalid');
+  }
+  if (clientSecret.length < 16 || clientSecret.length > 512 || /\s/.test(clientSecret)) {
+    throw new Error('Google client secret is invalid');
+  }
+}
+
+function validateApple(clientId, clientSecret, nowSeconds) {
+  if (!/^[A-Za-z0-9.-]{3,255}$/.test(clientId)) throw new Error('Apple Services ID is invalid');
+  const parts = clientSecret.split('.');
+  if (parts.length !== 3 || parts.some((part) => !part)) throw new Error('Apple client secret is invalid');
+  let header;
+  let payload;
+  try {
+    header = decodeCanonicalBase64UrlJSON(parts[0], 'Apple JWT header');
+    payload = decodeCanonicalBase64UrlJSON(parts[1], 'Apple JWT payload');
+  } catch {
+    throw new Error('Apple client secret is invalid');
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(parts[2]) || Buffer.from(parts[2], 'base64url').length !== 64 ||
+      Buffer.from(parts[2], 'base64url').toString('base64url') !== parts[2]) {
+    throw new Error('Apple client secret is invalid');
+  }
+  if (header.alg !== 'ES256' || typeof header.kid !== 'string' ||
+      !/^[A-Z0-9]{10}$/.test(header.kid)) {
+    throw new Error('Apple client secret header is invalid');
+  }
+  if (typeof payload.iss !== 'string' || !/^[A-Z0-9]{10}$/.test(payload.iss) ||
+      payload.sub !== clientId ||
+      payload.aud !== 'https://appleid.apple.com' || !Number.isInteger(payload.iat) ||
+      !Number.isInteger(payload.exp) || payload.iat > nowSeconds + 300 ||
+      payload.exp <= nowSeconds || payload.exp <= payload.iat ||
+      payload.exp - payload.iat > MAX_APPLE_LIFETIME_SECONDS) {
+    throw new Error('Apple client secret claims are invalid');
+  }
+}
+
+function replaceExact(contents, key, value) {
+  const lines = contents.replace(/\r\n/g, '\n').split('\n');
+  let count = 0;
+  const updated = lines.map((line) => {
+    if (!line.startsWith(`${key}=`)) return line;
+    count += 1;
+    return `${key}=${value}`;
+  });
+  if (count !== 1) throw new Error(`Account environment must contain exactly one ${key}`);
+  return updated.join('\n');
+}
+
+export function buildSocialProviderActivation({
+  accountContents,
+  bundleContents,
+  environment,
+  provider,
+  nowSeconds = Math.floor(Date.now() / 1000),
+}) {
+  if (!ENVIRONMENTS.has(environment)) throw new Error('environment must be staging or production');
+  if (!PROVIDERS.has(provider)) throw new Error('provider must be google or apple');
+  const upper = provider.toUpperCase();
+  const account = assignments(accountContents, 'Account environment');
+  const bundle = assignments(bundleContents, 'provider bundle');
+  const expectedOrigin = environment === 'staging'
+    ? 'https://account-staging.harmonicbeacon.com'
+    : 'https://account.harmonicbeacon.com';
+  if (account.get('BEACON_ACCOUNT_BASE_URL') !== expectedOrigin) {
+    throw new Error('Account environment issuer mismatch');
+  }
+  const flagKey = `BEACON_ACCOUNT_${upper}_ENABLED`;
+  const idKey = `BEACON_ACCOUNT_${upper}_CLIENT_ID`;
+  const secretKey = `BEACON_ACCOUNT_${upper}_CLIENT_SECRET`;
+  if (account.get(flagKey) !== '0' || (account.get(idKey) ?? '') !== '' ||
+      (account.get(secretKey) ?? '') !== '') {
+    throw new Error('target provider must be fully disabled before first activation');
+  }
+  const expectedBundleKeys = new Set([idKey, secretKey]);
+  if (bundle.size !== expectedBundleKeys.size ||
+      [...bundle.keys()].some((key) => !expectedBundleKeys.has(key))) {
+    throw new Error('provider bundle must contain only the exact provider client ID and secret');
+  }
+  const clientId = bundle.get(idKey) ?? '';
+  const clientSecret = bundle.get(secretKey) ?? '';
+  if (provider === 'google') validateGoogle(clientId, clientSecret);
+  else validateApple(clientId, clientSecret, nowSeconds);
+
+  let result = accountContents;
+  result = replaceExact(result, idKey, clientId);
+  result = replaceExact(result, secretKey, clientSecret);
+  result = replaceExact(result, flagKey, '1');
+  const effective = assignments(result, 'activated Account environment');
+  if (effective.get(flagKey) !== '1' || effective.get(idKey) !== clientId ||
+      effective.get(secretKey) !== clientSecret) {
+    throw new Error('provider activation output is inconsistent');
+  }
+  return result.endsWith('\n') ? result : `${result}\n`;
+}
+
+function requireRootPrivateFile(file, label) {
+  const metadata = fs.lstatSync(file);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) throw new Error(`${label} must be a regular file`);
+  if (metadata.uid !== 0 || metadata.gid !== 0 || (metadata.mode & 0o777) !== 0o600) {
+    throw new Error(`${label} must be root:root mode 0600`);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  const [accountFile, bundleFile, outputFile, environment, provider] = process.argv.slice(2);
+  if (!accountFile || !bundleFile || !outputFile || !environment || !provider) {
+    throw new Error('usage: social-provider-env.mjs account.env bundle.env output.env staging|production google|apple');
+  }
+  requireRootPrivateFile(accountFile, 'Account environment');
+  requireRootPrivateFile(bundleFile, 'provider bundle');
+  if (fs.existsSync(outputFile)) throw new Error('activation output already exists');
+  const directory = fs.lstatSync(path.dirname(outputFile));
+  if (!directory.isDirectory() || directory.isSymbolicLink() || directory.uid !== 0 ||
+      directory.gid !== 0 || (directory.mode & 0o777) !== 0o700) {
+    throw new Error('activation output directory must be root:root mode 0700');
+  }
+  const result = buildSocialProviderActivation({
+    accountContents: fs.readFileSync(accountFile, 'utf8'),
+    bundleContents: fs.readFileSync(bundleFile, 'utf8'),
+    environment,
+    provider,
+  });
+  fs.writeFileSync(outputFile, result, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+  process.stdout.write(`Beacon Account ${provider} activation environment prepared for ${environment}.\n`);
+}


### PR DESCRIPTION
Adds a root-only, exact-image lifecycle for enabling Google or Apple on central Account one environment at a time. It prepares and validates a complete candidate env offline, creates a verified encrypted DB backup, atomically recreates only the Account app, keeps the mail worker and DB unchanged, and restores the prior env/app automatically on failure. Manual rollback retains identities and sessions.

Evidence: Account contracts 27/27; full Vitest 1792 pass / 44 skip; ESLint; TypeScript; Prisma validate; production dependency audit; Next production build; Docker runner build with the transformer copied into the image; Compose config; shell/node syntax and diff-check. No provider credentials, runtime, DNS, payments, events, streams, or audio changed.