### PR TITLE
Fix Account return to RP after credential sign-in

### DIFF
--- a/src/app/api/account/auth/[...all]/route.test.ts
+++ b/src/app/api/account/auth/[...all]/route.test.ts
@@ -120,6 +120,48 @@ describe('Account catch-all route confidential OAuth boundary', () => {
             .toBe('__Host-hb_account_session=opaque-session');
     });
 
+    it('uses the completed RP callback when the credential Location still points to Account', async () => {
+        const callback = 'https://listen.harmonicbeacon.com/api/account/callback' +
+            '?code=opaque-code&state=opaque-state';
+        const headers = new Headers({ Location: '/account' });
+        headers.append('Set-Cookie',
+            '__Host-hb_account_session=oauth-session.signature; Path=/; HttpOnly; Secure; SameSite=Lax');
+        authHandler.mockResolvedValueOnce(Response.json({
+            redirect: true,
+            url: callback,
+        }, { headers }));
+        userFindUnique.mockResolvedValueOnce({ id: 'account-1', securityRevision: 3 });
+        getSession
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ user: { id: 'account-1' }, session: { id: 'session-1' } });
+        transaction.mockImplementationOnce(async (callbackTransaction) => callbackTransaction({
+            $queryRaw: vi.fn(),
+            earlyBirdAuthSession: {
+                findUnique: vi.fn().mockResolvedValue({
+                    id: 'session-1', userId: 'account-1', securityRevision: 3,
+                    user: { securityRevision: 3 },
+                }),
+                deleteMany: vi.fn(),
+            },
+        }));
+
+        const response = await POST(new Request(`${origin}/api/account/auth/sign-in/email`, {
+            method: 'POST',
+            headers: {
+                host: 'account.harmonicbeacon.com', origin,
+                'sec-fetch-site': 'same-origin', 'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+                email: 'listener@example.invalid', password: '12345678',
+                oauth_query: 'signed-provider-query',
+            }),
+        }));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ status: 'authenticated', redirect: callback });
+        expect(response.headers.getSetCookie()).toHaveLength(1);
+    });
+
     it.each([
         ['underlying success', 200],
         ['underlying rejection', 422],

--- a/src/app/api/account/auth/[...all]/route.ts
+++ b/src/app/api/account/auth/[...all]/route.ts
@@ -7,7 +7,7 @@ import {
     accountEnvironment,
     accountOrigin,
     ACCOUNT_SESSION_COOKIE,
-    ACCOUNT_STATIC_CLIENTS,
+    activeAccountStaticClients,
 } from '@/lib/account/config';
 import { accountAuthorityDatabaseReady } from '@/lib/account/authority-db';
 import { accountCredentialRequestAllowed, accountRequestAllowed } from '@/lib/account/request-boundary';
@@ -24,17 +24,26 @@ async function safeRPRedirect(response: Response): Promise<string | null> {
     const body = await response.clone().json().catch(() => null) as {
         url?: unknown; redirect_uri?: unknown;
     } | null;
-    const candidate = response.headers.get('location') ??
-        (typeof body?.redirect_uri === 'string' ? body.redirect_uri : null) ??
-        (typeof body?.url === 'string' ? body.url : null);
-    if (!candidate) return null;
-    try {
-        const parsed = new URL(candidate);
-        return ACCOUNT_STATIC_CLIENTS.some((client) =>
-            new URL(client.redirectUri).origin === parsed.origin &&
-            new URL(client.redirectUri).pathname === parsed.pathname)
-            ? parsed.toString() : null;
-    } catch { return null; }
+    // Better Auth can preserve the credential callback (`/account`) in the
+    // Location header while returning the completed OAuth RP callback in its
+    // JSON body. A non-RP Location must not shadow a later valid RP result.
+    const candidates = [
+        response.headers.get('location'),
+        typeof body?.redirect_uri === 'string' ? body.redirect_uri : null,
+        typeof body?.url === 'string' ? body.url : null,
+    ];
+    const clients = activeAccountStaticClients();
+    for (const candidate of candidates) {
+        if (!candidate) continue;
+        try {
+            const parsed = new URL(candidate);
+            if (!parsed.username && !parsed.password && !parsed.hash && clients.some((client) => {
+                const registered = new URL(client.redirectUri);
+                return registered.origin === parsed.origin && registered.pathname === parsed.pathname;
+            })) return parsed.toString();
+        } catch { /* Continue to the provider's next result shape. */ }
+    }
+    return null;
 }
 
 async function genericCredentialResponse(response: Response, path: string): Promise<Response> {

--- a/src/lib/account/__tests__/oauth-provider.postgres.test.ts
+++ b/src/lib/account/__tests__/oauth-provider.postgres.test.ts
@@ -72,8 +72,40 @@ postgres('pinned OAuth Provider 1.6.30 confidential-client lifecycle', () => {
     });
 
     it('exchanges an auth code and introspects using the provisioned full secret', async () => {
-        const signIn = await accountRoutePOST(jsonRequest('/api/account/auth/sign-in/email', { email, password }));
+        const verifier = randomBytes(48).toString('base64url');
+        const challenge = createHash('sha256').update(verifier).digest('base64url');
+        const authorizeURL = new URL('/api/account/auth/oauth2/authorize', issuer);
+        authorizeURL.search = new URLSearchParams({
+            client_id: clientId,
+            redirect_uri: 'https://listen.harmonicbeacon.com/api/account/callback',
+            response_type: 'code', scope: 'openid profile',
+            state: 'state-for-handler-regression', nonce: 'nonce-for-handler-regression',
+            code_challenge: challenge, code_challenge_method: 'S256',
+        }).toString();
+        const preLoginAuthorize = await handler(new Request(authorizeURL, {
+            headers: { host: 'account.harmonicbeacon.com' },
+        }));
+        expect(preLoginAuthorize.status).toBe(302);
+        const accountLogin = new URL(preLoginAuthorize.headers.get('location')!, issuer);
+        expect(accountLogin.origin + accountLogin.pathname)
+            .toBe('https://account.harmonicbeacon.com/account');
+        expect(accountLogin.searchParams.get('sig')).toBeTruthy();
+
+        const signIn = await accountRoutePOST(jsonRequest('/api/account/auth/sign-in/email', {
+            email,
+            password,
+            callbackURL: '/account',
+            oauth_query: accountLogin.searchParams.toString(),
+        }));
         expect(signIn.status).toBe(200);
+        const signInBody = await signIn.clone().json() as { redirect?: string };
+        expect(signInBody.redirect).toBeTruthy();
+        const callback = new URL(signInBody.redirect!);
+        expect(callback.origin + callback.pathname)
+            .toBe('https://listen.harmonicbeacon.com/api/account/callback');
+        expect(callback.searchParams.get('state')).toBe('state-for-handler-regression');
+        const code = callback.searchParams.get('code');
+        expect(code).toBeTruthy();
         const setCookies = signIn.headers.getSetCookie();
         const sessionCookies = setCookies.filter((entry) =>
             entry.startsWith('__Host-hb_account_session='));
@@ -87,25 +119,6 @@ postgres('pinned OAuth Provider 1.6.30 confidential-client lifecycle', () => {
         const sessionCookie = setCookies.map((entry) => entry.split(';', 1)[0]).join('; ');
         const resolved = await currentAccountSession(new Headers({ cookie: sessionCookie }));
         expect(resolved).toMatchObject({ user: { id: accountId, accessMethod: 'email' } });
-
-        const verifier = randomBytes(48).toString('base64url');
-        const challenge = createHash('sha256').update(verifier).digest('base64url');
-        const authorizeURL = new URL('/api/account/auth/oauth2/authorize', issuer);
-        authorizeURL.search = new URLSearchParams({
-            client_id: clientId,
-            redirect_uri: 'https://listen.harmonicbeacon.com/api/account/callback',
-            response_type: 'code', scope: 'openid profile',
-            state: 'state-for-handler-regression', nonce: 'nonce-for-handler-regression',
-            code_challenge: challenge, code_challenge_method: 'S256',
-        }).toString();
-        const authorize = await handler(new Request(authorizeURL, {
-            headers: { host: 'account.harmonicbeacon.com', cookie: sessionCookie },
-        }));
-        expect(authorize.status).toBeGreaterThanOrEqual(300);
-        expect(authorize.status).toBeLessThan(400);
-        const callback = new URL(authorize.headers.get('location')!);
-        const code = callback.searchParams.get('code');
-        expect(code).toBeTruthy();
 
         const basic = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
         const token = await handler(new Request(`${issuer}/api/account/auth/oauth2/token`, {


### PR DESCRIPTION
## What

- preserve a valid completed OAuth RP callback even when Better Auth also retains the local `/account` callback in `Location`
- restrict forwarded callbacks to active clients in the current Account environment
- add unit and real PostgreSQL coverage for logged-out authorize → credential sign-in → RP callback → token exchange/introspection

## Evidence

- 24 focused tests pass, including PostgreSQL lifecycle
- full Vitest: 1793 passed / 44 skipped
- TypeScript and focused ESLint pass
- production Next build passes
- no Docker image built for this review slice

## Runtime

No deploy or runtime mutation in this PR yet.