### PR TITLE
Fix Live canonical Account profile propagation

### DIFF
--- a/scripts/live-staging/account-preflight.mjs
+++ b/scripts/live-staging/account-preflight.mjs
@@ -59,6 +59,7 @@ async function main() {
         authorization_endpoint: '/api/account/auth/oauth2/authorize',
         token_endpoint: '/api/account/auth/oauth2/token',
         jwks_uri: '/.well-known/jwks.json',
+        userinfo_endpoint: '/api/account/auth/oauth2/userinfo',
         introspection_endpoint: '/api/account/auth/oauth2/introspect',
         end_session_endpoint: '/api/account/auth/oauth2/end-session',
     };

--- a/src/lib/__tests__/account-rp.test.ts
+++ b/src/lib/__tests__/account-rp.test.ts
@@ -48,6 +48,7 @@ function discovery(overrides: Record<string, unknown> = {}) {
         authorization_endpoint: `${ISSUER}/oauth2/authorize`,
         token_endpoint: `${ISSUER}/oauth2/token`,
         jwks_uri: `${ISSUER}/oauth2/jwks`,
+        userinfo_endpoint: `${ISSUER}/oauth2/userinfo`,
         introspection_endpoint: `${ISSUER}/oauth2/introspect`,
         end_session_endpoint: `${ISSUER}/oauth2/logout`,
         code_challenge_methods_supported: ['S256'],
@@ -68,7 +69,7 @@ async function idToken(
     issuedAt = Math.floor(NOW.getTime() / 1000),
     expiresAt = Math.floor(NOW.getTime() / 1000) + 600,
 ) {
-    return new SignJWT({ nonce, sid: SID, name: '  Ana   Beacon  ' })
+    return new SignJWT({ nonce, sid: SID })
         .setProtectedHeader({ alg: 'RS256', kid: 'account-test-key' })
         .setIssuer(ISSUER)
         .setSubject(SUBJECT)
@@ -228,6 +229,11 @@ describe('Beacon Account OAuth 2.1 RP', () => {
                 client_id: CLIENT_ID,
                 sub: SUBJECT,
             });
+            if (url === `${ISSUER}/oauth2/userinfo`) return json({
+                sub: SUBJECT,
+                name: '  Ana   Beacon  ',
+                profile_revision: 2,
+            });
             throw new Error(`unexpected fetch ${url}`);
         });
         vi.stubGlobal('fetch', fetchMock);
@@ -264,6 +270,52 @@ describe('Beacon Account OAuth 2.1 RP', () => {
             Authorization: expect.stringMatching(/^Basic /),
         });
         expect(String((tokenCall?.[1] as RequestInit).body)).toContain('code_verifier=pkce-verifier-value');
+        const userInfoCall = fetchMock.mock.calls.find(([url]) => String(url) === `${ISSUER}/oauth2/userinfo`);
+        expect((userInfoCall?.[1] as RequestInit).headers).toMatchObject({
+            Authorization: 'Bearer opaque-access-token',
+        });
+    });
+
+    it('rejects UserInfo for a different subject without creating a local session', async () => {
+        findAttempt.mockResolvedValue({
+            stateDigest: stateDigest(),
+            codeVerifier: 'pkce-verifier-value',
+            nonce: NONCE,
+            flow: 'attendee',
+            returnTo: '/',
+            expiresAt: new Date(NOW.getTime() + 60_000),
+            consumedAt: null,
+            pendingPromoDigest: null,
+            pendingDisplayName: null,
+            pendingTermsVersion: null,
+            pendingTermsAcceptedAt: null,
+        });
+        const signed = await idToken();
+        vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.endsWith('/.well-known/openid-configuration')) return json(discovery());
+            if (url === `${ISSUER}/oauth2/token`) return json({
+                access_token: 'opaque-access-token', id_token: signed, token_type: 'Bearer',
+            });
+            if (url === `${ISSUER}/oauth2/jwks`) return json({ keys: [publicJwk] });
+            if (url === `${ISSUER}/oauth2/introspect`) return json({
+                active: true, client_id: CLIENT_ID, sub: SUBJECT,
+            });
+            if (url === `${ISSUER}/oauth2/userinfo`) return json({
+                sub: 'different-account', name: 'Wrong Person',
+            });
+            throw new Error(`unexpected fetch ${url}`);
+        }));
+        const { completeAccountAuthorization } = await import('../account-rp');
+
+        await expect(completeAccountAuthorization({
+            code: 'one-use-authorization-code',
+            state: STATE,
+            stateCookie: STATE,
+            origin: 'http://localhost:3000',
+            now: NOW,
+        })).rejects.toThrow(/UserInfo subject mismatch/);
+        expect(createSession).not.toHaveBeenCalled();
     });
 
     it('rejects an ID token whose issued-at exceeds the callback freshness window', async () => {

--- a/src/lib/__tests__/live-staging-deploy-contract.test.ts
+++ b/src/lib/__tests__/live-staging-deploy-contract.test.ts
@@ -78,6 +78,7 @@ describe('isolated Live staging deploy contract', () => {
         expect(accountPreflight).toContain("const CLIENT_ID = 'hb-live-staging'");
         expect(accountPreflight).toContain('/.well-known/openid-configuration');
         expect(accountPreflight).toContain('/.well-known/jwks.json');
+        expect(accountPreflight).toContain("userinfo_endpoint: '/api/account/auth/oauth2/userinfo'");
         expect(accountPreflight).toContain('/api/account/session-status');
         expect(accountPreflight).toContain("body: new URLSearchParams({ sid: 'live-staging-preflight', sub: 'live-staging-preflight' })");
         expect(accountPreflight).toContain("status.active !== false");

--- a/src/lib/account-rp.ts
+++ b/src/lib/account-rp.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 
-import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
 
 import { prisma } from '@/lib/db';
 import {
@@ -45,6 +45,7 @@ type Discovery = {
     authorization_endpoint: string;
     token_endpoint: string;
     jwks_uri: string;
+    userinfo_endpoint: string;
     introspection_endpoint: string;
     end_session_endpoint: string;
     code_challenge_methods_supported?: string[];
@@ -158,6 +159,7 @@ export async function discoverAccountIssuer(
         authorization_endpoint: exactIssuerEndpoint(raw.authorization_endpoint, config.issuer, 'authorization_endpoint'),
         token_endpoint: exactIssuerEndpoint(raw.token_endpoint, config.issuer, 'token_endpoint'),
         jwks_uri: exactIssuerEndpoint(raw.jwks_uri, config.issuer, 'jwks_uri'),
+        userinfo_endpoint: exactIssuerEndpoint(raw.userinfo_endpoint, config.issuer, 'userinfo_endpoint'),
         introspection_endpoint: exactIssuerEndpoint(raw.introspection_endpoint, config.issuer, 'introspection_endpoint'),
         end_session_endpoint: exactIssuerEndpoint(raw.end_session_endpoint, config.issuer, 'end_session_endpoint'),
         code_challenge_methods_supported: raw.code_challenge_methods_supported as string[],
@@ -313,7 +315,7 @@ function boundedCredential(value: unknown, label: string): string {
     return value;
 }
 
-function profileDisplayName(payload: JWTPayload): string | null {
+function profileDisplayName(payload: Record<string, unknown>): string | null {
     const raw = typeof payload.name === 'string'
         ? payload.name
         : typeof payload.preferred_username === 'string'
@@ -391,11 +393,25 @@ async function exchangeAuthorizationCode(input: {
     ) {
         throw new Error('Beacon Account access token is not active for this client');
     }
+
+    const userInfoResponse = await fetch(discovery.userinfo_endpoint, {
+        headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+        },
+        cache: 'no-store',
+        redirect: 'error',
+        signal: AbortSignal.timeout(8_000),
+    });
+    if (!userInfoResponse.ok) throw new Error('Beacon Account UserInfo unavailable');
+    const userInfo = await userInfoResponse.json() as Record<string, unknown>;
+    if (userInfo.sub !== subject) throw new Error('Beacon Account UserInfo subject mismatch');
+
     return {
         issuer: config.issuer,
         subject,
         sessionId,
-        displayName: profileDisplayName(verified.payload),
+        displayName: profileDisplayName(userInfo),
         validatedAt: new Date(),
     };
 }


### PR DESCRIPTION
## Outcome

Live now reads the canonical display name from the Account OIDC UserInfo endpoint after validating the ID token and introspecting the access token. It verifies the UserInfo subject matches the signed ID-token subject before creating a local session.

The Live staging deployment preflight now pins the exact Account UserInfo endpoint too.

## Verification

- focused Account RP/navigation/deploy contract: 45 passed
- full Vitest: 1039 passed, 23 skipped integrations
- TypeScript and focused ESLint: pass
- Next production build: pass
- diff check: pass
- deployed Account staging discovery advertises the exact canonical UserInfo endpoint

No audio, LiveKit, event, payment, membership, schema, migration, or production runtime files changed.