### PR TITLE
Fix Live Account logout handshake

### DIFF
--- a/docs/architecture/BEACON_ACCOUNT_LIVE_RP.md
+++ b/docs/architecture/BEACON_ACCOUNT_LIVE_RP.md
@@ -70,8 +70,10 @@ audit entry. There is no MFA claim or MFA policy in this slice.
 - `GET /api/account/login?flow=attendee|staff&next=<local path>`
 - `GET /api/account/callback`
 - `GET /api/account/frontchannel-logout?iss=<exact issuer>&sid=<exact sid>`
-- existing `POST /api/auth/logout` revokes locally and returns the issuer
-  end-session URL; `?scope=all` first revokes every local SID for the subject.
+- existing `POST /api/auth/logout` revokes locally and returns a 120-second,
+  client-secret-signed Account logout initiation bound to the exact central
+  `sid`, mode and registered Live origin; `?scope=all` first revokes every
+  local SID for the subject. Live never persists an ID token merely to log out.
 
 Apply the forward-only migration with the feature disabled, seed and review the
 four staff bindings, register exact clients/callbacks, verify discovery and

--- a/src/app/api/auth/logout/__tests__/route.test.ts
+++ b/src/app/api/auth/logout/__tests__/route.test.ts
@@ -36,6 +36,8 @@ describe('POST /api/auth/logout', () => {
 
     afterEach(() => {
         vi.doUnmock('@/lib/db');
+        vi.doUnmock('@/lib/principal');
+        vi.doUnmock('@/lib/account-rp');
         vi.restoreAllMocks();
         delete process.env.TICKET_LOGIN_URL_PREFIX;
     });
@@ -104,6 +106,46 @@ describe('POST /api/auth/logout', () => {
         expect(sessionCookieOf(response)).toMatchObject({ value: '', maxAge: 0 });
         expect(error).toHaveBeenCalled();
         expect(String(error.mock.calls[0][0])).not.toContain(TOKEN);
+    });
+
+    it('returns a signed current-session Account logout initiation bound to the exact sid', async () => {
+        const accountLogoutUrl = vi.fn().mockResolvedValue(
+            'https://account-staging.harmonicbeacon.com/account/logout?initiation=signed',
+        );
+        const revokeWebSessionByToken = vi.fn().mockResolvedValue(undefined);
+        vi.doMock('@/lib/principal', () => ({
+            accountIdentityFromToken: vi.fn().mockResolvedValue({
+                issuer: 'https://account-staging.harmonicbeacon.com',
+                subject: 'central-subject',
+                sessionId: 'central-sid',
+            }),
+            revokeWebSessionByToken,
+            clearedSessionCookie: () => ({
+                name: 'hb_session', value: '', maxAge: 0, httpOnly: true,
+                secure: true, sameSite: 'lax' as const, path: '/',
+            }),
+        }));
+        vi.doMock('@/lib/account-rp', () => ({
+            beaconAccountEnabled: () => true,
+            trustedLiveRequestOrigin: () => 'https://live-staging.harmonicbeacon.com',
+            revokeAllAccountSessions: vi.fn(),
+            accountLogoutUrl,
+        }));
+        const { POST } = await import('../route');
+
+        const response = await POST(logoutRequest(TOKEN));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            ok: true,
+            issuerLogoutUrl: 'https://account-staging.harmonicbeacon.com/account/logout?initiation=signed',
+        });
+        expect(revokeWebSessionByToken).toHaveBeenCalledWith(TOKEN);
+        expect(accountLogoutUrl).toHaveBeenCalledWith({
+            origin: 'https://live-staging.harmonicbeacon.com',
+            sessionId: 'central-sid',
+            mode: 'current',
+        });
     });
 
     it.each([

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -62,9 +62,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     let issuerLogoutUrl: string | null = null;
     if (account) {
         try {
-            issuerLogoutUrl = await accountLogoutUrl(liveOrigin);
+            issuerLogoutUrl = await accountLogoutUrl({
+                origin: liveOrigin,
+                sessionId: account.sessionId,
+                mode: allDevices ? 'all' : 'current',
+            });
         } catch (error) {
-            console.error(`[auth] account logout discovery failed: ${redactError(error)}`);
+            console.error(`[auth] account logout initiation failed: ${redactError(error)}`);
         }
     }
     const response = NextResponse.json({

--- a/src/components/brand/LiveNavigationAccountMenu.tsx
+++ b/src/components/brand/LiveNavigationAccountMenu.tsx
@@ -17,6 +17,7 @@ export function trustedAccountLogoutURL(
         if (
             logoutURL.protocol !== 'https:' ||
             logoutURL.origin !== accountOrigin ||
+            logoutURL.pathname !== '/account/logout' ||
             logoutURL.username ||
             logoutURL.password
         ) return null;

--- a/src/components/brand/__tests__/LiveNavigationAccountMenu.test.tsx
+++ b/src/components/brand/__tests__/LiveNavigationAccountMenu.test.tsx
@@ -89,8 +89,10 @@ describe('Live navigation Account menu', () => {
     });
 
     it.each([
-        ['https://account-staging.harmonicbeacon.com/api/account/auth/oauth2/end-session?state=opaque', true],
+        ['https://account-staging.harmonicbeacon.com/account/logout?initiation=opaque', true],
+        ['https://account-staging.harmonicbeacon.com/api/account/auth/oauth2/end-session?state=opaque', false],
         ['https://account.harmonicbeacon.com/account/logout', false],
+        ['https://account-staging.harmonicbeacon.com/account', false],
         ['https://account-staging.harmonicbeacon.com.evil.example/logout', false],
         ['javascript:alert(1)', false],
         ['not a URL', false],

--- a/src/lib/__tests__/account-rp.test.ts
+++ b/src/lib/__tests__/account-rp.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 
 import { exportJWK, generateKeyPair, SignJWT, type JWK } from 'jose';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -381,6 +381,38 @@ describe('Beacon Account OAuth 2.1 RP', () => {
         const { accountIdentityIsFresh } = await import('../account-rp');
         expect(accountIdentityIsFresh({ validatedAt: NOW }, new Date(NOW.getTime() + 899_999))).toBe(true);
         expect(accountIdentityIsFresh({ validatedAt: NOW }, new Date(NOW.getTime() + 900_001))).toBe(false);
+    });
+
+    it('creates a short-lived signed Account logout initiation without retaining an ID token', async () => {
+        process.env.TICKET_LOGIN_URL_PREFIX = 'https://live-staging.harmonicbeacon.com';
+        const { accountLogoutUrl } = await import('../account-rp');
+
+        const result = new URL(await accountLogoutUrl({
+            origin: 'https://live-staging.harmonicbeacon.com',
+            sessionId: SID,
+            mode: 'current',
+            now: NOW,
+        }));
+
+        expect(result.origin + result.pathname).toBe(`${ISSUER}/account/logout`);
+        expect(result.searchParams.get('mode')).toBe('current');
+        expect(result.searchParams.get('return_to')).toBe('https://live-staging.harmonicbeacon.com/');
+        const initiation = result.searchParams.get('initiation')!;
+        const [encoded, signature, extra] = initiation.split('.');
+        expect(extra).toBeUndefined();
+        expect(signature).toBe(createHmac('sha256', CLIENT_SECRET)
+            .update(encoded, 'utf8').digest('base64url'));
+        expect(JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'))).toMatchObject({
+            v: 1,
+            iss: ISSUER,
+            client_id: CLIENT_ID,
+            sid: SID,
+            mode: 'current',
+            return_to: 'https://live-staging.harmonicbeacon.com/',
+            iat: Math.floor(NOW.getTime() / 1_000),
+            exp: Math.floor(NOW.getTime() / 1_000) + 120,
+        });
+        expect(initiation).not.toContain(CLIENT_SECRET);
     });
 
     it('revalidates and coalesces stale local sessions through the exact Account backchannel', async () => {

--- a/src/lib/account-rp.ts
+++ b/src/lib/account-rp.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, createHmac, randomBytes } from 'node:crypto';
 
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
@@ -675,12 +675,37 @@ export async function validatedAccountIdentity(
         : null;
 }
 
-export async function accountLogoutUrl(origin: string): Promise<string> {
+export async function accountLogoutUrl(input: {
+    origin: string;
+    sessionId: string;
+    mode: 'current' | 'all';
+    now?: Date;
+}): Promise<string> {
     const config = accountConfiguration();
-    const discovery = await discoverAccountIssuer(config);
-    const url = new URL(discovery.end_session_endpoint);
-    url.searchParams.set('client_id', config.clientId);
-    url.searchParams.set('post_logout_redirect_uri', new URL('/', trustedLiveOrigin(origin)).href);
+    if (!OPAQUE_CLAIM.test(input.sessionId) || input.sessionId.length > 128) {
+        throw new Error('Beacon Account session id is invalid for logout');
+    }
+    const returnTo = new URL('/', trustedLiveOrigin(input.origin)).href;
+    const now = Math.floor((input.now ?? new Date()).getTime() / 1_000);
+    const payload = {
+        v: 1,
+        iss: config.issuer,
+        client_id: config.clientId,
+        sid: input.sessionId,
+        mode: input.mode,
+        return_to: returnTo,
+        state: randomOpaque(16),
+        iat: now,
+        exp: now + 120,
+    } as const;
+    const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+    const signature = createHmac('sha256', config.clientSecret)
+        .update(encoded, 'utf8')
+        .digest('base64url');
+    const url = new URL('/account/logout', config.issuer);
+    url.searchParams.set('mode', input.mode);
+    url.searchParams.set('return_to', returnTo);
+    url.searchParams.set('initiation', `${encoded}.${signature}`);
     return url.href;
 }
 


### PR DESCRIPTION
## Outcome

Live now uses the Account authority signed RP logout-initiation contract instead of constructing an incomplete OIDC end-session request without an ID-token hint. The initiation is HMAC-SHA256 signed with the confidential client secret, lasts 120 seconds, and is bound to the exact issuer, client, central sid, current/all mode and registered Live return origin.

The browser accepts only the exact Account /account/logout path. Live still revokes its local session first and never persists an ID token.

## Runtime reproduction fixed

Real staging browser acceptance showed the previous URL returned not_found after local revocation. The canonical display name/UserInfo fix itself passed and showed Nicolás Echániz + Administración.

## Verification

- focused RP/logout/menu: 33 passed
- full Vitest: 1043 passed, 23 skipped integrations
- TypeScript and focused ESLint: pass
- Next production build: pass
- diff check: pass

No audio, LiveKit, event, payment, membership, schema or migration files changed.