### PR TITLE
feat(nav): reveal production Account only when enabled

### DIFF
--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -7,6 +7,7 @@
   var LISTENER_STAGING_ORIGIN = 'https://earlybirds-staging.harmonicbeacon.com';
   var LIVE_ORIGIN = 'https://live.harmonicbeacon.com';
   var LIVE_STAGING_ORIGIN = 'https://live-staging.harmonicbeacon.com';
+  var ACCOUNT_ORIGIN = 'https://account.harmonicbeacon.com';
   var ACCOUNT_STAGING_ORIGIN = 'https://account-staging.harmonicbeacon.com';
   var ELEMENT_NAME = 'hb-global-nav';
 
@@ -90,11 +91,21 @@
     return null;
   }
 
-  function accountControlAvailable() {
+  function accountControlAvailable(element) {
     var host = location.hostname.toLowerCase();
     return host === 'earlybirds-staging.harmonicbeacon.com' ||
       host === 'live-staging.harmonicbeacon.com' ||
-      host === 'account-staging.harmonicbeacon.com';
+      host === 'account-staging.harmonicbeacon.com' ||
+      element.hasAttribute('data-account-available');
+  }
+
+  function accountOrigin() {
+    var host = location.hostname.toLowerCase();
+    return host === 'earlybirds-staging.harmonicbeacon.com' ||
+      host === 'live-staging.harmonicbeacon.com' ||
+      host === 'account-staging.harmonicbeacon.com'
+      ? ACCOUNT_STAGING_ORIGIN
+      : ACCOUNT_ORIGIN;
   }
 
   function accountReturnTo() {
@@ -109,7 +120,7 @@
   }
 
   function accountPageHref(language) {
-    var url = new URL('/account', ACCOUNT_STAGING_ORIGIN);
+    var url = new URL('/account', accountOrigin());
     url.searchParams.set('lang', language);
     url.searchParams.set('return_to', accountReturnTo());
     return url.toString();
@@ -184,11 +195,11 @@
 
   class HarmonicBeaconGlobalNav extends HTMLElement {
     static get observedAttributes() {
-      return ['data-account-signed-in'];
+      return ['data-account-available', 'data-account-signed-in'];
     }
 
     attributeChangedCallback(name, previous, next) {
-      if (name === 'data-account-signed-in' && previous !== next && this.shadowRoot) this.render();
+      if (this.constructor.observedAttributes.includes(name) && previous !== next && this.shadowRoot) this.render();
     }
 
     connectedCallback() {
@@ -234,7 +245,7 @@
         ? (accountSignedIn ? 'Menú de usuario, sesión iniciada' : 'Menú de usuario')
         : (accountSignedIn ? 'User menu, signed in' : 'User menu');
       var accountLabel = language === 'es' ? 'Cuenta' : 'Account';
-      var accountControl = accountControlAvailable()
+      var accountControl = accountControlAvailable(this)
         ? '<div class="account-control">' +
             '<button class="account-trigger' + (accountSignedIn ? ' signed-in' : '') + '" type="button" aria-label="' + userMenuLabel + '" aria-haspopup="menu" aria-controls="hb-account-menu" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="12" cy="8" r="3.25"></circle><path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5"></path></svg></button>' +
             '<div class="account-menu" id="hb-account-menu" role="menu" hidden><slot name="account-menu"><a role="menuitem" href="' + accountPageHref(language) + '">' + accountLabel + '</a></slot></div>' +

--- a/src/app/__tests__/layout-locale.test.tsx
+++ b/src/app/__tests__/layout-locale.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
     requestBrowserLocale: vi.fn(),
     locallyKnownAccountSession: vi.fn(),
     locallyKnownListenerNavigationIdentity: vi.fn(),
+    validateListenerAccountRPEnvironment: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({ headers: mocks.headers }));
@@ -20,6 +21,7 @@ vi.mock('@/lib/account/auth', () => ({
 }));
 vi.mock('@/lib/listener/account-rp', () => ({
     locallyKnownListenerNavigationIdentity: mocks.locallyKnownListenerNavigationIdentity,
+    validateListenerAccountRPEnvironment: mocks.validateListenerAccountRPEnvironment,
 }));
 vi.mock('next/font/local', () => ({
     default: () => ({ variable: 'local-font' }),
@@ -41,6 +43,9 @@ describe('root document locale boundary', () => {
         vi.clearAllMocks();
         mocks.locallyKnownAccountSession.mockResolvedValue(false);
         mocks.locallyKnownListenerNavigationIdentity.mockResolvedValue(null);
+        mocks.validateListenerAccountRPEnvironment.mockReturnValue(false);
+        delete process.env.BEACON_ACCOUNT_RUNTIME;
+        delete process.env.BEACON_ACCOUNT_BASE_URL;
     });
 
     it('matches the canonical Listener SSR document to browser-language content', async () => {
@@ -92,6 +97,8 @@ describe('root document locale boundary', () => {
     });
 
     it('enhances Account staging navigation and reflects only a local signed-in boolean', async () => {
+        process.env.BEACON_ACCOUNT_RUNTIME = '1';
+        process.env.BEACON_ACCOUNT_BASE_URL = 'https://account-staging.harmonicbeacon.com';
         const incoming = requestHeaders('account-staging.harmonicbeacon.com', 'en-US');
         incoming.set('x-hb-account-locale', 'en');
         mocks.headers.mockResolvedValue(incoming);
@@ -107,6 +114,7 @@ describe('root document locale boundary', () => {
     });
 
     it('uses only the local Listener projection for the signed-in navigation hint', async () => {
+        mocks.validateListenerAccountRPEnvironment.mockReturnValue(true);
         mocks.headers.mockResolvedValue(requestHeaders(
             'earlybirds-staging.harmonicbeacon.com',
             'en-US',
@@ -124,6 +132,23 @@ describe('root document locale boundary', () => {
         expect(bodyChildren[1].type).toBe(ListenerIdentityCacheBoundary);
         expect(mocks.locallyKnownListenerNavigationIdentity).toHaveBeenCalledOnce();
         expect(mocks.locallyKnownAccountSession).not.toHaveBeenCalled();
+    });
+
+    it('exposes production Account only when the Listener RP environment is enabled', async () => {
+        const incoming = requestHeaders('listen.harmonicbeacon.com', 'en-US');
+        mocks.headers.mockResolvedValue(incoming);
+        mocks.requestBrowserLocale.mockResolvedValue('en');
+        mocks.validateListenerAccountRPEnvironment.mockReturnValue(true);
+        mocks.locallyKnownListenerNavigationIdentity.mockResolvedValue({ displayName: 'Nico' });
+
+        const result = await RootLayout({ children: <main /> });
+        const bodyChildren = result.props.children.props.children;
+        const navigation = bodyChildren[0];
+
+        expect(navigation.props.accountHref).toBe('https://account.harmonicbeacon.com/account');
+        expect(navigation.props.accountSignedIn).toBe(true);
+        expect(navigation.props.accountMenu.props.displayName).toBe('Nico');
+        expect(mocks.locallyKnownListenerNavigationIdentity).toHaveBeenCalledOnce();
     });
 
     it('does not expose an Account control on production before Account production exists', async () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,9 +11,12 @@ import {
 } from "@/lib/brand/global-navigation";
 import { requestBrowserLocale, requestLocale } from "@/lib/i18n-server";
 import { isCanonicalListenerHost, isListenerStagingHost } from "@/lib/listener/public-discovery";
-import { isAccountHost } from "@/lib/account/config";
+import { isAccountHost, isCurrentAccountHost } from "@/lib/account/config";
 import { locallyKnownAccountSession } from "@/lib/account/auth";
-import { locallyKnownListenerNavigationIdentity } from "@/lib/listener/account-rp";
+import {
+  locallyKnownListenerNavigationIdentity,
+  validateListenerAccountRPEnvironment,
+} from "@/lib/listener/account-rp";
 import "@/styles/hb-brand.css";
 import "./globals.css";
 import { Toaster } from "sonner";
@@ -120,7 +123,20 @@ export default async function RootLayout({
   const listenerHost = isCanonicalListenerHost(incomingHeaders);
   const listenerAccountHost = listenerHost || isListenerStagingHost(incomingHeaders);
   const accountHost = isAccountHost(incomingHeaders.get('host'));
-  const accountHref = globalNavigationAccountHref(incomingHeaders);
+  const accountAuthorityAvailable = accountHost && process.env.BEACON_ACCOUNT_RUNTIME === '1' &&
+    isCurrentAccountHost(incomingHeaders.get('host'));
+  let listenerAccountAvailable = false;
+  if (listenerAccountHost) {
+    try {
+      listenerAccountAvailable = validateListenerAccountRPEnvironment();
+    } catch {
+      listenerAccountAvailable = false;
+    }
+  }
+  const accountHref = globalNavigationAccountHref(
+    incomingHeaders,
+    accountAuthorityAvailable || listenerAccountAvailable,
+  );
   const localHeaders = new Headers(incomingHeaders);
   const listenerNavigationIdentity = accountHref && listenerAccountHost
     ? await locallyKnownListenerNavigationIdentity(localHeaders).catch(() => null)

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -28,12 +28,14 @@ manifest and visual-review update together.
 Listener, Live and Account serve a byte-pinned local snapshot of the canonical
 web component rather than executing JavaScript supplied at runtime by another
 origin. The source is `AlterMundi/harmonicbeacon.com` commit
-`7e2730344e543e6c6ff5abde6d8133fc198214ae`; the vendored
+`6bd32262318e9a1faf6f4fc54b85b96f856544df`; the vendored
 `public/assets/hb-global-nav.js` SHA-256 is
-`ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08`.
+`5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6`.
 The local light-DOM markup remains the accessible, same-destination fallback.
 Both implementations keep Account out of the primary destination list and
-expose it from the user-icon menu. The enhanced navigation renders both the
+expose it from the user-icon menu only when the product server supplies the
+presence-only `data-account-available` capability (or on the exact staging
+hosts). The enhanced navigation renders both the
 Beacon mark and user glyph locally; it does not embed Account in an iframe or
 fetch a cross-origin image. Product layouts may pass the boolean presence of a
 locally known Account session and may fill the canonical menu slot with

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -11,13 +11,13 @@
   },
   "globalNavigation": {
     "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
-    "commit": "7e2730344e543e6c6ff5abde6d8133fc198214ae",
+    "commit": "6bd32262318e9a1faf6f4fc54b85b96f856544df",
     "source": "assets/hb-global-nav.js",
     "path": "public/assets/hb-global-nav.js",
-    "sha256": "ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08"
+    "sha256": "5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6"
   },
   "snapshots": {
-    "public/assets/hb-global-nav.js": "ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08",
+    "public/assets/hb-global-nav.js": "5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6",
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
   },

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -6,8 +6,8 @@ import type { UiLocale } from '@/lib/i18n';
 // Byte-pinned local snapshot of harmonicbeacon.com@7e27303. Protected product
 // origins never execute remotely supplied JavaScript with their host cookies.
 export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
-export const GLOBAL_NAVIGATION_PROVENANCE = '7e2730344e543e6c6ff5abde6d8133fc198214ae';
-export const GLOBAL_NAVIGATION_SHA256 = 'ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08';
+export const GLOBAL_NAVIGATION_PROVENANCE = '6bd32262318e9a1faf6f4fc54b85b96f856544df';
+export const GLOBAL_NAVIGATION_SHA256 = '5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6';
 
 export type GlobalNavigationSurface = 'events' | 'listen' | 'account';
 
@@ -34,7 +34,7 @@ export function GlobalNavigation({
     active: GlobalNavigationSurface;
     locale: UiLocale;
     allowRemoteEnhancement?: boolean;
-    accountHref?: 'https://account-staging.harmonicbeacon.com/account' | null;
+    accountHref?: 'https://account.harmonicbeacon.com/account' | 'https://account-staging.harmonicbeacon.com/account' | null;
     accountSignedIn?: boolean;
     accountMenu?: ReactNode;
 }) {
@@ -91,6 +91,7 @@ export function GlobalNavigation({
         <>
             {createElement('hb-global-nav', {
                 'data-surface': active,
+                ...(accountHref ? { 'data-account-available': '' } : {}),
                 ...(accountSignedIn ? { 'data-account-signed-in': '' } : {}),
             }, fallback, accountMenu ? (
                 <div key="account-menu" slot="account-menu" className="hb-global-navigation-local-account-slot">

--- a/src/components/brand/ListenerNavigationAccountMenu.tsx
+++ b/src/components/brand/ListenerNavigationAccountMenu.tsx
@@ -11,7 +11,7 @@ export function ListenerNavigationAccountMenu({
     locale,
 }: {
     displayName: string;
-    accountHref: 'https://account-staging.harmonicbeacon.com/account';
+    accountHref: 'https://account.harmonicbeacon.com/account' | 'https://account-staging.harmonicbeacon.com/account';
     locale: UiLocale;
 }) {
     const [signOutError, setSignOutError] = useState(false);

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -32,14 +32,16 @@ describe('canonical Harmonic Beacon global navigation', () => {
     });
 
     it.each([
-        ['account-staging.harmonicbeacon.com', 'https://account-staging.harmonicbeacon.com/account'],
-        ['earlybirds-staging.harmonicbeacon.com', 'https://account-staging.harmonicbeacon.com/account'],
-        ['live-staging.harmonicbeacon.com', 'https://account-staging.harmonicbeacon.com/account'],
-        ['listen.harmonicbeacon.com', null],
-        ['account.harmonicbeacon.com', null],
-        ['earlybirds-staging.harmonicbeacon.com, account.harmonicbeacon.com', null],
-    ] as const)('maps the exact host %s to Account href %s', (host, expected) => {
-        expect(globalNavigationAccountHref(new Headers({ host }))).toBe(expected);
+        ['account-staging.harmonicbeacon.com', true, 'https://account-staging.harmonicbeacon.com/account'],
+        ['earlybirds-staging.harmonicbeacon.com', true, 'https://account-staging.harmonicbeacon.com/account'],
+        ['live-staging.harmonicbeacon.com', true, 'https://account-staging.harmonicbeacon.com/account'],
+        ['listen.harmonicbeacon.com', true, 'https://account.harmonicbeacon.com/account'],
+        ['account.harmonicbeacon.com', true, 'https://account.harmonicbeacon.com/account'],
+        ['listen.harmonicbeacon.com', false, null],
+        ['earlybirds-staging.harmonicbeacon.com', false, null],
+        ['earlybirds-staging.harmonicbeacon.com, account.harmonicbeacon.com', true, null],
+    ] as const)('maps the exact host %s with availability %s to Account href %s', (host, available, expected) => {
+        expect(globalNavigationAccountHref(new Headers({ host }), available)).toBe(expected);
     });
 
     it('keeps an accessible same-destination fallback while the shared asset loads', () => {
@@ -54,7 +56,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
     });
 
     it('loads a byte-pinned local canonical asset instead of remote same-origin code', () => {
-        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('7e2730344e543e6c6ff5abde6d8133fc198214ae');
+        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('6bd32262318e9a1faf6f4fc54b85b96f856544df');
         const bytes = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'));
         expect(createHash('sha256').update(bytes).digest('hex')).toBe(GLOBAL_NAVIGATION_SHA256);
         expect(manifest.globalNavigation.commit).toBe(GLOBAL_NAVIGATION_PROVENANCE);
@@ -64,6 +66,8 @@ describe('canonical Harmonic Beacon global navigation', () => {
         const source = bytes.toString('utf8');
         expect(source).toContain('class="account-trigger');
         expect(source).toContain("'data-account-signed-in'");
+        expect(source).toContain("'data-account-available'");
+        expect(source).toContain("element.hasAttribute('data-account-available')");
         expect(source).toContain("this.hasAttribute('data-account-signed-in')");
         expect(source).toContain('User menu, signed in');
         expect(source).toContain('Menú de usuario, sesión iniciada');
@@ -149,5 +153,20 @@ describe('canonical Harmonic Beacon global navigation', () => {
 
         expect(shadow?.querySelector('.account-trigger')).toBeNull();
         expect(shadow?.querySelector('.account-menu')).toBeNull();
+    });
+
+    it('reveals only the production Account menu when the server supplies availability', () => {
+        const view = render(<GlobalNavigation
+            active="listen"
+            locale="en"
+            accountHref="https://account.harmonicbeacon.com/account"
+            accountSignedIn
+            accountMenu={<button role="menuitem">Sign out</button>}
+        />);
+
+        expect(view.container.querySelector('hb-global-nav')).toHaveAttribute('data-account-available', '');
+        expect(within(view.container).getByRole('menuitem', { name: 'Account' }))
+            .toHaveAttribute('href', 'https://account.harmonicbeacon.com/account?lang=en');
+        expect(within(view.container).getByRole('menuitem', { name: 'Sign out' })).toBeInTheDocument();
     });
 });

--- a/src/lib/brand/global-navigation.ts
+++ b/src/lib/brand/global-navigation.ts
@@ -1,7 +1,8 @@
 import type { GlobalNavigationSurface } from '@/components/brand/GlobalNavigation';
 
 export type GlobalNavigationAccountHref =
-    'https://account-staging.harmonicbeacon.com/account';
+    | 'https://account.harmonicbeacon.com/account'
+    | 'https://account-staging.harmonicbeacon.com/account';
 
 const PUBLIC_SURFACES: Record<string, GlobalNavigationSurface> = {
     'live.harmonicbeacon.com': 'events',
@@ -29,11 +30,16 @@ export function globalNavigationSurface(headers: Pick<Headers, 'get'>): GlobalNa
  * the server-rendered fallback shown before the pinned navigation asset loads. */
 export function globalNavigationAccountHref(
     headers: Pick<Headers, 'get'>,
+    accountAvailable = false,
 ): GlobalNavigationAccountHref | null {
+    if (!accountAvailable) return null;
     const host = normalizedHost(headers.get('host'));
-    return host === 'account-staging.harmonicbeacon.com' ||
+    if (host === 'account-staging.harmonicbeacon.com' ||
         host === 'earlybirds-staging.harmonicbeacon.com' ||
-        host === 'live-staging.harmonicbeacon.com'
-        ? 'https://account-staging.harmonicbeacon.com/account'
+        host === 'live-staging.harmonicbeacon.com') {
+        return 'https://account-staging.harmonicbeacon.com/account';
+    }
+    return host === 'account.harmonicbeacon.com' || host === 'listen.harmonicbeacon.com'
+        ? 'https://account.harmonicbeacon.com/account'
         : null;
 }


### PR DESCRIPTION
## Outcome

Repins the exact canonical navigation from harmonicbeacon.com PR #75 and makes the production Account user control available only when the current Account authority or Listener RP runtime validates as enabled. Until then, production keeps the existing no-control state and cannot emit a dead Account link.

Staging remains staging-only. Production Account/Listener target only `https://account.harmonicbeacon.com`; no production-to-staging path is introduced.

## Boundary

- availability and signed-in state are presence-only booleans
- no fetch, identity field, cookie, subject, provider token or PII enters the static asset
- Account authority availability requires exact current Account host/runtime
- Listener availability reuses its fail-closed environment validator
- local presentation remains a read-only host-local hint, not authorization

## Evidence

- canonical source: `6bd32262318e9a1faf6f4fc54b85b96f856544df`
- vendored SHA-256: `5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6`
- focused layout/navigation/RP suite: 46/46
- focused ESLint and diff-check: pass
