### PR TITLE
ops(live): add reversible production Account activation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/scripts/commerce-media-worker.ts 
 # Root-invoked, staging-only Account preparation commands. They are not
 # reachable from the application process and accept no caller-supplied paths.
 COPY --from=builder --chown=root:root /app/scripts/live-staging ./scripts/live-staging
+# Root-invoked production Account authenticated preflight. These scripts are
+# not reachable from the application process; the networked preflight receives
+# only the dedicated hb-live RP bundle.
+COPY --from=builder --chown=root:root /app/scripts/live-production ./scripts/live-production
 COPY --from=builder --chown=nextjs:nodejs /app/src/lib/event-stabilization.ts ./src/lib/event-stabilization.ts
 COPY --from=builder --chown=nextjs:nodejs /app/src/lib/redact.ts ./src/lib/redact.ts
 COPY --from=builder --chown=nextjs:nodejs /app/src/lib/commerce-media-reconciler.ts ./src/lib/commerce-media-reconciler.ts

--- a/deploy/LIVE_ACCOUNT_PRODUCTION.md
+++ b/deploy/LIVE_ACCOUNT_PRODUCTION.md
@@ -1,0 +1,103 @@
+# Live production — central Beacon Account activation
+
+This is a separate, reversible feature cutover after both products already run
+their reviewed immutable releases. It does not build an image, run a migration,
+recreate PostgreSQL, LiveKit, playlist, tapestry or commerce, or enable Apple.
+
+## Preconditions
+
+1. Deploy the reviewed Account production authority first. Require exact
+   readiness/provenance, discovery, JWKS, mail delivery and the confidential
+   `hb-live` client. Apple remains disabled until its external developer
+   material exists.
+2. Deploy the reviewed Live production release with Account **off**, including
+   its ordinary database backup/migration and event/audio/payment regression
+   gates. The running `beacon-app` image and `BEACON_GIT_SHA` must equal the
+   exact release SHA before this activation begins.
+   Before advancing `release`, install the exact reviewed
+   `deploy/hb-deploy-root` as `/usr/local/sbin/hb-deploy` with root ownership
+   and mode 0755, then require `cmp` byte equality; the deploy workflow refuses
+   a stale privileged helper.
+3. The live vhost must still equal the reviewed pre-Account SHA-256 pinned in
+   `activate-account.sh`. A different hash is operator drift and requires a new
+   review; never overwrite it by hand.
+4. Run outside an event. Capture the existing protected container IDs/images,
+   current Live DB counts and a fresh verified custom-format PostgreSQL backup.
+
+The Account authority environment stays root:root 0600. Do not print, source or
+copy its values through chat, shell arguments, issue comments or CI logs.
+
+## Prepare the app-only RP bundle
+
+From a clean checkout of the exact running Live SHA, after its exact image is
+present:
+
+```bash
+sudo scripts/live-production/prepare-account.sh "$LIVE_SHA"
+```
+
+The fixed-path POSIX script reads the root-only Account file locally and copies
+only the dedicated `hb-live` client secret; no container receives the full
+authority environment. It writes exactly four keys to
+`/etc/harmonic-beacon/live-production-secrets/account.env`, root:root 0600:
+the enable flag, exact issuer/client ID and the `hb-live` client secret.
+`docker-compose.yml` mounts this optional
+bundle only into `beacon-app`; no other service inherits it. Merely preparing
+the file does not change the already-running container. Preparation shares the
+activation lock and refuses an already Account-enabled app; rotating a live RP
+credential is deliberately a separate reviewed operation.
+
+The production deploy helper uses a dedicated `migrate` service. It has only
+the shared database environment and receives neither the Account bundle nor
+the commerce bundle. Every future deploy boundary rejects Account secrets in
+PostgreSQL, LiveKit, playlist, tapestry and the commerce reconciler.
+
+## Activate
+
+Record the exact Account readiness coordinates, then run:
+
+```bash
+sudo scripts/live-production/activate-account.sh \
+  "$LIVE_SHA" "$ACCOUNT_SHA" "$ACCOUNT_SCHEMA"
+```
+
+The command fails before mutation unless:
+
+- the checkout, image and already-running Live app all equal `LIVE_SHA`;
+- the current app is healthy and Account-off;
+- Account readiness equals `ACCOUNT_SHA`/`ACCOUNT_SCHEMA`;
+- discovery is exact, only S256 + client_secret_basic are advertised, the Ed25519
+  JWKS is usable and the hb-live secret authenticates session-status;
+- the current Nginx vhost is the reviewed pre-Account file.
+
+It then installs the exact no-log Account edge, reloads Nginx, and recreates
+**only** `beacon-app` from the same image. Public readiness must report Account
+ok; login must redirect only to Account production with `hb-live`, the exact
+Live callback and PKCE S256. Callback/frontchannel method, suffix and access-log
+negative smokes run before success. Protected container fingerprints must be
+byte-identical. Evidence is stored root-only below
+`/var/lib/harmonic-beacon/live-account-production/`.
+
+## Human acceptance
+
+Use a normal non-incognito browser and one production test account. Check
+participant sign-in, explicit Team sign-in for a pre-bound staff identity,
+canonical profile/nav, Account link, current-device logout and frontchannel
+logout. Do not enter a room or exercise payments during identity acceptance.
+Record no email, subject, sid, OAuth code/state, cookie or token.
+
+## Rollback
+
+```bash
+sudo scripts/live-production/rollback-account.sh
+```
+
+The successful activation also prints a durable command inside its root-only
+evidence directory. Prefer that copy if the Actions workspace has since moved
+or been cleaned; its Compose, candidate Nginx and checksum manifest are stored
+beside it.
+
+Rollback moves the app-only bundle into the root-only activation evidence,
+recreates only the same exact `beacon-app` with Account absent/off, verifies
+readiness, then restores and reloads the prior vhost. The dormant bundle is not
+deleted and production data is never downgraded or removed.

--- a/deploy/hb-deploy-root
+++ b/deploy/hb-deploy-root
@@ -11,6 +11,7 @@ export PATH
 
 readonly PRODUCTION_ENV='/etc/harmonic-beacon/production.env'
 readonly COMMERCE_ENV='/etc/harmonic-beacon/commerce.env'
+readonly ACCOUNT_ENV='/etc/harmonic-beacon/live-production-secrets/account.env'
 readonly WORKSPACE='/opt/actions-runner/_work/harmonic-beacon-webapp/harmonic-beacon-webapp'
 readonly PRIVATE_NETWORK='pmp_beacon_internal'
 readonly EXPECTED_NETWORK_MEMBERS=$'beacon-app\npmp-myth-worker\npmp-myth-worker-secondary'
@@ -126,6 +127,16 @@ preflight() {
   [ -r "$COMMERCE_ENV" ] || die 'commerce environment is not readable by root'
   [ "$(stat -c '%a:%U:%G' "$COMMERCE_ENV")" = '600:root:root' ] ||
     die 'commerce environment permissions are not 600:root:root'
+  if [ -e "$ACCOUNT_ENV" ]; then
+    [ -f "$ACCOUNT_ENV" ] && [ ! -L "$ACCOUNT_ENV" ] ||
+      die 'Account environment must be a regular file'
+    [ "$(stat -c '%a:%U:%G' "$ACCOUNT_ENV")" = '600:root:root' ] ||
+      die 'Account environment permissions are not 600:root:root'
+    container_has_env_name beacon-app BEACON_ACCOUNT_ENABLED &&
+      [ "$(docker inspect beacon-app --format '{{range .Config.Env}}{{println .}}{{end}}' |
+        sed -n 's/^BEACON_ACCOUNT_ENABLED=//p' | tail -n 1)" = true ] ||
+      die 'Account bundle exists before the supervised Account activation'
+  fi
   if grep -Fxq 'E2E_DASHBOARD_ENABLED=1' "$PRODUCTION_ENV"; then
     die 'production E2E dashboard must be disabled before deploy'
   fi
@@ -184,8 +195,8 @@ migrate() {
 
   validate_workspace "$workspace"
   validate_checkout "$sha"
-  compose "$workspace" "$sha" run --rm --no-deps app npx prisma migrate deploy
-  compose "$workspace" "$sha" run --rm --no-deps app npx prisma migrate status
+  compose "$workspace" "$sha" run --rm --no-deps migrate npx prisma migrate deploy
+  compose "$workspace" "$sha" run --rm --no-deps migrate npx prisma migrate status
 }
 
 replace() {
@@ -229,6 +240,22 @@ boundary() {
     pmp-myth-waha pmp-myth-rag pmp-myth-gateway; do
     if docker inspect "$container" >/dev/null 2>&1 && container_has_commerce_key "$container"; then
       die "commerce bearer reached unexpected container: $container"
+    fi
+  done
+
+  if [ -e "$ACCOUNT_ENV" ]; then
+    [ "$(docker inspect beacon-app --format '{{range .Config.Env}}{{println .}}{{end}}' |
+      sed -n 's/^BEACON_ACCOUNT_ENABLED=//p' | tail -n 1)" = true ] ||
+      die 'app has Account secrets but Account is not enabled'
+    container_has_env_name beacon-app BEACON_ACCOUNT_CLIENT_SECRET ||
+      die 'app is missing the Account client secret'
+  elif container_has_env_name beacon-app BEACON_ACCOUNT_CLIENT_SECRET; then
+    die 'app received Account secrets without the root-owned bundle'
+  fi
+  for container in beacon-postgres beacon-livekit beacon-playlist-bot \
+    beacon-tapestry beacon-commerce-reconciler; do
+    if container_has_env_name "$container" BEACON_ACCOUNT_CLIENT_SECRET; then
+      die "Account RP secret reached unexpected container: $container"
     fi
   done
 }

--- a/deploy/nginx-harmonic-beacon.conf
+++ b/deploy/nginx-harmonic-beacon.conf
@@ -22,6 +22,7 @@ map $http_upgrade $connection_upgrade {
 
 # Rate limiting: 10 req/s per IP for the API zone
 limit_req_zone $binary_remote_addr zone=beacon_api:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=live_account_auth:10m rate=5r/s;
 
 # --- HTTP → HTTPS redirect ---
 server {
@@ -65,6 +66,81 @@ server {
     }
 
     location ^~ /api/internal/ {
+        return 404;
+    }
+
+    # Exact central Account RP surface. OAuth code/state and logout sid values
+    # are private one-use/session material and must never enter the general
+    # access log. Unknown suffixes remain denied until separately reviewed.
+    location = /api/account/login {
+        if ($request_method != GET) { return 405; }
+        access_log off;
+        limit_req zone=live_account_auth burst=5 nodelay;
+        limit_req_status 429;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        proxy_pass http://harmonic_beacon_app;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Authorization "";
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 15s;
+        proxy_read_timeout 15s;
+    }
+
+    location = /api/account/callback {
+        if ($request_method != GET) { return 405; }
+        access_log off;
+        limit_req zone=live_account_auth burst=10 nodelay;
+        limit_req_status 429;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        proxy_pass http://harmonic_beacon_app;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Authorization "";
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 15s;
+        proxy_read_timeout 15s;
+    }
+
+    location = /api/account/frontchannel-logout {
+        if ($request_method != GET) { return 405; }
+        access_log off;
+        limit_req zone=live_account_auth burst=10 nodelay;
+        limit_req_status 429;
+        add_header Cache-Control "private, no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        # No X-Frame-Options: the app supplies an issuer-scoped
+        # frame-ancestors policy for OIDC front-channel logout.
+        proxy_pass http://harmonic_beacon_app;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Authorization "";
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 15s;
+        proxy_read_timeout 15s;
+    }
+
+    location ^~ /api/account/ {
+        access_log off;
         return 404;
     }
 

--- a/deploy/production.env.example
+++ b/deploy/production.env.example
@@ -29,6 +29,11 @@ PROMO_INVITATIONS_ENABLED=false
 # /etc/harmonic-beacon/commerce.env; see deploy/commerce.env.example. Never add
 # them here because this shared file is also loaded by non-app containers.
 
+# Beacon Account RP credentials also never belong in this shared file. The
+# reviewed production activation writes the four-key app-only bundle at
+# /etc/harmonic-beacon/live-production-secrets/account.env. Its presence turns
+# Account on only for beacon-app; its absence keeps Account fail-closed/off.
+
 # ── Staff credentials (seed-contract scrypt digests) ─────────────────
 # Generate with: node -e "const {scryptSync,randomBytes}=require('crypto');const s=randomBytes(16);const d=scryptSync('<password>',s,32);console.log('scrypt\$'+s.toString('base64url')+'\$'+d.toString('base64url'))"
 STAFF_FACILITATOR_NAME=Julián

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,27 @@ services:
         max-size: "30m"
         max-file: "3"
 
+  # One-shot migrations intentionally inherit neither the app-only Account RP
+  # bundle nor the app-only commerce bearer bundle.
+  migrate:
+    image: harmonic-beacon/app:${BEACON_IMAGE_TAG:-latest}
+    command: [npx, prisma, migrate, deploy]
+    restart: "no"
+    env_file:
+      - path: /etc/harmonic-beacon/production.env
+        required: true
+    environment:
+      - NODE_ENV=production
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-beacon}:${POSTGRES_PASSWORD:?required}@postgres:5432/${POSTGRES_DB:-beacon}
+    networks:
+      - beacon
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp:size=32m,mode=1777
+
   # ── Next.js app ───────────────────────────────────────────────────
   app:
     image: harmonic-beacon/app:${BEACON_IMAGE_TAG:-latest}
@@ -93,10 +114,17 @@ services:
     container_name: beacon-app
     restart: unless-stopped
     env_file:
-      - /etc/harmonic-beacon/production.env
+      - path: /etc/harmonic-beacon/production.env
+        required: true
+      # Confidential hb-live RP material is app-only. In particular, it must
+      # never enter PostgreSQL, LiveKit, playlist, tapestry or the commerce
+      # reconciler through the shared production environment.
+      - path: /etc/harmonic-beacon/live-production-secrets/account.env
+        required: false
       # Kept separate so playlist, tapestry, Postgres and the media worker can
       # never inherit the private PMP bearer from the shared stack env.
-      - /etc/harmonic-beacon/commerce.env
+      - path: /etc/harmonic-beacon/commerce.env
+        required: true
     environment:
       - NODE_ENV=production
       - DATABASE_URL=postgresql://${POSTGRES_USER:-beacon}:${POSTGRES_PASSWORD:?required}@postgres:5432/${POSTGRES_DB:-beacon}

--- a/public/assets/hb-global-nav.js
+++ b/public/assets/hb-global-nav.js
@@ -7,6 +7,7 @@
   var LISTENER_STAGING_ORIGIN = 'https://earlybirds-staging.harmonicbeacon.com';
   var LIVE_ORIGIN = 'https://live.harmonicbeacon.com';
   var LIVE_STAGING_ORIGIN = 'https://live-staging.harmonicbeacon.com';
+  var ACCOUNT_ORIGIN = 'https://account.harmonicbeacon.com';
   var ACCOUNT_STAGING_ORIGIN = 'https://account-staging.harmonicbeacon.com';
   var ELEMENT_NAME = 'hb-global-nav';
 
@@ -90,11 +91,21 @@
     return null;
   }
 
-  function accountControlAvailable() {
+  function accountControlAvailable(element) {
     var host = location.hostname.toLowerCase();
     return host === 'earlybirds-staging.harmonicbeacon.com' ||
       host === 'live-staging.harmonicbeacon.com' ||
-      host === 'account-staging.harmonicbeacon.com';
+      host === 'account-staging.harmonicbeacon.com' ||
+      element.hasAttribute('data-account-available');
+  }
+
+  function accountOrigin() {
+    var host = location.hostname.toLowerCase();
+    return host === 'earlybirds-staging.harmonicbeacon.com' ||
+      host === 'live-staging.harmonicbeacon.com' ||
+      host === 'account-staging.harmonicbeacon.com'
+      ? ACCOUNT_STAGING_ORIGIN
+      : ACCOUNT_ORIGIN;
   }
 
   function accountReturnTo() {
@@ -109,7 +120,7 @@
   }
 
   function accountPageHref(language) {
-    var url = new URL('/account', ACCOUNT_STAGING_ORIGIN);
+    var url = new URL('/account', accountOrigin());
     url.searchParams.set('lang', language);
     url.searchParams.set('return_to', accountReturnTo());
     return url.toString();
@@ -184,11 +195,11 @@
 
   class HarmonicBeaconGlobalNav extends HTMLElement {
     static get observedAttributes() {
-      return ['data-account-signed-in'];
+      return ['data-account-available', 'data-account-signed-in'];
     }
 
     attributeChangedCallback(name, previous, next) {
-      if (name === 'data-account-signed-in' && previous !== next && this.shadowRoot) this.render();
+      if (this.constructor.observedAttributes.includes(name) && previous !== next && this.shadowRoot) this.render();
     }
 
     connectedCallback() {
@@ -234,7 +245,7 @@
         ? (accountSignedIn ? 'Menú de usuario, sesión iniciada' : 'Menú de usuario')
         : (accountSignedIn ? 'User menu, signed in' : 'User menu');
       var accountLabel = language === 'es' ? 'Cuenta' : 'Account';
-      var accountControl = accountControlAvailable()
+      var accountControl = accountControlAvailable(this)
         ? '<div class="account-control">' +
             '<button class="account-trigger' + (accountSignedIn ? ' signed-in' : '') + '" type="button" aria-label="' + userMenuLabel + '" aria-haspopup="menu" aria-controls="hb-account-menu" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="12" cy="8" r="3.25"></circle><path d="M5.75 19c.6-3.25 2.7-5 6.25-5s5.65 1.75 6.25 5"></path></svg></button>' +
             '<div class="account-menu" id="hb-account-menu" role="menu" hidden><slot name="account-menu"><a role="menuitem" href="' + accountPageHref(language) + '">' + accountLabel + '</a></slot></div>' +

--- a/scripts/live-production/account-env.d.mts
+++ b/scripts/live-production/account-env.d.mts
@@ -1,0 +1,13 @@
+export const AUTHORITY_ENV: string;
+export const TARGET_DIRECTORY: string;
+export const TARGET_ENV: string;
+export const ISSUER: string;
+export const CLIENT_ID: string;
+export const AUTHORITY_KEY: string;
+export const TARGET_KEYS: string[];
+
+export function parseEnv(contents: string): Map<string, string>;
+export function validateTarget(values: Map<string, string>): Map<string, string>;
+export function buildTarget(
+    authority: Map<string, string>,
+): string;

--- a/scripts/live-production/account-env.mjs
+++ b/scripts/live-production/account-env.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+export const AUTHORITY_ENV = '/etc/harmonic-beacon/account.production.env';
+export const TARGET_DIRECTORY = '/etc/harmonic-beacon/live-production-secrets';
+export const TARGET_ENV = `${TARGET_DIRECTORY}/account.env`;
+export const ISSUER = 'https://account.harmonicbeacon.com';
+export const CLIENT_ID = 'hb-live';
+export const AUTHORITY_KEY = 'BEACON_ACCOUNT_CLIENT_SECRET_HB_LIVE';
+export const TARGET_KEYS = [
+    'BEACON_ACCOUNT_ENABLED',
+    'BEACON_ACCOUNT_ISSUER_URL',
+    'BEACON_ACCOUNT_CLIENT_ID',
+    'BEACON_ACCOUNT_CLIENT_SECRET',
+];
+
+function fail(message) {
+    throw new Error(message);
+}
+
+export function parseEnv(contents) {
+    const values = new Map();
+    for (const rawLine of contents.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+        const separator = line.indexOf('=');
+        if (separator < 1) fail('invalid environment file');
+        const key = line.slice(0, separator).trim();
+        const value = line.slice(separator + 1);
+        if (!/^[A-Z][A-Z0-9_]*$/.test(key) || values.has(key)) {
+            fail('invalid or duplicate environment key');
+        }
+        values.set(key, value);
+    }
+    return values;
+}
+
+function secret(value, name) {
+    if (typeof value !== 'string' || value.length < 32 || /[\r\n\0]/.test(value)) {
+        fail(`${name} is invalid`);
+    }
+    return value;
+}
+
+export function validateTarget(values) {
+    if ([...values.keys()].join('\n') !== TARGET_KEYS.join('\n')) {
+        fail('Live production Account bundle keys or ordering are invalid');
+    }
+    if (values.get('BEACON_ACCOUNT_ENABLED') !== 'true') fail('Account bundle must enable Account');
+    if (values.get('BEACON_ACCOUNT_ISSUER_URL') !== ISSUER) fail('Account issuer is not production');
+    if (values.get('BEACON_ACCOUNT_CLIENT_ID') !== CLIENT_ID) fail('Account client ID is not hb-live');
+    secret(values.get('BEACON_ACCOUNT_CLIENT_SECRET'), 'Account client secret');
+    return values;
+}
+
+export function buildTarget(authority) {
+    if (authority.get('BEACON_ACCOUNT_BASE_URL') !== ISSUER ||
+        authority.get('BEACON_ACCOUNT_RUNTIME') !== '1') {
+        fail('Account production authority is not exact and enabled');
+    }
+    const clientSecret = secret(authority.get(AUTHORITY_KEY), 'Authority hb-live client secret');
+    if (authority.get('BEACON_ACCOUNT_CLIENT_SECRET_HB_LIVE_STAGING')) {
+        fail('Account production authority must not carry the staging Live client secret');
+    }
+    const values = new Map([
+        ['BEACON_ACCOUNT_ENABLED', 'true'],
+        ['BEACON_ACCOUNT_ISSUER_URL', ISSUER],
+        ['BEACON_ACCOUNT_CLIENT_ID', CLIENT_ID],
+        ['BEACON_ACCOUNT_CLIENT_SECRET', clientSecret],
+    ]);
+    validateTarget(values);
+    return `${[...values].map(([key, value]) => `${key}=${value}`).join('\n')}\n`;
+}

--- a/scripts/live-production/account-preflight.mjs
+++ b/scripts/live-production/account-preflight.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { lstat, readFile } from 'node:fs/promises';
+import { CLIENT_ID, ISSUER, TARGET_ENV, parseEnv, validateTarget } from './account-env.mjs';
+
+const LIVE_ORIGIN = 'https://live.harmonicbeacon.com';
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function exactSha(value) {
+    if (!/^[0-9a-f]{40}$/.test(value ?? '')) fail('exact Account SHA required');
+    return value;
+}
+
+function exactSchema(value) {
+    if (!/^[0-9]{14}_[a-z0-9_]+$/.test(value ?? '')) fail('exact Account schema required');
+    return value;
+}
+
+async function rootOnlyBundle() {
+    const metadata = await lstat(TARGET_ENV);
+    if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.uid !== 0 || metadata.gid !== 0 ||
+        (metadata.mode & 0o777) !== 0o600) {
+        fail(`${TARGET_ENV} must be a root:root mode-0600 regular file`);
+    }
+    return validateTarget(parseEnv(await readFile(TARGET_ENV, 'utf8')));
+}
+
+async function jsonResponse(url, init = {}) {
+    const response = await fetch(url, {
+        ...init,
+        cache: 'no-store',
+        redirect: 'error',
+        signal: AbortSignal.timeout(8_000),
+    });
+    const body = await response.json().catch(() => fail(`${url} did not return JSON`));
+    return { response, body };
+}
+
+async function main() {
+    if (process.getuid?.() !== 0) fail('run as root');
+    const mode = process.argv[2] ?? '';
+    const accountSha = exactSha(process.argv[3]);
+    const accountSchema = exactSchema(process.argv[4]);
+    if (!['prepared', 'public'].includes(mode) || process.argv.length !== 5) {
+        fail('usage: account-preflight.mjs prepared|public account-sha40 account-schema');
+    }
+    const bundle = await rootOnlyBundle();
+    const rpSecret = bundle.get('BEACON_ACCOUNT_CLIENT_SECRET');
+
+    const { response: readyResponse, body: ready } = await jsonResponse(`${ISSUER}/api/account/health/ready`);
+    if (!readyResponse.ok || ready.status !== 'ok' || ready.gitSha !== accountSha ||
+        ready.schemaVersion !== accountSchema || ready.checks?.database !== 'ok' || ready.checks?.mail !== 'ok' ||
+        ready.checks?.issuer !== 'ok' || ready.checks?.jwks !== 'ok' || ready.checks?.clients !== 'ok' ||
+        ready.checks?.providers !== 'ok') {
+        fail('Account production readiness or provenance mismatch');
+    }
+
+    const { response: discoveryResponse, body: discovery } = await jsonResponse(
+        `${ISSUER}/.well-known/openid-configuration`,
+        { headers: { Accept: 'application/json' } },
+    );
+    const endpoints = {
+        authorization_endpoint: '/api/account/auth/oauth2/authorize',
+        token_endpoint: '/api/account/auth/oauth2/token',
+        jwks_uri: '/.well-known/jwks.json',
+        userinfo_endpoint: '/api/account/auth/oauth2/userinfo',
+        introspection_endpoint: '/api/account/auth/oauth2/introspect',
+        end_session_endpoint: '/api/account/auth/oauth2/end-session',
+    };
+    if (!discoveryResponse.ok || discovery.issuer !== ISSUER) fail('Account production discovery mismatch');
+    for (const [name, path] of Object.entries(endpoints)) {
+        if (discovery[name] !== `${ISSUER}${path}`) fail(`Account discovery ${name} mismatch`);
+    }
+    if (!Array.isArray(discovery.code_challenge_methods_supported) ||
+        discovery.code_challenge_methods_supported.length !== 1 ||
+        discovery.code_challenge_methods_supported[0] !== 'S256' ||
+        !Array.isArray(discovery.token_endpoint_auth_methods_supported) ||
+        discovery.token_endpoint_auth_methods_supported.length !== 1 ||
+        discovery.token_endpoint_auth_methods_supported[0] !== 'client_secret_basic') {
+        fail('Account discovery does not advertise the frozen RP contract');
+    }
+
+    const { response: jwksResponse, body: jwks } = await jsonResponse(`${ISSUER}/.well-known/jwks.json`);
+    if (!jwksResponse.ok || !Array.isArray(jwks.keys) || jwks.keys.length < 1 ||
+        jwks.keys.some((key) => typeof key !== 'object' || key === null || typeof key.kid !== 'string' ||
+            key.kid.length < 1 || key.kty !== 'OKP' || key.alg !== 'EdDSA' || key.crv !== 'Ed25519' ||
+            typeof key.x !== 'string' || !/^[A-Za-z0-9_-]{43}$/.test(key.x) || 'd' in key ||
+            ('use' in key && key.use !== 'sig') ||
+            ('key_ops' in key && (!Array.isArray(key.key_ops) || key.key_ops.length !== 1 || key.key_ops[0] !== 'verify'))) ||
+        new Set(jwks.keys.map((key) => key?.kid)).size !== jwks.keys.length) {
+        fail('Account production JWKS unavailable or invalid');
+    }
+
+    const basic = Buffer.from(`${CLIENT_ID}:${rpSecret}`, 'utf8').toString('base64');
+    const { response: statusResponse, body: status } = await jsonResponse(
+        `${ISSUER}/api/account/session-status`,
+        {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                Authorization: `Basic ${basic}`,
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({ sid: 'live-production-preflight', sub: 'live-production-preflight' }),
+        },
+    );
+    if (!statusResponse.ok || status.active !== false ||
+        !statusResponse.headers.get('cache-control')?.toLowerCase().includes('no-store')) {
+        fail('Account production session-status client authentication failed');
+    }
+
+    if (mode === 'public') {
+        const { response, body } = await jsonResponse(`${LIVE_ORIGIN}/api/health/ready`);
+        if (!response.ok || body.status !== 'ok' || body.checks?.database !== 'ok' || body.checks?.account !== 'ok') {
+            fail('public Live production Account readiness mismatch');
+        }
+    }
+    process.stdout.write(`Live production Account ${mode} preflight passed without exposing secrets.\n`);
+}
+
+main().catch((error) => {
+    process.stderr.write(`Live production Account preflight failed: ${error instanceof Error ? error.message : 'unknown error'}\n`);
+    process.exitCode = 1;
+});

--- a/scripts/live-production/activate-account.sh
+++ b/scripts/live-production/activate-account.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env sh
+set -eu
+
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+live_sha=${1:?usage: activate-account.sh live-sha40 account-sha40 account-schema}
+account_sha=${2:?usage: activate-account.sh live-sha40 account-sha40 account-schema}
+account_schema=${3:?usage: activate-account.sh live-sha40 account-sha40 account-schema}
+for exact_sha in "$live_sha" "$account_sha"; do
+  case "$exact_sha" in *[!0-9a-f]*|'') echo 'exact lowercase sha40 required' >&2; exit 2 ;; esac
+  test "${#exact_sha}" -eq 40 || { echo 'exact lowercase sha40 required' >&2; exit 2; }
+done
+printf '%s\n' "$account_schema" | grep -Eq '^[0-9]{14}_[a-z0-9_]+$' || {
+  echo 'exact Account schema required' >&2
+  exit 2
+}
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+image="harmonic-beacon/app:$live_sha"
+production_env=/etc/harmonic-beacon/production.env
+bundle=/etc/harmonic-beacon/live-production-secrets/account.env
+vhost=/etc/nginx/sites-enabled/harmonic-beacon
+state_root=/var/lib/harmonic-beacon/live-account-production
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+state="$state_root/activation-$live_sha-$stamp"
+# Exact public vhost in use before this Account surface existed. If production
+# changes independently, activation stops for a fresh review instead of
+# overwriting operator drift.
+pre_account_vhost_sha=9cfa7d4ba1ae5c1de767c02a154ef4ff980a2927a66a64b85062a87f296f3be3
+
+fail() { echo "Live production Account activation: $*" >&2; exit 2; }
+private_file() {
+  test -f "$1" && test ! -L "$1" || fail "$2 must be a regular file"
+  test "$(stat -c '%U:%G:%a' "$1")" = root:root:600 || fail "$2 must be root:root mode 0600"
+}
+container_env_value() {
+  docker inspect beacon-app --format '{{range .Config.Env}}{{println .}}{{end}}' |
+    sed -n "s/^${1}=//p" | tail -n 1 | tr -d '\r'
+}
+wait_healthy() {
+  attempt=0
+  while test "$attempt" -lt 60; do
+    health=$(docker inspect beacon-app --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>/dev/null || true)
+    test "$health" != healthy || return 0
+    test "$health" != exited || return 1
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+  return 1
+}
+write_protected_containers() {
+  destination=$1
+  : > "$destination"
+  for name in beacon-postgres beacon-livekit beacon-playlist-bot beacon-tapestry beacon-commerce-reconciler; do
+    docker inspect "$name" --format '{{.Name}}|{{.Id}}|{{.Config.Image}}|{{.State.Running}}|{{.RestartCount}}' >> "$destination"
+  done
+  chmod 0600 "$destination"
+}
+compose_app() {
+  BEACON_IMAGE_TAG="$live_sha" docker compose -p app --env-file "$production_env" \
+    -f "$root/docker-compose.yml" up -d --no-deps --force-recreate --no-build app
+}
+run_account_preflight() {
+  mode=$1
+  docker run --rm --pull never --read-only --user 0:0 --cap-drop ALL \
+    --security-opt no-new-privileges \
+    --mount "type=bind,src=$bundle,dst=/etc/harmonic-beacon/live-production-secrets/account.env,readonly" \
+    --tmpfs /tmp:size=16m,mode=1777 \
+    --entrypoint node "$image" /app/scripts/live-production/account-preflight.mjs \
+    "$mode" "$account_sha" "$account_schema"
+}
+
+exec 9>/run/lock/live-account-production.lock
+flock -n 9 || fail 'another Live production Account activation is active'
+test "$(git -C "$root" rev-parse HEAD)" = "$live_sha" || fail 'release checkout SHA mismatch'
+test -z "$(git -C "$root" status --porcelain)" || fail 'release checkout is dirty'
+private_file "$production_env" 'Live production environment'
+private_file "$bundle" 'Live production Account bundle'
+test -f "$vhost" && test ! -L "$vhost" || fail 'Live production vhost must be a regular file'
+test "$(sha256sum "$vhost" | awk '{print $1}')" = "$pre_account_vhost_sha" || fail 'current Live vhost is not the reviewed pre-Account boundary'
+docker image inspect "$image" >/dev/null 2>&1 || fail 'exact Live image is missing'
+baked_sha=$(docker image inspect "$image" --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$baked_sha" = "$live_sha" || fail 'Live image provenance mismatch'
+running_image=$(docker inspect beacon-app --format '{{.Config.Image}}')
+test "$running_image" = "$image" || fail 'deploy the exact Live release with Account OFF before activation'
+test "$(docker inspect beacon-app --format '{{.State.Running}}|{{if .State.Health}}{{.State.Health.Status}}{{end}}')" = 'true|healthy' ||
+  fail 'current Live app is not healthy'
+test "$(container_env_value BEACON_ACCOUNT_ENABLED)" != true || fail 'Live Account is already enabled'
+
+# Prove the authority and the exact confidential hb-live credential before any
+# persistent edge or runtime mutation. This candidate receives only its own
+# four-key app bundle while it has egress.
+run_account_preflight prepared
+
+if test -e "$state_root"; then
+  test -d "$state_root" && test ! -L "$state_root" || fail 'state root must be a regular directory'
+  test "$(stat -c '%U:%G:%a' "$state_root")" = root:root:700 || fail 'state root must be root:root mode 0700'
+else
+  install -d -o root -g root -m 0700 "$state_root"
+fi
+test ! -e "$state" || fail 'activation state already exists'
+install -d -o root -g root -m 0700 "$state"
+install -o root -g root -m 0600 "$bundle" "$state/account.env.prepared"
+install -o root -g root -m 0600 "$vhost" "$state/nginx.previous"
+install -o root -g root -m 0600 "$root/deploy/nginx-harmonic-beacon.conf" "$state/nginx.candidate"
+install -o root -g root -m 0600 "$root/docker-compose.yml" "$state/docker-compose.yml"
+install -o root -g root -m 0700 "$root/scripts/live-production/rollback-account.sh" "$state/rollback-account.sh"
+printf '%s\n' "$image" > "$state/live-image.txt"
+printf '%s\n' "$account_sha" > "$state/account-sha.txt"
+printf '%s\n' "$account_schema" > "$state/account-schema.txt"
+chmod 0600 "$state/live-image.txt" "$state/account-sha.txt" "$state/account-schema.txt"
+write_protected_containers "$state/protected-containers.before"
+
+cutover_started=0
+rollback_on_failure() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if test "$status" -ne 0 && test "$cutover_started" -eq 1; then
+    echo 'Live production Account activation failed; restoring Account-OFF app and prior vhost.' >&2
+    if test -f "$bundle"; then mv -f "$bundle" "$state/account.env.failed" || true; fi
+    compose_app || true
+    wait_healthy || true
+    install -o root -g root -m 0644 "$state/nginx.previous" "$vhost" || true
+    nginx -t >/dev/null 2>&1 && systemctl reload nginx || true
+  elif test "$status" -ne 0; then
+    rm -rf "$state"
+  fi
+  exit "$status"
+}
+trap rollback_on_failure EXIT
+trap 'exit 130' HUP INT TERM
+
+cutover_started=1
+install -o root -g root -m 0644 "$root/deploy/nginx-harmonic-beacon.conf" "$vhost"
+nginx -t >/dev/null || fail 'candidate Live Nginx configuration is invalid'
+systemctl reload nginx
+compose_app
+wait_healthy || fail 'Live app did not become healthy with Account enabled'
+
+test "$(docker inspect beacon-app --format '{{.Config.Image}}')" = "$image" || fail 'running Live image mismatch'
+test "$(container_env_value BEACON_GIT_SHA)" = "$live_sha" || fail 'running Live SHA mismatch'
+test "$(container_env_value BEACON_ACCOUNT_ENABLED)" = true || fail 'running Live Account flag mismatch'
+test "$(container_env_value BEACON_ACCOUNT_ISSUER_URL)" = https://account.harmonicbeacon.com || fail 'running issuer mismatch'
+test "$(container_env_value BEACON_ACCOUNT_CLIENT_ID)" = hb-live || fail 'running client mismatch'
+docker inspect beacon-app --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  grep -q '^BEACON_ACCOUNT_CLIENT_SECRET=' || fail 'running client secret is absent'
+if docker inspect beacon-postgres beacon-livekit beacon-playlist-bot beacon-tapestry beacon-commerce-reconciler \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  grep -q '^BEACON_ACCOUNT_CLIENT_SECRET='; then
+  fail 'non-app container received the Account client secret'
+fi
+
+"$root/scripts/live-production/health-smoke.sh" "$live_sha"
+run_account_preflight public
+write_protected_containers "$state/protected-containers.after"
+cmp -s "$state/protected-containers.before" "$state/protected-containers.after" ||
+  fail 'protected Live, event, audio or payment containers changed during Account activation'
+
+{
+  printf 'activated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'live_sha=%s\n' "$live_sha"
+  printf 'account_sha=%s\n' "$account_sha"
+  printf 'account_schema=%s\n' "$account_schema"
+  printf 'account_preflight=pass\n'
+  printf 'public_edge=pass\n'
+  printf 'protected_runtime=unchanged\n'
+} > "$state/result.txt"
+chmod 0600 "$state/result.txt"
+(cd "$state" && sha256sum account.env.prepared nginx.previous nginx.candidate docker-compose.yml \
+  rollback-account.sh live-image.txt account-sha.txt \
+  account-schema.txt protected-containers.before protected-containers.after result.txt > SHA256SUMS)
+chmod 0600 "$state/SHA256SUMS"
+temporary="$state_root/last-activation.tmp-$$"
+printf '%s\n' "$state" > "$temporary"
+chmod 0600 "$temporary"
+mv -T "$temporary" "$state_root/last-activation"
+
+cutover_started=0
+trap - EXIT HUP INT TERM
+echo "Live production Account is healthy at exact Live SHA $live_sha."
+echo "Rollback state: $state"
+echo "Durable rollback command: sudo $state/rollback-account.sh"

--- a/scripts/live-production/health-smoke.sh
+++ b/scripts/live-production/health-smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+set -eu
+
+expected_sha=${1:?usage: health-smoke.sh exact-live-sha40}
+case "$expected_sha" in *[!0-9a-f]*|'') echo 'exact lowercase sha40 required' >&2; exit 2 ;; esac
+test "${#expected_sha}" -eq 40 || { echo 'exact lowercase sha40 required' >&2; exit 2; }
+command -v curl >/dev/null 2>&1 || { echo 'curl required' >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo 'jq required' >&2; exit 2; }
+
+origin=https://live.harmonicbeacon.com
+headers=$(mktemp)
+trap 'rm -f -- "$headers"' EXIT HUP INT TERM
+curl_flags='--silent --show-error --connect-timeout 3 --max-time 8'
+
+curl $curl_flags --fail --proto '=https' "$origin/api/health" |
+  jq --exit-status --arg sha "$expected_sha" '.status == "ok" and .gitSha == $sha' >/dev/null
+curl $curl_flags --fail --proto '=https' "$origin/api/health/ready" |
+  jq --exit-status '.status == "ok" and .checks.database == "ok" and .checks.account == "ok"' >/dev/null
+
+status=$(curl $curl_flags --proto '=https' --output /dev/null --dump-header "$headers" \
+  --write-out '%{http_code}' "$origin/api/account/login")
+test "$status" = 303 || { echo 'Live Account login did not redirect' >&2; exit 1; }
+location=$(sed -n 's/^[Ll]ocation:[[:space:]]*//p' "$headers" | tail -n 1 | tr -d '\r')
+case "$location" in
+  https://account.harmonicbeacon.com/api/account/auth/oauth2/authorize\?*) ;;
+  *) echo 'Live Account login escaped the production issuer' >&2; exit 1 ;;
+esac
+case "$location" in *'client_id=hb-live'*) ;; *) echo 'Live Account client mismatch' >&2; exit 1 ;; esac
+case "$location" in *'redirect_uri=https%3A%2F%2Flive.harmonicbeacon.com%2Fapi%2Faccount%2Fcallback'*) ;;
+  *) echo 'Live Account callback mismatch' >&2; exit 1 ;;
+esac
+case "$location" in *'code_challenge_method=S256'*) ;; *) echo 'Live Account PKCE mismatch' >&2; exit 1 ;; esac
+case "$location" in *client_secret*) echo 'Live Account redirect exposed a client secret field' >&2; exit 1 ;; esac
+rm -f -- "$headers"
+headers=$(mktemp)
+unset location
+
+sentinel="hb-live-account-smoke-$$-$(date +%s)"
+status=$(curl $curl_flags --proto '=https' --output /dev/null --write-out '%{http_code}' \
+  "$origin/api/account/callback?code=$sentinel&state=$sentinel")
+test "$status" = 302 || { echo 'malformed Live Account callback was not bounded' >&2; exit 1; }
+test "$(curl $curl_flags --proto '=https' --output /dev/null --write-out '%{http_code}' \
+  "$origin/api/account/frontchannel-logout")" = 400 || { echo 'unsigned frontchannel logout was accepted' >&2; exit 1; }
+for route in login callback frontchannel-logout; do
+  test "$(curl $curl_flags --proto '=https' --request POST --output /dev/null --write-out '%{http_code}' \
+    "$origin/api/account/$route")" = 405 || { echo "POST $route did not fail closed" >&2; exit 1; }
+done
+test "$(curl $curl_flags --proto '=https' --output /dev/null --write-out '%{http_code}' \
+  "$origin/api/account/login/extra")" = 404 || { echo 'unknown Account suffix was exposed' >&2; exit 1; }
+if test -r /var/log/nginx/access.log && tail -n 5000 /var/log/nginx/access.log | grep -Fq "$sentinel"; then
+  echo 'OAuth callback material entered the Nginx access log' >&2
+  exit 1
+fi
+unset sentinel
+echo "Live production Account edge is healthy at exact SHA $expected_sha."

--- a/scripts/live-production/prepare-account.sh
+++ b/scripts/live-production/prepare-account.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+set -eu
+
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+expected_sha=${1:?usage: prepare-account.sh exact-live-sha40}
+case "$expected_sha" in *[!0-9a-f]*|'') echo 'exact lowercase sha40 required' >&2; exit 2 ;; esac
+test "${#expected_sha}" -eq 40 || { echo 'exact lowercase sha40 required' >&2; exit 2; }
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+image="harmonic-beacon/app:$expected_sha"
+authority=/etc/harmonic-beacon/account.production.env
+target_dir=/etc/harmonic-beacon/live-production-secrets
+target="$target_dir/account.env"
+
+fail() { echo "Live production Account preparation: $*" >&2; exit 2; }
+private_file() {
+  test -f "$1" && test ! -L "$1" || fail "$2 must be a regular file"
+  test "$(stat -c '%U:%G:%a' "$1")" = root:root:600 || fail "$2 must be root:root mode 0600"
+}
+env_value() {
+  key=$1
+  file=$2
+  test "$(grep -c "^${key}=" "$file")" -eq 1 || fail "$key must occur exactly once"
+  sed -n "s/^${key}=//p" "$file" | tail -n 1 | tr -d '\r'
+}
+
+exec 9>/run/lock/live-account-production.lock
+flock -n 9 || fail 'another Live production Account operation is active'
+
+test "$(git -C "$root" rev-parse HEAD)" = "$expected_sha" || fail 'release checkout SHA mismatch'
+test -z "$(git -C "$root" status --porcelain)" || fail 'release checkout is dirty'
+private_file "$authority" 'Account production environment'
+docker image inspect "$image" >/dev/null 2>&1 || fail 'exact Live image is missing'
+baked_sha=$(docker image inspect "$image" --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$baked_sha" = "$expected_sha" || fail 'Live image provenance mismatch'
+if docker inspect beacon-app >/dev/null 2>&1; then
+  running_account=$(docker inspect beacon-app --format '{{range .Config.Env}}{{println .}}{{end}}' |
+    sed -n 's/^BEACON_ACCOUNT_ENABLED=//p' | tail -n 1 | tr -d '\r')
+  test "$running_account" != true || fail 'Account is already active; use a separately reviewed credential rotation'
+fi
+
+if test -e "$target_dir"; then
+  test -d "$target_dir" && test ! -L "$target_dir" || fail 'target must be a regular directory'
+  test "$(stat -c '%U:%G:%a' "$target_dir")" = root:root:700 ||
+    fail 'target directory must be root:root mode 0700'
+else
+  install -d -o root -g root -m 0700 "$target_dir"
+fi
+test "$(env_value BEACON_ACCOUNT_BASE_URL "$authority")" = https://account.harmonicbeacon.com || fail 'authority issuer mismatch'
+test "$(env_value BEACON_ACCOUNT_RUNTIME "$authority")" = 1 || fail 'authority runtime is not enabled'
+test -z "$(env_value BEACON_ACCOUNT_CLIENT_SECRET_HB_LIVE_STAGING "$authority")" || fail 'production authority carries staging Live material'
+authority_secret=$(env_value BEACON_ACCOUNT_CLIENT_SECRET_HB_LIVE "$authority")
+test "${#authority_secret}" -ge 32 || fail 'authority client secret is too short'
+case "$authority_secret" in *[!A-Za-z0-9._~-]*) fail 'authority client secret has an unsafe character' ;; esac
+
+if test -e "$target"; then
+  private_file "$target" 'existing Live production Account bundle'
+  test "$(grep -Ec '^[A-Z][A-Z0-9_]*=' "$target")" -eq 4 || fail 'existing bundle key count mismatch'
+  test "$(grep -Ec '^(BEACON_ACCOUNT_ENABLED|BEACON_ACCOUNT_ISSUER_URL|BEACON_ACCOUNT_CLIENT_ID|BEACON_ACCOUNT_CLIENT_SECRET)=' "$target")" -eq 4 ||
+    fail 'existing bundle contains an unexpected key'
+  test "$(env_value BEACON_ACCOUNT_ENABLED "$target")" = true || fail 'existing bundle is not enabled'
+  test "$(env_value BEACON_ACCOUNT_ISSUER_URL "$target")" = https://account.harmonicbeacon.com || fail 'existing issuer mismatch'
+  test "$(env_value BEACON_ACCOUNT_CLIENT_ID "$target")" = hb-live || fail 'existing client mismatch'
+fi
+
+temporary=$(mktemp "$target_dir/.account.env.XXXXXX")
+cleanup() { rm -f -- "$temporary"; }
+trap cleanup EXIT HUP INT TERM
+{
+  printf 'BEACON_ACCOUNT_ENABLED=true\n'
+  printf 'BEACON_ACCOUNT_ISSUER_URL=https://account.harmonicbeacon.com\n'
+  printf 'BEACON_ACCOUNT_CLIENT_ID=hb-live\n'
+  printf 'BEACON_ACCOUNT_CLIENT_SECRET=%s\n' "$authority_secret"
+} > "$temporary"
+chown root:root "$temporary"
+chmod 0600 "$temporary"
+mv -T "$temporary" "$target"
+trap - EXIT HUP INT TERM
+unset authority_secret
+
+private_file "$target" 'Live production Account bundle'
+test "$(grep -Ec '^[A-Z][A-Z0-9_]*=' "$target")" -eq 4 || fail 'bundle key count mismatch'
+test "$(grep -Ec '^(BEACON_ACCOUNT_ENABLED|BEACON_ACCOUNT_ISSUER_URL|BEACON_ACCOUNT_CLIENT_ID|BEACON_ACCOUNT_CLIENT_SECRET)=' "$target")" -eq 4 || fail 'bundle contains an unexpected key'
+
+echo 'Live production Account app-only bundle is prepared; runtime remains unchanged.'

--- a/scripts/live-production/rollback-account.sh
+++ b/scripts/live-production/rollback-account.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env sh
+set -eu
+
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+production_env=/etc/harmonic-beacon/production.env
+bundle=/etc/harmonic-beacon/live-production-secrets/account.env
+vhost=/etc/nginx/sites-enabled/harmonic-beacon
+state_root=/var/lib/harmonic-beacon/live-account-production
+last_activation="$state_root/last-activation"
+
+fail() { echo "Live production Account rollback: $*" >&2; exit 2; }
+case "$script_directory" in
+  "$state_root"/activation-*) state=$script_directory ;;
+  *)
+    test -f "$last_activation" && test ! -L "$last_activation" || fail 'last activation pointer is missing'
+    test "$(stat -c '%U:%G:%a' "$last_activation")" = root:root:600 || fail 'last activation pointer permissions are invalid'
+    state=$(cat "$last_activation")
+    ;;
+esac
+case "$state" in "$state_root"/activation-*) ;; *) fail 'last activation path is invalid' ;; esac
+test -d "$state" && test ! -L "$state" || fail 'activation state is missing'
+(cd "$state" && sha256sum -c SHA256SUMS >/dev/null) || fail 'activation evidence checksum mismatch'
+live_image=$(cat "$state/live-image.txt")
+live_sha=${live_image##*:}
+case "$live_sha" in *[!0-9a-f]*|'') fail 'saved Live SHA is invalid' ;; esac
+test "${#live_sha}" -eq 40 || fail 'saved Live SHA is invalid'
+test "$(docker inspect beacon-app --format '{{.Config.Image}}')" = "$live_image" || fail 'running Live image mismatch'
+test -f "$bundle" && test ! -L "$bundle" || fail 'active Account bundle is missing'
+compose_file="$state/docker-compose.yml"
+candidate_vhost="$state/nginx.candidate"
+test -f "$compose_file" && test ! -L "$compose_file" || fail 'saved Compose file is missing'
+test -f "$candidate_vhost" && test ! -L "$candidate_vhost" || fail 'saved candidate vhost is missing'
+
+exec 9>/run/lock/live-account-production.lock
+flock -n 9 || fail 'another Live production Account operation is active'
+disabled="$state/account.env.disabled-$(date -u +%Y%m%dT%H%M%SZ)"
+mv "$bundle" "$disabled"
+chmod 0600 "$disabled"
+
+rollback_failed=1
+restore_enabled() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if test "$rollback_failed" -eq 1; then
+    test -f "$bundle" || mv -f "$disabled" "$bundle" || true
+    BEACON_IMAGE_TAG="$live_sha" docker compose -p app --env-file "$production_env" \
+      -f "$compose_file" up -d --no-deps --force-recreate --no-build app || true
+    install -o root -g root -m 0644 "$candidate_vhost" "$vhost" || true
+    nginx -t >/dev/null 2>&1 && systemctl reload nginx || true
+  fi
+  exit "$status"
+}
+trap restore_enabled EXIT
+trap 'exit 130' HUP INT TERM
+
+BEACON_IMAGE_TAG="$live_sha" docker compose -p app --env-file "$production_env" \
+  -f "$compose_file" up -d --no-deps --force-recreate --no-build app
+attempt=0
+while test "$attempt" -lt 60; do
+  health=$(docker inspect beacon-app --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>/dev/null || true)
+  test "$health" != healthy || break
+  test "$health" != exited || fail 'Account-OFF Live app exited'
+  attempt=$((attempt + 1))
+  sleep 2
+done
+test "$health" = healthy || fail 'Account-OFF Live app did not become healthy'
+enabled=$(docker inspect beacon-app --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_ACCOUNT_ENABLED=//p' | tail -n 1)
+test "$enabled" != true || fail 'Account remained enabled after bundle removal'
+curl --silent --show-error --fail --connect-timeout 3 --max-time 8 --proto '=https' \
+  https://live.harmonicbeacon.com/api/health/ready |
+  jq --exit-status '.status == "ok" and .checks.database == "ok" and .checks.account == "disabled"' >/dev/null
+
+install -o root -g root -m 0644 "$state/nginx.previous" "$vhost"
+nginx -t >/dev/null || fail 'previous Live Nginx configuration is invalid'
+systemctl reload nginx
+rollback_failed=0
+trap - EXIT HUP INT TERM
+
+{
+  printf 'rolled_back_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'live_sha=%s\n' "$live_sha"
+  printf 'account=disabled\n'
+  printf 'previous_vhost=restored\n'
+} > "$state/rollback-result.txt"
+chmod 0600 "$state/rollback-result.txt"
+echo "Live production Account is disabled; app remains healthy at exact SHA $live_sha."
+echo "Dormant app-only bundle retained at $disabled"

--- a/src/app/__tests__/layout-account-navigation.test.tsx
+++ b/src/app/__tests__/layout-account-navigation.test.tsx
@@ -21,11 +21,17 @@ vi.mock('@/lib/brand/account-navigation-state', () => ({
     locallyKnownLiveNavigationIdentity: mocks.localNavigationIdentity,
 }));
 vi.mock('@/components/brand/GlobalNavigation', () => ({
-    GlobalNavigation: ({ accountHref, accountSignedIn, accountMenu }: {
+    GlobalNavigation: ({ accountHref, accountAvailable, accountSignedIn, accountMenu }: {
         accountHref: string;
+        accountAvailable: boolean;
         accountSignedIn: boolean;
         accountMenu?: React.ReactNode;
-    }) => <div data-testid="global-navigation" data-account-href={accountHref} data-signed-in={accountSignedIn}>{accountMenu}</div>,
+    }) => <div
+        data-testid="global-navigation"
+        data-account-href={accountHref}
+        data-account-available={accountAvailable}
+        data-signed-in={accountSignedIn}
+    >{accountMenu}</div>,
 }));
 vi.mock('@/components/brand/LiveNavigationAccountMenu', () => ({
     LiveNavigationAccountMenu: ({ displayName, staffRoleLabel }: { displayName: string; staffRoleLabel: string | null }) => (
@@ -46,9 +52,11 @@ describe('root layout Account navigation hint', () => {
     afterEach(() => {
         cleanup();
         vi.clearAllMocks();
+        delete process.env.BEACON_ACCOUNT_ENABLED;
     });
 
     it('derives the staging hint from the host-local session and SSRs only the boolean', async () => {
+        process.env.BEACON_ACCOUNT_ENABLED = 'true';
         const requestHeaders = new Headers({
             host: 'live-staging.harmonicbeacon.com',
             cookie: `hb_session=${'a'.repeat(43)}`,
@@ -64,12 +72,14 @@ describe('root layout Account navigation hint', () => {
             'https://account-staging.harmonicbeacon.com/account',
         );
         expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-signed-in', 'true');
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-account-available', 'true');
         expect(screen.getByTestId('local-account-menu')).toHaveTextContent('Nicolás');
         expect(screen.getByTestId('local-account-menu')).toHaveAttribute('data-role', 'Administration');
         expect(screen.getByTestId('identity-cache-boundary')).toBeInTheDocument();
     });
 
     it('keeps production Account hidden without reading local identity state', async () => {
+        process.env.BEACON_ACCOUNT_ENABLED = 'false';
         mocks.headers.mockResolvedValue(new Headers({
             host: 'live.harmonicbeacon.com',
             cookie: `hb_session=${'a'.repeat(43)}`,
@@ -83,11 +93,13 @@ describe('root layout Account navigation hint', () => {
             'https://account.harmonicbeacon.com/account',
         );
         expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-signed-in', 'false');
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-account-available', 'false');
         expect(screen.queryByTestId('local-account-menu')).toBeNull();
         expect(screen.queryByTestId('identity-cache-boundary')).toBeNull();
     });
 
     it('fails neutral when the local presentation lookup is unavailable', async () => {
+        process.env.BEACON_ACCOUNT_ENABLED = 'true';
         mocks.headers.mockResolvedValue(new Headers({ host: 'live-staging.harmonicbeacon.com' }));
         mocks.localNavigationIdentity.mockRejectedValue(new Error('database unavailable'));
 
@@ -95,5 +107,26 @@ describe('root layout Account navigation hint', () => {
 
         expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-signed-in', 'false');
         expect(screen.queryByTestId('local-account-menu')).toBeNull();
+    });
+
+    it('enables the same local menu on production only after the RP feature is active', async () => {
+        process.env.BEACON_ACCOUNT_ENABLED = 'true';
+        const requestHeaders = new Headers({
+            host: 'live.harmonicbeacon.com',
+            cookie: `hb_session=${'b'.repeat(43)}`,
+        });
+        mocks.headers.mockResolvedValue(requestHeaders);
+        mocks.localNavigationIdentity.mockResolvedValue({ displayName: 'Production Tester', staffRole: null });
+
+        render(await RootLayout({ children: <main>Live</main> }), { container: document });
+
+        expect(mocks.localNavigationIdentity).toHaveBeenCalledWith(requestHeaders);
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute(
+            'data-account-href',
+            'https://account.harmonicbeacon.com/account',
+        );
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-account-available', 'true');
+        expect(screen.getByTestId('global-navigation')).toHaveAttribute('data-signed-in', 'true');
+        expect(screen.getByTestId('local-account-menu')).toHaveTextContent('Production Tester');
     });
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { GlobalNavigation } from "@/components/brand/GlobalNavigation";
 import { LiveIdentityCacheBoundary } from "@/components/brand/LiveIdentityCacheBoundary";
 import { LiveNavigationAccountMenu } from "@/components/brand/LiveNavigationAccountMenu";
 import { LocaleProvider } from "@/context/LocaleContext";
+import { beaconAccountEnabled } from "@/lib/account-rp";
 import {
   globalNavigationAccountHref,
   globalNavigationSurface,
@@ -85,7 +86,8 @@ export default async function RootLayout({
   const locale = await requestLocale();
   const navigationSurface = globalNavigationSurface(incomingHeaders) ?? "events";
   const accountHref = globalNavigationAccountHref(incomingHeaders);
-  const navigationIdentity = accountHref === "https://account-staging.harmonicbeacon.com/account"
+  const accountAvailable = beaconAccountEnabled();
+  const navigationIdentity = accountAvailable
     ? await locallyKnownLiveNavigationIdentity(incomingHeaders).catch(() => null)
     : null;
 
@@ -96,8 +98,9 @@ export default async function RootLayout({
           active={navigationSurface}
           locale={locale}
           accountHref={accountHref}
+          accountAvailable={accountAvailable}
           accountSignedIn={Boolean(navigationIdentity)}
-          accountMenu={navigationIdentity && accountHref === "https://account-staging.harmonicbeacon.com/account" ? (
+          accountMenu={navigationIdentity ? (
             <LiveNavigationAccountMenu
               displayName={navigationIdentity.displayName}
               staffRoleLabel={navigationIdentity.staffRole

--- a/src/brand/canonical/PROVENANCE.md
+++ b/src/brand/canonical/PROVENANCE.md
@@ -28,16 +28,18 @@ manifest and visual-review update together.
 Listener, Live and Account serve a byte-pinned local snapshot of the canonical
 web component rather than executing JavaScript supplied at runtime by another
 origin. The source is `AlterMundi/harmonicbeacon.com` commit
-`7e2730344e543e6c6ff5abde6d8133fc198214ae`; the vendored
+`6bd32262318e9a1faf6f4fc54b85b96f856544df`; the vendored
 `public/assets/hb-global-nav.js` SHA-256 is
-`ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08`.
+`5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6`.
 The local light-DOM markup remains the accessible, same-destination fallback.
 Both implementations keep Account out of the primary destination list and
-expose it from the user-icon menu only on staging while the production Account
-authority remains unavailable. The host may supply only the boolean
-`data-account-signed-in` hint; no name, email, subject, cookie or token enters
-the asset. A product may provide its own same-origin light-DOM menu through the
-canonical `account-menu` slot; the asset does not read or transmit its content.
+expose it from the user-icon menu automatically on staging. Production remains
+hidden until the product server supplies the presence-only
+`data-account-available` capability after its Account RP is enabled. The host
+may also supply only the boolean `data-account-signed-in` hint; no name, email,
+subject, cookie or token enters the asset. A product may provide its own
+same-origin light-DOM menu through the canonical `account-menu` slot; the asset
+does not read or transmit its content.
 The enhanced navigation renders both the Beacon mark and user glyph locally;
 it does not embed Account in an iframe or fetch a cross-origin image.
 

--- a/src/brand/canonical/manifest.json
+++ b/src/brand/canonical/manifest.json
@@ -11,13 +11,13 @@
   },
   "globalNavigation": {
     "repository": "https://github.com/AlterMundi/harmonicbeacon.com",
-    "commit": "7e2730344e543e6c6ff5abde6d8133fc198214ae",
+    "commit": "6bd32262318e9a1faf6f4fc54b85b96f856544df",
     "source": "assets/hb-global-nav.js",
     "path": "public/assets/hb-global-nav.js",
-    "sha256": "ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08"
+    "sha256": "5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6"
   },
   "snapshots": {
-    "public/assets/hb-global-nav.js": "ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08",
+    "public/assets/hb-global-nav.js": "5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6",
     "src/brand/canonical/hb-brand-root.css": "9a4b97ef7545de47c99f37704a86c2317ea77e9b2c8c0bb078dda0be546ab89d",
     "src/brand/canonical/hb-mark.ts": "f832213a4ac29023a38dca3bdc0e0a8d5db9f324f8b3e119538b9aa2c3dcd881"
   },

--- a/src/components/brand/GlobalNavigation.tsx
+++ b/src/components/brand/GlobalNavigation.tsx
@@ -6,8 +6,8 @@ import type { UiLocale } from '@/lib/i18n';
 // Byte-pinned local snapshot of harmonicbeacon.com@7e27303. Protected product
 // origins never execute remotely supplied JavaScript with their host cookies.
 export const GLOBAL_NAVIGATION_ASSET = '/assets/hb-global-nav.js';
-export const GLOBAL_NAVIGATION_PROVENANCE = '7e2730344e543e6c6ff5abde6d8133fc198214ae';
-export const GLOBAL_NAVIGATION_SHA256 = 'ec27014086a96c5e2187967dde0f96f238ef95a49c9382a6028af1d59e6deb08';
+export const GLOBAL_NAVIGATION_PROVENANCE = '6bd32262318e9a1faf6f4fc54b85b96f856544df';
+export const GLOBAL_NAVIGATION_SHA256 = '5e0add357a923bf4609fd1eafd4a96d4989481f17e6c31296252842ce9d881d6';
 export const GLOBAL_NAVIGATION_EMBED_GUARD = `
 (() => {
     if (window.self === window.top) return;
@@ -34,6 +34,7 @@ export function GlobalNavigation({
     locale,
     allowRemoteEnhancement = true,
     accountHref,
+    accountAvailable = false,
     accountSignedIn = false,
     accountMenu,
 }: {
@@ -41,6 +42,7 @@ export function GlobalNavigation({
     locale: UiLocale;
     allowRemoteEnhancement?: boolean;
     accountHref?: 'https://account.harmonicbeacon.com/account' | 'https://account-staging.harmonicbeacon.com/account';
+    accountAvailable?: boolean;
     accountSignedIn?: boolean;
     accountMenu?: ReactNode;
 }) {
@@ -48,8 +50,8 @@ export function GlobalNavigation({
     const userMenuLabel = locale === 'es' ? 'Menú de usuario' : 'User menu';
     const accountLabel = locale === 'es' ? 'Cuenta' : 'Account';
     const resolvedAccountHref = accountHref ?? 'https://account.harmonicbeacon.com/account';
-    const accountAvailable = resolvedAccountHref === 'https://account-staging.harmonicbeacon.com/account';
-    const showSignedIn = accountAvailable && accountSignedIn;
+    const showAccount = accountAvailable || resolvedAccountHref === 'https://account-staging.harmonicbeacon.com/account';
+    const showSignedIn = showAccount && accountSignedIn;
     const accountControlLabel = showSignedIn
         ? (locale === 'es' ? 'Menú de usuario, sesión iniciada' : 'User menu, signed in')
         : userMenuLabel;
@@ -71,7 +73,7 @@ export function GlobalNavigation({
                         </li>
                     ))}
                 </ul>
-                {accountAvailable && (
+                {showAccount && (
                     <details
                         className="hb-global-navigation-fallback__account-control"
                         data-account-signed-in={showSignedIn ? '' : undefined}
@@ -105,8 +107,9 @@ export function GlobalNavigation({
             />
             {createElement('hb-global-nav', {
                 'data-surface': active,
+                'data-account-available': showAccount ? '' : undefined,
                 'data-account-signed-in': showSignedIn ? '' : undefined,
-            }, fallback, accountMenu && accountAvailable ? (
+            }, fallback, accountMenu && showAccount ? (
                 <div key="account-menu" slot="account-menu" className="hb-global-navigation-local-account-slot">
                     {accountMenu}
                 </div>

--- a/src/components/brand/LiveNavigationAccountMenu.tsx
+++ b/src/components/brand/LiveNavigationAccountMenu.tsx
@@ -6,9 +6,13 @@ import { useRouter } from 'next/navigation';
 
 import type { UiLocale } from '@/lib/i18n';
 
+type AccountHref =
+    | 'https://account.harmonicbeacon.com/account'
+    | 'https://account-staging.harmonicbeacon.com/account';
+
 export function trustedAccountLogoutURL(
     raw: unknown,
-    accountHref: 'https://account-staging.harmonicbeacon.com/account',
+    accountHref: AccountHref,
 ): string | null {
     if (typeof raw !== 'string') return null;
     try {
@@ -35,7 +39,7 @@ export function LiveNavigationAccountMenu({
 }: {
     displayName: string | null;
     staffRoleLabel: string | null;
-    accountHref: 'https://account-staging.harmonicbeacon.com/account';
+    accountHref: AccountHref;
     locale: UiLocale;
 }) {
     const [busy, setBusy] = useState(false);

--- a/src/lib/__tests__/live-production-account-deploy-contract.test.ts
+++ b/src/lib/__tests__/live-production-account-deploy-contract.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildTarget,
+    parseEnv,
+    validateTarget,
+} from '../../../scripts/live-production/account-env.mjs';
+
+const root = process.cwd();
+const source = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+const client = 'c'.repeat(64);
+const authority = () => parseEnv([
+    'BEACON_ACCOUNT_BASE_URL=https://account.harmonicbeacon.com',
+    'BEACON_ACCOUNT_RUNTIME=1',
+    `BEACON_ACCOUNT_CLIENT_SECRET_HB_LIVE=${client}`,
+    'BEACON_ACCOUNT_CLIENT_SECRET_HB_LIVE_STAGING=',
+    '',
+].join('\n'));
+
+describe('Live production Account app-only contract', () => {
+    it('builds only the exact production hb-live bundle', () => {
+        const first = buildTarget(authority());
+        expect(first).toBe([
+            'BEACON_ACCOUNT_ENABLED=true',
+            'BEACON_ACCOUNT_ISSUER_URL=https://account.harmonicbeacon.com',
+            'BEACON_ACCOUNT_CLIENT_ID=hb-live',
+            `BEACON_ACCOUNT_CLIENT_SECRET=${client}`,
+            '',
+        ].join('\n'));
+        expect([...validateTarget(parseEnv(first)).keys()]).toHaveLength(4);
+    });
+
+    it('rejects staging material, extra keys and shared secrets', () => {
+        const withStaging = authority();
+        withStaging.set('BEACON_ACCOUNT_CLIENT_SECRET_HB_LIVE_STAGING', 'x'.repeat(64));
+        expect(() => buildTarget(withStaging)).toThrow(/staging/);
+        const extra = parseEnv(`${buildTarget(authority())}DATABASE_URL=forbidden\n`);
+        expect(() => validateTarget(extra)).toThrow(/keys or ordering/);
+    });
+
+    it('mounts the secret bundle once and only on beacon-app', () => {
+        const compose = source('docker-compose.yml');
+        const bundle = '/etc/harmonic-beacon/live-production-secrets/account.env';
+        expect(compose.split(bundle)).toHaveLength(2);
+        const app = compose.slice(compose.indexOf('  app:'), compose.indexOf('  commerce-reconciler:'));
+        expect(app).toContain(bundle);
+        expect(compose.slice(0, compose.indexOf('  app:'))).not.toContain(bundle);
+        expect(compose.slice(compose.indexOf('  commerce-reconciler:'))).not.toContain(bundle);
+        const migrate = compose.slice(compose.indexOf('  migrate:'), compose.indexOf('  app:'));
+        expect(migrate).not.toContain(bundle);
+        expect(migrate).not.toContain('/etc/harmonic-beacon/commerce.env');
+        expect(source('deploy/production.env.example')).not.toContain('BEACON_ACCOUNT_CLIENT_SECRET=');
+    });
+
+    it('ships fixed-path host preparation and a least-privilege network preflight', () => {
+        const dockerfile = source('Dockerfile');
+        const prepare = source('scripts/live-production/prepare-account.sh');
+        const activate = source('scripts/live-production/activate-account.sh');
+        const preflight = source('scripts/live-production/account-preflight.mjs');
+        expect(dockerfile).toContain('/app/scripts/live-production ./scripts/live-production');
+        expect(prepare).not.toContain('docker run');
+        expect(prepare).toContain('authority=/etc/harmonic-beacon/account.production.env');
+        expect(prepare).toContain('BEACON_ACCOUNT_CLIENT_SECRET_HB_LIVE');
+        expect(prepare).not.toContain('DATABASE_URL');
+        expect(prepare).toContain('flock -n 9');
+        expect(prepare).toContain('Account is already active; use a separately reviewed credential rotation');
+        expect(activate).toContain('src=$bundle,dst=/etc/harmonic-beacon/live-production-secrets/account.env,readonly');
+        expect(activate).not.toContain('src=$production_env');
+        expect(preflight).toContain("const LIVE_ORIGIN = 'https://live.harmonicbeacon.com'");
+        expect(preflight).toContain("CLIENT_ID, ISSUER, TARGET_ENV");
+        expect(preflight).toContain("'client_secret_basic'");
+    });
+
+    it('uses an exact no-log edge and denies the remaining Account prefix', () => {
+        const nginx = source('deploy/nginx-harmonic-beacon.conf');
+        for (const route of ['login', 'callback', 'frontchannel-logout']) {
+            const start = nginx.indexOf(`location = /api/account/${route}`);
+            expect(start).toBeGreaterThan(-1);
+            expect(nginx.slice(start, nginx.indexOf('\n    }', start))).toContain('access_log off;');
+        }
+        expect(nginx).toContain('location ^~ /api/account/ {');
+        expect(nginx).toMatch(/location \^~ \/api\/account\/ \{\s+access_log off;\s+return 404;/);
+        expect(nginx).not.toContain('location ^~ /assets/');
+    });
+
+    it('recreates only the app and preserves a tested rollback boundary', () => {
+        const activate = source('scripts/live-production/activate-account.sh');
+        const rollback = source('scripts/live-production/rollback-account.sh');
+        const smoke = source('scripts/live-production/health-smoke.sh');
+        const deploy = source('deploy/hb-deploy-root');
+        expect(activate).toContain('up -d --no-deps --force-recreate --no-build app');
+        expect(activate).toContain('protected-containers.before');
+        expect(activate).toContain('cmp -s "$state/protected-containers.before" "$state/protected-containers.after"');
+        expect(activate).toContain('restoring Account-OFF app and prior vhost');
+        expect(activate).toContain('"$state/rollback-account.sh"');
+        expect(activate).toContain('"$state/docker-compose.yml"');
+        expect(rollback).toContain('compose_file="$state/docker-compose.yml"');
+        expect(rollback).not.toContain('git -C');
+        expect(rollback).toContain('mv "$bundle" "$disabled"');
+        expect(rollback).toContain('.checks.account == "disabled"');
+        expect(smoke).toContain("--connect-timeout 3 --max-time 8");
+        expect(smoke).toContain("--proto '=https'");
+        expect(smoke).toContain('/var/log/nginx/access.log');
+        expect(smoke).not.toMatch(/\bnode\b/);
+        expect(deploy).toContain('run --rm --no-deps migrate npx prisma migrate deploy');
+        expect(deploy).toContain('Account RP secret reached unexpected container');
+        expect(deploy).toContain('Account bundle exists before the supervised Account activation');
+        expect(deploy).toContain("ACCOUNT_ENV='/etc/harmonic-beacon/live-production-secrets/account.env'");
+    });
+});

--- a/src/lib/brand/__tests__/global-navigation.test.tsx
+++ b/src/lib/brand/__tests__/global-navigation.test.tsx
@@ -58,7 +58,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
     });
 
     it('loads a byte-pinned local canonical asset instead of remote same-origin code', () => {
-        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('7e2730344e543e6c6ff5abde6d8133fc198214ae');
+        expect(GLOBAL_NAVIGATION_PROVENANCE).toBe('6bd32262318e9a1faf6f4fc54b85b96f856544df');
         const bytes = readFileSync(resolve(process.cwd(), 'public/assets/hb-global-nav.js'));
         expect(createHash('sha256').update(bytes).digest('hex')).toBe(GLOBAL_NAVIGATION_SHA256);
         expect(manifest.globalNavigation.commit).toBe(GLOBAL_NAVIGATION_PROVENANCE);
@@ -67,8 +67,9 @@ describe('canonical Harmonic Beacon global navigation', () => {
             .toBe(GLOBAL_NAVIGATION_SHA256);
         const source = bytes.toString('utf8');
         expect(source).toContain('class="account-trigger\' + (accountSignedIn ? \' signed-in\' : \'\')');
-        expect(source).toContain('function accountControlAvailable()');
-        expect(source).toContain("return ['data-account-signed-in'];");
+        expect(source).toContain('function accountControlAvailable(element)');
+        expect(source).toContain("return ['data-account-available', 'data-account-signed-in'];");
+        expect(source).toContain("element.hasAttribute('data-account-available')");
         expect(source).toContain('User menu, signed in');
         expect(source).toContain('Menú de usuario, sesión iniciada');
         expect(source).toContain('.account-trigger.signed-in::after');
@@ -86,7 +87,7 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(source).toContain("querySelectorAll('[role=\"menuitem\"]')");
         expect(source).toContain('event.composedPath().includes(this)');
         expect(source).not.toContain('class="account-link"');
-        expect(source).not.toContain('https://account.harmonicbeacon.com');
+        expect(source).toContain("var ACCOUNT_ORIGIN = 'https://account.harmonicbeacon.com'");
         expect(source).not.toContain('fetch(');
         expect(source).not.toContain('<iframe');
         expect(source).not.toContain('/favicon.svg');
@@ -180,5 +181,23 @@ describe('canonical Harmonic Beacon global navigation', () => {
         expect(view.container.querySelector('hb-global-nav')).not.toHaveAttribute('data-account-signed-in');
         expect(view.container.querySelector('details')).toBeNull();
         expect(view.container.querySelector('[slot="account-menu"]')).toBeNull();
+    });
+
+    it('exposes the production Account control only with the server availability capability', () => {
+        const view = render(<GlobalNavigation
+            active="events"
+            locale="en"
+            accountHref="https://account.harmonicbeacon.com/account"
+            accountAvailable
+            accountSignedIn
+            accountMenu={<button role="menuitem">Operations</button>}
+        />);
+
+        expect(within(view.container).getByLabelText('User menu, signed in')).toBeInTheDocument();
+        expect(within(view.container).getByRole('menuitem', { name: 'Account' }))
+            .toHaveAttribute('href', 'https://account.harmonicbeacon.com/account?lang=en');
+        expect(view.container.querySelector('hb-global-nav')).toHaveAttribute('data-account-available', '');
+        expect(view.container.querySelector('hb-global-nav')).toHaveAttribute('data-account-signed-in', '');
+        expect(within(view.container).getByRole('menuitem', { name: 'Operations' })).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Outcome

Adds the last production-only Live RP boundary without enabling it: an app-only four-key Account bundle, exact no-log OAuth edge, least-privilege authority preflight, same-image activation, durable automatic/manual rollback, and future deploy isolation. Also repins canonical navigation PR #75 so the production Account control appears only after the RP runtime is enabled.

No runtime, DNS, database, event, audio, LiveKit or payment state is changed by this PR.

## Production safety

- exact `hb-live` secret copied from the fixed root-only Account authority file into a root:root 0600 app-only bundle
- Account/commerce secrets absent from the dedicated migration service and all protected containers
- Account production readiness/provenance, exact discovery, PKCE S256, Basic-only client auth, unique public Ed25519 JWKS and authenticated inactive session-status preflight before mutation
- exact login/callback/frontchannel edge only; OAuth callback logging disabled; remaining Account prefix denied
- activation recreates only `beacon-app` from the already-running immutable image
- protected Postgres/LiveKit/playlist/tapestry/commerce fingerprints must remain byte-identical
- rollback state stores checksummed Compose, prior/candidate Nginx, exact coordinates and executable rollback independently of a later checkout
- Apple remains disabled and is not part of this change

## Evidence

- focused lifecycle/RP/navigation suite: 65/65
- canonical suite 86/86 + static build
- real Chromium capability toggle: production Account absent by default, exact production link when enabled, absent again when removed
- Mona Docker Compose v5.3.1 candidate render: pass
- Mona Nginx 1.26.3 candidate syntax in isolated temporary include: pass, no install/reload
- shell syntax, Node syntax, focused ESLint, diff-check: pass

Full repository test/lint/build and frozen event/audio gates are delegated to the exact-head PR checks; no duplicate Docker image is built for review.
