### PR TITLE
Pin the release visual gate browser

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
   release-e2e:
     uses: ./.github/workflows/e2e.yml
     with:
-      use_runner_chrome: true
+      release_gate: true
 
   deploy:
     needs: release-e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,8 +26,8 @@ on:
       - '**/*.md'
   workflow_call:
     inputs:
-      use_runner_chrome:
-        description: Use the Google Chrome already installed on the hosted runner.
+      release_gate:
+        description: Run the focused pre-deploy browser matrix for an exact release commit.
         required: false
         type: boolean
         default: false
@@ -61,7 +61,6 @@ jobs:
       E2E_LIVEKIT_URL: ws://localhost:7880
       E2E_LIVEKIT_API_KEY: devkey
       E2E_LIVEKIT_API_SECRET: secret
-      PLAYWRIGHT_CHROME_EXECUTABLE: ${{ inputs.use_runner_chrome && '/usr/bin/google-chrome' || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -77,8 +76,11 @@ jobs:
 
       - run: npm ci
 
-      - if: ${{ !inputs.use_runner_chrome }}
-        run: npx playwright install --with-deps chromium
+      # Both PR and release gates use Playwright's version-pinned Chromium.
+      # The hosted runner's auto-updated Google Chrome can render the same
+      # page with different font metrics and invalidate otherwise-correct
+      # visual baselines after the PR has already passed.
+      - run: npx playwright install --with-deps chromium
 
       - name: Start LiveKit dev server
         run: |
@@ -145,7 +147,7 @@ jobs:
           DATABASE_URL="$CLEAN_URL" npx prisma migrate deploy
 
       - name: Run Chromium and Android gates
-        if: ${{ !inputs.use_runner_chrome }}
+        if: ${{ !inputs.release_gate }}
         run: >-
           npx playwright test
           --project=chromium
@@ -157,14 +159,14 @@ jobs:
           --project=android-chrome
 
       - name: Run release Chromium and Android functional gates
-        if: ${{ inputs.use_runner_chrome }}
+        if: ${{ inputs.release_gate }}
         run: >-
           npx playwright test
           --project=chromium
           --project=android-chrome
 
       - name: Run release public responsive and visual gates
-        if: ${{ inputs.use_runner_chrome }}
+        if: ${{ inputs.release_gate }}
         run: >-
           npx playwright test
           e2e/tests/responsive.spec.ts
@@ -177,19 +179,19 @@ jobs:
           --grep 'responsive public surfaces|visual baselines.*landing'
 
       - name: Install Firefox after Chromium screenshot gates
-        if: ${{ !inputs.use_runner_chrome }}
+        if: ${{ !inputs.release_gate }}
         run: npx playwright install --with-deps firefox
 
       - name: Run Firefox functional and accessibility gates
-        if: ${{ !inputs.use_runner_chrome }}
+        if: ${{ !inputs.release_gate }}
         run: npx playwright test --project=firefox
 
       - name: Install WebKit after Chromium screenshot gates
-        if: ${{ !inputs.use_runner_chrome }}
+        if: ${{ !inputs.release_gate }}
         run: npx playwright install --with-deps webkit
 
       - name: Run iPhone/WebKit media gate
-        if: ${{ !inputs.use_runner_chrome }}
+        if: ${{ !inputs.release_gate }}
         run: npx playwright test e2e/tests/media-continuity.spec.ts --project=iphone-webkit
 
       - name: Verify commerce transaction and durable outbox contract

--- a/src/lib/__tests__/deploy-contract.test.ts
+++ b/src/lib/__tests__/deploy-contract.test.ts
@@ -62,6 +62,13 @@ describe('production deploy contract', () => {
     expect(e2eWorkflow).toContain('workflow_call:');
     expect(workflow).toContain('release-e2e:');
     expect(workflow).toContain('uses: ./.github/workflows/e2e.yml');
+    expect(workflow).toContain('release_gate: true');
+    expect(e2eWorkflow).toContain('release_gate:');
+    expect(e2eWorkflow).toContain(
+      '- run: npx playwright install --with-deps chromium',
+    );
+    expect(e2eWorkflow).not.toContain('PLAYWRIGHT_CHROME_EXECUTABLE:');
+    expect(e2eWorkflow).not.toContain('/usr/bin/google-chrome');
     expect(workflow).toMatch(/deploy:\n\s+needs: release-e2e\n\s+runs-on: \[self-hosted, mona\]/);
   });
 


### PR DESCRIPTION
Fixes the exact release deploy gate failure from run 32286306215. The PR E2E used Playwright Chromium while the pre-deploy workflow switched to the hosted runner auto-updated Google Chrome, so the same correct landing rendered with different font metrics at all five widths. This keeps the focused pre-deploy matrix but installs and uses the same version-pinned Playwright Chromium as pull-request validation. No product/runtime/audio/session/payment code or visual baseline changes.\n\nEvidence: deploy contract 12/12, full Vitest 1073 pass / 23 integration skips, TypeScript, ESLint, YAML parse and diff-check green. The failed deploy skipped Mona entirely; production remains on ff94d609.