### PR TITLE
fix(ops): accept canonical Live callback redirect

### DIFF
--- a/scripts/live-production/health-smoke.sh
+++ b/scripts/live-production/health-smoke.sh
@@ -38,7 +38,7 @@ unset location
 sentinel="hb-live-account-smoke-$$-$(date +%s)"
 status=$(curl $curl_flags --proto '=https' --output /dev/null --write-out '%{http_code}' \
   "$origin/api/account/callback?code=$sentinel&state=$sentinel")
-test "$status" = 302 || { echo 'malformed Live Account callback was not bounded' >&2; exit 1; }
+test "$status" = 303 || { echo 'malformed Live Account callback was not bounded' >&2; exit 1; }
 test "$(curl $curl_flags --proto '=https' --output /dev/null --write-out '%{http_code}' \
   "$origin/api/account/frontchannel-logout")" = 400 || { echo 'unsigned frontchannel logout was accepted' >&2; exit 1; }
 for route in login callback frontchannel-logout; do

--- a/src/app/api/account/frontchannel-logout/__tests__/route.test.ts
+++ b/src/app/api/account/frontchannel-logout/__tests__/route.test.ts
@@ -1,32 +1,90 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
 
-import { createRequest } from '@/__tests__/helpers';
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const revoke = vi.fn();
+const updateSessions = vi.hoisted(() => vi.fn());
 
-vi.mock('@/lib/account-rp', () => ({
-    beaconAccountEnabled: () => true,
-    accountConfiguration: () => ({ issuer: 'https://account.harmonicbeacon.com' }),
-    revokeCentralSession: revoke,
+vi.mock('@/lib/db', () => ({
+    prisma: { webSession: { updateMany: updateSessions } },
 }));
+
+const ISSUER = 'https://account.harmonicbeacon.com';
+const CLIENT_ID = 'hb-live';
+const CLIENT_SECRET = 'live-client-secret-with-more-than-32-characters';
+
+function logoutToken(overrides: Record<string, unknown> = {}): string {
+    const now = Math.floor(Date.now() / 1_000);
+    const payload = Buffer.from(JSON.stringify({
+        v: 1,
+        iss: ISSUER,
+        aud: CLIENT_ID,
+        sid: 'central-device-session',
+        state: 'logout-state-that-is-opaque',
+        iat: now,
+        exp: now + 120,
+        ...overrides,
+    }), 'utf8').toString('base64url');
+    const signature = createHmac('sha256', CLIENT_SECRET).update(payload, 'utf8').digest('base64url');
+    return `${payload}.${signature}`;
+}
+
+function request(token = ''): NextRequest {
+    const url = new URL('/api/account/frontchannel-logout', 'https://live.harmonicbeacon.com');
+    if (token) url.searchParams.set('logout_token', token);
+    return new NextRequest(url, { headers: { host: 'live.harmonicbeacon.com' } });
+}
 
 describe('GET /api/account/frontchannel-logout', () => {
     beforeEach(() => {
-        revoke.mockReset().mockResolvedValue(1);
+        updateSessions.mockReset().mockResolvedValue({ count: 1 });
+        vi.stubEnv('BEACON_ACCOUNT_ENABLED', 'true');
+        vi.stubEnv('BEACON_ACCOUNT_ISSUER_URL', ISSUER);
+        vi.stubEnv('BEACON_ACCOUNT_CLIENT_ID', CLIENT_ID);
+        vi.stubEnv('BEACON_ACCOUNT_CLIENT_SECRET', CLIENT_SECRET);
     });
 
-    it('permits framing only by the exact central Account origin', async () => {
+    afterEach(() => vi.unstubAllEnvs());
+
+    it('revokes only the issuer and sid authorized by the signed Account token', async () => {
         const { GET } = await import('../route');
-        const response = await GET(createRequest(
-            '/api/account/frontchannel-logout?iss=https%3A%2F%2Faccount.harmonicbeacon.com&sid=device-session',
-        ));
+        const response = await GET(request(logoutToken()));
         expect(response.status).toBe(200);
         expect(response.headers.get('content-security-policy')).toBe(
             "default-src 'none'; frame-ancestors https://account.harmonicbeacon.com",
         );
-        expect(revoke).toHaveBeenCalledWith(
-            'https://account.harmonicbeacon.com',
-            'device-session',
-        );
+        expect(updateSessions).toHaveBeenCalledWith({
+            where: {
+                accountIssuer: ISSUER,
+                accountSessionId: 'central-device-session',
+                revokedAt: null,
+            },
+            data: {
+                revokedAt: expect.any(Date),
+                revocationReason: 'account_frontchannel_logout',
+            },
+        });
+    });
+
+    it.each([
+        ['unsigned', ''],
+        ['wrong audience', logoutToken({ aud: 'hb-live-staging' })],
+        ['expired', logoutToken({ iat: 1, exp: 2 })],
+    ])('rejects %s logout without touching a local session', async (_label, token) => {
+        const { GET } = await import('../route');
+        const response = await GET(request(token));
+        expect(response.status).toBe(400);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(updateSessions).not.toHaveBeenCalled();
+    });
+
+    it('rejects a tampered signature without touching a local session', async () => {
+        const { GET } = await import('../route');
+        const valid = logoutToken();
+        const [payload, signature] = valid.split('.');
+        const tampered = `${payload}.${signature[0] === 'A' ? 'B' : 'A'}${signature.slice(1)}`;
+        const response = await GET(request(tampered));
+        expect(response.status).toBe(400);
+        expect(updateSessions).not.toHaveBeenCalled();
     });
 });

--- a/src/app/api/account/frontchannel-logout/route.ts
+++ b/src/app/api/account/frontchannel-logout/route.ts
@@ -4,6 +4,7 @@ import {
     accountConfiguration,
     beaconAccountEnabled,
     revokeCentralSession,
+    verifyAccountFrontchannelLogoutToken,
 } from '@/lib/account-rp';
 import { redactError } from '@/lib/redact';
 
@@ -13,16 +14,22 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     if (!beaconAccountEnabled()) {
         return new NextResponse(null, { status: 404 });
     }
-    const issuer = request.nextUrl.searchParams.get('iss') ?? '';
-    const sid = request.nextUrl.searchParams.get('sid') ?? '';
+    const token = request.nextUrl.searchParams.get('logout_token') ?? '';
     try {
-        const expectedIssuer = accountConfiguration().issuer;
-        await revokeCentralSession(issuer, sid);
+        const config = accountConfiguration();
+        const authority = verifyAccountFrontchannelLogoutToken(token, config);
+        if (!authority) {
+            return new NextResponse(null, {
+                status: 400,
+                headers: { 'Cache-Control': 'private, no-store' },
+            });
+        }
+        await revokeCentralSession(authority.iss, authority.sid);
         return new NextResponse('<!doctype html><title>Signed out</title>', {
             status: 200,
             headers: {
                 'Cache-Control': 'private, no-store',
-                'Content-Security-Policy': `default-src 'none'; frame-ancestors ${new URL(expectedIssuer).origin}`,
+                'Content-Security-Policy': `default-src 'none'; frame-ancestors ${new URL(config.issuer).origin}`,
                 'Content-Type': 'text/html; charset=utf-8',
                 'Referrer-Policy': 'no-referrer',
                 'X-Content-Type-Options': 'nosniff',

--- a/src/lib/__tests__/live-production-account-deploy-contract.test.ts
+++ b/src/lib/__tests__/live-production-account-deploy-contract.test.ts
@@ -110,6 +110,7 @@ describe('Live production Account app-only contract', () => {
         expect(rollback).toContain('.checks.account == "disabled"');
         expect(smoke).toContain("--connect-timeout 3 --max-time 8");
         expect(smoke).toContain("--proto '=https'");
+        expect(smoke).toContain("test \"$status\" = 303 || { echo 'malformed Live Account callback was not bounded'");
         expect(smoke).toContain('/var/log/nginx/access.log');
         expect(smoke).not.toMatch(/\bnode\b/);
         expect(deploy).toContain('run --rm --no-deps migrate npx prisma migrate deploy');

--- a/src/lib/account-rp.ts
+++ b/src/lib/account-rp.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac, randomBytes } from 'node:crypto';
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
@@ -56,6 +56,16 @@ type TokenResponse = {
     access_token?: unknown;
     id_token?: unknown;
     token_type?: unknown;
+};
+
+type AccountFrontchannelPayload = {
+    v: 1;
+    iss: string;
+    aud: string;
+    sid: string;
+    state: string;
+    iat: number;
+    exp: number;
 };
 
 type Introspection = {
@@ -717,6 +727,41 @@ export async function revokeCentralSession(issuer: string, sid: string, now = ne
         data: { revokedAt: now, revocationReason: 'account_frontchannel_logout' },
     });
     return result.count;
+}
+
+function canonicalBase64Url(value: string): Buffer | null {
+    if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+    const decoded = Buffer.from(value, 'base64url');
+    return decoded.toString('base64url') === value ? decoded : null;
+}
+
+export function verifyAccountFrontchannelLogoutToken(
+    token: string,
+    config = accountConfiguration(),
+    now = new Date(),
+): AccountFrontchannelPayload | null {
+    if (token.length > 2048) return null;
+    try {
+        const [encoded, presented, extra] = token.split('.');
+        if (!encoded || !presented || extra) return null;
+        const payloadBytes = canonicalBase64Url(encoded);
+        const actual = canonicalBase64Url(presented);
+        if (!payloadBytes || !actual) return null;
+        const expected = createHmac('sha256', config.clientSecret).update(encoded, 'utf8').digest();
+        if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) return null;
+        const payload = JSON.parse(payloadBytes.toString('utf8')) as AccountFrontchannelPayload;
+        const timestamp = Math.floor(now.getTime() / 1_000);
+        if (
+            payload.v !== 1 || payload.iss !== config.issuer || payload.aud !== config.clientId ||
+            typeof payload.sid !== 'string' || payload.sid.length < 1 || payload.sid.length > 128 ||
+            !/^[A-Za-z0-9_-]{20,64}$/.test(payload.state) ||
+            !Number.isSafeInteger(payload.iat) || !Number.isSafeInteger(payload.exp) ||
+            payload.iat > timestamp + 30 || payload.exp < timestamp || payload.exp > payload.iat + 120
+        ) return null;
+        return payload;
+    } catch {
+        return null;
+    }
 }
 
 export async function revokeAllAccountSessions(


### PR DESCRIPTION
Align the production lifecycle smoke with the route's canonical 303 See Other response for malformed callbacks. Runtime route behavior is unchanged.\n\nEvidence: focused Account RP + lifecycle 21/21, full pre-commit suite, shell syntax, ESLint and diff-check green.