### PR TITLE
feat(ops): add production Account staff binding utility

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -134,6 +134,15 @@ jobs:
           DATABASE_URL: ${{ env.E2E_DATABASE_URL }}
           STAFF_BINDING_INTEGRATION_TEST: '1'
 
+      - name: Verify production staff Account binding contract in PostgreSQL
+        run: npx vitest run --no-file-parallelism scripts/live-production/__tests__/bind-staff-account.integration.test.ts
+        env:
+          DATABASE_URL: ${{ env.E2E_DATABASE_URL }}
+          STAFF_BINDING_INTEGRATION_TEST: '1'
+
+      - name: Verify Live production lifecycle shell syntax
+        run: sh -n scripts/live-production/*.sh
+
       - name: Verify every migration against a clean database
         # The fixture proves migrations apply on an existing database; this
         # proves the whole chain also builds from zero. The scratch database

--- a/deploy/live-production-staff-binding.env.example
+++ b/deploy/live-production-staff-binding.env.example
@@ -1,0 +1,7 @@
+# Copy to /etc/harmonic-beacon/live-production-secrets/staff-account-binding.env,
+# replace the two opaque identifiers locally, and keep the file root:root mode
+# 0600. Never commit or paste a real subject, cookie, token or email into an
+# issue, chat message or shell history.
+ACCOUNT_ISSUER=https://account.harmonicbeacon.com
+ACCOUNT_SUBJECT=opaque-production-account-subject-from-the-account-operator
+STAFF_USER_ID=00000000-0000-4000-8000-000000000000

--- a/scripts/live-production/__tests__/bind-staff-account.integration.test.ts
+++ b/scripts/live-production/__tests__/bind-staff-account.integration.test.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from 'node:crypto';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+    AUDIT_ACTION,
+    AUDIT_REASON,
+    BindingConflictError,
+    PRODUCTION_ACCOUNT_ISSUER,
+    provisionStaffAccountBinding,
+} from '../bind-staff-account';
+
+const enabled = process.env.STAFF_BINDING_INTEGRATION_TEST === '1';
+const databaseUrl = process.env.DATABASE_URL ?? '';
+const suite = enabled ? describe : describe.skip;
+let pool: Pool;
+let prisma: PrismaClient;
+const userIds: string[] = [];
+
+function input(staffUserId: string, accountSubject: string) {
+    return { accountIssuer: PRODUCTION_ACCOUNT_ISSUER, accountSubject, staffUserId };
+}
+
+async function createStaff(disabled = false): Promise<string> {
+    const id = randomUUID();
+    userIds.push(id);
+    await prisma.user.create({
+        data: {
+            id,
+            email: `production-staff-binding-${id}@invalid.example`,
+            name: 'Synthetic production staff binding test',
+            role: 'ADMIN',
+            passwordDigest: 'synthetic-not-a-login-secret',
+            disabledAt: disabled ? new Date() : null,
+        },
+    });
+    return id;
+}
+
+suite('Live production staff Account binding PostgreSQL contract', () => {
+    beforeAll(async () => {
+        const parsed = new URL(databaseUrl);
+        if (!parsed.pathname.endsWith('_test') && parsed.pathname !== '/beacon_test') {
+            throw new Error('production staff binding integration test refuses a non-test database');
+        }
+        pool = new Pool({ connectionString: databaseUrl, max: 8 });
+        prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    });
+
+    afterAll(async () => {
+        if (!prisma) return;
+        await prisma.auditLog.deleteMany({ where: { action: AUDIT_ACTION, reason: AUDIT_REASON } });
+        await prisma.staffAccountBinding.deleteMany({ where: { staffUserId: { in: userIds } } });
+        await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+        await prisma.$disconnect();
+        await pool.end();
+    });
+
+    it('dry-runs, creates atomically and replays with one production audit', async () => {
+        const staffUserId = await createStaff();
+        const bindingInput = input(staffUserId, `opaque-production-${randomUUID()}`);
+        const before = {
+            sessions: await prisma.webSession.count(),
+            tickets: await prisma.ticketEntitlement.count(),
+            events: await prisma.scheduledSession.count(),
+        };
+
+        await expect(provisionStaffAccountBinding(prisma, bindingInput, false)).resolves.toMatchObject({
+            outcome: 'would-create', bindingId: null,
+        });
+        expect(await prisma.staffAccountBinding.count({ where: { staffUserId } })).toBe(0);
+        const created = await provisionStaffAccountBinding(prisma, bindingInput, true);
+        expect(created.outcome).toBe('created');
+        await expect(provisionStaffAccountBinding(prisma, bindingInput, true)).resolves.toMatchObject({
+            outcome: 'already-bound', bindingId: created.bindingId,
+        });
+        expect(await prisma.auditLog.findMany({
+            where: { action: AUDIT_ACTION, targetId: created.bindingId ?? undefined },
+            select: { actorUserId: true, reason: true, metadata: true },
+        })).toEqual([{
+            actorUserId: null,
+            reason: AUDIT_REASON,
+            metadata: { accountIssuer: PRODUCTION_ACCOUNT_ISSUER, source: 'root_one_shot_utility' },
+        }]);
+        expect({
+            sessions: await prisma.webSession.count(),
+            tickets: await prisma.ticketEntitlement.count(),
+            events: await prisma.scheduledSession.count(),
+        }).toEqual(before);
+    });
+
+    it('keeps the mapping one-to-one and rejects disabled local authority', async () => {
+        const firstStaff = await createStaff();
+        const secondStaff = await createStaff();
+        const subject = `opaque-production-race-${randomUUID()}`;
+        const outcomes = await Promise.allSettled([
+            provisionStaffAccountBinding(prisma, input(firstStaff, subject), true),
+            provisionStaffAccountBinding(prisma, input(secondStaff, subject), true),
+        ]);
+        expect(outcomes.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+        expect(outcomes.filter((result) => result.status === 'rejected')).toHaveLength(1);
+        expect(await prisma.staffAccountBinding.count({
+            where: { accountIssuer: PRODUCTION_ACCOUNT_ISSUER, accountSubject: subject },
+        })).toBe(1);
+
+        const disabledStaff = await createStaff(true);
+        await expect(provisionStaffAccountBinding(prisma,
+            input(disabledStaff, `opaque-production-disabled-${randomUUID()}`), true))
+            .rejects.toBeInstanceOf(BindingConflictError);
+    });
+});

--- a/scripts/live-production/__tests__/bind-staff-account.test.ts
+++ b/scripts/live-production/__tests__/bind-staff-account.test.ts
@@ -1,0 +1,65 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import {
+    AUDIT_REASON,
+    INPUT_PATH,
+    PRODUCTION_ACCOUNT_ISSUER,
+    parseBindingInput,
+    readRootOnlyBindingInput,
+    validateProductionEnvironment,
+} from '../bind-staff-account';
+
+const validInput = [
+    `ACCOUNT_ISSUER=${PRODUCTION_ACCOUNT_ISSUER}`,
+    'ACCOUNT_SUBJECT=opaque_subject:production-123',
+    'STAFF_USER_ID=123e4567-e89b-42d3-a456-426614174000',
+].join('\n');
+
+describe('Live production staff Account binding guardrails', () => {
+    it('accepts only the production issuer and non-email fixed input contract', () => {
+        expect(parseBindingInput(validInput)).toEqual({
+            accountIssuer: PRODUCTION_ACCOUNT_ISSUER,
+            accountSubject: 'opaque_subject:production-123',
+            staffUserId: '123e4567-e89b-42d3-a456-426614174000',
+        });
+        expect(() => parseBindingInput(`${validInput}\nEMAIL=operator@example.com`)).toThrow(/exactly/);
+        expect(() => parseBindingInput(validInput.replace('opaque_subject:production-123', 'contains whitespace')))
+            .toThrow(/opaque/);
+        expect(() => parseBindingInput(validInput.replace(PRODUCTION_ACCOUNT_ISSUER,
+            'https://account-staging.harmonicbeacon.com'))).toThrow(/production issuer/);
+    });
+
+    it('is default-off and requires every production marker', () => {
+        const complete = {
+            LIVE_PRODUCTION_STAFF_BINDING_ENABLED: '1',
+            LIVE_PRODUCTION_ENVIRONMENT: 'production',
+            BEACON_ACCOUNT_ISSUER_URL: PRODUCTION_ACCOUNT_ISSUER,
+            DATABASE_URL: 'postgresql://unused@postgres/beacon',
+        };
+        expect(() => validateProductionEnvironment({ ...complete, LIVE_PRODUCTION_STAFF_BINDING_ENABLED: undefined }))
+            .toThrow(/disabled/);
+        expect(() => validateProductionEnvironment({ ...complete, LIVE_PRODUCTION_ENVIRONMENT: 'live-staging' }))
+            .toThrow(/environment marker/);
+        expect(() => validateProductionEnvironment({ ...complete, BEACON_ACCOUNT_ISSUER_URL:
+            'https://account-staging.harmonicbeacon.com' })).toThrow(/issuer marker/);
+        expect(() => validateProductionEnvironment({ ...complete,
+            DATABASE_URL: 'postgresql://unused@postgres/beacon_live_staging' })).toThrow(/other than beacon/);
+        expect(validateProductionEnvironment(complete).pathname).toBe('/beacon');
+    });
+
+    it('does not permit an operator-selected input path', async () => {
+        await expect(readRootOnlyBindingInput('/tmp/operator-selected.env')).rejects.toThrow(/fixed/);
+        expect(INPUT_PATH).toBe('/run/harmonic-beacon/staff-account-binding.env');
+        expect(AUDIT_REASON).toBe('live_production_operator_provision');
+    });
+
+    it('has no path to sessions, tickets, events, email matching or provider APIs', async () => {
+        const source = await readFile(new URL('../bind-staff-account.ts', import.meta.url), 'utf8');
+        for (const forbidden of [
+            'webSession.', 'ticketEntitlement.', 'scheduledSession.', 'email:',
+            'fetch(', 'paypal', 'mercadopago', 'LIVEKIT_API_SECRET',
+        ]) {
+            expect(source.toLowerCase()).not.toContain(forbidden.toLowerCase());
+        }
+    });
+});

--- a/scripts/live-production/__tests__/run-staff-account-binding.test.ts
+++ b/scripts/live-production/__tests__/run-staff-account-binding.test.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+describe('Live production staff binding runner contract', () => {
+    it('uses an exact runtime image, a clean source checkout and fixed root-only input', async () => {
+        const source = await readFile(new URL('../run-staff-account-binding.sh', import.meta.url), 'utf8');
+        expect(source).toContain('harmonic-beacon/app:$runtime_sha');
+        expect(source).toContain("git -C \"$root\" status --porcelain");
+        expect(source).toContain('/etc/harmonic-beacon/live-production-secrets/staff-account-binding.env');
+        expect(source).toContain('root:root:600');
+        expect(source).toContain('BEACON_ACCOUNT_ENABLED');
+        expect(source).toContain('https://account.harmonicbeacon.com');
+    });
+
+    it('gives the runner only a temporary internal database network and minimal environment', async () => {
+        const source = await readFile(new URL('../run-staff-account-binding.sh', import.meta.url), 'utf8');
+        expect(source).toContain('docker network create --internal');
+        expect(source).toContain('--cap-drop ALL');
+        expect(source).toContain('--security-opt no-new-privileges');
+        expect(source).toContain('--read-only');
+        expect(source).toContain('--env-file "$minimal_env"');
+        expect(source).toContain('--cidfile "$runner_cidfile"');
+        expect(source).not.toContain('--name "$runner"');
+        expect(source).not.toContain('--env-file "$production_env"');
+        expect(source).not.toContain('--network app_beacon');
+        expect(source).not.toContain('LIVEKIT_API_SECRET=');
+        expect(source).not.toContain('BEACON_ACCOUNT_CLIENT_SECRET=');
+    });
+
+    it('requires a verified database backup before apply and retains sanitized evidence', async () => {
+        const source = await readFile(new URL('../run-staff-account-binding.sh', import.meta.url), 'utf8');
+        expect(source).toContain('pg_dump');
+        expect(source).toContain('pg_restore --list');
+        expect(source).toContain('live.before.dump');
+        expect(source).toContain('subjectDigest');
+        expect(source).not.toContain('ACCOUNT_SUBJECT=$(env_value');
+    });
+});

--- a/scripts/live-production/__tests__/run-staff-account-binding.test.ts
+++ b/scripts/live-production/__tests__/run-staff-account-binding.test.ts
@@ -20,6 +20,7 @@ describe('Live production staff binding runner contract', () => {
         expect(source).toContain('--read-only');
         expect(source).toContain('--env-file "$minimal_env"');
         expect(source).toContain('--cidfile "$runner_cidfile"');
+        expect(source).toContain('timeout --signal=TERM 30s docker run');
         expect(source).not.toContain('--name "$runner"');
         expect(source).not.toContain('--env-file "$production_env"');
         expect(source).not.toContain('--network app_beacon');

--- a/scripts/live-production/bind-staff-account.ts
+++ b/scripts/live-production/bind-staff-account.ts
@@ -133,6 +133,8 @@ export async function provisionStaffAccountBinding(
     if (!apply) {
         return prisma.$transaction((tx) => inspectBinding(tx, input), {
             isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+            maxWait: 5_000,
+            timeout: 10_000,
         });
     }
 
@@ -163,7 +165,11 @@ export async function provisionStaffAccountBinding(
                     },
                 });
                 return { outcome: 'created', bindingId: binding.id };
-            }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+            }, {
+                isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+                maxWait: 5_000,
+                timeout: 10_000,
+            });
         } catch (error) {
             const retryable = error instanceof Prisma.PrismaClientKnownRequestError &&
                 (error.code === 'P2002' || error.code === 'P2034');
@@ -192,7 +198,13 @@ export async function main(
     }
     const databaseUrl = validateProductionEnvironment(environment);
     const input = await readRootOnlyBindingInput();
-    const pool = new Pool({ connectionString: databaseUrl.toString(), max: 2 });
+    const pool = new Pool({
+        connectionString: databaseUrl.toString(),
+        max: 2,
+        connectionTimeoutMillis: 5_000,
+        query_timeout: 10_000,
+        statement_timeout: 10_000,
+    });
     const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
     try {
         await assertDatabaseIdentity(prisma);

--- a/scripts/live-production/bind-staff-account.ts
+++ b/scripts/live-production/bind-staff-account.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { lstat, readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
+
+export const PRODUCTION_ACCOUNT_ISSUER = 'https://account.harmonicbeacon.com';
+export const PRODUCTION_DATABASE_NAME = 'beacon';
+export const INPUT_PATH = '/run/harmonic-beacon/staff-account-binding.env';
+export const AUDIT_ACTION = 'account.staff.binding.provisioned';
+export const AUDIT_REASON = 'live_production_operator_provision';
+
+export type BindingInput = {
+    accountIssuer: string;
+    accountSubject: string;
+    staffUserId: string;
+};
+
+export type BindingResult = {
+    outcome: 'would-create' | 'created' | 'already-bound';
+    bindingId: string | null;
+};
+
+export class BindingConflictError extends Error {}
+
+function fail(message: string): never {
+    throw new Error(message);
+}
+
+export function parseBindingInput(contents: string): BindingInput {
+    const values = new Map<string, string>();
+    for (const rawLine of contents.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+        const separator = line.indexOf('=');
+        if (separator < 1) fail('invalid binding input');
+        const key = line.slice(0, separator).trim();
+        const value = line.slice(separator + 1);
+        if (!/^[A-Z][A-Z0-9_]*$/.test(key) || values.has(key)) {
+            fail('invalid or duplicate binding input key');
+        }
+        values.set(key, value);
+    }
+
+    const allowed = new Set(['ACCOUNT_ISSUER', 'ACCOUNT_SUBJECT', 'STAFF_USER_ID']);
+    if ([...values.keys()].some((key) => !allowed.has(key)) || values.size !== allowed.size) {
+        fail('binding input must contain exactly ACCOUNT_ISSUER, ACCOUNT_SUBJECT and STAFF_USER_ID');
+    }
+
+    const accountIssuer = values.get('ACCOUNT_ISSUER') ?? '';
+    const accountSubject = values.get('ACCOUNT_SUBJECT') ?? '';
+    const staffUserId = values.get('STAFF_USER_ID') ?? '';
+    if (accountIssuer !== PRODUCTION_ACCOUNT_ISSUER) fail('Account issuer is not the exact production issuer');
+    if (accountSubject.length < 1 || accountSubject.length > 255 || /[\u0000-\u0020\u007f]/.test(accountSubject)) {
+        fail('Account subject must be an opaque, non-empty value without whitespace or control characters');
+    }
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(staffUserId)) {
+        fail('staff user ID must be a UUID');
+    }
+    return { accountIssuer, accountSubject, staffUserId: staffUserId.toLowerCase() };
+}
+
+export function validateProductionEnvironment(environment: Record<string, string | undefined>): URL {
+    if (environment.LIVE_PRODUCTION_STAFF_BINDING_ENABLED !== '1') {
+        fail('staff binding utility is disabled; set LIVE_PRODUCTION_STAFF_BINDING_ENABLED=1 explicitly');
+    }
+    if (environment.LIVE_PRODUCTION_ENVIRONMENT !== 'production') fail('exact production environment marker required');
+    if (environment.BEACON_ACCOUNT_ISSUER_URL !== PRODUCTION_ACCOUNT_ISSUER) {
+        fail('exact production Account issuer marker required');
+    }
+    const databaseUrl = new URL(environment.DATABASE_URL ?? fail('DATABASE_URL is required'));
+    if (databaseUrl.protocol !== 'postgresql:' && databaseUrl.protocol !== 'postgres:') {
+        fail('PostgreSQL DATABASE_URL required');
+    }
+    if (databaseUrl.pathname !== `/${PRODUCTION_DATABASE_NAME}`) fail('refusing a database other than beacon');
+    return databaseUrl;
+}
+
+export async function readRootOnlyBindingInput(path = INPUT_PATH): Promise<BindingInput> {
+    if (path !== INPUT_PATH) fail('binding input path is fixed');
+    const metadata = await lstat(path);
+    if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.uid !== 0 || metadata.gid !== 0 ||
+        (metadata.mode & 0o777) !== 0o600) {
+        fail(`${INPUT_PATH} must be a root:root mode-0600 regular file`);
+    }
+    return parseBindingInput(await readFile(path, 'utf8'));
+}
+
+async function inspectBinding(tx: Prisma.TransactionClient, input: BindingInput): Promise<BindingResult> {
+    const staff = await tx.user.findUnique({
+        where: { id: input.staffUserId },
+        select: { id: true, disabledAt: true },
+    });
+    if (!staff) throw new BindingConflictError('staff user does not exist');
+    if (staff.disabledAt) throw new BindingConflictError('staff user is disabled');
+
+    const [byStaff, byAccount] = await Promise.all([
+        tx.staffAccountBinding.findUnique({ where: { staffUserId: input.staffUserId } }),
+        tx.staffAccountBinding.findUnique({
+            where: {
+                accountIssuer_accountSubject: {
+                    accountIssuer: input.accountIssuer,
+                    accountSubject: input.accountSubject,
+                },
+            },
+        }),
+    ]);
+
+    if (byStaff?.disabledAt || byAccount?.disabledAt) {
+        throw new BindingConflictError('a matching staff binding is disabled and cannot be re-enabled by this utility');
+    }
+    if (byStaff && (byStaff.accountIssuer !== input.accountIssuer || byStaff.accountSubject !== input.accountSubject)) {
+        throw new BindingConflictError('staff user is already bound to another Account identity');
+    }
+    if (byAccount && byAccount.staffUserId !== input.staffUserId) {
+        throw new BindingConflictError('Account identity is already bound to another staff user');
+    }
+    if (byStaff && byAccount && byStaff.id === byAccount.id) {
+        return { outcome: 'already-bound', bindingId: byStaff.id };
+    }
+    if (byStaff || byAccount) throw new BindingConflictError('inconsistent one-to-one staff binding state');
+    return { outcome: 'would-create', bindingId: null };
+}
+
+export async function provisionStaffAccountBinding(
+    prisma: PrismaClient,
+    input: BindingInput,
+    apply: boolean,
+): Promise<BindingResult> {
+    if (!apply) {
+        return prisma.$transaction((tx) => inspectBinding(tx, input), {
+            isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        });
+    }
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+            return await prisma.$transaction(async (tx) => {
+                const inspected = await inspectBinding(tx, input);
+                if (inspected.outcome === 'already-bound') return inspected;
+                const binding = await tx.staffAccountBinding.create({
+                    data: {
+                        accountIssuer: input.accountIssuer,
+                        accountSubject: input.accountSubject,
+                        staffUserId: input.staffUserId,
+                    },
+                    select: { id: true },
+                });
+                await tx.auditLog.create({
+                    data: {
+                        actorUserId: null,
+                        action: AUDIT_ACTION,
+                        targetType: 'STAFF_ACCOUNT_BINDING',
+                        targetId: binding.id,
+                        reason: AUDIT_REASON,
+                        metadata: {
+                            accountIssuer: input.accountIssuer,
+                            source: 'root_one_shot_utility',
+                        },
+                    },
+                });
+                return { outcome: 'created', bindingId: binding.id };
+            }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+        } catch (error) {
+            const retryable = error instanceof Prisma.PrismaClientKnownRequestError &&
+                (error.code === 'P2002' || error.code === 'P2034');
+            if (!retryable || attempt === 2) throw error;
+        }
+    }
+    throw new Error('unreachable binding retry state');
+}
+
+async function assertDatabaseIdentity(prisma: PrismaClient): Promise<void> {
+    const rows = await prisma.$queryRaw<Array<{ database_name: string }>>`
+        SELECT current_database() AS database_name
+    `;
+    if (rows.length !== 1 || rows[0]?.database_name !== PRODUCTION_DATABASE_NAME) {
+        fail('connected database is not the production Live database');
+    }
+}
+
+export async function main(
+    argv = process.argv.slice(2),
+    environment: Record<string, string | undefined> = process.env,
+): Promise<void> {
+    if (process.getuid?.() !== 0) fail('run as root');
+    if (argv.length !== 1 || !['--dry-run', '--apply'].includes(argv[0] ?? '')) {
+        fail('usage: bind-staff-account.ts (--dry-run|--apply)');
+    }
+    const databaseUrl = validateProductionEnvironment(environment);
+    const input = await readRootOnlyBindingInput();
+    const pool = new Pool({ connectionString: databaseUrl.toString(), max: 2 });
+    const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+    try {
+        await assertDatabaseIdentity(prisma);
+        const result = await provisionStaffAccountBinding(prisma, input, argv[0] === '--apply');
+        const subjectDigest = createHash('sha256').update(input.accountSubject).digest('hex').slice(0, 12);
+        process.stdout.write(JSON.stringify({
+            mode: argv[0] === '--apply' ? 'apply' : 'dry-run',
+            outcome: result.outcome,
+            staffUserId: input.staffUserId,
+            subjectDigest,
+        }) + '\n');
+    } finally {
+        await prisma.$disconnect();
+        await pool.end();
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        process.stderr.write(`Live production staff binding failed: ${error instanceof Error ? error.message : 'unknown error'}\n`);
+        process.exitCode = 1;
+    });
+}

--- a/scripts/live-production/run-staff-account-binding.sh
+++ b/scripts/live-production/run-staff-account-binding.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env sh
+set -eu
+
+test "$(id -u)" -eq 0 || { echo 'run as root' >&2; exit 2; }
+runtime_sha=${1:?usage: run-staff-account-binding.sh runtime-sha40 (--dry-run|--apply)}
+mode=${2:?usage: run-staff-account-binding.sh runtime-sha40 (--dry-run|--apply)}
+test "$#" -eq 2 || { echo 'exactly two arguments required' >&2; exit 2; }
+case "$runtime_sha" in *[!0-9a-f]*|'') echo 'exact lowercase runtime sha40 required' >&2; exit 2 ;; esac
+test "${#runtime_sha}" -eq 40 || { echo 'exact lowercase runtime sha40 required' >&2; exit 2; }
+case "$mode" in --dry-run|--apply) ;; *) echo 'mode must be --dry-run or --apply' >&2; exit 2 ;; esac
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+source_script="$root/scripts/live-production/bind-staff-account.ts"
+image="harmonic-beacon/app:$runtime_sha"
+production_env=/etc/harmonic-beacon/production.env
+input=/etc/harmonic-beacon/live-production-secrets/staff-account-binding.env
+state_root=/var/lib/harmonic-beacon/live-production-staff-binding
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+state="$state_root/run-$stamp"
+network="hb-live-staff-binding-$$"
+minimal_env=$(mktemp /run/hb-live-staff-binding.XXXXXX)
+runner_cidfile=$(mktemp /run/hb-live-staff-binding-cid.XXXXXX)
+network_created=0
+database_connected=0
+
+fail() { echo "Live production staff binding: $*" >&2; exit 2; }
+private_file() {
+  test -f "$1" && test ! -L "$1" || fail "$2 must be a regular file"
+  test "$(stat -c '%U:%G:%a' "$1")" = root:root:600 || fail "$2 must be root:root mode 0600"
+}
+env_value() {
+  key=$1
+  count=$(grep -c "^${key}=" "$production_env" || true)
+  test "$count" -eq 1 || fail "$key must appear exactly once in production env"
+  sed -n "s/^${key}=//p" "$production_env"
+}
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if test -s "$runner_cidfile"; then
+    runner_cid=$(cat "$runner_cidfile")
+    case "$runner_cid" in *[!0-9a-f]*|'') ;; *) docker rm -f "$runner_cid" >/dev/null 2>&1 || true ;; esac
+  fi
+  if test "$database_connected" -eq 1; then
+    docker network disconnect -f "$network" beacon-postgres >/dev/null 2>&1 || true
+  fi
+  if test "$network_created" -eq 1; then docker network rm "$network" >/dev/null 2>&1 || true; fi
+  rm -f -- "$minimal_env" "$runner_cidfile"
+  exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+private_file "$production_env" 'production environment'
+private_file "$input" 'staff binding input'
+test -f "$source_script" && test ! -L "$source_script" || fail 'operator source must be a regular file'
+source_sha=$(git -C "$root" rev-parse HEAD)
+test -n "$source_sha" && test "${#source_sha}" -eq 40 || fail 'operator source checkout is invalid'
+test -z "$(git -C "$root" status --porcelain)" || fail 'operator source checkout is dirty'
+docker image inspect "$image" >/dev/null 2>&1 || fail 'exact runtime image is absent'
+baked_sha=$(docker image inspect "$image" --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
+test "$baked_sha" = "$runtime_sha" || fail 'runtime image provenance mismatch'
+test "$(docker inspect beacon-app --format '{{.Config.Image}}')" = "$image" || fail 'runtime image is not active'
+test "$(docker inspect beacon-app --format '{{.State.Running}}|{{if .State.Health}}{{.State.Health.Status}}{{end}}')" = 'true|healthy' ||
+  fail 'Live app is not healthy'
+test "$(docker inspect beacon-app --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_ACCOUNT_ENABLED=//p' | tail -n 1)" = true || fail 'Live Account is not enabled'
+test "$(docker inspect beacon-app --format '{{range .Config.Env}}{{println .}}{{end}}' |
+  sed -n 's/^BEACON_ACCOUNT_ISSUER_URL=//p' | tail -n 1)" = https://account.harmonicbeacon.com ||
+  fail 'Live Account issuer is not production'
+
+postgres_user=$(env_value POSTGRES_USER)
+postgres_password=$(env_value POSTGRES_PASSWORD)
+postgres_database=$(env_value POSTGRES_DB)
+test "$postgres_database" = beacon || fail 'production database name is not beacon'
+command -v jq >/dev/null 2>&1 || fail 'jq is required'
+encoded_user=$(jq -rn --arg value "$postgres_user" '$value|@uri')
+encoded_password=$(jq -rn --arg value "$postgres_password" '$value|@uri')
+encoded_database=$(jq -rn --arg value "$postgres_database" '$value|@uri')
+unset postgres_user postgres_password postgres_database
+{
+  printf 'DATABASE_URL=postgresql://%s:%s@postgres:5432/%s\n' "$encoded_user" "$encoded_password" "$encoded_database"
+  printf 'LIVE_PRODUCTION_STAFF_BINDING_ENABLED=1\n'
+  printf 'LIVE_PRODUCTION_ENVIRONMENT=production\n'
+  printf 'BEACON_ACCOUNT_ISSUER_URL=https://account.harmonicbeacon.com\n'
+} > "$minimal_env"
+unset encoded_user encoded_password encoded_database
+chown root:root "$minimal_env"
+chmod 0600 "$minimal_env"
+private_file "$minimal_env" 'minimal runner environment'
+
+if test -e "$state_root"; then
+  test -d "$state_root" && test ! -L "$state_root" || fail 'state root must be a regular directory'
+  test "$(stat -c '%U:%G:%a' "$state_root")" = root:root:700 || fail 'state root must be root:root mode 0700'
+else
+  install -d -o root -g root -m 0700 "$state_root"
+fi
+test ! -e "$state" || fail 'operator state already exists'
+install -d -o root -g root -m 0700 "$state"
+install -o root -g root -m 0600 "$source_script" "$state/bind-staff-account.ts"
+printf 'source_sha=%s\nruntime_sha=%s\nmode=%s\n' "$source_sha" "$runtime_sha" "$mode" > "$state/provenance.txt"
+chmod 0600 "$state/provenance.txt"
+
+if test "$mode" = --apply; then
+  docker exec beacon-postgres sh -ec \
+    'exec pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc --no-owner --no-acl' > "$state/live.before.dump"
+  test -s "$state/live.before.dump" || fail 'database backup is empty'
+  chmod 0600 "$state/live.before.dump"
+  docker exec -i beacon-postgres pg_restore --list < "$state/live.before.dump" >/dev/null ||
+    fail 'database backup could not be listed'
+fi
+
+docker network create --internal --driver bridge "$network" >/dev/null
+network_created=1
+docker network connect --alias postgres "$network" beacon-postgres
+database_connected=1
+output=$(docker run --rm --pull never --cidfile "$runner_cidfile" --network "$network" \
+  --read-only --user 0:0 --cap-drop ALL --security-opt no-new-privileges \
+  --mount "type=bind,src=$source_script,dst=/app/scripts/live-production/bind-staff-account.operator.ts,readonly" \
+  --mount "type=bind,src=$input,dst=/run/harmonic-beacon/staff-account-binding.env,readonly" \
+  --env-file "$minimal_env" --tmpfs /tmp:size=16m,mode=1777 --workdir /app \
+  --entrypoint npx "$image" tsx /app/scripts/live-production/bind-staff-account.operator.ts "$mode")
+printf '%s\n' "$output" | jq -e --arg mode "${mode#--}" \
+  '.mode == $mode and (.outcome == "would-create" or .outcome == "created" or .outcome == "already-bound") and
+   (.staffUserId | type == "string") and (.subjectDigest | test("^[0-9a-f]{12}$"))' >/dev/null ||
+  fail 'operator returned an invalid result'
+printf '%s\n' "$output" > "$state/result.json"
+chmod 0600 "$state/result.json"
+(cd "$state" && sha256sum bind-staff-account.ts provenance.txt result.json \
+  $(test -f live.before.dump && printf '%s' live.before.dump) > SHA256SUMS)
+chmod 0600 "$state/SHA256SUMS"
+printf '%s\n' "$output"
+printf 'Evidence: %s\n' "$state"

--- a/scripts/live-production/run-staff-account-binding.sh
+++ b/scripts/live-production/run-staff-account-binding.sh
@@ -74,6 +74,7 @@ postgres_password=$(env_value POSTGRES_PASSWORD)
 postgres_database=$(env_value POSTGRES_DB)
 test "$postgres_database" = beacon || fail 'production database name is not beacon'
 command -v jq >/dev/null 2>&1 || fail 'jq is required'
+command -v timeout >/dev/null 2>&1 || fail 'timeout is required'
 encoded_user=$(jq -rn --arg value "$postgres_user" '$value|@uri')
 encoded_password=$(jq -rn --arg value "$postgres_password" '$value|@uri')
 encoded_database=$(jq -rn --arg value "$postgres_database" '$value|@uri')
@@ -114,7 +115,7 @@ docker network create --internal --driver bridge "$network" >/dev/null
 network_created=1
 docker network connect --alias postgres "$network" beacon-postgres
 database_connected=1
-output=$(docker run --rm --pull never --cidfile "$runner_cidfile" --network "$network" \
+output=$(timeout --signal=TERM 30s docker run --rm --pull never --cidfile "$runner_cidfile" --network "$network" \
   --read-only --user 0:0 --cap-drop ALL --security-opt no-new-privileges \
   --mount "type=bind,src=$source_script,dst=/app/scripts/live-production/bind-staff-account.operator.ts,readonly" \
   --mount "type=bind,src=$input,dst=/run/harmonic-beacon/staff-account-binding.env,readonly" \

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         include: [
             'src/**/*.test.{ts,tsx}',
             'scripts/live-staging/**/*.test.ts',
+            'scripts/live-production/**/*.test.ts',
             'middleware.test.ts',
         ],
         coverage: {


### PR DESCRIPTION
## Outcome

Adds the production-only, default-off operator path needed to bind one explicit central Account subject to one existing Live staff UUID without email matching.

## Safety boundary

- exact production issuer and `beacon` database only;
- fixed root:root 0600 three-key input, no email;
- Serializable one-to-one transaction with one durable audit row and idempotent replay;
- exact active runtime image plus clean source SHA;
- minimal four-key runner environment on a temporary internal database-only network;
- read-only rootfs, caps dropped, no-new-privileges, no provider/Account/LiveKit secret bundle;
- verified custom-format DB backup before `--apply`;
- touches no sessions, tickets, events, audio, payments or provider APIs.

No binding or runtime mutation is performed by this PR.

## Evidence

- 7 focused unit/contract tests
- PostgreSQL 16 integration: 2/2
- full Vitest: 1,084 passed / 25 skipped
- TypeScript, focused ESLint, shell syntax and diff-check green
