### PR TITLE
fix(ops): allow production staff binding runner to start

### DIFF
--- a/scripts/live-production/__tests__/run-staff-account-binding.test.ts
+++ b/scripts/live-production/__tests__/run-staff-account-binding.test.ts
@@ -19,7 +19,10 @@ describe('Live production staff binding runner contract', () => {
         expect(source).toContain('--security-opt no-new-privileges');
         expect(source).toContain('--read-only');
         expect(source).toContain('--env-file "$minimal_env"');
+        expect(source).toContain('runner_state=$(mktemp -d /run/hb-live-staff-binding-run.XXXXXX)');
+        expect(source).toContain('runner_cidfile="$runner_state/container.cid"');
         expect(source).toContain('--cidfile "$runner_cidfile"');
+        expect(source).not.toContain('runner_cidfile=$(mktemp');
         expect(source).toContain('timeout --signal=TERM 30s docker run');
         expect(source).not.toContain('--name "$runner"');
         expect(source).not.toContain('--env-file "$production_env"');

--- a/scripts/live-production/run-staff-account-binding.sh
+++ b/scripts/live-production/run-staff-account-binding.sh
@@ -19,7 +19,8 @@ stamp=$(date -u +%Y%m%dT%H%M%SZ)
 state="$state_root/run-$stamp"
 network="hb-live-staff-binding-$$"
 minimal_env=$(mktemp /run/hb-live-staff-binding.XXXXXX)
-runner_cidfile=$(mktemp /run/hb-live-staff-binding-cid.XXXXXX)
+runner_state=$(mktemp -d /run/hb-live-staff-binding-run.XXXXXX)
+runner_cidfile="$runner_state/container.cid"
 network_created=0
 database_connected=0
 
@@ -46,6 +47,7 @@ cleanup() {
   fi
   if test "$network_created" -eq 1; then docker network rm "$network" >/dev/null 2>&1 || true; fi
   rm -f -- "$minimal_env" "$runner_cidfile"
+  rmdir -- "$runner_state" >/dev/null 2>&1 || true
   exit "$status"
 }
 trap cleanup EXIT HUP INT TERM


### PR DESCRIPTION
Fixes the root-only production staff binding runner after a real dry-run proved Docker rejects a pre-created empty --cidfile. The runner now creates a private root-owned directory and passes an absent child path, retaining cleanup and all existing isolation.\n\nVerification: sh -n; 7 focused tests; ESLint; diff-check. No runtime app, schema, session, event, audio, payment, or DNS changes.