### PR TITLE
fix(listener): resume central Account sessions automatically

### DIFF
--- a/src/app/api/account/frontchannel-logout/__tests__/route.test.ts
+++ b/src/app/api/account/frontchannel-logout/__tests__/route.test.ts
@@ -34,6 +34,8 @@ describe('Listener signed frontchannel logout boundary', () => {
         expect(response.status).toBe(204);
         expect(response.headers.get('content-security-policy'))
             .toBe(`default-src 'none'; frame-ancestors ${issuer}`);
+        expect(response.headers.get('set-cookie'))
+            .toContain('__Host-hb_listener_account_auto_handoff=1');
         expect(db.deleteMany).toHaveBeenCalledWith({
             where: { issuer, sid: 'central-session' },
         });

--- a/src/app/api/account/frontchannel-logout/route.ts
+++ b/src/app/api/account/frontchannel-logout/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/db';
 import { verifyAccountFrontchannelLogout } from '@/lib/account/frontchannel-token';
 import {
     listenerAccountCookie,
+    listenerAutomaticHandoffCookie,
     listenerAccountRPConfig,
 } from '@/lib/listener/account-rp';
 import { isCanonicalListenerHost, isListenerStagingHost } from '@/lib/listener/public-discovery';
@@ -26,12 +27,14 @@ export async function GET(request: Request): Promise<Response> {
     await prisma.listenerAccountSession.deleteMany({
         where: { issuer: authority.iss, sid: authority.sid },
     });
+    const responseHeaders = new Headers({
+        'Cache-Control': 'private, no-store',
+        'Content-Security-Policy': `default-src 'none'; frame-ancestors ${config.issuer}`,
+    });
+    responseHeaders.append('Set-Cookie', listenerAccountCookie('', 0));
+    responseHeaders.append('Set-Cookie', listenerAutomaticHandoffCookie('1'));
     return new Response(null, {
         status: 204,
-        headers: {
-            'Set-Cookie': listenerAccountCookie('', 0),
-            'Cache-Control': 'private, no-store',
-            'Content-Security-Policy': `default-src 'none'; frame-ancestors ${config.issuer}`,
-        },
+        headers: responseHeaders,
     });
 }

--- a/src/app/api/account/login/route.test.ts
+++ b/src/app/api/account/login/route.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from './route';
+
+function request(path = '/api/account/login', host = 'listen.harmonicbeacon.com') {
+    return new Request(`http://127.0.0.1:3000${path}`, { headers: { host } });
+}
+
+describe('Listener Account login handoff', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal('fetch', fetchMock);
+        vi.stubEnv('BEACON_LISTENER_ACCOUNT_ENABLED', '1');
+        vi.stubEnv('BEACON_LISTENER_ACCOUNT_ENVIRONMENT', 'production');
+        vi.stubEnv('BEACON_LISTENER_ACCOUNT_CLIENT_SECRET', 'p'.repeat(32));
+        vi.stubEnv('BEACON_LISTENER_ACCOUNT_STATE_SECRET', 's'.repeat(32));
+    });
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.unstubAllEnvs();
+    });
+
+    it('preserves explicit sign-in and clears any logout suppression', async () => {
+        const response = await GET(request());
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location'))
+            .toMatch(/^https:\/\/account\.harmonicbeacon\.com\/api\/account\/auth\/oauth2\/authorize\?/);
+        expect(response.headers.get('set-cookie')).toContain('__Host-hb_listener_account_attempt=');
+        expect(response.headers.get('set-cookie'))
+            .toContain('__Host-hb_listener_account_auto_handoff=;');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('preflights a healthy issuer before the automatic top-level handoff', async () => {
+        fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: 'ok' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        }));
+        const response = await GET(request('/api/account/login?auto=1'));
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toContain('account.harmonicbeacon.com');
+        expect(response.headers.get('set-cookie')).toContain('__Host-hb_listener_account_attempt=');
+        expect(response.headers.get('set-cookie'))
+            .not.toContain('__Host-hb_listener_account_auto_handoff=;');
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('returns to a bounded visible retry when Account is unavailable', async () => {
+        fetchMock.mockResolvedValue(new Response(null, { status: 503 }));
+        const response = await GET(request('/api/account/login?auto=1'));
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location'))
+            .toBe('https://listen.harmonicbeacon.com/?accountUnavailable=1');
+        expect(response.headers.get('set-cookie'))
+            .toContain('__Host-hb_listener_account_auto_handoff=1');
+        expect(response.headers.get('set-cookie'))
+            .not.toContain('__Host-hb_listener_account_attempt=');
+    });
+
+    it('does not accept an internal or sibling Host', async () => {
+        expect((await GET(request('/api/account/login?auto=1', '127.0.0.1:3000'))).status)
+            .toBe(404);
+        expect((await GET(request('/api/account/login?auto=1', 'live.harmonicbeacon.com'))).status)
+            .toBe(404);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/account/login/route.ts
+++ b/src/app/api/account/login/route.ts
@@ -1,19 +1,58 @@
-import { createListenerAccountAuthorization, listenerAttemptCookie } from '@/lib/listener/account-rp';
+import {
+    createListenerAccountAuthorization,
+    listenerAttemptCookie,
+    listenerAutomaticHandoffCookie,
+    listenerAccountRPConfig,
+} from '@/lib/listener/account-rp';
 import { isCanonicalListenerHost, isListenerStagingHost } from '@/lib/listener/public-discovery';
+
+async function accountReadyForAutomaticHandoff(headers: Headers): Promise<boolean> {
+    try {
+        const config = listenerAccountRPConfig(headers);
+        const response = await fetch(new URL('/api/account/health/ready', config.issuer), {
+            cache: 'no-store',
+            redirect: 'error',
+            signal: AbortSignal.timeout(2_000),
+        });
+        if (!response.ok) return false;
+        const body = await response.json().catch(() => null) as { status?: unknown } | null;
+        return body?.status === 'ok';
+    } catch {
+        return false;
+    }
+}
 
 export async function GET(request: Request): Promise<Response> {
     const headers = new Headers(request.headers);
     if (!isCanonicalListenerHost(headers) && !isListenerStagingHost(headers)) return new Response(null, { status: 404 });
-    try {
-        const authorization = createListenerAccountAuthorization(headers);
+    const automaticValues = new URL(request.url).searchParams.getAll('auto');
+    const automatic = automaticValues.length === 1 && automaticValues[0] === '1';
+    if (automatic && !await accountReadyForAutomaticHandoff(headers)) {
+        const listenerOrigin = isListenerStagingHost(headers)
+            ? 'https://earlybirds-staging.harmonicbeacon.com'
+            : 'https://listen.harmonicbeacon.com';
         return new Response(null, {
             status: 302,
             headers: {
-                Location: authorization.url.toString(),
-                'Set-Cookie': listenerAttemptCookie(authorization.cookie),
+                Location: `${listenerOrigin}/?accountUnavailable=1`,
+                'Set-Cookie': listenerAutomaticHandoffCookie('1', 60),
                 'Cache-Control': 'private, no-store',
                 'Referrer-Policy': 'no-referrer',
             },
+        });
+    }
+    try {
+        const authorization = createListenerAccountAuthorization(headers);
+        const responseHeaders = new Headers({
+            Location: authorization.url.toString(),
+            'Cache-Control': 'private, no-store',
+            'Referrer-Policy': 'no-referrer',
+        });
+        responseHeaders.append('Set-Cookie', listenerAttemptCookie(authorization.cookie));
+        if (!automatic) responseHeaders.append('Set-Cookie', listenerAutomaticHandoffCookie('', 0));
+        return new Response(null, {
+            status: 302,
+            headers: responseHeaders,
         });
     } catch { return Response.json({ error: 'identity_unavailable' }, { status: 503 }); }
 }

--- a/src/app/api/listener/auth/recover/__tests__/route.test.ts
+++ b/src/app/api/listener/auth/recover/__tests__/route.test.ts
@@ -53,6 +53,8 @@ describe('Listener same-origin central logout initiation', () => {
             where: { id: 'local-session', sid: 'central-sid' },
         });
         expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+        expect(response.headers.get('set-cookie'))
+            .toContain('__Host-hb_listener_account_auto_handoff=1');
     });
 
     it('offers human confirmation when state_mismatch left no local RP session', async () => {
@@ -62,6 +64,8 @@ describe('Listener same-origin central logout initiation', () => {
         const target = new URL(result.url);
         expect(response.status).toBe(200);
         expect(result.confirmation).toBe(true);
+        expect(response.headers.get('set-cookie'))
+            .toContain('__Host-hb_listener_account_auto_handoff=1');
         expect(target.searchParams.has('initiation')).toBe(false);
         expect(target.searchParams.get('return_to'))
             .toBe('https://earlybirds-staging.harmonicbeacon.com/');

--- a/src/app/api/listener/auth/recover/route.ts
+++ b/src/app/api/listener/auth/recover/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db';
 import { signAccountLogoutInitiation } from '@/lib/account/frontchannel-token';
 import {
     listenerAccountCookie,
+    listenerAutomaticHandoffCookie,
     listenerAccountRPConfig,
     readListenerAccountCookie,
 } from '@/lib/listener/account-rp';
@@ -34,6 +35,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         'Cache-Control': 'private, no-store',
         'Set-Cookie': listenerAccountCookie('', 0),
     });
+    responseHeaders.append('Set-Cookie', listenerAutomaticHandoffCookie('1'));
     const returnTo = isListenerStagingHost(headers)
         ? 'https://earlybirds-staging.harmonicbeacon.com/'
         : 'https://listen.harmonicbeacon.com/';

--- a/src/app/early-birds/__tests__/page.test.tsx
+++ b/src/app/early-birds/__tests__/page.test.tsx
@@ -55,6 +55,63 @@ const availableQuota = {
 };
 
 describe('EarlyBird Listener page', () => {
+    function enableProductionAccount() {
+        vi.stubEnv('BEACON_LISTENER_ACCOUNT_ENABLED', '1');
+        vi.stubEnv('BEACON_LISTENER_ACCOUNT_ENVIRONMENT', 'production');
+        vi.stubEnv('BEACON_LISTENER_ACCOUNT_CLIENT_SECRET', 'p'.repeat(32));
+        vi.stubEnv('BEACON_LISTENER_ACCOUNT_STATE_SECRET', 's'.repeat(32));
+    }
+
+    it('starts one bounded Account handoff instead of rendering a redundant signed-out CTA', async () => {
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
+        enableProductionAccount();
+        mocks.headers.mockResolvedValue(new Headers({ host: 'listen.harmonicbeacon.com' }));
+        mocks.currentEarlyBirdSession.mockResolvedValue(null);
+        const redirected = new Error('redirected');
+        mocks.redirect.mockImplementation(() => { throw redirected; });
+
+        await expect(EarlyBirdsPage({ searchParams: Promise.resolve({}) }))
+            .rejects.toBe(redirected);
+        expect(mocks.redirect).toHaveBeenCalledWith('/api/account/login?auto=1');
+        expect(mocks.getEarlyBirdListeningAccess).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['logout suppression', { cookie: '__Host-hb_listener_account_auto_handoff=1' }, {}],
+        ['callback failure', {}, { authError: '1' }],
+    ])('keeps a visible retry path after %s instead of redirecting in a loop', async (_label, headerValues, params) => {
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
+        enableProductionAccount();
+        mocks.headers.mockResolvedValue(new Headers({
+            host: 'listen.harmonicbeacon.com',
+            ...headerValues,
+        }));
+        mocks.currentEarlyBirdSession.mockResolvedValue(null);
+
+        const result = await EarlyBirdsPage({ searchParams: Promise.resolve(params) });
+        expect(result.type).toBeDefined();
+        expect(mocks.redirect).not.toHaveBeenCalled();
+    });
+
+    it('turns an unavailable automatic handoff into a truthful retryable landing', async () => {
+        vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
+        vi.stubEnv('EARLY_BIRDS_FREE_FOR_ALL', '0');
+        enableProductionAccount();
+        mocks.headers.mockResolvedValue(new Headers({ host: 'listen.harmonicbeacon.com' }));
+        mocks.currentEarlyBirdSession.mockResolvedValue(null);
+
+        const result = await EarlyBirdsPage({
+            searchParams: Promise.resolve({ accountUnavailable: '1' }),
+        });
+        expect(result.props).toMatchObject({
+            signedIn: false,
+            serviceUnavailable: 'identity',
+        });
+        expect(mocks.redirect).not.toHaveBeenCalled();
+    });
+
     it('cleans provider return parameters without treating them as payment authority', async () => {
         vi.stubEnv('EARLY_BIRDS_ENABLED', '1');
         mocks.headers.mockResolvedValue(new Headers({

--- a/src/app/early-birds/page.tsx
+++ b/src/app/early-birds/page.tsx
@@ -14,7 +14,10 @@ import {
 } from '@/lib/early-birds/invitation-cookie';
 import { syntheticTeamEntryAllowed } from '@/lib/early-birds/synthetic-team-entry';
 import { configuredEarlyBirdDropIn } from '@/lib/early-birds/drop-ins';
-import { listenerAccountRPConfig } from '@/lib/listener/account-rp';
+import {
+    listenerAccountRPConfig,
+    listenerAutomaticHandoffSuppressed,
+} from '@/lib/listener/account-rp';
 import { serializeEarlyBirdQuotaSnapshot } from '@/lib/early-birds/quota';
 import {
     isCanonicalListenerHost,
@@ -111,11 +114,16 @@ export default async function EarlyBirdsPage({
     let accountIdentityAvailable = true;
     try { listenerAccountRPConfig(incomingHeaders); } catch { accountIdentityAvailable = false; }
     const syntheticTeamEntryAvailable = syntheticTeamEntryAllowed({ headers: incomingHeaders });
+    const accountUnavailable = params.accountUnavailable === '1';
+    if (!session && accountIdentityAvailable && !accountUnavailable && params.authError !== '1' &&
+        !listenerAutomaticHandoffSuppressed(incomingHeaders)) {
+        redirect('/api/account/login?auto=1');
+    }
     const identityUnavailable = sessionResolution.unavailable || (
         !session
         && !accountIdentityAvailable
         && !syntheticTeamEntryAvailable
-    );
+    ) || accountUnavailable;
     return (
         <EarlyBirdLanding
             signedIn={Boolean(session)}

--- a/src/lib/listener/__tests__/account-rp.test.ts
+++ b/src/lib/listener/__tests__/account-rp.test.ts
@@ -11,6 +11,7 @@ import {
     listenerAccountRPConfig,
     locallyKnownListenerNavigationIdentity,
     locallyKnownListenerAccountSession,
+    listenerAutomaticHandoffSuppressed,
     localListenerAccountId,
     readListenerAccountCookie,
     readListenerAccountAttemptCookie,
@@ -74,6 +75,15 @@ describe('Listener Account RP subject namespace', () => {
         expect(readListenerAccountAttemptCookie(new Headers({
             cookie: '__Host-hb_listener_account_attempt=one; __Host-hb_listener_account_attempt=two',
         }))).toBeNull();
+        expect(listenerAutomaticHandoffSuppressed(new Headers({
+            cookie: '__Host-hb_listener_account_auto_handoff=1',
+        }))).toBe(true);
+        expect(listenerAutomaticHandoffSuppressed(new Headers({
+            cookie: '__Host-hb_listener_account_auto_handoff=0',
+        }))).toBe(false);
+        expect(listenerAutomaticHandoffSuppressed(new Headers({
+            cookie: '__Host-hb_listener_account_auto_handoff=1; __Host-hb_listener_account_auto_handoff=1',
+        }))).toBe(false);
     });
 
     it('preserves production opaque account IDs for existing commercial foreign keys', () => {

--- a/src/lib/listener/account-rp.ts
+++ b/src/lib/listener/account-rp.ts
@@ -10,6 +10,7 @@ import { isListenerStagingHost } from '@/lib/listener/public-discovery';
 
 export const LISTENER_ACCOUNT_COOKIE = '__Host-hb_listener_account';
 export const LISTENER_ACCOUNT_ATTEMPT_COOKIE = '__Host-hb_listener_account_attempt';
+export const LISTENER_ACCOUNT_AUTO_HANDOFF_COOKIE = '__Host-hb_listener_account_auto_handoff';
 const MAX_LISTENER_ACCOUNT_COOKIE_LENGTH = 512;
 
 function readSingleBoundedCookie(headers: Headers, name: string, maxLength: number): string | null {
@@ -34,6 +35,11 @@ export function readListenerAccountCookie(headers: Headers): string | null {
 
 export function readListenerAccountAttemptCookie(headers: Headers): string | null {
     return readSingleBoundedCookie(headers, LISTENER_ACCOUNT_ATTEMPT_COOKIE, 2048);
+}
+
+/** A logout/recovery marker suppresses only the optional automatic OIDC hop. */
+export function listenerAutomaticHandoffSuppressed(headers: Headers): boolean {
+    return readSingleBoundedCookie(headers, LISTENER_ACCOUNT_AUTO_HANDOFF_COOKIE, 8) === '1';
 }
 
 type RPConfig = {
@@ -399,4 +405,8 @@ export function listenerAccountCookie(value: string, maxAge = 30 * 24 * 60 * 60)
 
 export function listenerAttemptCookie(value: string, maxAge = 10 * 60) {
     return `${LISTENER_ACCOUNT_ATTEMPT_COOKIE}=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
+}
+
+export function listenerAutomaticHandoffCookie(value: '' | '1', maxAge = 10 * 60) {
+    return `${LISTENER_ACCOUNT_AUTO_HANDOFF_COOKIE}=${value}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
 }


### PR DESCRIPTION
Closes #446. Signed-out Listener performs one bounded top-level OIDC handoff after an exact Account readiness probe. Existing central sessions return without the redundant CTA; absent sessions reach normal Account sign-in. Logout/recovery set a short-lived host-only suppression cookie, explicit sign-in clears it, callback/outage paths remain visible and retryable, and no iframe/shared cookie/storage auth/PII is introduced.\n\nPreserves PayPal Live and Mercado Pago Live flags and does not touch audio, membership, quota, Founder, payment, event, schema or migration paths.\n\nLocal gates: 52 focused tests; full 1805 pass/44 skip; TypeScript; focused ESLint; production build; diff-check.