### PR TITLE
fix(listener): allow Account-on production redeploys

### DIFF
--- a/ops/listener-account-production/README.md
+++ b/ops/listener-account-production/README.md
@@ -25,8 +25,12 @@ the coordinated Account/Listener cutover.
    it, recreates only the Listener app, and keeps rollback active through local
    and public login smokes. It does not rebuild/restart the stream origin,
    PostgreSQL, withdrawal worker, payments, LiveKit or event services.
+   Subsequent immutable Listener releases use this same command while Account
+   is already on. The generator then requires the active production RP secrets
+   to match the protected bundle exactly and rejects any reintroduced legacy
+   Google, Apple or magic-link credential before replacing the app.
 6. The printed root-only activation directory is the only accepted argument to
-   `rollback.sh`. Rollback restores the Account-off env and exact prior image;
+   `rollback.sh`. Rollback restores the exact prior Account mode, env and image;
    it never downgrades the shared database.
 
 The first Account production migration revokes legacy Listener authentication

--- a/ops/listener-account-production/test/contract.test.mjs
+++ b/ops/listener-account-production/test/contract.test.mjs
@@ -92,9 +92,22 @@ test('builds a production-only Listener activation without changing unrelated va
   assert.match(activated, /BEACON_LISTENER_PAYPAL_LIVE_CHECKOUT_ENABLED=1/);
   assert.match(activated, /BEACON_LISTENER_MERCADO_PAGO_LIVE_CHECKOUT_ENABLED=1/);
   assert.match(activated, /UNRELATED=preserved/);
+
+  const redeployed = buildProductionActivation({
+    listenerContents: activated,
+    bundleContents: `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\n`,
+    expectedSha: 'b'.repeat(40),
+    buildTime: '2026-08-20T20:00:00Z',
+    expectedSchema: '20260818010000_beacon_account_authority',
+  });
+  assert.match(redeployed, new RegExp(`EARLYBIRDS_PREVIEW_IMAGE_TAG=${'b'.repeat(40)}`));
+  assert.match(redeployed, /BEACON_LISTENER_ACCOUNT_ENABLED=1/);
+  assert.match(redeployed, /BEACON_LISTENER_PAYPAL_LIVE_CHECKOUT_ENABLED=1/);
+  assert.match(redeployed, /BEACON_LISTENER_MERCADO_PAGO_LIVE_CHECKOUT_ENABLED=1/);
+  assert.match(redeployed, /UNRELATED=preserved/);
 });
 
-test('activation refuses enabled, cross-environment, ambiguous and invalid input', () => {
+test('activation refuses drifted enabled, cross-environment, ambiguous and invalid input', () => {
   const input = {
     listenerContents: activationListener,
     bundleContents: `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}\nBEACON_LISTENER_ACCOUNT_STATE_SECRET=${state}\n`,
@@ -104,13 +117,25 @@ test('activation refuses enabled, cross-environment, ambiguous and invalid input
   };
   assert.throws(() => buildProductionActivation({
     ...input,
-    listenerContents: activationListener.replace('ENABLED=0', 'ENABLED=1'),
-  }), /absent or 0/);
+    listenerContents: activationListener.replace('ACCOUNT_ENABLED=0', 'ACCOUNT_ENABLED=2'),
+  }), /must be 0 or 1/);
   const withoutFlag = buildProductionActivation({
     ...input,
     listenerContents: activationListener.replace('BEACON_LISTENER_ACCOUNT_ENABLED=0\n', ''),
   });
   assert.match(withoutFlag, /BEACON_LISTENER_ACCOUNT_ENABLED=1/);
+  const active = buildProductionActivation(input);
+  assert.throws(() => buildProductionActivation({
+    ...input,
+    listenerContents: active.replace(
+      `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${client}`,
+      `BEACON_LISTENER_ACCOUNT_CLIENT_SECRET=${'x'.repeat(64)}`,
+    ),
+  }), /enabled Listener environment BEACON_LISTENER_ACCOUNT_CLIENT_SECRET mismatch/);
+  assert.throws(() => buildProductionActivation({
+    ...input,
+    listenerContents: active.replace('EARLY_BIRDS_GOOGLE_CLIENT_ID=', 'EARLY_BIRDS_GOOGLE_CLIENT_ID=drifted'),
+  }), /enabled Listener environment EARLY_BIRDS_GOOGLE_CLIENT_ID mismatch/);
   assert.throws(() => buildProductionActivation({
     ...input,
     listenerContents: `${activationListener}BEACON_LISTENER_ACCOUNT_STATE_SECRET_STAGING=${state}\n`,
@@ -158,6 +183,8 @@ test('host wrappers constrain secrets, networking, provenance and arguments', ()
   assert.match(activate, /health-smoke\.sh"[\s\\\n]+"\$expected_sha" 1 "\$expected_schema"/);
   assert.match(activate, /candidate image schema provenance mismatch/);
   assert.match(activate, /previous-schema\.txt/);
+  assert.match(activate, /previous-account-mode\.txt/);
+  assert.match(activate, /health-smoke\.sh"[\s\\\n]+"\$previous_sha" "\$previous_account_mode" "\$previous_schema"/);
   assert.match(activate, /BEACON_LISTENER_PAYPAL_LIVE_CHECKOUT_ENABLED/);
   assert.match(activate, /protected-containers\.before/);
   assert.match(activate, /protected-containers\.after/);
@@ -178,6 +205,8 @@ test('host wrappers constrain secrets, networking, provenance and arguments', ()
   assert.match(rollback, /running Listener does not match this rollback candidate/);
   assert.match(rollback, /--no-deps --force-recreate --no-build listener/);
   assert.match(rollback, /database was not downgraded/);
+  assert.match(rollback, /previous-account-mode\.txt/);
+  assert.match(rollback, /health-smoke\.sh"[\s\\\n]+"\$previous_sha" "\$previous_account_mode" "\$previous_schema"/);
   assert.match(rollback, /trap '' HUP INT TERM/);
   assert.doesNotMatch(rollback, /require_synthetic_env/);
   assert.match(health, /--connect-timeout 3 --max-time 8/);

--- a/scripts/listener-account-production/activate-env.mjs
+++ b/scripts/listener-account-production/activate-env.mjs
@@ -56,8 +56,9 @@ export function buildProductionActivation({
   const listener = assignments(listenerContents, 'Listener environment');
   const bundle = assignments(bundleContents, 'Listener Account bundle');
 
-  if ((listener.get('BEACON_LISTENER_ACCOUNT_ENABLED') ?? '0') !== '0') {
-    throw new Error('Listener environment BEACON_LISTENER_ACCOUNT_ENABLED must be absent or 0');
+  const accountMode = listener.get('BEACON_LISTENER_ACCOUNT_ENABLED') ?? '0';
+  if (accountMode !== '0' && accountMode !== '1') {
+    throw new Error('Listener environment BEACON_LISTENER_ACCOUNT_ENABLED must be 0 or 1');
   }
   exact(listener, 'EARLY_BIRDS_AUTH_BASE_URL', 'https://listen.harmonicbeacon.com', 'Listener environment');
   exact(
@@ -67,8 +68,6 @@ export function buildProductionActivation({
     'Listener environment',
   );
   for (const key of [
-    'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET',
-    'BEACON_LISTENER_ACCOUNT_STATE_SECRET',
     'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET_STAGING',
     'BEACON_LISTENER_ACCOUNT_STATE_SECRET_STAGING',
   ]) {
@@ -89,6 +88,40 @@ export function buildProductionActivation({
     throw new Error('Listener Account bundle contains an invalid secret');
   }
   if (clientSecret === stateSecret) throw new Error('Listener Account secrets must differ');
+
+  if (accountMode === '0') {
+    for (const key of [
+      'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET',
+      'BEACON_LISTENER_ACCOUNT_STATE_SECRET',
+    ]) {
+      if ((listener.get(key) ?? '') !== '') throw new Error(`Listener environment ${key} must be empty`);
+    }
+  } else {
+    exact(
+      listener,
+      'BEACON_LISTENER_ACCOUNT_CLIENT_SECRET',
+      clientSecret,
+      'enabled Listener environment',
+    );
+    exact(
+      listener,
+      'BEACON_LISTENER_ACCOUNT_STATE_SECRET',
+      stateSecret,
+      'enabled Listener environment',
+    );
+    for (const [key, expected] of [
+      ['EARLY_BIRDS_GOOGLE_CLIENT_ID', ''],
+      ['EARLY_BIRDS_GOOGLE_CLIENT_SECRET', ''],
+      ['BEACON_LISTENER_APPLE_ENABLED', '0'],
+      ['BEACON_LISTENER_APPLE_CLIENT_ID', ''],
+      ['BEACON_LISTENER_APPLE_CLIENT_SECRET', ''],
+      ['EARLY_BIRDS_MAGIC_LINK_DELIVERY_URL', ''],
+      ['EARLY_BIRDS_MAGIC_LINK_DELIVERY_TOKEN', ''],
+      ['EARLY_BIRDS_MAGIC_LINK_RATE_SECRET', ''],
+    ]) {
+      exact(listener, key, expected, 'enabled Listener environment');
+    }
+  }
 
   let result = listenerContents;
   for (const [key, value] of [

--- a/scripts/listener-account-production/activate.sh
+++ b/scripts/listener-account-production/activate.sh
@@ -96,6 +96,12 @@ test "$previous_image" = "harmonic-beacon/earlybirds-preview-listener:$previous_
 previous_schema=$(sed -n 's/^EARLYBIRDS_PREVIEW_SCHEMA_VERSION=//p' "$listener_env" | tail -n 1 | tr -d '\r')
 printf '%s\n' "$previous_schema" | grep -Eq '^[0-9]{14}_[a-z0-9_]+$' ||
   fail 'previous Listener schema provenance is invalid'
+previous_account_mode=$(sed -n 's/^BEACON_LISTENER_ACCOUNT_ENABLED=//p' "$listener_env" | tail -n 1 | tr -d '\r')
+case "$previous_account_mode" in
+  ''|0) previous_account_mode=0 ;;
+  1) ;;
+  *) fail 'previous Listener Account mode is invalid' ;;
+esac
 test "$previous_image" != "$image" || fail 'candidate is already running'
 
 # This is intentionally before every persistent write and runtime mutation.
@@ -115,9 +121,10 @@ install -o root -g root -m 0600 "$listener_env" "$state/previous.env"
 printf '%s\n' "$previous_image" > "$state/previous-image.txt"
 printf '%s\n' "$previous_sha" > "$state/previous-sha.txt"
 printf '%s\n' "$previous_schema" > "$state/previous-schema.txt"
+printf '%s\n' "$previous_account_mode" > "$state/previous-account-mode.txt"
 printf '%s\n' "$image" > "$state/candidate-image.txt"
 chmod 0600 "$state/previous-image.txt" "$state/previous-sha.txt" \
-  "$state/previous-schema.txt" "$state/candidate-image.txt"
+  "$state/previous-schema.txt" "$state/previous-account-mode.txt" "$state/candidate-image.txt"
 write_protected_environment "$listener_env" "$state/protected-env.before"
 write_protected_containers "$state/protected-containers.before"
 
@@ -147,7 +154,7 @@ rollback_on_failure() {
     preview_compose_command "$listener_env" up -d --no-deps --force-recreate --no-build listener || true
     wait_healthy || true
     "$root/scripts/listener-account-production/health-smoke.sh" \
-      "$previous_sha" 0 "$previous_schema" || true
+      "$previous_sha" "$previous_account_mode" "$previous_schema" || true
   elif test "$status" -ne 0; then
     rm -rf "$state"
   fi
@@ -188,6 +195,7 @@ cmp -s "$state/protected-containers.before" "$state/protected-containers.after" 
   printf 'candidate_sha=%s\n' "$expected_sha"
   printf 'candidate_schema=%s\n' "$expected_schema"
   printf 'previous_sha=%s\n' "$previous_sha"
+  printf 'previous_account_mode=%s\n' "$previous_account_mode"
   printf 'listener_health=pass\n'
   printf 'account_preflight=pass\n'
   printf 'public_login=pass\n'
@@ -195,6 +203,7 @@ cmp -s "$state/protected-containers.before" "$state/protected-containers.after" 
 } > "$state/result.txt"
 chmod 0600 "$state/result.txt"
 (cd "$state" && sha256sum previous.env previous-image.txt previous-sha.txt previous-schema.txt \
+  previous-account-mode.txt \
   candidate-image.txt protected-env.before protected-env.after protected-containers.before \
   protected-containers.after result.txt > SHA256SUMS)
 chmod 0600 "$state/SHA256SUMS"

--- a/scripts/listener-account-production/rollback.sh
+++ b/scripts/listener-account-production/rollback.sh
@@ -11,7 +11,7 @@ test -d "$state" && test ! -L "$state" || { echo 'rollback state must be a regul
 test "$(stat -c '%U:%G:%a' "$state")" = root:root:700 || {
   echo 'rollback state must be root:root mode 0700' >&2; exit 2;
 }
-for file in previous.env previous-image.txt previous-sha.txt previous-schema.txt \
+for file in previous.env previous-image.txt previous-sha.txt previous-schema.txt previous-account-mode.txt \
   candidate-image.txt protected-env.before protected-env.after \
   protected-containers.before protected-containers.after result.txt SHA256SUMS; do
   test -f "$state/$file" && test ! -L "$state/$file" || { echo 'rollback state is incomplete' >&2; exit 2; }
@@ -26,6 +26,7 @@ listener_env=/etc/harmonic-beacon/earlybirds-preview.env
 previous_image=$(sed -n '1p' "$state/previous-image.txt")
 previous_sha=$(sed -n '1p' "$state/previous-sha.txt")
 previous_schema=$(sed -n '1p' "$state/previous-schema.txt")
+previous_account_mode=$(sed -n '1p' "$state/previous-account-mode.txt")
 candidate_image=$(sed -n '1p' "$state/candidate-image.txt")
 test "$previous_image" = "harmonic-beacon/earlybirds-preview-listener:$previous_sha" || {
   echo 'previous image provenance is inconsistent' >&2; exit 2;
@@ -41,6 +42,10 @@ printf '%s\n' "$candidate_sha" | grep -Eq '^[0-9a-f]{40}$' || {
 printf '%s\n' "$previous_schema" | grep -Eq '^[0-9]{14}_[a-z0-9_]+$' || {
   echo 'previous schema provenance is invalid' >&2; exit 2;
 }
+case "$previous_account_mode" in
+  0|1) ;;
+  *) echo 'previous Listener Account mode is invalid' >&2; exit 2 ;;
+esac
 test "$(docker inspect earlybirds-preview-listener-1 --format '{{.Config.Image}}')" = "$candidate_image" || {
   echo 'running Listener does not match this rollback candidate' >&2; exit 2;
 }
@@ -84,6 +89,6 @@ running_sha=$(docker inspect earlybirds-preview-listener-1 \
   sed -n 's/^BEACON_GIT_SHA=//p' | tail -n 1)
 test "$running_sha" = "$previous_sha" || { echo 'restored Listener SHA mismatch' >&2; exit 2; }
 "$root/scripts/listener-account-production/health-smoke.sh" \
-  "$previous_sha" 0 "$previous_schema"
+  "$previous_sha" "$previous_account_mode" "$previous_schema"
 trap - EXIT HUP INT TERM
 echo "Listener production restored to exact SHA $previous_sha; database was not downgraded."


### PR DESCRIPTION
Closes the operational upgrade seam found while deploying #448.

- accepts an already-enabled production Listener only when its RP secrets exactly match the protected bundle
- rejects staging secrets and any reintroduced legacy Google, Apple, or magic-link credentials
- preserves the original Account-off first activation contract
- captures the previous Account mode and uses it for both automatic and manual rollback health checks
- covers first activation, Account-on immutable redeploy, credential drift, provider drift, and rollback mode propagation

Production impact: none until the existing reviewed activation lifecycle is rerun. The failed attempt stopped before env replacement/container recreation; current production remains healthy.

Evidence: listener-account-production 7/7, syntax check, focused ESLint, diff-check, plus a networkless/read-only exact-production-env validation using an ephemeral tmpfs (no secret output or retained candidate env).