### PR TITLE
fix(listener): preserve buffered playback across HLS refills

### DIFF
--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -189,19 +189,27 @@ jobs:
 
   network-resilience:
     name: network-resilience (${{ matrix.project }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - project: chromium
             browser: chromium
+            runner: ubuntu-latest
           - project: firefox
             browser: firefox
+            # Playwright documents that media codec availability varies by
+            # host OS. Its patched Linux Firefox does not expose the approved
+            # AAC/fMP4 MSE pipeline, so exercise Firefox on macOS rather than
+            # silently substituting a different stream codec.
+            runner: macos-15
           - project: android-chrome
             browser: chromium
+            runner: ubuntu-latest
           - project: iphone-webkit
             browser: webkit
+            runner: ubuntu-latest
     env:
       E2E_LISTENER_NETWORK_GATE: '1'
     steps:
@@ -213,9 +221,15 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps ${{ matrix.browser }}
       - name: Install deterministic HLS fixture encoder
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ffmpeg
+          ffmpeg -version | head -n 1
+      - name: Install deterministic HLS fixture encoder on macOS
+        if: runner.os == 'macOS'
+        run: |
+          command -v ffmpeg >/dev/null || brew install ffmpeg
           ffmpeg -version | head -n 1
       - name: Run network resilience in an isolated browser process
         run: >-

--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -204,10 +204,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ffmpeg
           ffmpeg -version | head -n 1
-      - run: >-
+      - name: Run network resilience without cross-browser decoder contention
+        run: >-
           npx playwright test e2e/tests/listener-network-resilience.spec.ts
           --project=chromium
           --project=firefox
           --project=android-chrome
           --project=iphone-webkit
-          --workers=4
+          --workers=1

--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -188,7 +188,20 @@ jobs:
           --project=firefox
 
   network-resilience:
+    name: network-resilience (${{ matrix.project }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: chromium
+            browser: chromium
+          - project: firefox
+            browser: firefox
+          - project: android-chrome
+            browser: chromium
+          - project: iphone-webkit
+            browser: webkit
     env:
       E2E_LISTENER_NETWORK_GATE: '1'
     steps:
@@ -198,17 +211,14 @@ jobs:
           node-version: '22.22'
           cache: 'npm'
       - run: npm ci
-      - run: npx playwright install --with-deps chromium firefox webkit
+      - run: npx playwright install --with-deps ${{ matrix.browser }}
       - name: Install deterministic HLS fixture encoder
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ffmpeg
           ffmpeg -version | head -n 1
-      - name: Run network resilience without cross-browser decoder contention
+      - name: Run network resilience in an isolated browser process
         run: >-
           npx playwright test e2e/tests/listener-network-resilience.spec.ts
-          --project=chromium
-          --project=firefox
-          --project=android-chrome
-          --project=iphone-webkit
+          --project=${{ matrix.project }}
           --workers=1

--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -199,7 +199,11 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npx playwright install --with-deps chromium firefox webkit
-      - run: command -v ffmpeg
+      - name: Install deterministic HLS fixture encoder
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+          ffmpeg -version | head -n 1
       - run: >-
           npx playwright test e2e/tests/listener-network-resilience.spec.ts
           --project=chromium

--- a/.github/workflows/early-birds-fast-forward.yml
+++ b/.github/workflows/early-birds-fast-forward.yml
@@ -17,6 +17,7 @@ on:
       - src/lib/listener/**
       - e2e/fixtures/listener-account-switch.ts
       - e2e/tests/listener-account-switch.spec.ts
+      - e2e/tests/listener-network-resilience.spec.ts
       - playwright.config.ts
       - src/app/layout.tsx
       - src/app/globals.css
@@ -55,6 +56,7 @@ on:
       - src/lib/listener/**
       - e2e/fixtures/listener-account-switch.ts
       - e2e/tests/listener-account-switch.spec.ts
+      - e2e/tests/listener-network-resilience.spec.ts
       - playwright.config.ts
       - src/app/layout.tsx
       - src/app/globals.css
@@ -184,3 +186,24 @@ jobs:
           npx playwright test e2e/tests/listener-account-switch.spec.ts
           --project=chromium
           --project=firefox
+
+  network-resilience:
+    runs-on: ubuntu-latest
+    env:
+      E2E_LISTENER_NETWORK_GATE: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium firefox webkit
+      - run: command -v ffmpeg
+      - run: >-
+          npx playwright test e2e/tests/listener-network-resilience.spec.ts
+          --project=chromium
+          --project=firefox
+          --project=android-chrome
+          --project=iphone-webkit
+          --workers=4

--- a/e2e/tests/listener-account-switch.spec.ts
+++ b/e2e/tests/listener-account-switch.spec.ts
@@ -109,13 +109,17 @@ test.describe('Listener Account A/B cache boundary', () => {
             await page.goto('/listener/privacy');
             await useListenerAccount(context, baseURL, pair.free);
             await page.goBack({ waitUntil: 'domcontentloaded' });
+            await expect(page).toHaveURL(/\/listener$/);
+            await expectFree(page);
             // The Account-derived response is deliberately not bfcacheable in
             // current engines, so this history traversal must fetch B anew.
+            // Assert this only after B's server-derived presentation is stable:
+            // Chromium can destroy the first DOMContentLoaded execution context
+            // while completing a history traversal.
             expect(await page.evaluate(() => Boolean(
                 (window as typeof window & { __hbPageShowPersisted?: boolean })
                     .__hbPageShowPersisted,
             ))).toBe(false);
-            await expectFree(page);
 
             await page.goForward({ waitUntil: 'domcontentloaded' });
             await expect(page).toHaveURL(/\/listener\/privacy$/);

--- a/e2e/tests/listener-network-resilience.spec.ts
+++ b/e2e/tests/listener-network-resilience.spec.ts
@@ -362,6 +362,16 @@ test.describe('Listener network resilience', () => {
         });
 
         await page.goto('/early-birds');
+        const codecSupport = await page.evaluate(() => ({
+            mediaSource: typeof MediaSource !== 'undefined'
+                && MediaSource.isTypeSupported('audio/mp4; codecs="mp4a.40.2"'),
+            audio: document.createElement('audio')
+                .canPlayType('audio/mp4; codecs="mp4a.40.2"'),
+        }));
+        expect(codecSupport.mediaSource, `${browserName} lacks the approved AAC/fMP4 MSE codec`)
+            .toBe(true);
+        expect(codecSupport.audio, `${browserName} cannot decode the approved AAC-LC stream`)
+            .not.toBe('');
         const listen = page.getByRole('button', { name: /Listen|Escuchar/ });
         await expect(listen).toBeEnabled({ timeout: 20_000 });
         await listen.click();

--- a/e2e/tests/listener-network-resilience.spec.ts
+++ b/e2e/tests/listener-network-resilience.spec.ts
@@ -9,6 +9,7 @@ import { expect, test } from '@playwright/test';
 const execFileAsync = promisify(execFile);
 const STREAM_ORIGIN = 'https://stream.e2e.invalid';
 const MEDIA_SEGMENT_SECONDS = 6;
+const SOURCE_FIXTURE_SEGMENTS = 240;
 const SOURCE_WINDOW_SEGMENTS = 50;
 // Browsers may retain a sub-frame tail in TimeRanges after the decoder clock
 // has genuinely stalled. Half a second is still two orders of magnitude below
@@ -29,7 +30,7 @@ async function createHlsFixture(): Promise<HlsFixture> {
         '-loglevel', 'error',
         '-f', 'lavfi',
         '-i', 'sine=frequency=440:sample_rate=48000',
-        '-t', String(MEDIA_SEGMENT_SECONDS * SOURCE_WINDOW_SEGMENTS),
+        '-t', String(MEDIA_SEGMENT_SECONDS * SOURCE_FIXTURE_SEGMENTS),
         '-c:a', 'aac',
         '-b:a', '64k',
         '-f', 'hls',
@@ -43,10 +44,11 @@ async function createHlsFixture(): Promise<HlsFixture> {
     const manifest = await readFile(path.join(root, 'source.m3u8'), 'utf8');
     const initialization = /#EXT-X-MAP:URI="([^"]+)"/.exec(manifest)?.[1];
     const generatedSegments = manifest.split('\n').filter((line) => /^\d{5}\.m4s$/.test(line));
-    // ffmpeg may emit one final encoder-drain fragment after the exact 300s
-    // boundary. The test window deliberately uses only fifty full segments.
-    const segments = generatedSegments.slice(0, SOURCE_WINDOW_SEGMENTS);
-    if (!initialization || segments.length !== SOURCE_WINDOW_SEGMENTS) {
+    // ffmpeg may emit one final encoder-drain fragment after the requested
+    // boundary. Keep a monotonic 24-minute source behind the rolling 5-minute
+    // manifest so a slower CI runner never wraps media timestamps mid-outage.
+    const segments = generatedSegments.slice(0, SOURCE_FIXTURE_SEGMENTS);
+    if (!initialization || segments.length !== SOURCE_FIXTURE_SEGMENTS) {
         throw new Error(`unexpected HLS fixture inventory: ${generatedSegments.length}`);
     }
     return { root, initialization, segments };
@@ -63,8 +65,8 @@ function renderLiveManifest(fixture: HlsFixture, edgeSequence: number): string {
         `#EXT-X-MAP:URI="${fixture.initialization}"`,
     ];
     for (let sequence = firstSequence; sequence <= edgeSequence; sequence += 1) {
-        const index = sequence % fixture.segments.length;
-        if (index === 0 && sequence !== 0) lines.push('#EXT-X-DISCONTINUITY');
+        const index = sequence;
+        if (!fixture.segments[index]) break;
         lines.push(`#EXTINF:${MEDIA_SEGMENT_SECONDS.toFixed(6)},`);
         lines.push(fixture.segments[index]);
     }
@@ -191,8 +193,11 @@ test.describe('Listener network resilience', () => {
             if (file === 'live.m3u8') {
                 manifestRequests += 1;
                 const elapsedMediaSeconds = (Date.now() - sourceStartedAt) / 1_000 * 4;
-                const edgeSequence = SOURCE_WINDOW_SEGMENTS - 1
-                    + Math.floor(elapsedMediaSeconds / MEDIA_SEGMENT_SECONDS);
+                const edgeSequence = Math.min(
+                    SOURCE_FIXTURE_SEGMENTS - 1,
+                    SOURCE_WINDOW_SEGMENTS - 1
+                        + Math.floor(elapsedMediaSeconds / MEDIA_SEGMENT_SECONDS),
+                );
                 await route.fulfill({
                     status: 200,
                     contentType: 'application/vnd.apple.mpegurl',

--- a/e2e/tests/listener-network-resilience.spec.ts
+++ b/e2e/tests/listener-network-resilience.spec.ts
@@ -125,6 +125,76 @@ async function availablePlaybackSeconds(page: import('@playwright/test').Page): 
     return media.bufferedAheadSeconds + retained;
 }
 
+async function waitForAvailablePlaybackSeconds(
+    page: import('@playwright/test').Page,
+    minimumSeconds: number,
+    timeout: number,
+    message: string,
+): Promise<void> {
+    try {
+        await page.waitForFunction((minimum) => {
+            const media = document.querySelector<HTMLAudioElement>('audio[aria-label="Beacon"]');
+            if (!media) return false;
+            let bufferedAheadSeconds = 0;
+            for (let index = 0; index < media.buffered.length; index += 1) {
+                const start = media.buffered.start(index);
+                const end = media.buffered.end(index);
+                if (media.currentTime >= start - 0.25 && media.currentTime <= end + 0.25) {
+                    bufferedAheadSeconds = Math.max(0, end - media.currentTime);
+                    break;
+                }
+            }
+            const diagnostics = (window as typeof window & { __hbNetworkDiagnostics?: unknown[] })
+                .__hbNetworkDiagnostics ?? [];
+            let retainedSeconds = 0;
+            for (const diagnostic of diagnostics) {
+                if (!diagnostic || typeof diagnostic !== 'object') continue;
+                const value = (diagnostic as { reservoirAheadSeconds?: unknown })
+                    .reservoirAheadSeconds;
+                if (typeof value === 'number' && Number.isFinite(value)) retainedSeconds = value;
+            }
+            return bufferedAheadSeconds + retainedSeconds >= minimum;
+        }, minimumSeconds, { timeout, polling: 250 });
+    } catch (error) {
+        const evidence = await page.evaluate(() => {
+            const media = document.querySelector<HTMLAudioElement>('audio[aria-label="Beacon"]');
+            const diagnostics = (window as typeof window & { __hbNetworkDiagnostics?: unknown[] })
+                .__hbNetworkDiagnostics ?? [];
+            return {
+                currentTime: media?.currentTime ?? null,
+                readyState: media?.readyState ?? null,
+                errorCode: media?.error?.code ?? null,
+                retainedSeconds: diagnostics.reduce((latest, diagnostic) => {
+                    if (!diagnostic || typeof diagnostic !== 'object') return latest;
+                    const value = (diagnostic as { reservoirAheadSeconds?: unknown })
+                        .reservoirAheadSeconds;
+                    return typeof value === 'number' && Number.isFinite(value) ? value : latest;
+                }, 0),
+                recent: diagnostics.slice(-8).map((diagnostic) => {
+                    if (!diagnostic || typeof diagnostic !== 'object') return null;
+                    const record = diagnostic as {
+                        reason?: unknown;
+                        action?: unknown;
+                        reservoirAheadSeconds?: unknown;
+                        media?: { bufferedAheadSeconds?: unknown };
+                        hls?: { type?: unknown; details?: unknown; fatal?: unknown };
+                    };
+                    return {
+                        reason: record.reason,
+                        action: record.action,
+                        reservoirAheadSeconds: record.reservoirAheadSeconds,
+                        bufferedAheadSeconds: record.media?.bufferedAheadSeconds,
+                        hlsType: record.hls?.type,
+                        hlsDetails: record.hls?.details,
+                        hlsFatal: record.hls?.fatal,
+                    };
+                }),
+            };
+        });
+        throw new Error(`${message}: ${JSON.stringify(evidence)}`, { cause: error });
+    }
+}
+
 async function reservoirSnapshotCount(page: import('@playwright/test').Page): Promise<number> {
     return page.evaluate(() => (
         ((window as typeof window & { __hbNetworkDiagnostics?: Array<{ reason?: unknown }> })
@@ -206,8 +276,11 @@ test.describe('Listener network resilience', () => {
             (window as typeof window & { __hbNetworkDiagnostics?: unknown[] })
                 .__hbNetworkDiagnostics = [];
             window.addEventListener('listener:playback-diagnostic', (event) => {
-                (window as typeof window & { __hbNetworkDiagnostics: unknown[] })
-                    .__hbNetworkDiagnostics.push((event as CustomEvent).detail);
+            (window as typeof window & { __hbNetworkDiagnostics: unknown[] })
+                .__hbNetworkDiagnostics.push((event as CustomEvent).detail);
+            const diagnostics = (window as typeof window & { __hbNetworkDiagnostics: unknown[] })
+                .__hbNetworkDiagnostics;
+            if (diagnostics.length > 256) diagnostics.splice(0, diagnostics.length - 256);
             });
         });
         await page.route(`${STREAM_ORIGIN}/**`, async (route) => {
@@ -294,10 +367,12 @@ test.describe('Listener network resilience', () => {
         await listen.click();
         await expect(page.getByRole('button', { name: /Stop|Detener/ })).toBeVisible();
 
-        await expect.poll(async () => availablePlaybackSeconds(page), {
-            timeout: 90_000,
-            message: `${browserName} did not fill the promised Listener buffer`,
-        }).toBeGreaterThanOrEqual(180);
+        await waitForAvailablePlaybackSeconds(
+            page,
+            180,
+            90_000,
+            `${browserName} did not fill the promised Listener buffer`,
+        );
         await expect.poll(async () => (await mediaState(page)).bufferedAheadSeconds, {
             timeout: 20_000,
             message: `${browserName} did not make retained audio immediately playable`,
@@ -334,10 +409,12 @@ test.describe('Listener network resilience', () => {
                 timeout: 30_000,
                 message: `${browserName} did not complete a reservoir refill`,
             }).toBeGreaterThan(snapshotsBeforeRefill);
-            await expect.poll(async () => availablePlaybackSeconds(page), {
-                timeout: 45_000,
-                message: `${browserName} did not refill after a ${outageMediaSeconds}s outage`,
-            }).toBeGreaterThanOrEqual(180);
+            await waitForAvailablePlaybackSeconds(
+                page,
+                180,
+                45_000,
+                `${browserName} did not refill after a ${outageMediaSeconds}s outage`,
+            );
             await expect(page.locator('.listener-experience[data-phase="beacon"]'))
                 .toBeVisible({ timeout: 20_000 });
         }
@@ -366,9 +443,12 @@ test.describe('Listener network resilience', () => {
             media.playbackRate = 4;
         });
         setSourcePlaybackRate(4);
-        await expect.poll(async () => availablePlaybackSeconds(page), {
-            timeout: 45_000,
-        }).toBeGreaterThanOrEqual(180);
+        await waitForAvailablePlaybackSeconds(
+            page,
+            180,
+            45_000,
+            `${browserName} did not refill after degraded connectivity`,
+        );
 
         // Exercise an outage ten seconds below the promised three-minute
         // target. The MediaSource and reservoir counters are intentionally
@@ -391,9 +471,12 @@ test.describe('Listener network resilience', () => {
         await page.evaluate(() => window.dispatchEvent(new Event('online')));
         await expect.poll(async () => reservoirSnapshotCount(page), { timeout: 30_000 })
             .toBeGreaterThan(nearLimitSnapshots);
-        await expect.poll(async () => availablePlaybackSeconds(page), {
-            timeout: 60_000,
-        }).toBeGreaterThanOrEqual(180);
+        await waitForAvailablePlaybackSeconds(
+            page,
+            180,
+            60_000,
+            `${browserName} did not refill after its near-limit outage`,
+        );
         await expect(page.locator('.listener-experience[data-phase="beacon"]'))
             .toBeVisible({ timeout: 20_000 });
 

--- a/e2e/tests/listener-network-resilience.spec.ts
+++ b/e2e/tests/listener-network-resilience.spec.ts
@@ -11,6 +11,7 @@ const STREAM_ORIGIN = 'https://stream.e2e.invalid';
 const MEDIA_SEGMENT_SECONDS = 6;
 const SOURCE_FIXTURE_SEGMENTS = 240;
 const SOURCE_WINDOW_SEGMENTS = 50;
+const SOURCE_PROGRAM_EPOCH_MS = Date.parse('2026-08-20T00:00:00.000Z');
 // Browsers may retain a sub-frame tail in TimeRanges after the decoder clock
 // has genuinely stalled. Half a second is still two orders of magnitude below
 // the promised reservoir and prevents pretending that millisecond rounding is
@@ -60,6 +61,7 @@ function renderLiveManifest(fixture: HlsFixture, edgeSequence: number): string {
         '#EXTM3U',
         '#EXT-X-VERSION:7',
         `#EXT-X-TARGETDURATION:${MEDIA_SEGMENT_SECONDS}`,
+        '#EXT-X-DISCONTINUITY-SEQUENCE:0',
         `#EXT-X-MEDIA-SEQUENCE:${firstSequence}`,
         '#EXT-X-INDEPENDENT-SEGMENTS',
         `#EXT-X-MAP:URI="${fixture.initialization}"`,
@@ -67,6 +69,9 @@ function renderLiveManifest(fixture: HlsFixture, edgeSequence: number): string {
     for (let sequence = firstSequence; sequence <= edgeSequence; sequence += 1) {
         const index = sequence;
         if (!fixture.segments[index]) break;
+        lines.push(`#EXT-X-PROGRAM-DATE-TIME:${new Date(
+            SOURCE_PROGRAM_EPOCH_MS + sequence * MEDIA_SEGMENT_SECONDS * 1_000,
+        ).toISOString()}`);
         lines.push(`#EXTINF:${MEDIA_SEGMENT_SECONDS.toFixed(6)},`);
         lines.push(fixture.segments[index]);
     }
@@ -164,7 +169,7 @@ test.describe('Listener network resilience', () => {
         page,
         browserName,
     }, testInfo) => {
-        test.setTimeout(browserName === 'webkit' ? 420_000 : 360_000);
+        test.setTimeout(browserName === 'webkit' ? 600_000 : 480_000);
         const sourceStartedAt = Date.now();
         let originOnline = true;
         let originDelayMs = 0;
@@ -368,6 +373,19 @@ test.describe('Listener network resilience', () => {
         // lease or a manual reload when the origin returns.
         const beforeExhaustion = await mediaState(page);
         const retainedBeforeExhaustion = await retainedReservoirSeconds(page);
+        const rateProbeStartedAt = Date.now();
+        await page.waitForTimeout(2_000);
+        const rateProbeEnded = await mediaState(page);
+        expect(rateProbeEnded.paused).toBe(false);
+        expect(rateProbeEnded.currentTime - beforeExhaustion.currentTime).toBeGreaterThan(0.5);
+        const effectivePlaybackRate = Math.max(
+            0.5,
+            Math.min(
+                4,
+                (rateProbeEnded.currentTime - beforeExhaustion.currentTime)
+                    / ((Date.now() - rateProbeStartedAt) / 1_000),
+            ),
+        );
         originOnline = false;
         const exhaustionDeadline = Date.now()
             // MediaSource and the memory reservoir can hold partially distinct
@@ -377,9 +395,9 @@ test.describe('Listener network resilience', () => {
             + Math.ceil((
                 beforeExhaustion.bufferedAheadSeconds
                 + retainedBeforeExhaustion
-            ) / 4 * 1_000)
-            + 45_000;
-        let maxCurrentTime = beforeExhaustion.currentTime;
+            ) / effectivePlaybackRate * 1_000)
+            + 60_000;
+        let maxCurrentTime = rateProbeEnded.currentTime;
         let exhaustedState: Awaited<ReturnType<typeof mediaState>> | null = null;
         while (Date.now() < exhaustionDeadline) {
             const state = await mediaState(page);
@@ -430,6 +448,7 @@ test.describe('Listener network resilience', () => {
                 browserName,
                 bufferTargetSeconds: 180,
                 achievedBufferSeconds,
+                effectivePlaybackRate,
                 outageMediaSeconds: outageDurations,
                 nearLimitOutageSeconds,
                 exhaustionRecoveryMs: Math.max(0, recoveredAt - reconnectingObservedAt),

--- a/e2e/tests/listener-network-resilience.spec.ts
+++ b/e2e/tests/listener-network-resilience.spec.ts
@@ -10,6 +10,11 @@ const execFileAsync = promisify(execFile);
 const STREAM_ORIGIN = 'https://stream.e2e.invalid';
 const MEDIA_SEGMENT_SECONDS = 6;
 const SOURCE_WINDOW_SEGMENTS = 50;
+// Browsers may retain a sub-frame tail in TimeRanges after the decoder clock
+// has genuinely stalled. Half a second is still two orders of magnitude below
+// the promised reservoir and prevents pretending that millisecond rounding is
+// audible continuity.
+const EXHAUSTED_MEDIA_TOLERANCE_SECONDS = 0.5;
 
 type HlsFixture = {
     root: string;
@@ -111,6 +116,32 @@ async function reservoirSnapshotCount(page: import('@playwright/test').Page): Pr
             .__hbNetworkDiagnostics ?? [])
             .filter((diagnostic) => diagnostic?.reason === 'reservoir-ready').length
     ));
+}
+
+async function lastRecoveryBufferedAheadSeconds(
+    page: import('@playwright/test').Page,
+): Promise<number | null> {
+    return page.evaluate(() => {
+        const diagnostics = (window as typeof window & { __hbNetworkDiagnostics?: unknown[] })
+            .__hbNetworkDiagnostics ?? [];
+        for (let index = diagnostics.length - 1; index >= 0; index -= 1) {
+            const diagnostic = diagnostics[index];
+            if (!diagnostic || typeof diagnostic !== 'object') continue;
+            const record = diagnostic as {
+                reason?: unknown;
+                media?: { bufferedAheadSeconds?: unknown };
+            };
+            if (![
+                'media-clock-stalled',
+                'paused-unexpectedly',
+                'ended-unexpectedly',
+                'media-error',
+            ].includes(String(record.reason))) continue;
+            const value = record.media?.bufferedAheadSeconds;
+            return typeof value === 'number' && Number.isFinite(value) ? value : null;
+        }
+        return null;
+    });
 }
 
 test.describe('Listener network resilience', () => {
@@ -331,26 +362,38 @@ test.describe('Listener network resilience', () => {
         // to reconnecting, but it must keep trying and resume without a new
         // lease or a manual reload when the origin returns.
         const beforeExhaustion = await mediaState(page);
+        const retainedBeforeExhaustion = await retainedReservoirSeconds(page);
         originOnline = false;
         const exhaustionDeadline = Date.now()
-            + Math.ceil(beforeExhaustion.bufferedAheadSeconds / 4 * 1_000)
+            // MediaSource and the memory reservoir can hold partially distinct
+            // fragments. Their sum is a conservative upper bound; using only
+            // the larger value races WebKit while it is still consuming valid
+            // bytes from the other layer.
+            + Math.ceil((
+                beforeExhaustion.bufferedAheadSeconds
+                + retainedBeforeExhaustion
+            ) / 4 * 1_000)
             + 45_000;
         let maxCurrentTime = beforeExhaustion.currentTime;
-        let bufferExhaustedObserved = false;
+        let exhaustedState: Awaited<ReturnType<typeof mediaState>> | null = null;
         while (Date.now() < exhaustionDeadline) {
             const state = await mediaState(page);
             maxCurrentTime = Math.max(maxCurrentTime, state.currentTime);
-            if (state.bufferedAheadSeconds <= 0.25) {
-                bufferExhaustedObserved = true;
+            const phase = await page.locator('.listener-experience').getAttribute('data-phase');
+            if (phase === 'reconnecting') {
+                exhaustedState = state;
                 break;
             }
             await page.waitForTimeout(250);
         }
-        expect(bufferExhaustedObserved).toBe(true);
+        expect(exhaustedState, `${browserName} did not enter reconnecting after exhausting retained audio`)
+            .not.toBeNull();
+        expect(await lastRecoveryBufferedAheadSeconds(page))
+            .toBeLessThanOrEqual(EXHAUSTED_MEDIA_TOLERANCE_SECONDS);
         expect(maxCurrentTime - beforeExhaustion.currentTime)
             .toBeGreaterThanOrEqual(Math.max(0, beforeExhaustion.bufferedAheadSeconds - 5));
         await expect(page.locator('.listener-experience[data-phase="reconnecting"]'))
-            .toBeVisible({ timeout: 20_000 });
+            .toBeVisible();
         const reconnectingObservedAt = Date.now();
         await expect(page.getByText(/unavailable right now|no está disponible/i)).toHaveCount(0);
         originOnline = true;

--- a/e2e/tests/listener-network-resilience.spec.ts
+++ b/e2e/tests/listener-network-resilience.spec.ts
@@ -110,11 +110,19 @@ async function retainedReservoirSeconds(page: import('@playwright/test').Page): 
             if (!diagnostic || typeof diagnostic !== 'object') continue;
             const value = (diagnostic as { reservoirAheadSeconds?: unknown }).reservoirAheadSeconds;
             if (typeof value === 'number' && Number.isFinite(value)) {
-                retainedSeconds = Math.max(retainedSeconds, value);
+                retainedSeconds = value;
             }
         }
         return retainedSeconds;
     });
+}
+
+async function availablePlaybackSeconds(page: import('@playwright/test').Page): Promise<number> {
+    const [media, retained] = await Promise.all([
+        mediaState(page),
+        retainedReservoirSeconds(page),
+    ]);
+    return media.bufferedAheadSeconds + retained;
 }
 
 async function reservoirSnapshotCount(page: import('@playwright/test').Page): Promise<number> {
@@ -272,7 +280,7 @@ test.describe('Listener network resilience', () => {
         await listen.click();
         await expect(page.getByRole('button', { name: /Stop|Detener/ })).toBeVisible();
 
-        await expect.poll(async () => retainedReservoirSeconds(page), {
+        await expect.poll(async () => availablePlaybackSeconds(page), {
             timeout: 90_000,
             message: `${browserName} did not fill the promised Listener buffer`,
         }).toBeGreaterThanOrEqual(180);
@@ -280,7 +288,7 @@ test.describe('Listener network resilience', () => {
             timeout: 20_000,
             message: `${browserName} did not make retained audio immediately playable`,
         }).toBeGreaterThan(5);
-        const achievedBufferSeconds = await retainedReservoirSeconds(page);
+        const achievedBufferSeconds = await availablePlaybackSeconds(page);
         await page.locator('audio[aria-label="Beacon"]').evaluate((media: HTMLAudioElement) => {
             media.playbackRate = 4;
         });
@@ -311,7 +319,7 @@ test.describe('Listener network resilience', () => {
                 timeout: 30_000,
                 message: `${browserName} did not complete a reservoir refill`,
             }).toBeGreaterThan(snapshotsBeforeRefill);
-            await expect.poll(async () => retainedReservoirSeconds(page), {
+            await expect.poll(async () => availablePlaybackSeconds(page), {
                 timeout: 45_000,
                 message: `${browserName} did not refill after a ${outageMediaSeconds}s outage`,
             }).toBeGreaterThanOrEqual(180);
@@ -341,7 +349,7 @@ test.describe('Listener network resilience', () => {
         await page.locator('audio[aria-label="Beacon"]').evaluate((media: HTMLAudioElement) => {
             media.playbackRate = 4;
         });
-        await expect.poll(async () => retainedReservoirSeconds(page), {
+        await expect.poll(async () => availablePlaybackSeconds(page), {
             timeout: 45_000,
         }).toBeGreaterThanOrEqual(180);
 
@@ -349,8 +357,8 @@ test.describe('Listener network resilience', () => {
         // equals buffered media. Leave ten seconds in reserve so the assertion
         // proves continuous playback without intentionally exhausting it.
         const nearLimit = await mediaState(page);
-        const retainedNearLimitSeconds = await retainedReservoirSeconds(page);
-        const nearLimitOutageSeconds = Math.max(60, Math.floor(retainedNearLimitSeconds - 10));
+        const availableNearLimitSeconds = await availablePlaybackSeconds(page);
+        const nearLimitOutageSeconds = Math.max(60, Math.floor(availableNearLimitSeconds - 10));
         originOnline = false;
         await expect.poll(async () => (await mediaState(page)).currentTime - nearLimit.currentTime, {
             timeout: Math.ceil(nearLimitOutageSeconds / 4 * 1_000) + 20_000,
@@ -362,7 +370,7 @@ test.describe('Listener network resilience', () => {
         await page.evaluate(() => window.dispatchEvent(new Event('online')));
         await expect.poll(async () => reservoirSnapshotCount(page), { timeout: 30_000 })
             .toBeGreaterThan(nearLimitSnapshots);
-        await expect.poll(async () => retainedReservoirSeconds(page), {
+        await expect.poll(async () => availablePlaybackSeconds(page), {
             timeout: 60_000,
         }).toBeGreaterThanOrEqual(180);
         await expect(page.locator('.listener-experience[data-phase="beacon"]'))

--- a/e2e/tests/listener-network-resilience.spec.ts
+++ b/e2e/tests/listener-network-resilience.spec.ts
@@ -178,7 +178,21 @@ test.describe('Listener network resilience', () => {
         browserName,
     }, testInfo) => {
         test.setTimeout(browserName === 'webkit' ? 600_000 : 480_000);
-        const sourceStartedAt = Date.now();
+        let sourceElapsedMediaSeconds = 0;
+        let sourceClockUpdatedAt = Date.now();
+        let sourcePlaybackRate = 1;
+        // Keep the synthetic live edge aligned with the listener clock. A
+        // permanently 4x origin makes a slow decoder fall out of the rolling
+        // window before the test has even enabled accelerated playback.
+        const currentSourceElapsedMediaSeconds = () => (
+            sourceElapsedMediaSeconds
+            + (Date.now() - sourceClockUpdatedAt) / 1_000 * sourcePlaybackRate
+        );
+        const setSourcePlaybackRate = (nextRate: number) => {
+            sourceElapsedMediaSeconds = currentSourceElapsedMediaSeconds();
+            sourceClockUpdatedAt = Date.now();
+            sourcePlaybackRate = nextRate;
+        };
         let originOnline = true;
         let originDelayMs = 0;
         let failEveryMediaRequest = 0;
@@ -205,7 +219,7 @@ test.describe('Listener network resilience', () => {
             const file = path.basename(url.pathname);
             if (file === 'live.m3u8') {
                 manifestRequests += 1;
-                const elapsedMediaSeconds = (Date.now() - sourceStartedAt) / 1_000 * 4;
+                const elapsedMediaSeconds = currentSourceElapsedMediaSeconds();
                 const edgeSequence = Math.min(
                     SOURCE_FIXTURE_SEGMENTS - 1,
                     SOURCE_WINDOW_SEGMENTS - 1
@@ -292,6 +306,7 @@ test.describe('Listener network resilience', () => {
         await page.locator('audio[aria-label="Beacon"]').evaluate((media: HTMLAudioElement) => {
             media.playbackRate = 4;
         });
+        setSourcePlaybackRate(4);
 
         const outageDurations = [5, 15, 30, 60];
         for (const outageMediaSeconds of outageDurations) {
@@ -332,6 +347,7 @@ test.describe('Listener network resilience', () => {
         await page.locator('audio[aria-label="Beacon"]').evaluate((media: HTMLAudioElement) => {
             media.playbackRate = 1;
         });
+        setSourcePlaybackRate(1);
         originDelayMs = 250;
         failEveryMediaRequest = 9;
         const degradedStarted = (await mediaState(page)).currentTime;
@@ -349,16 +365,21 @@ test.describe('Listener network resilience', () => {
         await page.locator('audio[aria-label="Beacon"]').evaluate((media: HTMLAudioElement) => {
             media.playbackRate = 4;
         });
+        setSourcePlaybackRate(4);
         await expect.poll(async () => availablePlaybackSeconds(page), {
             timeout: 45_000,
         }).toBeGreaterThanOrEqual(180);
 
-        // Exercise the actual achieved limit rather than assuming the config
-        // equals buffered media. Leave ten seconds in reserve so the assertion
-        // proves continuous playback without intentionally exhausting it.
+        // Exercise an outage ten seconds below the promised three-minute
+        // target. The MediaSource and reservoir counters are intentionally
+        // separate and may briefly overstate what the decoder can consume, so
+        // never turn their sum into a larger product promise here.
         const nearLimit = await mediaState(page);
         const availableNearLimitSeconds = await availablePlaybackSeconds(page);
-        const nearLimitOutageSeconds = Math.max(60, Math.floor(availableNearLimitSeconds - 10));
+        const nearLimitOutageSeconds = Math.max(
+            60,
+            Math.min(170, Math.floor(availableNearLimitSeconds - 10)),
+        );
         originOnline = false;
         await expect.poll(async () => (await mediaState(page)).currentTime - nearLimit.currentTime, {
             timeout: Math.ceil(nearLimitOutageSeconds / 4 * 1_000) + 20_000,

--- a/e2e/tests/listener-network-resilience.spec.ts
+++ b/e2e/tests/listener-network-resilience.spec.ts
@@ -531,6 +531,21 @@ test.describe('Listener network resilience', () => {
             .toBeVisible();
         const reconnectingObservedAt = Date.now();
         await expect(page.getByText(/unavailable right now|no está disponible/i)).toHaveCount(0);
+
+        // An OS/browser `online` event is only advisory: captive portals and
+        // partial network recovery can emit it while the stream origin remains
+        // unreachable. It must not rebuild MediaSource, reset currentTime or
+        // mint a replacement lease before the bounded manifest probe succeeds.
+        const beforeAdvisoryOnline = await mediaState(page);
+        await page.evaluate(() => window.dispatchEvent(new Event('online')));
+        await page.waitForTimeout(2_500);
+        await expect(page.locator('.listener-experience[data-phase="reconnecting"]'))
+            .toBeVisible();
+        const afterAdvisoryOnline = await mediaState(page);
+        expect(afterAdvisoryOnline.currentTime)
+            .toBeGreaterThanOrEqual(beforeAdvisoryOnline.currentTime - 1);
+        expect(leaseRequests).toBe(1);
+
         originOnline = true;
         await page.evaluate(() => window.dispatchEvent(new Event('online')));
         await expect(page.locator('.listener-experience[data-phase="beacon"]'))

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,7 +57,11 @@ export default defineConfig({
         baseURL: BASE_URL,
         locale: 'es-CR',
         timezoneId: 'America/Costa_Rica',
-        trace: 'retain-on-failure',
+        // The network gate serves hundreds of immutable media fragments. A
+        // retained trace embeds every response body and can itself exhaust
+        // Firefox/Playwright while reporting a failure. The gate has a bounded
+        // purpose-built diagnostic ring and screenshots instead.
+        trace: LISTENER_NETWORK_GATE ? 'off' : 'retain-on-failure',
         screenshot: 'only-on-failure',
         launchOptions: {
             // Deterministic fake mic/camera for media-continuity tests.

--- a/src/app/listener/membership/page.test.tsx
+++ b/src/app/listener/membership/page.test.tsx
@@ -111,6 +111,22 @@ describe('Listener membership management route', () => {
         expect(result.props.checkoutAvailability).toEqual({ paypal: true, mercadoPago: false });
     });
 
+    it('keeps both approved Live providers available to an eligible production account', async () => {
+        mocks.headers.mockResolvedValue(new Headers({ host: 'listen.harmonicbeacon.com' }));
+        mocks.checkout.mockReturnValue({ paypal: true, mercadoPago: true });
+        mocks.membership.mockReturnValue({ kind: 'none', state: 'none' });
+
+        const result = await ListenerMembershipManagementPage();
+
+        expect(mocks.checkout).toHaveBeenCalledWith(process.env, 'live');
+        expect(result.props).toMatchObject({
+            membership: { kind: 'none', state: 'none' },
+            checkoutEnvironment: 'live',
+            checkoutAvailability: { paypal: true, mercadoPago: true },
+            liveWorkbench: null,
+        });
+    });
+
     it('fails closed when the authoritative access lookup is unavailable', async () => {
         mocks.access.mockRejectedValue(new Error('database unavailable'));
 

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -528,7 +528,11 @@ function ListenerPlayerController({
                     // never the MediaSource — so an online signal can refill
                     // immediately without discarding playable bytes.
                     instance.stopLoad();
-                    instance.startLoad(-1);
+                    // Do not let hls.js seek the media element while restarting
+                    // its loaders. Firefox can otherwise reset the clock to the
+                    // beginning of the live window even though playable bytes
+                    // are still buffered locally.
+                    instance.startLoad(-1, true);
                 } catch {
                     // The bounded timer remains authoritative. A later retry or
                     // the media-clock recovery can rebuild after buffer exhaustion.
@@ -1623,7 +1627,7 @@ function ListenerPlayerController({
                             && listenerBufferedAheadSeconds(currentAudio)
                                 <= LISTENER_BUFFER_EXHAUSTED_EPSILON_SECONDS;
                         hls.current?.stopLoad();
-                        hls.current?.startLoad(-1);
+                        hls.current?.startLoad(-1, true);
                         if (bufferExhausted) {
                             cancelRecovery(false);
                             scheduleAutomaticRecovery(0, 'online-buffer-exhausted');

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -1434,10 +1434,31 @@ function ListenerPlayerController({
             }));
             reportPresence('idle');
             deferLiveFade();
+            const networkRecoveryInstance = lastHlsSignal.current.type === 'networkError'
+                ? hls.current
+                : null;
+            if (networkRecoveryInstance) {
+                // An exhausted MediaSource is not permission to destroy the
+                // media timeline while the origin is still unreachable. The
+                // refill probe owns this state: it leaves currentTime intact,
+                // retries with bounded backoff and restarts the same hls.js
+                // instance only after a real manifest succeeds.
+                updateLiveState('recovering');
+                if (hlsRefillInstance.current !== networkRecoveryInstance) {
+                    scheduleHlsRefill(networkRecoveryInstance, 0);
+                }
+                return;
+            }
             scheduleAutomaticRecovery(0, 'watchdog-recovery');
         }, LISTENER_PLAYBACK_WATCHDOG_INTERVAL_MS);
         return () => window.clearInterval(interval);
-    }, [deferLiveFade, reportPresence, scheduleAutomaticRecovery]);
+    }, [
+        deferLiveFade,
+        reportPresence,
+        scheduleAutomaticRecovery,
+        scheduleHlsRefill,
+        updateLiveState,
+    ]);
 
     useEffect(() => {
         automaticRecovery.current = scheduleAutomaticRecovery;

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -1733,15 +1733,13 @@ function ListenerPlayerController({
                 void probeExistingLease().then((probe) => {
                     if (probe.kind === 'active') {
                         manifestExpiresAt.current = Date.parse(probe.grant.stream.expiresAt);
-                        const currentAudio = liveAudio.current;
-                        const bufferExhausted = currentAudio !== null
-                            && listenerBufferedAheadSeconds(currentAudio)
-                                <= LISTENER_BUFFER_EXHAUSTED_EPSILON_SECONDS;
-                        if (bufferExhausted) {
-                            cancelHlsRefill(false);
-                            cancelRecovery(false);
-                            scheduleAutomaticRecovery(0, 'online-buffer-exhausted');
-                        } else if (hls.current) {
+                        if (hls.current) {
+                            // A browser `online` event only proves that some
+                            // network interface is available. It does not prove
+                            // that the stream origin can answer yet. Keep the
+                            // same MediaSource/currentTime even after its buffer
+                            // drains; the bounded manifest probe is the only
+                            // authority allowed to restart hls.js in place.
                             const activeInstance = hls.current;
                             cancelHlsRefill(false);
                             scheduleHlsRefill(activeInstance, 0);

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -749,6 +749,13 @@ function ListenerPlayerController({
         };
         instance.on(HlsConstructor.Events.FRAG_LOADED, refillRecovered);
         instance.on(HlsConstructor.Events.LEVEL_LOADED, refillRecovered);
+        instance.on(HlsConstructor.Events.FRAG_BUFFERED, (_event, data) => {
+            // A loader response is not yet playable. Retain its bytes through
+            // transmuxing and SourceBuffer append so an append/retry boundary
+            // during an outage cannot turn a downloaded fragment into an
+            // offline cache miss. FRAG_BUFFERED is hls.js's acceptance point.
+            reservoir.markBuffered(data.frag.url);
+        });
         instance.on(HlsConstructor.Events.FRAG_CHANGED, (_event, data) => {
             const programStartMs = data.frag.programDateTime;
             const mediaStartSeconds = data.frag.start;

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -80,6 +80,7 @@ const STALL_RECOVERY_DELAY_MS = 1_000;
 const LIVE_FADE_IN_MS = 3_000;
 const TRANSPORT_FADE_OUT_MS = 650;
 const MEDIA_PLAY_ATTEMPT_TIMEOUT_MS = 8_000;
+const HLS_REFILL_PROBE_TIMEOUT_MS = 2_000;
 const DEFAULT_LISTENER_VOLUME = 0.7;
 const LISTENER_STABILITY_DELAY_SECONDS = LISTENER_BUFFER_TARGET_SECONDS;
 
@@ -110,6 +111,26 @@ function listenerHlsForwardLoadPosition(audio: HTMLMediaElement | null): number 
         }
     }
     return currentTime;
+}
+
+async function listenerManifestReachable(url: string): Promise<boolean> {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), HLS_REFILL_PROBE_TIMEOUT_MS);
+    try {
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: { accept: 'application/vnd.apple.mpegurl' },
+            cache: 'no-store',
+            credentials: 'omit',
+            redirect: 'error',
+            signal: controller.signal,
+        });
+        return response.ok;
+    } catch {
+        return false;
+    } finally {
+        window.clearTimeout(timeout);
+    }
 }
 
 export function resolveListenerAnalysisFramesPerSecond({
@@ -346,6 +367,7 @@ function ListenerPlayerController({
     const hlsRefillAttempts = useRef(0);
     const hlsRefillTimer = useRef<number | null>(null);
     const hlsRefillInstance = useRef<Hls | null>(null);
+    const hlsRefillGeneration = useRef(0);
     const nativeSuspendObserved = useRef(false);
     const playbackWatchdog = useRef(new ListenerPlaybackLivenessWatchdog());
     const lastPlaybackAction = useRef('mount');
@@ -519,6 +541,7 @@ function ListenerPlayerController({
     }, []);
 
     const cancelHlsRefill = useCallback((resetAttempts = true) => {
+        hlsRefillGeneration.current += 1;
         if (hlsRefillTimer.current !== null) {
             window.clearTimeout(hlsRefillTimer.current);
             hlsRefillTimer.current = null;
@@ -532,21 +555,40 @@ function ListenerPlayerController({
         if (hlsRefillTimer.current !== null && hlsRefillInstance.current === instance) return;
         cancelHlsRefill(false);
         hlsRefillInstance.current = instance;
+        const refillGeneration = hlsRefillGeneration.current;
 
         const schedule = (delayMs: number) => {
-            hlsRefillTimer.current = window.setTimeout(() => {
+            hlsRefillTimer.current = window.setTimeout(async () => {
                 hlsRefillTimer.current = null;
                 if (
                     !wantsLivePlayback.current
                     || hls.current !== instance
                     || hlsRefillInstance.current !== instance
+                    || hlsRefillGeneration.current !== refillGeneration
                 ) return;
+                const probedManifestUrl = manifestUrl.current;
+                const originReachable = probedManifestUrl
+                    ? await listenerManifestReachable(probedManifestUrl)
+                    : false;
+                if (
+                    !wantsLivePlayback.current
+                    || hls.current !== instance
+                    || hlsRefillInstance.current !== instance
+                    || hlsRefillGeneration.current !== refillGeneration
+                ) return;
+                if (!originReachable || manifestUrl.current !== probedManifestUrl) {
+                    hlsRefillAttempts.current = Math.min(
+                        hlsRefillAttempts.current + 1,
+                        1_000_000,
+                    );
+                    schedule(listenerRecoveryDelayMs(hlsRefillAttempts.current));
+                    return;
+                }
                 lastPlaybackAction.current = 'hls-network-refill';
                 try {
-                    // `startLoad()` alone is a no-op while hls.js still owns a
-                    // delayed internal retry. Reset only the loader state —
-                    // never the MediaSource — so an online signal can refill
-                    // immediately without discarding playable bytes.
+                    // Never touch hls.js merely because a request failed. Its
+                    // timeline stays isolated while buffered audio is playing;
+                    // only a successful origin probe may reset loader state.
                     instance.stopLoad();
                     // Resume loading at the first missing forward byte without
                     // seeking the media element. Restarting at the sentinel or
@@ -1651,14 +1693,14 @@ function ListenerPlayerController({
                         const bufferExhausted = currentAudio !== null
                             && listenerBufferedAheadSeconds(currentAudio)
                                 <= LISTENER_BUFFER_EXHAUSTED_EPSILON_SECONDS;
-                        hls.current?.stopLoad();
-                        hls.current?.startLoad(
-                            listenerHlsForwardLoadPosition(currentAudio),
-                            true,
-                        );
                         if (bufferExhausted) {
+                            cancelHlsRefill(false);
                             cancelRecovery(false);
                             scheduleAutomaticRecovery(0, 'online-buffer-exhausted');
+                        } else if (hls.current) {
+                            const activeInstance = hls.current;
+                            cancelHlsRefill(false);
+                            scheduleHlsRefill(activeInstance, 0);
                         }
                         return;
                     }
@@ -1694,12 +1736,14 @@ function ListenerPlayerController({
         attemptLivePlayback,
         beginLiveFade,
         cancelLiveFade,
+        cancelHlsRefill,
         cancelRecovery,
         deferLiveFade,
         dropAudio,
         reportPresence,
         probeExistingLease,
         revalidateIdlePreparedSource,
+        scheduleHlsRefill,
         scheduleAutomaticRecovery,
         startReactiveAnalysis,
         stopHls,

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -92,6 +92,26 @@ function boundedDiagnosticToken(value: unknown): string | null {
         : null;
 }
 
+function listenerHlsForwardLoadPosition(audio: HTMLMediaElement | null): number {
+    if (!audio || !Number.isFinite(audio.currentTime)) return -1;
+    const currentTime = audio.currentTime;
+    for (let index = 0; index < audio.buffered.length; index += 1) {
+        try {
+            const start = audio.buffered.start(index);
+            const end = audio.buffered.end(index);
+            if (
+                Number.isFinite(start)
+                && Number.isFinite(end)
+                && currentTime >= start - 0.25
+                && currentTime <= end + 0.25
+            ) return Math.max(currentTime, end);
+        } catch {
+            return currentTime;
+        }
+    }
+    return currentTime;
+}
+
 export function resolveListenerAnalysisFramesPerSecond({
     reducedMotion,
     saveData,
@@ -528,15 +548,14 @@ function ListenerPlayerController({
                     // never the MediaSource — so an online signal can refill
                     // immediately without discarding playable bytes.
                     instance.stopLoad();
-                    // Do not let hls.js seek the media element while restarting
-                    // its loaders. Firefox can otherwise reset the clock to the
-                    // beginning of the live window even though playable bytes
-                    // are still buffered locally.
+                    // Resume loading at the first missing forward byte without
+                    // seeking the media element. Restarting at the sentinel or
+                    // the currently playing fragment can rewind Firefox or feed
+                    // overlapping media into its decoder while valid bytes are
+                    // still buffered locally.
                     const currentAudio = liveAudio.current;
                     instance.startLoad(
-                        currentAudio && Number.isFinite(currentAudio.currentTime)
-                            ? currentAudio.currentTime
-                            : -1,
+                        listenerHlsForwardLoadPosition(currentAudio),
                         true,
                     );
                 } catch {
@@ -1634,9 +1653,7 @@ function ListenerPlayerController({
                                 <= LISTENER_BUFFER_EXHAUSTED_EPSILON_SECONDS;
                         hls.current?.stopLoad();
                         hls.current?.startLoad(
-                            currentAudio && Number.isFinite(currentAudio.currentTime)
-                                ? currentAudio.currentTime
-                                : -1,
+                            listenerHlsForwardLoadPosition(currentAudio),
                             true,
                         );
                         if (bufferExhausted) {

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -194,8 +194,12 @@ export const LISTENER_HLS_BUFFER_CONFIG = {
     liveMaxLatencyDurationCount: 48,
     liveSyncMode: 'buffered',
     startOnSegmentBoundary: true,
-    maxBufferLength: LISTENER_BUFFER_TARGET_SECONDS,
-    maxMaxBufferLength: 180,
+    // Keep MediaSource below the cross-browser append/eviction pressure that
+    // Firefox reaches near 180 seconds. The rolling reservoir owns the full
+    // network-continuity window and feeds this smaller decoder window as the
+    // media clock advances, so total playable headroom remains three minutes.
+    maxBufferLength: 60,
+    maxMaxBufferLength: 60,
     backBufferLength: 0,
 } as const;
 

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -682,20 +682,13 @@ function ListenerPlayerController({
             const bufferedNetworkFailure = action === 'restart-network-load'
                 && bufferedAheadSeconds > LISTENER_BUFFER_EXHAUSTED_EPSILON_SECONDS;
             if (bufferedNetworkFailure) {
-                const enteringOfflineMode = reservoir.mayReachOrigin();
                 reservoir.setOriginAllowed(false);
-                // Freeze hls.js on its first (usually non-fatal) network error.
-                // Restart it only against the in-memory reservoir so engines
-                // with a small MediaSource window can keep appending retained
-                // segments without retrying or seeking against the live origin.
-                try {
-                    instance.stopLoad();
-                    if (enteringOfflineMode) {
-                        instance.startLoad(listenerHlsForwardLoadPosition(audio), true);
-                    }
-                } catch {
-                    // The probe loop remains authoritative and can retry later.
-                }
+                // Do not stop/restart hls.js here. Its current loader retry can
+                // consume the in-memory playlist/fragments without losing the
+                // fragment tracker or MediaSource timestamp offset. Explicitly
+                // restarting at this boundary made Firefox/Chromium append an
+                // overlapping fragment, emit bufferAppendError and rewind the
+                // media clock even though accepted bytes were still playable.
                 if (hlsRefillInstance.current !== instance) scheduleHlsRefill(instance);
             }
             if (!data.fatal) return;

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -590,6 +590,7 @@ function ListenerPlayerController({
                     // timeline stays isolated while buffered audio is playing;
                     // only a successful origin probe may reset loader state.
                     instance.stopLoad();
+                    hlsReservoir.current?.setOriginAllowed(true);
                     // Resume loading at the first missing forward byte without
                     // seeking the media element. Restarting at the sentinel or
                     // the currently playing fragment can rewind Firefox or feed
@@ -676,9 +677,28 @@ function ListenerPlayerController({
                 details: boundedDiagnosticToken(data.details),
                 fatal: Boolean(data.fatal),
             };
-            if (!data.fatal) return;
             const action = listenerHlsRecoveryAction(data.type);
             const bufferedAheadSeconds = listenerBufferedAheadSeconds(audio);
+            const bufferedNetworkFailure = action === 'restart-network-load'
+                && bufferedAheadSeconds > LISTENER_BUFFER_EXHAUSTED_EPSILON_SECONDS;
+            if (bufferedNetworkFailure) {
+                const enteringOfflineMode = reservoir.mayReachOrigin();
+                reservoir.setOriginAllowed(false);
+                // Freeze hls.js on its first (usually non-fatal) network error.
+                // Restart it only against the in-memory reservoir so engines
+                // with a small MediaSource window can keep appending retained
+                // segments without retrying or seeking against the live origin.
+                try {
+                    instance.stopLoad();
+                    if (enteringOfflineMode) {
+                        instance.startLoad(listenerHlsForwardLoadPosition(audio), true);
+                    }
+                } catch {
+                    // The probe loop remains authoritative and can retry later.
+                }
+                if (hlsRefillInstance.current !== instance) scheduleHlsRefill(instance);
+            }
+            if (!data.fatal) return;
             window.dispatchEvent(new CustomEvent(LISTENER_PLAYBACK_DIAGNOSTIC_EVENT, {
                 detail: listenerTransportDiagnostic({
                     reason: 'hls-fatal',
@@ -694,7 +714,7 @@ function ListenerPlayerController({
                 // A manifest or segment failure does not invalidate bytes that
                 // MediaSource already accepted. Keep the audio clock, fade,
                 // presence and lease intact while hls.js refills in place.
-                scheduleHlsRefill(instance);
+                if (!bufferedNetworkFailure) scheduleHlsRefill(instance);
                 return;
             }
             if (action === 'recover-media') {
@@ -712,6 +732,9 @@ function ListenerPlayerController({
         });
         const refillRecovered = () => {
             if (hlsRefillInstance.current !== instance) return;
+            // Cached playlists/fragments prove only that the local reservoir is
+            // usable. Keep probing until an actual origin request succeeds.
+            if (!reservoir.mayReachOrigin()) return;
             const recoveryAttempt = hlsRefillAttempts.current;
             cancelHlsRefill();
             lastHlsSignal.current = { type: null, details: null, fatal: false };

--- a/src/components/early-birds/ListenerPlayer.tsx
+++ b/src/components/early-birds/ListenerPlayer.tsx
@@ -532,7 +532,13 @@ function ListenerPlayerController({
                     // its loaders. Firefox can otherwise reset the clock to the
                     // beginning of the live window even though playable bytes
                     // are still buffered locally.
-                    instance.startLoad(-1, true);
+                    const currentAudio = liveAudio.current;
+                    instance.startLoad(
+                        currentAudio && Number.isFinite(currentAudio.currentTime)
+                            ? currentAudio.currentTime
+                            : -1,
+                        true,
+                    );
                 } catch {
                     // The bounded timer remains authoritative. A later retry or
                     // the media-clock recovery can rebuild after buffer exhaustion.
@@ -1627,7 +1633,12 @@ function ListenerPlayerController({
                             && listenerBufferedAheadSeconds(currentAudio)
                                 <= LISTENER_BUFFER_EXHAUSTED_EPSILON_SECONDS;
                         hls.current?.stopLoad();
-                        hls.current?.startLoad(-1, true);
+                        hls.current?.startLoad(
+                            currentAudio && Number.isFinite(currentAudio.currentTime)
+                                ? currentAudio.currentTime
+                                : -1,
+                            true,
+                        );
                         if (bufferExhausted) {
                             cancelRecovery(false);
                             scheduleAutomaticRecovery(0, 'online-buffer-exhausted');

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -795,7 +795,7 @@ describe('EarlyBird Listener player', () => {
         hlsHarness.instances[0].emitFatal('networkError', 'fragLoadError');
 
         await waitFor(() => expect(hlsHarness.instances[0].startLoad)
-            .toHaveBeenCalledWith(120, true));
+            .toHaveBeenCalledWith(220, true));
         expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalled();
         expect(hlsHarness.instances).toHaveLength(1);
         expect(hlsHarness.instances[0].destroy).not.toHaveBeenCalled();
@@ -814,7 +814,7 @@ describe('EarlyBird Listener player', () => {
         window.dispatchEvent(new Event('online'));
         await waitFor(() => expect(hlsHarness.instances[0].startLoad.mock.calls.length)
             .toBeGreaterThan(startCallsBeforeOnline));
-        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(120, true);
+        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(220, true);
         expect(hlsHarness.instances[0].stopLoad.mock.calls.length).toBeGreaterThan(1);
         expect(fetchMock.mock.calls.filter(([url]) => (
             url === '/api/early-birds/stream/lease'

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -760,12 +760,27 @@ describe('EarlyBird Listener player', () => {
                 expiresAt: '2099-08-06T12:03:00.000Z',
             },
         }));
-        const fetchMock = vi.fn()
-            .mockResolvedValueOnce(new Response(JSON.stringify(grants[0]), { status: 200 }))
-            .mockResolvedValueOnce(new Response(JSON.stringify({ ...grants[0], presenceSequence: 1 }), { status: 200 }))
-            .mockResolvedValueOnce(new Response(JSON.stringify({ ...grants[0], presenceSequence: 2 }), { status: 200 }))
-            .mockResolvedValueOnce(new Response(JSON.stringify({ ...grants[1], presenceSequence: 2 }), { status: 200 }))
-            .mockResolvedValueOnce(new Response(JSON.stringify({ ...grants[1], presenceSequence: 3 }), { status: 200 }));
+        const apiResponses = [
+            new Response(JSON.stringify(grants[0]), { status: 200 }),
+            new Response(JSON.stringify({ ...grants[0], presenceSequence: 1 }), { status: 200 }),
+            new Response(JSON.stringify({ ...grants[0], presenceSequence: 2 }), { status: 200 }),
+            new Response(JSON.stringify({ ...grants[1], presenceSequence: 2 }), { status: 200 }),
+            new Response(JSON.stringify({ ...grants[1], presenceSequence: 3 }), { status: 200 }),
+        ];
+        let manifestProbes = 0;
+        const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+            if (String(input).startsWith(grants[0].stream.manifestUrl)) {
+                manifestProbes += 1;
+                if (manifestProbes === 1) throw new TypeError('origin unavailable');
+                return new Response('#EXTM3U\n', {
+                    status: 200,
+                    headers: { 'content-type': 'application/vnd.apple.mpegurl' },
+                });
+            }
+            const response = apiResponses.shift();
+            if (!response) throw new Error('unexpected API request');
+            return response;
+        });
         vi.stubGlobal('fetch', fetchMock);
         render(
             <LocaleProvider initialLocale="en">
@@ -794,9 +809,9 @@ describe('EarlyBird Listener player', () => {
         window.addEventListener(LISTENER_PLAYBACK_DIAGNOSTIC_EVENT, onDiagnostic);
         hlsHarness.instances[0].emitFatal('networkError', 'fragLoadError');
 
-        await waitFor(() => expect(hlsHarness.instances[0].startLoad)
-            .toHaveBeenCalledWith(220, true));
-        expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalled();
+        await waitFor(() => expect(manifestProbes).toBe(1));
+        expect(hlsHarness.instances[0].startLoad).not.toHaveBeenCalled();
+        expect(hlsHarness.instances[0].stopLoad).not.toHaveBeenCalled();
         expect(hlsHarness.instances).toHaveLength(1);
         expect(hlsHarness.instances[0].destroy).not.toHaveBeenCalled();
         expect(pause).toHaveBeenCalledTimes(pauseCallsBeforeFailure);
@@ -815,7 +830,8 @@ describe('EarlyBird Listener player', () => {
         await waitFor(() => expect(hlsHarness.instances[0].startLoad.mock.calls.length)
             .toBeGreaterThan(startCallsBeforeOnline));
         expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(220, true);
-        expect(hlsHarness.instances[0].stopLoad.mock.calls.length).toBeGreaterThan(1);
+        expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalledTimes(1);
+        expect(manifestProbes).toBeGreaterThanOrEqual(2);
         expect(fetchMock.mock.calls.filter(([url]) => (
             url === '/api/early-birds/stream/lease'
         ))).toHaveLength(1);

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -832,12 +832,21 @@ describe('EarlyBird Listener player', () => {
         });
         expect(screen.queryByText('Restoring connection…')).toBeNull();
         expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+        // The retained MediaSource can drain before an OS-level `online`
+        // signal. That signal is advisory: recovery must wait for the bounded
+        // manifest probe and preserve this exact hls.js/media-clock instance.
+        Object.defineProperty(live, 'buffered', {
+            value: { length: 1, start: () => 100, end: () => 120 },
+            configurable: true,
+        });
         const startCallsBeforeOnline = hlsHarness.instances[0].startLoad.mock.calls.length;
         window.dispatchEvent(new Event('online'));
         await waitFor(() => expect(hlsHarness.instances[0].startLoad.mock.calls.length)
             .toBeGreaterThan(startCallsBeforeOnline));
-        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(220, true);
+        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(120, true);
         expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalledTimes(3);
+        expect(hlsHarness.instances).toHaveLength(1);
+        expect(hlsHarness.instances[0].destroy).not.toHaveBeenCalled();
         expect(manifestProbes).toBeGreaterThanOrEqual(2);
         expect(fetchMock.mock.calls.filter(([url]) => (
             url === '/api/early-birds/stream/lease'

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -816,9 +816,8 @@ describe('EarlyBird Listener player', () => {
         hlsHarness.instances[0].emitFatal('networkError', 'fragLoadError');
 
         await waitFor(() => expect(manifestProbes).toBe(1));
-        expect(hlsHarness.instances[0].startLoad).toHaveBeenCalledTimes(1);
-        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(220, true);
-        expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalledTimes(2);
+        expect(hlsHarness.instances[0].startLoad).not.toHaveBeenCalled();
+        expect(hlsHarness.instances[0].stopLoad).not.toHaveBeenCalled();
         expect(hlsHarness.instances).toHaveLength(1);
         expect(hlsHarness.instances[0].destroy).not.toHaveBeenCalled();
         expect(pause).toHaveBeenCalledTimes(pauseCallsBeforeFailure);
@@ -844,7 +843,7 @@ describe('EarlyBird Listener player', () => {
         await waitFor(() => expect(hlsHarness.instances[0].startLoad.mock.calls.length)
             .toBeGreaterThan(startCallsBeforeOnline));
         expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(120, true);
-        expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalledTimes(3);
+        expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalledOnce();
         expect(hlsHarness.instances).toHaveLength(1);
         expect(hlsHarness.instances[0].destroy).not.toHaveBeenCalled();
         expect(manifestProbes).toBeGreaterThanOrEqual(2);

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -795,7 +795,7 @@ describe('EarlyBird Listener player', () => {
         hlsHarness.instances[0].emitFatal('networkError', 'fragLoadError');
 
         await waitFor(() => expect(hlsHarness.instances[0].startLoad)
-            .toHaveBeenCalledWith(-1, true));
+            .toHaveBeenCalledWith(120, true));
         expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalled();
         expect(hlsHarness.instances).toHaveLength(1);
         expect(hlsHarness.instances[0].destroy).not.toHaveBeenCalled();
@@ -814,7 +814,7 @@ describe('EarlyBird Listener player', () => {
         window.dispatchEvent(new Event('online'));
         await waitFor(() => expect(hlsHarness.instances[0].startLoad.mock.calls.length)
             .toBeGreaterThan(startCallsBeforeOnline));
-        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(-1, true);
+        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(120, true);
         expect(hlsHarness.instances[0].stopLoad.mock.calls.length).toBeGreaterThan(1);
         expect(fetchMock.mock.calls.filter(([url]) => (
             url === '/api/early-birds/stream/lease'

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -794,7 +794,8 @@ describe('EarlyBird Listener player', () => {
         window.addEventListener(LISTENER_PLAYBACK_DIAGNOSTIC_EVENT, onDiagnostic);
         hlsHarness.instances[0].emitFatal('networkError', 'fragLoadError');
 
-        await waitFor(() => expect(hlsHarness.instances[0].startLoad).toHaveBeenCalledWith(-1));
+        await waitFor(() => expect(hlsHarness.instances[0].startLoad)
+            .toHaveBeenCalledWith(-1, true));
         expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalled();
         expect(hlsHarness.instances).toHaveLength(1);
         expect(hlsHarness.instances[0].destroy).not.toHaveBeenCalled();
@@ -813,6 +814,7 @@ describe('EarlyBird Listener player', () => {
         window.dispatchEvent(new Event('online'));
         await waitFor(() => expect(hlsHarness.instances[0].startLoad.mock.calls.length)
             .toBeGreaterThan(startCallsBeforeOnline));
+        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(-1, true);
         expect(hlsHarness.instances[0].stopLoad.mock.calls.length).toBeGreaterThan(1);
         expect(fetchMock.mock.calls.filter(([url]) => (
             url === '/api/early-birds/stream/lease'

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -10,6 +10,7 @@ type HlsTestInstance = {
     startLoad: ReturnType<typeof vi.fn>;
     recoverMediaError: ReturnType<typeof vi.fn>;
     loadedSources: string[];
+    emitError(fatal: boolean, type?: string, details?: string): void;
     emitFatal(type?: string, details?: string): void;
     emitLoaded(): void;
     emitFragChanged(programDateTime: number, start: number): void;
@@ -128,8 +129,12 @@ vi.mock('hls.js', () => {
 
         attachMedia() {}
 
+        emitError(fatal: boolean, type = 'networkError', details = 'fragLoadError') {
+            this.errorHandler?.('error', { fatal, type, details });
+        }
+
         emitFatal(type = 'networkError', details = 'fragLoadError') {
-            this.errorHandler?.('error', { fatal: true, type, details });
+            this.emitError(true, type, details);
         }
 
         emitLoaded() {
@@ -746,7 +751,7 @@ describe('EarlyBird Listener player', () => {
         expect(earlyBirdLeaseRecoveryDisposition(null)).toBe('recoverable');
     });
 
-    it('keeps buffered audio playing while hls.js refills after a fatal network error', async () => {
+    it('freezes hls.js on the first network error while buffered audio keeps playing', async () => {
         const pause = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
         vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
         vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockReturnValue('');
@@ -807,11 +812,13 @@ describe('EarlyBird Listener player', () => {
             diagnostics.push((event as CustomEvent).detail);
         };
         window.addEventListener(LISTENER_PLAYBACK_DIAGNOSTIC_EVENT, onDiagnostic);
+        hlsHarness.instances[0].emitError(false, 'networkError', 'fragLoadError');
         hlsHarness.instances[0].emitFatal('networkError', 'fragLoadError');
 
         await waitFor(() => expect(manifestProbes).toBe(1));
-        expect(hlsHarness.instances[0].startLoad).not.toHaveBeenCalled();
-        expect(hlsHarness.instances[0].stopLoad).not.toHaveBeenCalled();
+        expect(hlsHarness.instances[0].startLoad).toHaveBeenCalledTimes(1);
+        expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(220, true);
+        expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalledTimes(2);
         expect(hlsHarness.instances).toHaveLength(1);
         expect(hlsHarness.instances[0].destroy).not.toHaveBeenCalled();
         expect(pause).toHaveBeenCalledTimes(pauseCallsBeforeFailure);
@@ -830,7 +837,7 @@ describe('EarlyBird Listener player', () => {
         await waitFor(() => expect(hlsHarness.instances[0].startLoad.mock.calls.length)
             .toBeGreaterThan(startCallsBeforeOnline));
         expect(hlsHarness.instances[0].startLoad).toHaveBeenLastCalledWith(220, true);
-        expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalledTimes(1);
+        expect(hlsHarness.instances[0].stopLoad).toHaveBeenCalledTimes(3);
         expect(manifestProbes).toBeGreaterThanOrEqual(2);
         expect(fetchMock.mock.calls.filter(([url]) => (
             url === '/api/early-birds/stream/lease'

--- a/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
+++ b/src/components/early-birds/__tests__/ListenerPlayer.test.tsx
@@ -629,7 +629,7 @@ describe('EarlyBird Listener player', () => {
         expect(audio.currentTime).toBe(70);
     });
 
-    it('keeps a stability-first desktop HLS buffer without enabling low latency', () => {
+    it('keeps a bounded decoder window beneath the rolling three-minute reservoir', () => {
         expect(LISTENER_HLS_BUFFER_CONFIG).toMatchObject({
             lowLatencyMode: false,
             initialLiveManifestSize: 31,
@@ -637,8 +637,8 @@ describe('EarlyBird Listener player', () => {
             liveMaxLatencyDurationCount: 48,
             liveSyncMode: 'buffered',
             startOnSegmentBoundary: true,
-            maxBufferLength: 180,
-            maxMaxBufferLength: 180,
+            maxBufferLength: 60,
+            maxMaxBufferLength: 60,
         });
     });
 

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -9,10 +9,11 @@ const MEDIA_FILE_SHA256 = {
     // stability vertical. The Listener now starts three minutes behind the
     // edge, retains the same bounded window in MSE plus an ephemeral segment
     // reservoir, preserves accepted bytes through network loss and retries the
-    // same lease indefinitely with bounded backoff. Codec, bitrate, channel,
-    // gain/fade, AudioContext, intro assets, quota, event and payment behavior
-    // remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': 'c4e3141c46add34b2ff90ba858ae1e806d4cf1a416280480adb84b9de483e43e',
+    // same lease indefinitely with bounded backoff. A loader restart explicitly
+    // skips hls.js seeking so Firefox cannot rewind the live clock while valid
+    // bytes remain buffered. Codec, bitrate, channel, gain/fade, AudioContext,
+    // intro assets, quota, event and payment behavior remain unchanged.
+    'src/components/early-birds/ListenerPlayer.tsx': 'f5616cad7ede9ae75cdfb7b0283bbe3494f68658de474f944ba1a9c9d506ea4a',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
     'src/lib/listener/segment-reservoir.ts': '40176ee8ace849990d7d23ddc78531ad637d5a5c6ec1f11b5ed6935fa81ee497',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -15,7 +15,7 @@ const MEDIA_FILE_SHA256 = {
     // that timeline intact until a real origin probe succeeds. Codec, bitrate,
     // channel, gain/fade, AudioContext, intro assets, quota, event and payment
     // behavior remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': 'c2ad33571625d1f6cfe4f3bb5f3383a6c6c7e13bf1ede2d3ca4766f3599d8daa',
+    'src/components/early-birds/ListenerPlayer.tsx': 'ac28ff1a52d6d07a5068ef965c1df8fb29d9d89fb432c5318b03f18f47b3efc8',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
     'src/lib/listener/segment-reservoir.ts': '31d37368c104d0754491217a5233081c93d1043ccca3c5ccc16dfc472078ee0a',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -15,7 +15,7 @@ const MEDIA_FILE_SHA256 = {
     // that timeline intact until a real origin probe succeeds. Codec, bitrate,
     // channel, gain/fade, AudioContext, intro assets, quota, event and payment
     // behavior remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': 'f90286b290df90f362ca77311bd2b7e0c854c8abece3017e7caf231d9aeb34b8',
+    'src/components/early-birds/ListenerPlayer.tsx': 'c2ad33571625d1f6cfe4f3bb5f3383a6c6c7e13bf1ede2d3ca4766f3599d8daa',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
     'src/lib/listener/segment-reservoir.ts': '31d37368c104d0754491217a5233081c93d1043ccca3c5ccc16dfc472078ee0a',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -11,12 +11,13 @@ const MEDIA_FILE_SHA256 = {
     // reservoir, preserves accepted bytes through network loss and retries the
     // same lease indefinitely with bounded backoff. During an outage hls.js can
     // drain only the in-memory reservoir, and a successful origin probe resumes
-    // forward loading without seeking the media clock. Codec, bitrate, channel,
-    // gain/fade, AudioContext, intro assets, quota, event and payment behavior
-    // remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': '2c3d9063e2a1ba9278aacd9420e9ef9cf8d5a587ecc2da5e0a3f2111ed200cda',
+    // forward loading without seeking the media clock. Exhaustion also keeps
+    // that timeline intact until a real origin probe succeeds. Codec, bitrate,
+    // channel, gain/fade, AudioContext, intro assets, quota, event and payment
+    // behavior remain unchanged.
+    'src/components/early-birds/ListenerPlayer.tsx': '1fbf179f544b8721689dbdeb6b9182a90ef506c8157c7d00ee6641299e3a3f65',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
-    'src/lib/listener/segment-reservoir.ts': '52bc108534e44ce600c66cd8d4b6ebc538ae92a7e6ec076600622dcdde7b2ea6',
+    'src/lib/listener/segment-reservoir.ts': '31d37368c104d0754491217a5233081c93d1043ccca3c5ccc16dfc472078ee0a',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',
     'src/lib/early-birds/drop-ins.ts': '3b0d18c2c8548aa3ee917ece726cbca4b6d253ea3b4941a8424f8bcbfb8922e2',
     'src/app/api/early-birds/stream/lease/route.ts': 'ec0e8780387bc1f493eb33d13a2d90e01cfdb6d899fc6232e04f51aaf2dfc508',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -9,13 +9,14 @@ const MEDIA_FILE_SHA256 = {
     // stability vertical. The Listener now starts three minutes behind the
     // edge, retains the same bounded window in MSE plus an ephemeral segment
     // reservoir, preserves accepted bytes through network loss and retries the
-    // same lease indefinitely with bounded backoff. A loader restart explicitly
-    // skips hls.js seeking so Firefox cannot rewind the live clock while valid
-    // bytes remain buffered. Codec, bitrate, channel, gain/fade, AudioContext,
-    // intro assets, quota, event and payment behavior remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': 'dd0b554e92afb9c839044e292d2cc67226a27ab8ddb60adbe899c0ba7385beb2',
+    // same lease indefinitely with bounded backoff. During an outage hls.js can
+    // drain only the in-memory reservoir, and a successful origin probe resumes
+    // forward loading without seeking the media clock. Codec, bitrate, channel,
+    // gain/fade, AudioContext, intro assets, quota, event and payment behavior
+    // remain unchanged.
+    'src/components/early-birds/ListenerPlayer.tsx': '2c3d9063e2a1ba9278aacd9420e9ef9cf8d5a587ecc2da5e0a3f2111ed200cda',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
-    'src/lib/listener/segment-reservoir.ts': '40176ee8ace849990d7d23ddc78531ad637d5a5c6ec1f11b5ed6935fa81ee497',
+    'src/lib/listener/segment-reservoir.ts': '0b09803fc25bdef43cfd6f8b0647aebd7b5caa898ede24139bd5163470568c6f',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',
     'src/lib/early-birds/drop-ins.ts': '3b0d18c2c8548aa3ee917ece726cbca4b6d253ea3b4941a8424f8bcbfb8922e2',
     'src/app/api/early-birds/stream/lease/route.ts': 'ec0e8780387bc1f493eb33d13a2d90e01cfdb6d899fc6232e04f51aaf2dfc508',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -15,7 +15,7 @@ const MEDIA_FILE_SHA256 = {
     // that timeline intact until a real origin probe succeeds. Codec, bitrate,
     // channel, gain/fade, AudioContext, intro assets, quota, event and payment
     // behavior remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': '1fbf179f544b8721689dbdeb6b9182a90ef506c8157c7d00ee6641299e3a3f65',
+    'src/components/early-birds/ListenerPlayer.tsx': 'f90286b290df90f362ca77311bd2b7e0c854c8abece3017e7caf231d9aeb34b8',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
     'src/lib/listener/segment-reservoir.ts': '31d37368c104d0754491217a5233081c93d1043ccca3c5ccc16dfc472078ee0a',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -16,7 +16,7 @@ const MEDIA_FILE_SHA256 = {
     // remain unchanged.
     'src/components/early-birds/ListenerPlayer.tsx': '2c3d9063e2a1ba9278aacd9420e9ef9cf8d5a587ecc2da5e0a3f2111ed200cda',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
-    'src/lib/listener/segment-reservoir.ts': '0b09803fc25bdef43cfd6f8b0647aebd7b5caa898ede24139bd5163470568c6f',
+    'src/lib/listener/segment-reservoir.ts': '52bc108534e44ce600c66cd8d4b6ebc538ae92a7e6ec076600622dcdde7b2ea6',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',
     'src/lib/early-birds/drop-ins.ts': '3b0d18c2c8548aa3ee917ece726cbca4b6d253ea3b4941a8424f8bcbfb8922e2',
     'src/app/api/early-birds/stream/lease/route.ts': 'ec0e8780387bc1f493eb33d13a2d90e01cfdb6d899fc6232e04f51aaf2dfc508',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -12,12 +12,13 @@ const MEDIA_FILE_SHA256 = {
     // same lease indefinitely with bounded backoff. During an outage hls.js can
     // drain only the in-memory reservoir, and a successful origin probe resumes
     // forward loading without seeking the media clock. Exhaustion also keeps
-    // that timeline intact until a real origin probe succeeds. Codec, bitrate,
+    // that timeline intact until a real origin probe succeeds. Reservoir bytes
+    // are released only after hls.js confirms MediaSource accepted them. Codec, bitrate,
     // channel, gain/fade, AudioContext, intro assets, quota, event and payment
     // behavior remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': 'ac28ff1a52d6d07a5068ef965c1df8fb29d9d89fb432c5318b03f18f47b3efc8',
+    'src/components/early-birds/ListenerPlayer.tsx': 'b56d635638f45c747d9abdc57efed20730d7599789e8c9bd0e7343b8eeb107b7',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
-    'src/lib/listener/segment-reservoir.ts': '31d37368c104d0754491217a5233081c93d1043ccca3c5ccc16dfc472078ee0a',
+    'src/lib/listener/segment-reservoir.ts': '4d04998653a1d97b40455358650c8520edf84aadea6ac67e35b80403c84b4c06',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',
     'src/lib/early-birds/drop-ins.ts': '3b0d18c2c8548aa3ee917ece726cbca4b6d253ea3b4941a8424f8bcbfb8922e2',
     'src/app/api/early-birds/stream/lease/route.ts': 'ec0e8780387bc1f493eb33d13a2d90e01cfdb6d899fc6232e04f51aaf2dfc508',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -13,7 +13,7 @@ const MEDIA_FILE_SHA256 = {
     // skips hls.js seeking so Firefox cannot rewind the live clock while valid
     // bytes remain buffered. Codec, bitrate, channel, gain/fade, AudioContext,
     // intro assets, quota, event and payment behavior remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': 'f5616cad7ede9ae75cdfb7b0283bbe3494f68658de474f944ba1a9c9d506ea4a',
+    'src/components/early-birds/ListenerPlayer.tsx': 'b129a507d3be038b3a66b903b2b9d7c9731318cc8c9260e9f1e69eb33184875e',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
     'src/lib/listener/segment-reservoir.ts': '40176ee8ace849990d7d23ddc78531ad637d5a5c6ec1f11b5ed6935fa81ee497',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -13,7 +13,7 @@ const MEDIA_FILE_SHA256 = {
     // skips hls.js seeking so Firefox cannot rewind the live clock while valid
     // bytes remain buffered. Codec, bitrate, channel, gain/fade, AudioContext,
     // intro assets, quota, event and payment behavior remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': 'b129a507d3be038b3a66b903b2b9d7c9731318cc8c9260e9f1e69eb33184875e',
+    'src/components/early-birds/ListenerPlayer.tsx': '3525cd23971d6ac9d6a5ab0590d4fe8c5a816fc17eb7bb054335d346330bb9ac',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
     'src/lib/listener/segment-reservoir.ts': '40176ee8ace849990d7d23ddc78531ad637d5a5c6ec1f11b5ed6935fa81ee497',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',

--- a/src/lib/listener/__tests__/media-boundary.test.ts
+++ b/src/lib/listener/__tests__/media-boundary.test.ts
@@ -13,7 +13,7 @@ const MEDIA_FILE_SHA256 = {
     // skips hls.js seeking so Firefox cannot rewind the live clock while valid
     // bytes remain buffered. Codec, bitrate, channel, gain/fade, AudioContext,
     // intro assets, quota, event and payment behavior remain unchanged.
-    'src/components/early-birds/ListenerPlayer.tsx': '3525cd23971d6ac9d6a5ab0590d4fe8c5a816fc17eb7bb054335d346330bb9ac',
+    'src/components/early-birds/ListenerPlayer.tsx': 'dd0b554e92afb9c839044e292d2cc67226a27ab8ddb60adbe899c0ba7385beb2',
     'src/lib/listener/playback-resilience.ts': '758c466216d2dfaef760665f28a35fdcefea167112fdc3ac96feb004dec7737f',
     'src/lib/listener/segment-reservoir.ts': '40176ee8ace849990d7d23ddc78531ad637d5a5c6ec1f11b5ed6935fa81ee497',
     'src/lib/early-birds/stream.ts': '40c5a17d27e8d6f820251d96dd33cd2bbbd83b164e50a212acf8fd0bb158c51c',

--- a/src/lib/listener/__tests__/segment-reservoir.test.ts
+++ b/src/lib/listener/__tests__/segment-reservoir.test.ts
@@ -16,13 +16,13 @@ import {
 
 const MANIFEST_URL = 'https://stream.example.test/v1/hls/approved/live.m3u8?grant=secret';
 
-function playlist(segmentCount = 4): string {
+function playlist(segmentCount = 4, startSequence = 0): string {
     const lines = [
         '#EXTM3U',
         '#EXT-X-VERSION:7',
         '#EXT-X-MAP:URI="segments/init.mp4?grant=secret"',
     ];
-    for (let index = 0; index < segmentCount; index += 1) {
+    for (let index = startSequence; index < startSequence + segmentCount; index += 1) {
         lines.push('#EXTINF:6.000000,');
         lines.push(`segments/${index}.m4s?grant=secret`);
     }
@@ -148,6 +148,98 @@ describe('ListenerSegmentReservoir', () => {
         expect(delegatedLoads).not.toHaveBeenCalled();
         expect([...new Uint8Array(onSuccess.mock.calls[0][0].data as ArrayBuffer)])
             .toEqual([4, 1, 9]);
+        reservoir.dispose();
+    });
+
+    it('drains only cached playlists and fragments while origin access is disabled', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(new Uint8Array([7, 2, 1]))));
+        const reservoir = new ListenerSegmentReservoir(undefined, true);
+        reservoir.observePlaylist(MANIFEST_URL, playlist(1));
+        const segmentUrl = 'https://stream.example.test/v1/hls/approved/segments/0.m4s?grant=secret';
+        await vi.waitFor(() => expect(reservoir.cached(segmentUrl)).not.toBeNull());
+
+        const delegatedLoads = vi.fn();
+        class UnexpectedNetworkLoader implements Loader<LoaderContext> {
+            context: LoaderContext | null = null;
+            stats = new LoadStats();
+            constructor() {}
+            load(): void { delegatedLoads(); }
+            abort(): void {}
+            destroy(): void {}
+        }
+        const ReservoirLoader = createListenerReservoirLoader(UnexpectedNetworkLoader, reservoir);
+        reservoir.setOriginAllowed(false);
+
+        const playlistSuccess = vi.fn();
+        new ReservoirLoader({} as HlsConfig).load(
+            { url: MANIFEST_URL, responseType: 'text' },
+            {} as LoaderConfiguration,
+            { onSuccess: playlistSuccess, onError: vi.fn(), onTimeout: vi.fn() },
+        );
+        const fragmentSuccess = vi.fn();
+        new ReservoirLoader({} as HlsConfig).load(
+            { url: segmentUrl, responseType: 'arraybuffer', rangeStart: 0, rangeEnd: 0 },
+            {} as LoaderConfiguration,
+            { onSuccess: fragmentSuccess, onError: vi.fn(), onTimeout: vi.fn() },
+        );
+        const missingError = vi.fn();
+        new ReservoirLoader({} as HlsConfig).load(
+            {
+                url: 'https://stream.example.test/v1/hls/approved/segments/missing.m4s',
+                responseType: 'arraybuffer',
+                rangeStart: 0,
+                rangeEnd: 0,
+            },
+            {} as LoaderConfiguration,
+            { onSuccess: vi.fn(), onError: missingError, onTimeout: vi.fn() },
+        );
+
+        await vi.waitFor(() => expect(playlistSuccess).toHaveBeenCalledOnce());
+        await vi.waitFor(() => expect(fragmentSuccess).toHaveBeenCalledOnce());
+        await vi.waitFor(() => expect(missingError).toHaveBeenCalledOnce());
+        expect(delegatedLoads).not.toHaveBeenCalled();
+        reservoir.dispose();
+    });
+
+    it('retains slid-out segments until the player consumes them', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(new Uint8Array([8, 1]))));
+        const snapshots: number[] = [];
+        const reservoir = new ListenerSegmentReservoir((snapshot) => {
+            snapshots.push(snapshot.retainedSeconds);
+        }, true);
+        reservoir.observePlaylist(MANIFEST_URL, playlist(4, 0));
+        await vi.waitFor(() => expect(snapshots.at(-1)).toBe(24));
+        reservoir.observePlaylist(MANIFEST_URL, playlist(4, 4));
+        await vi.waitFor(() => expect(snapshots.at(-1)).toBe(48));
+
+        const delegatedLoads = vi.fn();
+        class UnexpectedNetworkLoader implements Loader<LoaderContext> {
+            context: LoaderContext | null = null;
+            stats = new LoadStats();
+            constructor() {}
+            load(): void { delegatedLoads(); }
+            abort(): void {}
+            destroy(): void {}
+        }
+        const ReservoirLoader = createListenerReservoirLoader(UnexpectedNetworkLoader, reservoir);
+        reservoir.setOriginAllowed(false);
+        const success = vi.fn();
+        const consumedUrl = 'https://stream.example.test/v1/hls/approved/segments/0.m4s?grant=secret';
+        new ReservoirLoader({} as HlsConfig).load(
+            {
+                url: consumedUrl,
+                responseType: 'arraybuffer',
+                rangeStart: 0,
+                rangeEnd: 0,
+            },
+            {} as LoaderConfiguration,
+            { onSuccess: success, onError: vi.fn(), onTimeout: vi.fn() },
+        );
+
+        await vi.waitFor(() => expect(success).toHaveBeenCalledOnce());
+        expect(delegatedLoads).not.toHaveBeenCalled();
+        expect(reservoir.cached(consumedUrl)).toBeNull();
+        expect(snapshots.at(-1)).toBe(42);
         reservoir.dispose();
     });
 });

--- a/src/lib/listener/__tests__/segment-reservoir.test.ts
+++ b/src/lib/listener/__tests__/segment-reservoir.test.ts
@@ -193,10 +193,22 @@ describe('ListenerSegmentReservoir', () => {
             {} as LoaderConfiguration,
             { onSuccess: vi.fn(), onError: missingError, onTimeout: vi.fn() },
         );
+        const rangedError = vi.fn();
+        new ReservoirLoader({} as HlsConfig).load(
+            {
+                url: segmentUrl,
+                responseType: 'arraybuffer',
+                rangeStart: 1,
+                rangeEnd: 2,
+            },
+            {} as LoaderConfiguration,
+            { onSuccess: vi.fn(), onError: rangedError, onTimeout: vi.fn() },
+        );
 
         await vi.waitFor(() => expect(playlistSuccess).toHaveBeenCalledOnce());
         await vi.waitFor(() => expect(fragmentSuccess).toHaveBeenCalledOnce());
         await vi.waitFor(() => expect(missingError).toHaveBeenCalledOnce());
+        await vi.waitFor(() => expect(rangedError).toHaveBeenCalledOnce());
         expect(delegatedLoads).not.toHaveBeenCalled();
         reservoir.dispose();
     });

--- a/src/lib/listener/__tests__/segment-reservoir.test.ts
+++ b/src/lib/listener/__tests__/segment-reservoir.test.ts
@@ -215,7 +215,7 @@ describe('ListenerSegmentReservoir', () => {
         reservoir.dispose();
     });
 
-    it('retains slid-out segments until the player consumes them', async () => {
+    it('retains slid-out segments until MediaSource accepts them', async () => {
         vi.stubGlobal('fetch', vi.fn(async () => new Response(new Uint8Array([8, 1]))));
         const snapshots: number[] = [];
         const reservoir = new ListenerSegmentReservoir((snapshot) => {
@@ -252,6 +252,9 @@ describe('ListenerSegmentReservoir', () => {
 
         await vi.waitFor(() => expect(success).toHaveBeenCalledOnce());
         expect(delegatedLoads).not.toHaveBeenCalled();
+        expect(reservoir.cached(consumedUrl)).not.toBeNull();
+        expect(snapshots.at(-1)).toBe(48);
+        reservoir.markBuffered(consumedUrl);
         expect(reservoir.cached(consumedUrl)).toBeNull();
         expect(snapshots.at(-1)).toBe(42);
         reservoir.dispose();

--- a/src/lib/listener/__tests__/segment-reservoir.test.ts
+++ b/src/lib/listener/__tests__/segment-reservoir.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
     createListenerReservoirLoader,
+    LISTENER_RESERVOIR_PREFETCH_TARGET_SECONDS,
     ListenerSegmentReservoir,
     listenerReservoirInventory,
 } from '@/lib/listener/segment-reservoir';
@@ -69,10 +70,11 @@ describe('ListenerSegmentReservoir', () => {
             snapshots.push(snapshot.retainedSeconds);
         }, true);
 
-        reservoir.observePlaylist(MANIFEST_URL, playlist(4));
-        await vi.waitFor(() => expect(snapshots.at(-1)).toBe(24));
-        expect(fetch).toHaveBeenCalledTimes(5);
-        const url = 'https://stream.example.test/v1/hls/approved/segments/3.m4s?grant=secret';
+        reservoir.observePlaylist(MANIFEST_URL, playlist(40));
+        await vi.waitFor(() => expect(snapshots.at(-1))
+            .toBe(LISTENER_RESERVOIR_PREFETCH_TARGET_SECONDS));
+        expect(fetch).toHaveBeenCalledTimes(36);
+        const url = 'https://stream.example.test/v1/hls/approved/segments/39.m4s?grant=secret';
         const first = reservoir.cached(url);
         expect(first && [...new Uint8Array(first)]).toEqual([1, 2, 3]);
         new Uint8Array(first as ArrayBuffer)[0] = 9;

--- a/src/lib/listener/segment-reservoir.ts
+++ b/src/lib/listener/segment-reservoir.ts
@@ -164,7 +164,7 @@ export class ListenerSegmentReservoir {
         this.originAllowed = allowed;
     }
 
-    markDelivered(url: string): void {
+    markBuffered(url: string): void {
         if (this.disposed || this.initializationUrls.has(url)) return;
         this.delivered.add(url);
         if (!this.entries.delete(url)) return;
@@ -336,7 +336,6 @@ export function createListenerReservoirLoader(
             const serveBytes = (bytes: ArrayBuffer) => {
                 if (this.aborted) return;
                 Object.assign(this.stats, cachedStats(bytes.byteLength));
-                reservoir.markDelivered(context.url);
                 callbacks.onSuccess(
                     { url: context.url, data: bytes.slice(0), code: 200 },
                     this.stats,
@@ -419,8 +418,6 @@ export function createListenerReservoirLoader(
                 onSuccess: (response, stats, successfulContext, networkDetails) => {
                     if (typeof response.data === 'string') {
                         reservoir.observePlaylist(successfulContext.url, response.data);
-                    } else if (response.data instanceof ArrayBuffer) {
-                        reservoir.markDelivered(successfulContext.url);
                     }
                     callbacks.onSuccess(response, stats, successfulContext, networkDetails);
                 },

--- a/src/lib/listener/segment-reservoir.ts
+++ b/src/lib/listener/segment-reservoir.ts
@@ -11,6 +11,14 @@ import { LISTENER_BUFFER_TARGET_SECONDS } from './playback-resilience';
 
 const MAX_RESERVOIR_BYTES = 16 * 1024 * 1024;
 const MAX_PREFETCH_CONCURRENCY = 4;
+const MAX_PLAYLIST_SEGMENT_SECONDS = 30;
+
+// The media clock starts consuming the first fragment while the reservoir is
+// still filling. Keep one maximum-sized fragment beyond the user-visible
+// target so "three minutes available" does not immediately become 2:54 on a
+// six-second stream merely because playback started successfully.
+export const LISTENER_RESERVOIR_PREFETCH_TARGET_SECONDS =
+    LISTENER_BUFFER_TARGET_SECONDS + MAX_PLAYLIST_SEGMENT_SECONDS;
 
 type ReservoirEntry = {
     bytes: ArrayBuffer;
@@ -60,7 +68,9 @@ export function listenerReservoirInventory(
         const durationMatch = /^#EXTINF:([0-9]+(?:\.[0-9]+)?),/.exec(line);
         if (durationMatch) {
             const duration = Number(durationMatch[1]);
-            pendingDuration = Number.isFinite(duration) && duration > 0 && duration <= 30
+            pendingDuration = Number.isFinite(duration)
+                && duration > 0
+                && duration <= MAX_PLAYLIST_SEGMENT_SECONDS
                 ? duration
                 : null;
             continue;
@@ -188,7 +198,11 @@ export class ListenerSegmentReservoir {
 
     private prefetchPlaylist(url: string, playlist: string): void {
         const generation = ++this.generation;
-        const inventory = listenerReservoirInventory(playlist, url);
+        const inventory = listenerReservoirInventory(
+            playlist,
+            url,
+            LISTENER_RESERVOIR_PREFETCH_TARGET_SECONDS,
+        );
         const visibleUrls = new Set(inventory.segments.map((segment) => segment.url));
         for (const deliveredUrl of this.delivered) {
             if (!visibleUrls.has(deliveredUrl)) this.delivered.delete(deliveredUrl);

--- a/src/lib/listener/segment-reservoir.ts
+++ b/src/lib/listener/segment-reservoir.ts
@@ -344,7 +344,11 @@ export function createListenerReservoirLoader(
                 // rangeStart=0/rangeEnd=0. Only a real non-zero byte range
                 // must bypass the whole-object reservoir.
                 if ((context.rangeStart ?? 0) !== 0 || (context.rangeEnd ?? 0) !== 0) {
-                    this.loadDelegate(context, config, callbacks);
+                    if (reservoir.mayReachOrigin()) {
+                        this.loadDelegate(context, config, callbacks);
+                    } else {
+                        queueMicrotask(rejectOfflineMiss);
+                    }
                     return;
                 }
                 const cached = reservoir.cached(context.url);

--- a/src/lib/listener/segment-reservoir.ts
+++ b/src/lib/listener/segment-reservoir.ts
@@ -110,9 +110,12 @@ export class ListenerSegmentReservoir {
     private readonly inflight = new Map<string, Promise<ArrayBuffer | null>>();
     private readonly controllers = new Set<AbortController>();
     private readonly playlistFallback = new Map<string, { mediaSequence: number; playlist: string }>();
+    private readonly delivered = new Set<string>();
+    private readonly initializationUrls = new Set<string>();
     private generation = 0;
     private disposed = false;
     private enabled: boolean;
+    private originAllowed = true;
     private lastSnapshot: ListenerReservoirSnapshot = {
         retainedSeconds: 0,
         retainedBytes: 0,
@@ -140,6 +143,22 @@ export class ListenerSegmentReservoir {
 
     fallbackPlaylist(url: string): string | null {
         return this.playlistFallback.get(url)?.playlist ?? null;
+    }
+
+    mayReachOrigin(): boolean {
+        return this.originAllowed;
+    }
+
+    setOriginAllowed(allowed: boolean): void {
+        if (this.disposed) return;
+        this.originAllowed = allowed;
+    }
+
+    markDelivered(url: string): void {
+        if (this.disposed || this.initializationUrls.has(url)) return;
+        this.delivered.add(url);
+        if (!this.entries.delete(url)) return;
+        this.publishSnapshot();
     }
 
     private retainedByteCount(): number {
@@ -170,7 +189,28 @@ export class ListenerSegmentReservoir {
     private prefetchPlaylist(url: string, playlist: string): void {
         const generation = ++this.generation;
         const inventory = listenerReservoirInventory(playlist, url);
+        const visibleUrls = new Set(inventory.segments.map((segment) => segment.url));
+        for (const deliveredUrl of this.delivered) {
+            if (!visibleUrls.has(deliveredUrl)) this.delivered.delete(deliveredUrl);
+        }
+        if (inventory.initializationUrl) {
+            this.initializationUrls.clear();
+            this.initializationUrls.add(inventory.initializationUrl);
+        }
         void this.prefetchGeneration(generation, inventory.initializationUrl, inventory.segments);
+    }
+
+    private publishSnapshot(): void {
+        let retainedBytes = 0;
+        let retainedSeconds = 0;
+        let retainedSegments = 0;
+        for (const entry of this.entries.values()) {
+            retainedBytes += entry.bytes.byteLength;
+            retainedSeconds += entry.durationSeconds;
+            if (entry.durationSeconds > 0) retainedSegments += 1;
+        }
+        this.lastSnapshot = { retainedSeconds, retainedBytes, retainedSegments };
+        this.onSnapshot(this.snapshot());
     }
 
     private fetchBytes(url: string, durationSeconds: number): Promise<ArrayBuffer | null> {
@@ -192,9 +232,13 @@ export class ListenerSegmentReservoir {
             if (Number.isFinite(declaredBytes) && declaredBytes > MAX_RESERVOIR_BYTES) return null;
             const bytes = await response.arrayBuffer();
             if (bytes.byteLength <= 0 || bytes.byteLength > MAX_RESERVOIR_BYTES) return null;
-            if (!this.disposed && this.retainedByteCount() + bytes.byteLength <= MAX_RESERVOIR_BYTES) {
+            if (
+                !this.disposed
+                && !this.delivered.has(url)
+                && this.retainedByteCount() + bytes.byteLength <= MAX_RESERVOIR_BYTES
+            ) {
                 this.entries.set(url, { bytes, durationSeconds });
-            } else {
+            } else if (!this.delivered.has(url)) {
                 return null;
             }
             return bytes;
@@ -211,8 +255,6 @@ export class ListenerSegmentReservoir {
         initializationUrl: string | null,
         segments: PlaylistSegment[],
     ): Promise<void> {
-        const desired = new Set(segments.map((segment) => segment.url));
-        if (initializationUrl) desired.add(initializationUrl);
         const queue: PlaylistSegment[] = initializationUrl
             ? [{ url: initializationUrl, durationSeconds: 0 }, ...segments]
             : [...segments];
@@ -234,20 +276,10 @@ export class ListenerSegmentReservoir {
         await Promise.all(workers);
         if (this.disposed || generation !== this.generation) return;
 
-        let retainedBytes = 0;
-        let retainedSeconds = 0;
-        let retainedSegments = 0;
-        for (const [entryUrl, entry] of this.entries) {
-            if (!desired.has(entryUrl)) {
-                this.entries.delete(entryUrl);
-                continue;
-            }
-            retainedBytes += entry.bytes.byteLength;
-            retainedSeconds += entry.durationSeconds;
-            if (entry.durationSeconds > 0) retainedSegments += 1;
-        }
-        this.lastSnapshot = { retainedSeconds, retainedBytes, retainedSegments };
-        this.onSnapshot(this.snapshot());
+        // Do not prune a segment merely because it slid out of the newest live
+        // playlist. It may still be ahead of the listener's media clock after
+        // jitter or an outage. The loader releases it exactly when delivered.
+        this.publishSnapshot();
     }
 
     dispose(): void {
@@ -258,6 +290,8 @@ export class ListenerSegmentReservoir {
         this.inflight.clear();
         this.entries.clear();
         this.playlistFallback.clear();
+        this.delivered.clear();
+        this.initializationUrls.clear();
     }
 }
 
@@ -288,11 +322,21 @@ export function createListenerReservoirLoader(
             const serveBytes = (bytes: ArrayBuffer) => {
                 if (this.aborted) return;
                 Object.assign(this.stats, cachedStats(bytes.byteLength));
+                reservoir.markDelivered(context.url);
                 callbacks.onSuccess(
                     { url: context.url, data: bytes.slice(0), code: 200 },
                     this.stats,
                     context,
                     null,
+                );
+            };
+            const rejectOfflineMiss = () => {
+                if (this.aborted) return;
+                callbacks.onError(
+                    { code: 503, text: 'origin unavailable' },
+                    context,
+                    null,
+                    this.stats,
                 );
             };
             if (context.responseType === 'arraybuffer') {
@@ -313,10 +357,36 @@ export function createListenerReservoirLoader(
                     void pending.then((bytes) => {
                         if (this.aborted) return;
                         if (bytes) serveBytes(bytes);
-                        else this.loadDelegate(context, config, callbacks);
+                        else if (reservoir.mayReachOrigin()) {
+                            this.loadDelegate(context, config, callbacks);
+                        } else {
+                            rejectOfflineMiss();
+                        }
                     });
                     return;
                 }
+            }
+            if (!reservoir.mayReachOrigin()) {
+                const fallback = context.responseType !== 'arraybuffer'
+                    ? reservoir.fallbackPlaylist(context.url)
+                    : null;
+                if (fallback !== null) {
+                    const bytes = new TextEncoder().encode(fallback).byteLength;
+                    const fallbackStats = cachedStats(bytes);
+                    Object.assign(this.stats, fallbackStats);
+                    queueMicrotask(() => {
+                        if (this.aborted) return;
+                        callbacks.onSuccess(
+                            { url: context.url, data: fallback, code: 200 },
+                            fallbackStats,
+                            context,
+                            null,
+                        );
+                    });
+                } else {
+                    queueMicrotask(rejectOfflineMiss);
+                }
+                return;
             }
             this.loadDelegate(context, config, callbacks);
         }
@@ -331,6 +401,8 @@ export function createListenerReservoirLoader(
                 onSuccess: (response, stats, successfulContext, networkDetails) => {
                     if (typeof response.data === 'string') {
                         reservoir.observePlaylist(successfulContext.url, response.data);
+                    } else if (response.data instanceof ArrayBuffer) {
+                        reservoir.markDelivered(successfulContext.url);
                     }
                     callbacks.onSuccess(response, stats, successfulContext, networkDetails);
                 },


### PR DESCRIPTION
## Outcome

Closes the post-deploy #419 Firefox clock-rewind seam and makes the real-browser exhaustion gate deterministic across Chromium, Firefox, Android Chrome and iPhone WebKit.

## Root cause

hls.js recovery restarted its loaders with the sentinel position `-1`. Under Firefox CI timing, its first non-fatal retry could restart at the beginning of the available live window and rewind the media clock by exactly 120 seconds during a five-second outage, even though playable audio was still buffered. Restarting at the currently playing timestamp prevented the explicit seek but could request already-buffered fragments and produce `MEDIA_ERR_DECODE`.

WebKit exposed a second root cause: MediaSource retained about 26 seconds while the in-memory reservoir reported 180. The reservoir pruned segments as soon as they slid out of the newest live playlist, even when jitter or prior outages left those segments immediately ahead of the listener's media clock. The browser therefore reached a hole despite having downloaded enough newer bytes.

The exact-head remote gate then exposed two Firefox timing boundaries that a faster local decoder had hidden. The synthetic live edge ran at 4x before the test accelerated playback, so a slow initial fill could fall out of the rolling window. It also showed that consuming the first six-second fragment while filling turns an exact 180-second download into only about 174 playable seconds. Finally, after real exhaustion, the media-clock watchdog could destructively rebuild hls.js while the origin was still offline and reset `currentTime` to the start of the replacement MediaSource.

Buffered playback is now isolated from origin failure at the first network error, including the non-fatal event. The custom loader closes origin access—including byte-range request variants—while leaving hls.js's current fragment tracker, request and retry state intact so it can drain only cached playlists and whole segments. Calling `stopLoad/startLoad` at this boundary was itself unsafe: exact-head CI reproduced overlapping appends, `bufferAppendError` and 120–290 second rewinds in Firefox/Chromium. The reservoir keeps slid-out media until it is actually delivered to the player, then releases it, so MediaSource plus pending memory remains a bounded rolling window. Bounded credential-omitting manifest probes with backoff are the only path that re-enables origin access. A successful probe resumes at the end of the buffered range containing the media clock with `skipSeekToStartPosition=true`; a generation fence invalidates stale probes.

The reservoir now carries one maximum fragment beyond the visible 180-second target, while retaining the same 16 MiB cap. MediaSource itself is capped at a 60-second decoder window; the rolling memory reservoir owns the rest of the network-continuity window and feeds it as the clock advances. This avoids Firefox's reproducible `bufferAppendError` under a 180-second MSE append load without reducing the measured three-minute playable headroom. During a network-caused media-clock stall, the watchdog leaves the media element and hls.js instance intact and delegates exclusively to the successful-origin probe path. An OS/browser `online` event is explicitly advisory: a captive portal or partial reconnection cannot rebuild MediaSource while the origin remains unreachable. The test source clock advances at the decoder's actual selected rate; the near-limit contract is ten seconds below the promised three minutes, and exhaustion is measured separately rather than treating two internal counters as a larger product promise.

Unit tests pin a clock at 120 seconds plus a buffered edge at 220 seconds, prove the first error enters cache-only mode, prove offline cache misses never delegate to the network, preserve slid-out segments until MediaSource acceptance (`FRAG_BUFFERED`), and re-enable exact `startLoad(220, true)` only after the origin probe succeeds. This acceptance boundary prevents a failed append from discarding the only cached copy during an outage.

The browser fixture mirrors the production rolling live timeline with a monotonic 24-minute source, program-date-time tags and a five-minute manifest. Exhaustion waits for the actual reconnecting boundary and its bounded watchdog diagnostic, using the browser's measured playback rate rather than assuming a decoder achieves the requested rate. It emits one false `online` signal while the origin is still down and proves that the clock/MediaSource remain intact before the real recovery. Long buffer waits execute inside the browser instead of sending hundreds of Playwright protocol polls that starve a constrained Firefox decoder; the test-only diagnostic ring is capped at 256 bounded records. CI gives every browser its own runner/process. The final isolated Linux Firefox result exposed a separate fixture-host boundary before any outage: its patched Playwright build downloaded AAC/fMP4 fragments but never exposed the codec to MediaSource, leaving the audio element at `readyState=0`. This is a documented platform property of Playwright browsers, whose available media codecs vary by OS, not evidence of a buffering recovery failure ([Playwright browser documentation](https://playwright.dev/docs/browsers#firefox)). Firefox therefore runs on macOS against the unchanged approved AAC-LC/fMP4 fixture, with an explicit MSE and decoder capability assertion. The media-heavy gate also disables Playwright's generic retained trace—whose embedded fragment bodies caused a secondary `RangeError` while reporting the Linux failure—and keeps the bounded, PII-free diagnostic ring plus failure screenshot.

## Evidence

- Firefox repeated full matrix after origin isolation: 3/3 pass in 11.4 minutes
- Chromium + Firefox + Android Chrome + iPhone WebKit on the final exhaustion-safe implementation: 4/4 pass in 13.9 minutes
- iPhone WebKit final implementation, isolated reproduction: 1/1 pass in 3.8 minutes
- Firefox exact exhaustion/watchdog follow-up: 1/1 pass in 4.0 minutes
- Firefox exact false-online/origin-recovery follow-up: 1/1 pass in 4.1 minutes
- Firefox + Android Chrome exact no-restart follow-up: 2/2 pass in 7.3 minutes
- Firefox + Android Chrome exact 60-second decoder / 180-second total buffer: 2/2 pass in 7.4 minutes
- each engine runs in an isolated CI process; Firefox runs on macOS so the gate exercises the approved AAC-LC/fMP4 codec rather than substituting test media
- outages: 5/15/30/60 seconds, deterministic latency/jitter/loss, near the measured 180-second limit, true exhaustion and automatic recovery
- one lease throughout; no reload, duplicate playback or manual action
- full Vitest on the exact final SHA: 1818 pass / 44 skipped integrations
- focused reservoir/player/media boundary tests: 46/46
- identity A/B cache gate against fresh PostgreSQL: Chromium + Firefox 2/2
- TypeScript, ESLint and diff-check: pass; each Playwright run completed a production Next build

The production membership test explicitly preserves both approved Live checkout providers for an eligible account. The runtime delta is limited to the HLS recovery controller and its ephemeral segment reservoir. Codec, audio assets, gain/fades, introductions, quota, lease semantics, memberships, PayPal/Mercado Pago configuration, events and origin configuration are unchanged.

This SHA requires one controlled build, staging verification and promotion of the same image to production after CI is green. PayPal Live, Mercado Pago Live, Account and authority readiness are mandatory pre/post rollout gates.
