### PR TITLE
fix(live): corrige el ciclo público a 16:00 UTC

### DIFF
--- a/prisma/migrations/20260821194000_correct_four_saturday_cycle_start/migration.sql
+++ b/prisma/migrations/20260821194000_correct_four_saturday_cycle_start/migration.sql
@@ -1,0 +1,39 @@
+-- Correct the reviewed public cycle to its confirmed 16:00 UTC start.
+-- The four stable ids are already public, so this migration changes only
+-- their scheduled time and leaves access, facilitator and room state intact.
+WITH corrected_sessions ("id", "scheduled_at") AS (
+    VALUES
+        ('50000000-0000-4000-8000-202608220001'::uuid, '2026-08-22 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202608290001'::uuid, '2026-08-29 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202609050001'::uuid, '2026-09-05 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202609120001'::uuid, '2026-09-12 16:00:00'::timestamp)
+)
+UPDATE "scheduled_sessions" AS session
+SET
+    "scheduled_at" = corrected_sessions."scheduled_at",
+    "updated_at" = CURRENT_TIMESTAMP
+FROM corrected_sessions
+WHERE session."id" = corrected_sessions."id";
+
+DO $$
+DECLARE
+    initialized_count integer;
+    corrected_count integer;
+BEGIN
+    SELECT count(*) INTO initialized_count FROM "users";
+
+    SELECT count(*) INTO corrected_count
+    FROM "scheduled_sessions"
+    WHERE ("id", "scheduled_at") IN (
+        ('50000000-0000-4000-8000-202608220001'::uuid, '2026-08-22 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202608290001'::uuid, '2026-08-29 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202609050001'::uuid, '2026-09-05 16:00:00'::timestamp),
+        ('50000000-0000-4000-8000-202609120001'::uuid, '2026-09-12 16:00:00'::timestamp)
+    );
+
+    IF initialized_count = 0 AND corrected_count <> 0 THEN
+        RAISE EXCEPTION 'Empty installation contains a partial four-Saturday public cycle';
+    ELSIF initialized_count > 0 AND corrected_count <> 4 THEN
+        RAISE EXCEPTION 'Four-Saturday public cycle must contain four sessions at 16:00 UTC';
+    END IF;
+END $$;

--- a/src/lib/__tests__/public-cycle.test.ts
+++ b/src/lib/__tests__/public-cycle.test.ts
@@ -14,20 +14,21 @@ describe('public four-Saturday cycle', () => {
         expect(isPublicCycleSession('10000000-0000-4000-8000-000000000001')).toBe(false);
     });
 
-    it('keeps the final migration contract at the advertised 14:00 UTC', () => {
+    it('keeps the final migration contract at the confirmed 16:00 UTC', () => {
         const migration = readFileSync(
             new URL(
-                '../../../prisma/migrations/20260818163000_ensure_four_saturday_public_cycle/migration.sql',
+                '../../../prisma/migrations/20260821194000_correct_four_saturday_cycle_start/migration.sql',
                 import.meta.url,
             ),
             'utf8',
         );
 
         for (const date of ['2026-08-22', '2026-08-29', '2026-09-05', '2026-09-12']) {
-            expect(migration).toContain(`'${date} 14:00:00'::timestamp`);
+            expect(migration).toContain(`'${date} 16:00:00'::timestamp`);
         }
-        expect(migration).toContain('"public_access" = EXCLUDED."public_access"');
-        expect(migration).toContain('target_count <> 4');
+        expect(migration).toContain('initialized_count = 0 AND corrected_count <> 0');
+        expect(migration).toContain('initialized_count > 0 AND corrected_count <> 4');
+        expect(migration).not.toContain('14:00:00');
     });
 
     it('recognizes only an entirely anonymous COMP entitlement for a reviewed public room', () => {


### PR DESCRIPTION
## Cambio
- corrige las cuatro sesiones públicas de Del otro lado del umbral de 14:00 a 16:00 UTC
- conserva IDs, salas, facilitación y acceso; modifica solamente scheduled_at
- agrega una verificación que exige las cuatro sesiones corregidas en instalaciones inicializadas
- mantiene la cadena de migraciones compatible con bases vacías de ensayo

## Horarios resultantes
- 10:00 Costa Rica / CDMX
- 12:00 EE. UU. ET / Bolivia / Venezuela
- 13:00 Argentina / Uruguay
- Chile: 12:00 las primeras tres fechas y 13:00 el 12 de septiembre
- 18:00 España peninsular

## Verificación local
- 1.073 pruebas aprobadas, 23 omitidas
- build de producción aprobado
- lint aprobado
- diff-check limpio