### PR TITLE
fix(live): make stage device invitation prominent

### DIFF
--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -459,6 +459,21 @@ describe('SessionRoomPage - staff cockpit handoff', () => {
         );
     });
 
+    it('makes the staff camera and microphone invitation visually prominent', async () => {
+        installStaffToken(true);
+        await renderConnected();
+        const room = currentRoom();
+        room.localParticipant.permissions.canPublish = true;
+
+        act(() => room.emit('participantPermissionsChanged', null, room.localParticipant));
+
+        const invitation = await screen.findByTestId('stage-device-invitation');
+        expect(invitation).toHaveAttribute('role', 'status');
+        expect(invitation).toHaveAttribute('aria-live', 'polite');
+        expect(invitation).toHaveClass('border-2', 'border-[var(--gold)]', 'bg-[var(--gold)]/15');
+        expect(invitation).toHaveTextContent('Your turn — enable camera and microphone');
+    });
+
     it('explains that unassigned composite staff has operational access without publication', async () => {
         installStaffToken(false);
         await renderConnected();

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -1051,9 +1051,16 @@ function SessionRoom() {
                     )}
 
                     {needsDeviceGesture && (
-                        <p className="text-center text-sm text-[var(--lime)]">
-                            {copy.session.yourTurn}
-                        </p>
+                        <div
+                            role="status"
+                            aria-live="polite"
+                            data-testid="stage-device-invitation"
+                            className="event-card w-full max-w-md border-2 border-[var(--gold)] bg-[var(--gold)]/15 px-5 py-4 text-center shadow-[0_0_28px_rgba(221,179,90,0.22)]"
+                        >
+                            <p className="font-serif text-xl text-[var(--paper)]">
+                                {copy.session.yourTurn}
+                            </p>
+                        </div>
                     )}
                     {stageInvitationAccepted && stageInvitationError ? (
                         <p className="max-w-md text-center text-sm text-[var(--danger)]" role="alert">


### PR DESCRIPTION
Makes the existing staff/facilitator camera and microphone prompt visually prominent without changing invitation, publication, LiveKit, audio, session, event, ticket, payment, or Account behavior. The ticket-backed consent dialog remains unchanged. Adds an accessible polite status region and focused regression coverage.\n\nLocal gates: 33/33 focal; full Vitest 1085 passed / 25 skipped integrations; TypeScript; focused ESLint; diff-check.