### PR TITLE
fix(audio): restore asymmetric Beacon/Session mix

### DIFF
--- a/src/app/session/[id]/__tests__/media-continuity.test.tsx
+++ b/src/app/session/[id]/__tests__/media-continuity.test.tsx
@@ -145,6 +145,21 @@ async function renderConnectedWithRemoteAudio() {
 }
 
 describe('session shell — media continuity invariants', () => {
+    it('keeps a Beacon floor at Session and removes stage voice completely at Beacon', async () => {
+        const { remoteAudio } = await renderConnectedWithRemoteAudio();
+        const balance = screen.getByRole('slider', { name: 'Beacon / Session balance' });
+
+        fireEvent.change(balance, { target: { value: '1' } });
+        expect(remoteAudio.muted).toBe(false);
+        expect(remoteAudio.volume).toBe(0.8);
+        expect(audioMocks.setBeaconVolume).toHaveBeenLastCalledWith(0.2);
+
+        fireEvent.change(balance, { target: { value: '0' } });
+        expect(remoteAudio.muted).toBe(true);
+        expect(remoteAudio.volume).toBe(0);
+        expect(audioMocks.setBeaconVolume).toHaveBeenLastCalledWith(0.8);
+    });
+
     it('room controls never disconnect, remount, duplicate media, or re-activate audio', async () => {
         const { remoteAudio } = await renderConnectedWithRemoteAudio();
         const room = latestFakeRoom(Room);

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -924,7 +924,7 @@ describe('SessionRoomPage - two-room crossfader', () => {
         expect(sliders[1]).toHaveValue('0.5');
         await waitFor(() => {
             const initialBedGain = audioMocks.setBeaconVolume.mock.lastCall?.[0];
-            expect(initialBedGain).toBeCloseTo(0.4);
+            expect(initialBedGain).toBeCloseTo(0.5);
         });
 
         const stageAudio = document.createElement('audio');
@@ -949,7 +949,7 @@ describe('SessionRoomPage - two-room crossfader', () => {
         await waitFor(() => {
             expect(stageAudio.volume).toBeCloseTo(0.2);
             const bedGain = audioMocks.setBeaconVolume.mock.lastCall?.[0];
-            expect(bedGain).toBeCloseTo(0.6);
+            expect(bedGain).toBeCloseTo(0.65);
         });
     });
 

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -23,6 +23,7 @@ import ThumbnailSender from "@/components/session/ThumbnailSender";
 import ThumbnailTapestry from "@/components/session/ThumbnailTapestry";
 import type { StageVideoPublication } from "@/components/session/StageTile";
 import type { StageConnectionQuality } from "@/lib/stage-layout";
+import { roomMixGains } from "@/lib/audio-mix";
 import { redactErrorDetail } from "@/lib/redact";
 import { isLocalizedStaffRole, localeForEventLanguage, staffRolePresentation } from "@/lib/i18n";
 
@@ -212,7 +213,7 @@ function SessionRoom() {
     // even after LiveKit has already cleared its srcObject.
     const audioElementsRef = useRef<Map<RemoteTrack, HTMLAudioElement>>(new Map());
     const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const stageVolumeRef = useRef(volume * mix);
+    const stageVolumeRef = useRef(roomMixGains(volume, mix).session);
     const audioOnlyRef = useRef(audioOnly);
     const slotOrderRef = useRef<Map<string, number>>(new Map());
     const nextSlotRef = useRef(0);
@@ -529,6 +530,7 @@ function SessionRoom() {
                         }
                         const audioElement = track.attach() as HTMLAudioElement;
                         audioElement.volume = stageVolumeRef.current;
+                        audioElement.muted = stageVolumeRef.current === 0;
                         audioElement.style.display = "none";
                         document.body.appendChild(audioElement);
                         audioElementsRef.current.set(track, audioElement);
@@ -711,13 +713,15 @@ function SessionRoom() {
     }, [canPublish, principalKind, stageInvitationAccepted]);
 
     useEffect(() => {
-        const sessionVol = volume * mix;
-        const beaconVol = volume * (1 - mix);
-        stageVolumeRef.current = sessionVol;
+        const gains = roomMixGains(volume, mix);
+        stageVolumeRef.current = gains.session;
         audioElementsRef.current.forEach((el) => {
-            el.volume = sessionVol;
+            el.volume = gains.session;
+            // Volume zero should be enough, but an explicit mute guarantees
+            // the Beacon endpoint never leaks stage voice across engines.
+            el.muted = gains.session === 0;
         });
-        setBeaconVolume(beaconVol);
+        setBeaconVolume(gains.beacon);
     }, [volume, mix, setBeaconVolume]);
 
     const toggleMic = useCallback(async () => {

--- a/src/lib/__tests__/audio-mix.test.ts
+++ b/src/lib/__tests__/audio-mix.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { BEACON_SESSION_FLOOR_RATIO, roomMixGains } from '../audio-mix';
+
+describe('roomMixGains', () => {
+    it('makes the Beacon end exclusive and full-strength under the master volume', () => {
+        expect(roomMixGains(0.8, 0)).toEqual({
+            beacon: 0.8,
+            session: 0,
+        });
+    });
+
+    it('retains the documented Beacon floor at the Session end', () => {
+        expect(roomMixGains(0.8, 1)).toEqual({
+            beacon: 0.8 * BEACON_SESSION_FLOOR_RATIO,
+            session: 0.8,
+        });
+    });
+
+    it('starts centered with the Beacon slightly above the session instead of too quiet', () => {
+        expect(roomMixGains(0.8, 0.5)).toEqual({
+            beacon: 0.5,
+            session: 0.4,
+        });
+    });
+
+    it('clamps hostile values and obeys master mute', () => {
+        expect(roomMixGains(0, 0)).toEqual({ beacon: 0, session: 0 });
+        expect(roomMixGains(2, -1)).toEqual({ beacon: 1, session: 0 });
+        expect(roomMixGains(1, 2)).toEqual({
+            beacon: BEACON_SESSION_FLOOR_RATIO,
+            session: 1,
+        });
+    });
+});

--- a/src/lib/audio-mix.ts
+++ b/src/lib/audio-mix.ts
@@ -1,0 +1,25 @@
+export const BEACON_SESSION_FLOOR_RATIO = 0.25;
+
+function clampUnit(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Personal room mix. Balance 0 is fully Beacon; balance 1 is fully Session.
+ * The Session end deliberately retains a quiet Beacon bed, while the Beacon
+ * end is exclusive and removes the stage voice completely.
+ */
+export function roomMixGains(masterVolume: number, balance: number): {
+    beacon: number;
+    session: number;
+} {
+    const master = clampUnit(masterVolume);
+    const normalizedBalance = clampUnit(balance);
+    return {
+        beacon: master * (
+            1 - normalizedBalance * (1 - BEACON_SESSION_FLOOR_RATIO)
+        ),
+        session: master * normalizedBalance,
+    };
+}


### PR DESCRIPTION
## Critical rehearsal fix\n\nRestores the approved asymmetric balance contract:\n\n- Beacon extreme: Beacon follows master volume; session/stage audio is exactly zero and explicitly muted.\n- Session extreme: session follows master volume; Beacon remains audible at a 25% floor.\n- Center/default (master 0.8): Beacon 0.5, session 0.4.\n\nThis is an explicitly authorized audio-touching change requested during the 2026-08-22 rehearsal. It does not alter source audio bytes, fades, intros, leases, quotas, membership, payments, or event state.\n\n## Gates\n\n- focused media/session tests: 49/49\n- full Vitest: 1090 passed, 25 skipped\n- TypeScript: pass\n- focused ESLint: pass\n- production build: pass\n- diff-check: pass\n\nRollback image: current production release 62efa71979ef10f330e6c30eb0e1a191109ac512.