### PR TITLE
HOTFIX: lower Beacon floor to 5% at Session end

### DIFF
--- a/src/app/session/[id]/__tests__/media-continuity.test.tsx
+++ b/src/app/session/[id]/__tests__/media-continuity.test.tsx
@@ -152,7 +152,7 @@ describe('session shell — media continuity invariants', () => {
         fireEvent.change(balance, { target: { value: '1' } });
         expect(remoteAudio.muted).toBe(false);
         expect(remoteAudio.volume).toBe(0.8);
-        expect(audioMocks.setBeaconVolume).toHaveBeenLastCalledWith(0.2);
+        expect(audioMocks.setBeaconVolume.mock.lastCall?.[0]).toBeCloseTo(0.04);
 
         fireEvent.change(balance, { target: { value: '0' } });
         expect(remoteAudio.muted).toBe(true);

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -924,7 +924,7 @@ describe('SessionRoomPage - two-room crossfader', () => {
         expect(sliders[1]).toHaveValue('0.5');
         await waitFor(() => {
             const initialBedGain = audioMocks.setBeaconVolume.mock.lastCall?.[0];
-            expect(initialBedGain).toBeCloseTo(0.5);
+            expect(initialBedGain).toBeCloseTo(0.42);
         });
 
         const stageAudio = document.createElement('audio');
@@ -949,7 +949,7 @@ describe('SessionRoomPage - two-room crossfader', () => {
         await waitFor(() => {
             expect(stageAudio.volume).toBeCloseTo(0.2);
             const bedGain = audioMocks.setBeaconVolume.mock.lastCall?.[0];
-            expect(bedGain).toBeCloseTo(0.65);
+            expect(bedGain).toBeCloseTo(0.61);
         });
     });
 

--- a/src/lib/__tests__/audio-mix.test.ts
+++ b/src/lib/__tests__/audio-mix.test.ts
@@ -11,15 +11,14 @@ describe('roomMixGains', () => {
     });
 
     it('retains the documented Beacon floor at the Session end', () => {
-        expect(roomMixGains(0.8, 1)).toEqual({
-            beacon: 0.8 * BEACON_SESSION_FLOOR_RATIO,
-            session: 0.8,
-        });
+        const gains = roomMixGains(0.8, 1);
+        expect(gains.beacon).toBeCloseTo(0.8 * BEACON_SESSION_FLOOR_RATIO);
+        expect(gains.session).toBe(0.8);
     });
 
-    it('starts centered with the Beacon slightly above the session instead of too quiet', () => {
+    it('starts centered with both sources near parity while preserving the session-side floor', () => {
         expect(roomMixGains(0.8, 0.5)).toEqual({
-            beacon: 0.5,
+            beacon: 0.42000000000000004,
             session: 0.4,
         });
     });
@@ -27,9 +26,8 @@ describe('roomMixGains', () => {
     it('clamps hostile values and obeys master mute', () => {
         expect(roomMixGains(0, 0)).toEqual({ beacon: 0, session: 0 });
         expect(roomMixGains(2, -1)).toEqual({ beacon: 1, session: 0 });
-        expect(roomMixGains(1, 2)).toEqual({
-            beacon: BEACON_SESSION_FLOOR_RATIO,
-            session: 1,
-        });
+        const sessionEnd = roomMixGains(1, 2);
+        expect(sessionEnd.beacon).toBeCloseTo(BEACON_SESSION_FLOOR_RATIO);
+        expect(sessionEnd.session).toBe(1);
     });
 });

--- a/src/lib/audio-mix.ts
+++ b/src/lib/audio-mix.ts
@@ -1,4 +1,4 @@
-export const BEACON_SESSION_FLOOR_RATIO = 0.25;
+export const BEACON_SESSION_FLOOR_RATIO = 0.05;
 
 function clampUnit(value: number): number {
     if (!Number.isFinite(value)) return 0;


### PR DESCRIPTION
## Incident
During the live event the approved Beacon master overpowered the facilitator when listeners moved the balance toward Session.

## Contract
- Session end: Session 100%, Beacon 5%
- Beacon end: Beacon 100%, Session 0%
- No source bytes, LiveKit lifecycle, session, event, payment, tapestry, entitlement, or quota changes

## Evidence
- Focused audio/session tests: 40 passed
- Full Vitest: 1090 passed, 25 skipped integrations
- TypeScript, focused ESLint and diff-check green

## Rollback
Current production SHA d23b61eb624cc7fe8759dc9b0d1f7e267ca7b375 remains the rollback image.