### PR TITLE
test(e2e): stabilize dated public cycle fixture

### DIFF
--- a/e2e/fixtures/stabilize-public-cycle.ts
+++ b/e2e/fixtures/stabilize-public-cycle.ts
@@ -1,0 +1,44 @@
+import pg from 'pg';
+
+import { assertSafeFixtureDatabaseUrl } from './database-url';
+
+const PUBLIC_CYCLE_SESSION_IDS = [
+    '50000000-0000-4000-8000-202608220001',
+    '50000000-0000-4000-8000-202608290001',
+    '50000000-0000-4000-8000-202609050001',
+    '50000000-0000-4000-8000-202609120001',
+] as const;
+
+/**
+ * Keep the reviewed four-event landing fixture deterministic as wall-clock
+ * time advances through the real 2026 cycle. The browser gate uses a
+ * disposable database restored immediately before Playwright; marking these
+ * four rows LIVE keeps their canonical dates/copy intact while satisfying the
+ * same discovery rule used for a currently open event.
+ */
+export default async function stabilizePublicCycle(): Promise<void> {
+    const databaseUrl = process.env.E2E_DATABASE_URL;
+    if (!databaseUrl) {
+        throw new Error('E2E_DATABASE_URL is required to stabilize the public cycle fixture');
+    }
+    assertSafeFixtureDatabaseUrl(databaseUrl);
+
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        const result = await client.query<{ id: string }>(
+            `update scheduled_sessions
+                set status = 'LIVE', started_at = now(), ended_at = null
+              where id = any($1::uuid[])
+          returning id`,
+            [PUBLIC_CYCLE_SESSION_IDS],
+        );
+        if (result.rowCount !== PUBLIC_CYCLE_SESSION_IDS.length) {
+            throw new Error(
+                `expected ${PUBLIC_CYCLE_SESSION_IDS.length} public cycle fixtures, updated ${result.rowCount ?? 0}`,
+            );
+        }
+    } finally {
+        await client.end();
+    }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,6 +39,7 @@ const WEBKIT_ATTENDEE_CONTINUITY = /attendee controls without capture/;
 
 export default defineConfig({
     testDir: './e2e/tests',
+    globalSetup: './e2e/fixtures/stabilize-public-cycle.ts',
     fullyParallel: false,
     workers: 1,
     forbidOnly: !!process.env.CI,


### PR DESCRIPTION
Fixes the release-only clock drift exposed when the first reviewed public-cycle event began on 2026-08-22.

The disposable Playwright database now marks the exact four reviewed cycle rows LIVE immediately before browser gates, preserving canonical dates and production behavior while keeping the established four-card visual fixture deterministic.

Evidence: 1090/1090 unit tests; TypeScript/ESLint/diff-check green; release landing smoke 1/1; responsive/visual matrix 19/20 locally (all functional/geometry and 4/5 exact screenshots pass; the lone local 320px snapshot differs only by 15px page height under local rendering and remains covered by the pinned CI runner).

Runtime delta: none.