### PR TITLE
RTC-AUDIO: high-fidelity facilitator profile and Staff telemetry

### DIFF
--- a/docs/research/facilitator-audio-quality.md
+++ b/docs/research/facilitator-audio-quality.md
@@ -1,0 +1,75 @@
+# Facilitator audio quality contract
+
+Issue: [#459](https://github.com/AlterMundi/harmonic-beacon-webapp/issues/459)  
+Milestone: Encuentro — sábado 29 de agosto de 2026
+
+## Product contract
+
+- The assigned facilitator uses a deliberate high-fidelity voice profile when opening the microphone.
+- Every Staff role sees current measurements and a prominent warning when the observed path leaves reasonable operating ranges.
+- A warning is informational. It must never mute, unpublish, disconnect, reload, change a mixer, or stop a room.
+- Uplink and downlink are shown separately. The facilitator browser measures capture/uplink; every other Staff browser measures its own reception of that facilitator.
+- Telemetry contains no names, emails, participant identities, device IDs, IP addresses, tokens, or persistent history.
+
+## Selected profile
+
+| Setting | Value | Reason |
+| --- | --- | --- |
+| Codec | Opus | WebRTC interoperable full-band codec |
+| Maximum bitrate | 96 kbps | LiveKit high-quality mono preset; a ceiling, not a guaranteed minimum |
+| Network priority | high | Protect audio before ordinary video traffic |
+| Capture | 48 kHz, mono preferred | Full-band voice without paying stereo cost |
+| RED | on | Redundant Opus payload can recover isolated packet loss |
+| DTX | off | Avoid discontinuous voice gating |
+| AGC / echo cancellation / noise suppression / voice isolation | requested off | Preserve the good external microphone signal; actual browser settings are reported |
+
+The profile applies only to the event's assigned facilitator. Applying the same no-AEC profile to arbitrary attendees using open speakers would create an avoidable feedback risk.
+
+## What the browser can and cannot promise
+
+`RTCRtpEncodingParameters.maxBitrate` is a maximum. Congestion control is still allowed to transmit below it; there is no interoperable WebRTC minimum-bitrate control. Opus is also allowed to vary its instantaneous rate, so the system must measure the effective stream rather than claim literal CBR. Browser media constraints express the requested capture, and `MediaStreamTrack.getSettings()` is the evidence of what the browser actually delivered.
+
+The monitor therefore reads cumulative `RTCStatsReport` counters and computes deltas over two-second windows:
+
+- outbound/inbound audio bitrate;
+- remote packet loss;
+- jitter and round-trip time;
+- receiver concealed-sample percentage;
+- available candidate-pair bandwidth when implemented;
+- actual codec and sanitized capture settings;
+- LiveKit connection-quality state.
+
+Low bitrate is warned only while WebRTC reports active audio. Opus legitimately reduces its rate during silence even with DTX disabled.
+
+## Initial operating ranges
+
+These values are operational warnings, not media controls. They must be tuned with recorded rehearsal evidence.
+
+| Measurement | Warning | Critical |
+| --- | ---: | ---: |
+| Packet loss | ≥ 2% | ≥ 5% |
+| Jitter | ≥ 25 ms | ≥ 50 ms |
+| RTT | ≥ 200 ms | ≥ 400 ms |
+| Concealed samples | ≥ 1% | ≥ 5% |
+| Active-speech bitrate | < 48 kbps | < 32 kbps |
+| Telemetry age | — | > 7 s |
+
+An enabled browser voice processor or an actual sample rate below 44.1 kHz produces a warning. Unsupported metrics render as unavailable, never as zero.
+
+## Primary references
+
+- [LiveKit high-quality audio](https://docs.livekit.io/transport/media/advanced/)
+- [LiveKit connection quality](https://docs.livekit.io/home/client/events/#connection-quality)
+- [W3C Media Capture and Streams](https://www.w3.org/TR/mediacapture-streams/)
+- [W3C MediaStreamTrack content hints](https://www.w3.org/TR/mst-content-hint/)
+- [W3C WebRTC `maxBitrate`](https://www.w3.org/TR/webrtc/#dom-rtcrtpencodingparameters-maxbitrate)
+- [W3C WebRTC Statistics](https://www.w3.org/TR/webrtc-stats/)
+- [RFC 6716 — Opus](https://www.rfc-editor.org/rfc/rfc6716)
+- [RFC 7587 — RTP payload format for Opus](https://www.rfc-editor.org/rfc/rfc7587)
+- [RFC 8854 — RTP payload format for RED](https://www.rfc-editor.org/rfc/rfc8854)
+
+## Acceptance evidence
+
+Automated gates cover profile scoping, counter-delta math, bounded telemetry, warnings, and the invariant that degraded metrics do not touch media controls. The real-LiveKit browser continuity suite additionally requires the facilitator monitor to leave its waiting state after microphone publication while preserving the existing no-disconnect/no-remount/no-duplicate-media contract.
+
+A physical rehearsal with Julián's production microphone remains required to choose microphone gain and validate perceived quality. That rehearsal tunes thresholds; it does not replace or weaken the automated transport evidence.

--- a/e2e/tests/media-continuity.spec.ts
+++ b/e2e/tests/media-continuity.spec.ts
@@ -108,6 +108,10 @@ stackTest.describe('media continuity', () => {
         await expect(
             facilitator.getByRole('button', { name: /Mute microphone|Silenciar micrófono/i }),
         ).toBeVisible();
+        const qualityMonitor = facilitator.getByTestId('facilitator-audio-quality');
+        await expect(qualityMonitor).toBeVisible();
+        await expect(qualityMonitor).not.toHaveAttribute('data-severity', 'waiting', { timeout: 10_000 });
+        await expect(qualityMonitor).toContainText(/96 kbps/);
         await facilitator.getByRole('button', { name: /Turn camera on|Encender cámara/i }).click();
         await expect(
             facilitator.getByRole('button', { name: /Turn camera off|Apagar cámara/i }),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -170,6 +170,10 @@ export default defineConfig({
                   // production templates and runtime default remain OFF.
                   PROMO_INVITATIONS_ENABLED: 'true',
                   E2E_DASHBOARD_ENABLED: '1',
+                  // Keep the four-event fixture deterministic after the real
+                  // August cycle begins. Production ignores this value because
+                  // its E2E dashboard gate is disabled.
+                  E2E_CLOCK_NOW: '2026-08-21T12:00:00.000Z',
                   SESSION_COOKIE_TTL_SECONDS: '604800',
                   NEXT_PUBLIC_LIVEKIT_URL: process.env.E2E_LIVEKIT_URL ?? 'ws://localhost:7880',
                   LIVEKIT_API_KEY: process.env.E2E_LIVEKIT_API_KEY ?? 'devkey',

--- a/src/__tests__/livekit-fake.ts
+++ b/src/__tests__/livekit-fake.ts
@@ -31,12 +31,15 @@ export interface FakeParticipant {
     connectionQuality: string;
     permissions?: { canPublish: boolean };
     trackPublications: Map<string, FakeVideoPublication>;
+    audioTrackPublications: Map<string, never>;
     videoTrackPublications: Map<string, FakeVideoPublication>;
     isCameraEnabled: boolean;
     isMicrophoneEnabled: boolean;
     setCameraEnabled: ReturnType<typeof vi.fn>;
     setMicrophoneEnabled: ReturnType<typeof vi.fn>;
     enableCameraAndMicrophone: ReturnType<typeof vi.fn>;
+    getTrackPublication: ReturnType<typeof vi.fn>;
+    publishData: ReturnType<typeof vi.fn>;
 }
 
 export interface FakeParticipantOptions {
@@ -81,12 +84,15 @@ export function createFakeParticipant(options: FakeParticipantOptions): FakePart
         connectionQuality: options.quality ?? 'excellent',
         permissions: { canPublish },
         trackPublications: publications,
+        audioTrackPublications: new Map<string, never>(),
         videoTrackPublications: publications,
         isCameraEnabled: canPublish ? options.camera ?? true : false,
         isMicrophoneEnabled: canPublish ? options.mic ?? true : false,
         setCameraEnabled: vi.fn(),
         setMicrophoneEnabled: vi.fn(),
         enableCameraAndMicrophone: vi.fn(),
+        getTrackPublication: vi.fn(),
+        publishData: vi.fn().mockResolvedValue(undefined),
     };
 
     // Mirror the SDK: enabling a device flips the getter the UI reads back.
@@ -121,6 +127,11 @@ export class FakeRoom {
 
     on(event: string, cb: (...args: unknown[]) => void) {
         (this.listeners[event] ||= []).push(cb);
+        return this;
+    }
+
+    off(event: string, cb: (...args: unknown[]) => void) {
+        this.listeners[event] = (this.listeners[event] || []).filter((listener) => listener !== cb);
         return this;
     }
 
@@ -183,8 +194,12 @@ export function livekitClientMock() {
             ActiveSpeakersChanged: 'activeSpeakersChanged',
             ConnectionQualityChanged: 'connectionQualityChanged',
             ParticipantPermissionsChanged: 'participantPermissionsChanged',
+            DataReceived: 'dataReceived',
         },
-        Track: { Kind: { Audio: 'audio', Video: 'video' } },
+        Track: { Kind: { Audio: 'audio', Video: 'video' }, Source: { Camera: 'camera', Microphone: 'microphone' } },
+        AudioPresets: {
+            musicHighQuality: { maxBitrate: 96_000 },
+        },
         VideoPresets: {
             h180: fakePreset(320, 180, 150_000),
             h360: fakePreset(640, 360, 500_000),

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -130,6 +130,33 @@ describe('landing page', () => {
         ]);
     });
 
+    it('pins public discovery time only inside the E2E-gated stack', async () => {
+        const pinned = new Date('2026-08-21T12:00:00.000Z');
+        vi.stubEnv('E2E_DASHBOARD_ENABLED', '1');
+        vi.stubEnv('E2E_CLOCK_NOW', pinned.toISOString());
+        const findMany = mountDb(vi.fn().mockResolvedValue([]));
+
+        await renderPage();
+
+        expect(findMany.mock.calls[0][0].where.OR[0]).toEqual({
+            status: 'SCHEDULED',
+            scheduledAt: { gte: pinned },
+        });
+    });
+
+    it('ignores the E2E clock pin when the dashboard gate is disabled', async () => {
+        vi.stubEnv('E2E_DASHBOARD_ENABLED', '0');
+        vi.stubEnv('E2E_CLOCK_NOW', '2026-08-21T12:00:00.000Z');
+        const findMany = mountDb(vi.fn().mockResolvedValue([]));
+
+        await renderPage();
+
+        expect(findMany.mock.calls[0][0].where.OR[0]).toEqual({
+            status: 'SCHEDULED',
+            scheduledAt: { gte: NOW },
+        });
+    });
+
     it('fails closed when a missed lifecycle transition leaves an old session LIVE', async () => {
         const findMany = mountDb(vi.fn().mockResolvedValue([SATURDAY, SESSION_2]));
         vi.stubEnv('TICKET_PURCHASE_URL', 'https://tickets.example.invalid/harmonic-beacon');

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,19 @@ const INTERNAL_NEXT = /^\/session(\/[A-Za-z0-9_-]+)*$/;
 // before a stale row can be presented as the next paid event.
 const PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
+function publicScheduleNow(): Date {
+    const pinned = process.env.E2E_DASHBOARD_ENABLED === '1'
+        ? process.env.E2E_CLOCK_NOW?.trim()
+        : undefined;
+    if (!pinned) return new Date();
+
+    const now = new Date(pinned);
+    if (Number.isNaN(now.getTime())) {
+        throw new Error('E2E_CLOCK_NOW must be an ISO-8601 timestamp');
+    }
+    return now;
+}
+
 function safeNext(raw: string | string[] | undefined): string | undefined {
     const value = Array.isArray(raw) ? raw[0] : raw;
     return value && INTERNAL_NEXT.test(value) ? value : undefined;
@@ -44,7 +57,10 @@ function safeNext(raw: string | string[] | undefined): string | undefined {
 
 async function weekendEvents(): Promise<WeekendEvent[] | null> {
     try {
-        const now = new Date();
+        // Browser gates pin their own clock so a real event crossing its start
+        // time cannot change the fixture landing halfway through CI. The pin is
+        // ignored unless the already test-only dashboard gate is enabled.
+        const now = publicScheduleNow();
         const liveStartedAfter = new Date(now.getTime() - PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS);
 
         return await prisma.scheduledSession.findMany({

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -70,10 +70,11 @@ vi.mock('livekit-client', () => {
             isMicrophoneEnabled: false,
             connectionQuality: 'excellent',
             unpublishTrack: vi.fn(),
+            publishData: vi.fn().mockResolvedValue(undefined),
             setMicrophoneEnabled: vi.fn().mockResolvedValue(undefined),
             setCameraEnabled: vi.fn().mockResolvedValue(undefined),
-            getTrackPublication: vi.fn(() => (
-                this.localParticipant.isCameraEnabled
+            getTrackPublication: vi.fn((source: string) => (
+                source === 'camera' && this.localParticipant.isCameraEnabled
                     ? { videoTrack: this.cameraTrack }
                     : undefined
             )),
@@ -93,6 +94,10 @@ vi.mock('livekit-client', () => {
         startAudio = vi.fn().mockResolvedValue(undefined);
         on(event: string, cb: (...args: unknown[]) => void) {
             (this.listeners[event] ||= []).push(cb);
+            return this;
+        }
+        off(event: string, cb: (...args: unknown[]) => void) {
+            this.listeners[event] = (this.listeners[event] || []).filter((listener) => listener !== cb);
             return this;
         }
         emit(event: string, ...args: unknown[]) {
@@ -120,9 +125,13 @@ vi.mock('livekit-client', () => {
             Reconnected: 'reconnected',
             ConnectionQualityChanged: 'connectionQualityChanged',
             ParticipantPermissionsChanged: 'participantPermissionsChanged',
+            DataReceived: 'dataReceived',
             Disconnected: 'disconnected',
         },
-        Track: { Kind: { Audio: 'audio', Video: 'video' }, Source: { Camera: 'camera' } },
+        Track: { Kind: { Audio: 'audio', Video: 'video' }, Source: { Camera: 'camera', Microphone: 'microphone' } },
+        AudioPresets: {
+            musicHighQuality: { maxBitrate: 96_000 },
+        },
         VideoPresets: {
             h720: { resolution: { width: 1280, height: 720 }, encoding: {} },
             h360: { resolution: { width: 640, height: 360 }, encoding: {} },
@@ -150,7 +159,7 @@ vi.mock('livekit-client', () => {
 });
 
 import SessionRoomPage from '../page';
-import { Room, DisconnectReason } from 'livekit-client';
+import { Room, DisconnectReason, type RoomOptions } from 'livekit-client';
 
 interface EmittableRoom {
     emit: (event: string, ...args: unknown[]) => void;
@@ -457,6 +466,24 @@ describe('SessionRoomPage - staff cockpit handoff', () => {
         expect(screen.getByTestId('viewer-role-guidance')).toHaveTextContent(
             /Assigned facilitator.*camera and microphone remain under your control/i,
         );
+        const options = vi.mocked(Room).mock.calls.at(-1)?.[0] as RoomOptions;
+        expect(options).toMatchObject({
+            audioCaptureDefaults: {
+                sampleRate: { ideal: 48_000 },
+                channelCount: { ideal: 1 },
+                autoGainControl: false,
+                echoCancellation: false,
+                noiseSuppression: false,
+                voiceIsolation: false,
+            },
+            publishDefaults: {
+                audioPreset: { maxBitrate: 96_000, priority: 'high' },
+                dtx: false,
+                red: true,
+                forceStereo: false,
+            },
+        });
+        expect(screen.getByTestId('facilitator-audio-quality')).toBeInTheDocument();
     });
 
     it('explains that unassigned composite staff has operational access without publication', async () => {
@@ -466,6 +493,9 @@ describe('SessionRoomPage - staff cockpit handoff', () => {
         expect(screen.getByTestId('viewer-role-guidance')).toHaveTextContent(
             /Operational access.*do not publish as its assigned facilitator/i,
         );
+        const options = vi.mocked(Room).mock.calls.at(-1)?.[0] as RoomOptions;
+        expect(options.audioCaptureDefaults).toBeUndefined();
+        expect(options.publishDefaults?.audioPreset).toBeUndefined();
     });
 
     it('disconnects the standalone room and preserves device intent before opening the cockpit', async () => {

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import {
+    AudioPresets,
     DisconnectReason,
     Room,
     RoomEvent,
@@ -16,6 +17,7 @@ import {
 import { AudioProvider, useAudio } from "@/context/AudioContext";
 import { useLocale } from "@/context/LocaleContext";
 import HandRaiseButton from "@/components/session/HandRaiseButton";
+import FacilitatorAudioQuality from "@/components/session/FacilitatorAudioQuality";
 import SessionContributions from "@/components/session/SessionContributions";
 import SessionGuidance from "@/components/session/SessionGuidance";
 import StageLayout, { type StagePublisherView } from "@/components/session/StageLayout";
@@ -28,18 +30,39 @@ import { isLocalizedStaffRole, localeForEventLanguage, staffRolePresentation } f
 
 const LIVEKIT_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || "wss://live.altermundi.net";
 
-const STAGE_ROOM_OPTIONS: RoomOptions = {
-    adaptiveStream: true,
-    dynacast: true,
-    videoCaptureDefaults: {
-        resolution: VideoPresets.h720.resolution,
-    },
-    publishDefaults: {
-        simulcast: true,
-        videoEncoding: VideoPresets.h720.encoding,
-        videoSimulcastLayers: [VideoPresets.h180, VideoPresets.h360],
-    },
-};
+function stageRoomOptions(isAssignedFacilitator: boolean): RoomOptions {
+    return {
+        adaptiveStream: true,
+        dynacast: true,
+        videoCaptureDefaults: {
+            resolution: VideoPresets.h720.resolution,
+        },
+        ...(isAssignedFacilitator ? {
+            audioCaptureDefaults: {
+                sampleRate: { ideal: 48_000 },
+                channelCount: { ideal: 1 },
+                autoGainControl: false,
+                echoCancellation: false,
+                noiseSuppression: false,
+                voiceIsolation: false,
+            },
+        } : {}),
+        publishDefaults: {
+            simulcast: true,
+            videoEncoding: VideoPresets.h720.encoding,
+            videoSimulcastLayers: [VideoPresets.h180, VideoPresets.h360],
+            ...(isAssignedFacilitator ? {
+                // Audio keeps WebRTC's high network priority. This is a ceiling,
+                // not a promise that a constrained connection will deliver 96 kbps;
+                // the Staff monitor reports the effective rate instead of acting on it.
+                audioPreset: { ...AudioPresets.musicHighQuality, priority: 'high' as const },
+                dtx: false,
+                red: true,
+                forceStereo: false,
+            } : {}),
+        },
+    };
+}
 
 const STAGE_REFRESH_MS = 100;
 const STAGE_HANDOFF_MAX_AGE_MS = 30_000;
@@ -203,6 +226,7 @@ function SessionRoom() {
     const [retryToken, setRetryToken] = useState(0);
     const [audioActivationError, setAudioActivationError] = useState<string | null>(null);
     const [viewerInfo, setViewerInfo] = useState<ViewerInfo | null>(null);
+    const [activeRoom, setActiveRoom] = useState<Room | null>(null);
     const [stageInvitationAccepted, setStageInvitationAccepted] = useState(false);
     const [stageInvitationBusy, setStageInvitationBusy] = useState<'accept' | 'decline' | null>(null);
     const [stageInvitationError, setStageInvitationError] = useState<string | null>(null);
@@ -512,9 +536,10 @@ function SessionRoom() {
                     setDuration(Math.max(0, elapsed));
                 }
 
-                const room = new Room(STAGE_ROOM_OPTIONS);
+                const room = new Room(stageRoomOptions(data.isAssignedFacilitator === true));
                 ownedRoom = room;
                 roomRef.current = room;
+                setActiveRoom(room);
 
                 room.on(RoomEvent.TrackSubscribed, async (track: RemoteTrack, publication: RemoteTrackPublication) => {
                     if (track.kind === Track.Kind.Audio) {
@@ -664,7 +689,10 @@ function SessionRoom() {
             if (ownedRoom) {
                 intentionalDisconnectRef.current = true;
                 ownedRoom.disconnect();
-                if (roomRef.current === ownedRoom) roomRef.current = null;
+                if (roomRef.current === ownedRoom) {
+                    roomRef.current = null;
+                    setActiveRoom(null);
+                }
             }
             audioElements.forEach((el) => {
                 el.pause();
@@ -976,6 +1004,17 @@ function SessionRoom() {
                         <span className="font-mono text-xs text-[var(--gold)]">{formatTime(duration)}</span>
                     </div>
                 </header>
+
+                {principalKind === 'staff' ? (
+                    <div className="flex justify-center px-3 pt-3 sm:px-4">
+                        <FacilitatorAudioQuality
+                            key={`${viewerInfo?.identity ?? 'staff'}:${retryToken}`}
+                            room={activeRoom}
+                            isStaff
+                            isAssignedFacilitator={viewerInfo?.isAssignedFacilitator === true}
+                        />
+                    </div>
+                ) : null}
 
                 {/* Stage + contributions panel (side on desktop, below on mobile) */}
                 <div className="flex flex-1 flex-col lg:flex-row">

--- a/src/components/session/FacilitatorAudioQuality.tsx
+++ b/src/components/session/FacilitatorAudioQuality.tsx
@@ -51,7 +51,7 @@ function highestSeverity(values: AudioQualitySeverity[]): AudioQualitySeverity {
     if (!values.length || values.every((value) => value === 'waiting')) return 'waiting';
     return values.reduce((highest, value) => (
         SEVERITY_ORDER[value] > SEVERITY_ORDER[highest] ? value : highest
-    ), 'waiting');
+    ), values[0]);
 }
 
 function metric(value: number | undefined, suffix: string, unavailable: string): string {

--- a/src/components/session/FacilitatorAudioQuality.tsx
+++ b/src/components/session/FacilitatorAudioQuality.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+    RoomEvent,
+    Track,
+    type Participant,
+    type Room,
+} from 'livekit-client';
+
+import { useLocale } from '@/context/LocaleContext';
+import {
+    FACILITATOR_AUDIO_SAMPLE_MS,
+    FACILITATOR_AUDIO_TELEMETRY_TOPIC,
+    assessAudioQuality,
+    encodeFacilitatorTelemetry,
+    measureAudioQuality,
+    parseFacilitatorTelemetry,
+    type AudioQualityMeasurement,
+    type AudioQualitySeverity,
+    type AudioStatsBaseline,
+} from '@/lib/facilitator-audio-quality';
+import { isLocalizedStaffRole } from '@/lib/i18n';
+
+type Props = {
+    room: Room | null;
+    isStaff: boolean;
+    isAssignedFacilitator: boolean;
+};
+
+const SEVERITY_ORDER: Record<AudioQualitySeverity, number> = {
+    healthy: 1,
+    waiting: 2,
+    warning: 3,
+    critical: 4,
+};
+
+function metadata(participant: Participant): { role: string | null; isAssignedFacilitator: boolean } {
+    try {
+        const value = JSON.parse(participant.metadata || '{}') as Record<string, unknown>;
+        return {
+            role: typeof value.role === 'string' ? value.role : null,
+            isAssignedFacilitator: value.isAssignedFacilitator === true,
+        };
+    } catch {
+        return { role: null, isAssignedFacilitator: false };
+    }
+}
+
+function highestSeverity(values: AudioQualitySeverity[]): AudioQualitySeverity {
+    if (!values.length || values.every((value) => value === 'waiting')) return 'waiting';
+    return values.reduce((highest, value) => (
+        SEVERITY_ORDER[value] > SEVERITY_ORDER[highest] ? value : highest
+    ), 'waiting');
+}
+
+function metric(value: number | undefined, suffix: string, unavailable: string): string {
+    return value === undefined ? unavailable : `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}${suffix}`;
+}
+
+function MeasurementGrid({
+    measurement,
+    heading,
+    unavailable,
+    labels,
+}: {
+    measurement: AudioQualityMeasurement | null;
+    heading: string;
+    unavailable: string;
+    labels: {
+        bitrate: string;
+        packetLoss: string;
+        jitter: string;
+        roundTripTime: string;
+        concealment: string;
+        availableBitrate: string;
+        codec: string;
+        capture: string;
+    };
+}) {
+    const capture = measurement?.capture;
+    const captureParts = capture ? [
+        capture.sampleRateHz === undefined ? null : `${Math.round(capture.sampleRateHz / 1_000)} kHz`,
+        capture.channelCount === undefined ? null : `${capture.channelCount} ch`,
+        capture.autoGainControl === undefined ? null : `AGC ${capture.autoGainControl ? 'on' : 'off'}`,
+        capture.echoCancellation === undefined ? null : `AEC ${capture.echoCancellation ? 'on' : 'off'}`,
+        capture.noiseSuppression === undefined ? null : `NS ${capture.noiseSuppression ? 'on' : 'off'}`,
+        capture.voiceIsolation === undefined ? null : `VI ${capture.voiceIsolation ? 'on' : 'off'}`,
+    ].filter(Boolean).join(' · ') : unavailable;
+
+    const items = [
+        [labels.bitrate, metric(measurement?.bitrateKbps, ' kbps', unavailable)],
+        [labels.packetLoss, metric(measurement?.packetLossPct, '%', unavailable)],
+        [labels.jitter, metric(measurement?.jitterMs, ' ms', unavailable)],
+        [labels.roundTripTime, metric(measurement?.roundTripTimeMs, ' ms', unavailable)],
+        ...(measurement?.plane === 'downlink'
+            ? [[labels.concealment, metric(measurement?.concealmentPct, '%', unavailable)]]
+            : [[labels.availableBitrate, metric(measurement?.availableBitrateKbps, ' kbps', unavailable)]]),
+        [labels.codec, measurement?.codec ?? unavailable],
+        ...(measurement?.plane === 'uplink' ? [[labels.capture, captureParts]] : []),
+    ];
+
+    return (
+        <section aria-label={heading}>
+            <h3 className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--gold)]">{heading}</h3>
+            <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-2 text-xs sm:grid-cols-3">
+                {items.map(([label, value]) => (
+                    <div key={label} className={label === labels.capture ? 'col-span-2 sm:col-span-3' : ''}>
+                        <dt className="text-[var(--text-muted)]">{label}</dt>
+                        <dd className="mt-0.5 break-words font-mono text-[var(--cream)]">{value}</dd>
+                    </div>
+                ))}
+            </dl>
+        </section>
+    );
+}
+
+/**
+ * Staff-only, read-only quality monitor. It samples browser/LiveKit stats and
+ * exchanges a small identity-free uplink snapshot. It deliberately has no
+ * callback capable of muting, unpublishing, disconnecting, or changing tracks.
+ */
+export default function FacilitatorAudioQuality({ room, isStaff, isAssignedFacilitator }: Props) {
+    const { copy } = useLocale();
+    const [uplink, setUplink] = useState<AudioQualityMeasurement | null>(null);
+    const [downlink, setDownlink] = useState<AudioQualityMeasurement | null>(null);
+    const [now, setNow] = useState(() => Date.now());
+    const uplinkBaseline = useRef<AudioStatsBaseline | undefined>(undefined);
+    const downlinkBaseline = useRef<AudioStatsBaseline | undefined>(undefined);
+
+    useEffect(() => {
+        if (!room || !isStaff) return;
+        const activeRoom = room;
+        let cancelled = false;
+        uplinkBaseline.current = undefined;
+        downlinkBaseline.current = undefined;
+
+        const receiveTelemetry = (
+            payload: Uint8Array,
+            participant?: Participant,
+            _kind?: unknown,
+            topic?: string,
+        ) => {
+            if (topic !== FACILITATOR_AUDIO_TELEMETRY_TOPIC || !participant) return;
+            if (!metadata(participant).isAssignedFacilitator) return;
+            const parsed = parseFacilitatorTelemetry(payload);
+            // Sender and receiver wall clocks may differ. Freshness is based on
+            // local arrival time, while every numeric value remains the sender's.
+            if (parsed) setUplink({ ...parsed.measurement, sampledAt: Date.now() });
+        };
+        activeRoom.on(RoomEvent.DataReceived, receiveTelemetry);
+
+        async function sample() {
+            if (cancelled) return;
+            const sampledAt = Date.now();
+            setNow(sampledAt);
+
+            if (isAssignedFacilitator) {
+                const publication = activeRoom.localParticipant.getTrackPublication(Track.Source.Microphone);
+                const track = publication?.audioTrack;
+                const report = await track?.getRTCStatsReport().catch(() => undefined);
+                if (report && !cancelled) {
+                    const result = measureAudioQuality(report, 'uplink', uplinkBaseline.current, {
+                        sampledAt,
+                        connectionQuality: String(activeRoom.localParticipant.connectionQuality),
+                        captureSettings: track?.getSourceTrackSettings(),
+                    });
+                    if (result) {
+                        uplinkBaseline.current = result.baseline;
+                        setUplink(result.measurement);
+                        const destinations = [...activeRoom.remoteParticipants.values()]
+                            .filter((participant) => isLocalizedStaffRole(metadata(participant).role))
+                            .map((participant) => participant.identity);
+                        if (destinations.length) {
+                            void activeRoom.localParticipant.publishData(
+                                encodeFacilitatorTelemetry(result.measurement),
+                                {
+                                    reliable: false,
+                                    topic: FACILITATOR_AUDIO_TELEMETRY_TOPIC,
+                                    destinationIdentities: destinations,
+                                },
+                            ).catch(() => undefined);
+                        }
+                    }
+                }
+                setDownlink(null);
+                return;
+            }
+
+            const facilitator = [...activeRoom.remoteParticipants.values()]
+                .find((participant) => metadata(participant).isAssignedFacilitator);
+            const publication = facilitator?.getTrackPublication(Track.Source.Microphone);
+            const track = publication?.audioTrack;
+            const report = await track?.getRTCStatsReport().catch(() => undefined);
+            if (report && facilitator && !cancelled) {
+                const result = measureAudioQuality(report, 'downlink', downlinkBaseline.current, {
+                    sampledAt,
+                    connectionQuality: String(facilitator.connectionQuality),
+                });
+                if (result) {
+                    downlinkBaseline.current = result.baseline;
+                    setDownlink(result.measurement);
+                }
+            }
+        }
+
+        void sample();
+        const interval = window.setInterval(() => void sample(), FACILITATOR_AUDIO_SAMPLE_MS);
+        return () => {
+            cancelled = true;
+            window.clearInterval(interval);
+            activeRoom.off(RoomEvent.DataReceived, receiveTelemetry);
+        };
+    }, [isAssignedFacilitator, isStaff, room]);
+
+    const assessments = useMemo(() => [
+        assessAudioQuality(uplink, now),
+        ...(!isAssignedFacilitator ? [assessAudioQuality(downlink, now)] : []),
+    ], [downlink, isAssignedFacilitator, now, uplink]);
+    const severity = highestSeverity(assessments.map((assessment) => assessment.severity));
+    const reasons = [...new Set(assessments.flatMap((assessment) => assessment.reasons))];
+    const labels = copy.session.audioQuality;
+    const measuredAt = Math.max(uplink?.sampledAt ?? 0, downlink?.sampledAt ?? 0);
+    const ageSeconds = measuredAt ? Math.max(0, Math.round((now - measuredAt) / 1_000)) : null;
+    const severityClass = {
+        healthy: 'border-[var(--lime)]/45 bg-[var(--lime)]/10 text-[var(--lime)]',
+        warning: 'border-[var(--warning)]/60 bg-[var(--warning)]/10 text-[var(--warning)]',
+        critical: 'border-[var(--danger)]/70 bg-[var(--danger)]/10 text-[var(--danger)]',
+        waiting: 'border-white/20 bg-white/5 text-[var(--text-secondary)]',
+    }[severity];
+
+    if (!isStaff) return null;
+
+    return (
+        <aside
+            className={`w-full max-w-3xl rounded-lg border px-4 py-3 ${severityClass}`}
+            data-testid="facilitator-audio-quality"
+            data-severity={severity}
+            aria-live={severity === 'critical' ? 'assertive' : 'polite'}
+        >
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <h2 className="text-sm font-semibold text-current">{labels.heading}</h2>
+                <p className="font-mono text-xs">
+                    {labels[severity]}
+                    {ageSeconds === null ? '' : ` · ${labels.measuredAgo.replace('{seconds}', String(ageSeconds))}`}
+                </p>
+            </div>
+            {reasons.length ? (
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-current">
+                    {reasons.map((reason) => <li key={reason}>{labels.reasons[reason] ?? reason}</li>)}
+                </ul>
+            ) : null}
+            <details className="mt-3 text-[var(--text-secondary)]" open={severity === 'warning' || severity === 'critical'}>
+                <summary className="cursor-pointer text-xs font-semibold text-[var(--cream)]">{labels.profile}</summary>
+                <div className="mt-3 grid gap-4 md:grid-cols-2">
+                    <MeasurementGrid
+                        measurement={uplink}
+                        heading={labels.facilitatorUplink}
+                        unavailable={labels.unavailable}
+                        labels={labels}
+                    />
+                    {!isAssignedFacilitator ? (
+                        <MeasurementGrid
+                            measurement={downlink}
+                            heading={labels.thisDeviceDownlink}
+                            unavailable={labels.unavailable}
+                            labels={labels}
+                        />
+                    ) : null}
+                </div>
+                <p className="mt-3 text-xs text-[var(--text-muted)]">{labels.noAutomaticAction}</p>
+            </details>
+        </aside>
+    );
+}

--- a/src/components/session/__tests__/FacilitatorAudioQuality.test.tsx
+++ b/src/components/session/__tests__/FacilitatorAudioQuality.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LocaleProvider } from '@/context/LocaleContext';
+
+vi.mock('livekit-client', () => ({
+    RoomEvent: { DataReceived: 'dataReceived' },
+    Track: { Source: { Microphone: 'microphone' } },
+}));
+
+import FacilitatorAudioQuality from '../FacilitatorAudioQuality';
+
+function stats(values: Array<Record<string, unknown>>): RTCStatsReport {
+    return new Map(values.map((value, index) => [String(value.id ?? index), value])) as unknown as RTCStatsReport;
+}
+
+describe('FacilitatorAudioQuality', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => {
+        cleanup();
+        vi.useRealTimers();
+    });
+
+    it('shows real degradation to Staff without touching the transmission', async () => {
+        const reports = [
+            stats([
+                { type: 'outbound-rtp', kind: 'audio', timestamp: 1_000, bytesSent: 10_000, packetsSent: 100, audioLevel: 0.12 },
+                { type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 100, packetsLost: 0, jitter: 0.01, roundTripTime: 0.08 },
+            ]),
+            stats([
+                { type: 'outbound-rtp', kind: 'audio', timestamp: 3_000, bytesSent: 17_000, packetsSent: 200, audioLevel: 0.12 },
+                { type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 185, packetsLost: 15, jitter: 0.065, roundTripTime: 0.45 },
+            ]),
+        ];
+        let reportIndex = 0;
+        const setMicrophoneEnabled = vi.fn();
+        const unpublishTrack = vi.fn();
+        const disconnect = vi.fn();
+        const publishData = vi.fn().mockResolvedValue(undefined);
+        const listeners = new Map<string, (...args: unknown[]) => void>();
+        const room = {
+            localParticipant: {
+                connectionQuality: 'excellent',
+                getTrackPublication: () => ({
+                    audioTrack: {
+                        getRTCStatsReport: vi.fn(async () => reports[Math.min(reportIndex++, reports.length - 1)]),
+                        getSourceTrackSettings: () => ({
+                            sampleRate: 48_000,
+                            channelCount: 1,
+                            autoGainControl: false,
+                            echoCancellation: false,
+                            noiseSuppression: false,
+                        }),
+                    },
+                }),
+                publishData,
+                setMicrophoneEnabled,
+                unpublishTrack,
+            },
+            remoteParticipants: new Map([['staff', {
+                identity: 'opaque-staff',
+                metadata: JSON.stringify({ role: 'ADMIN', isAssignedFacilitator: false }),
+            }]]),
+            on: vi.fn((event: string, listener: (...args: unknown[]) => void) => listeners.set(event, listener)),
+            off: vi.fn((event: string) => listeners.delete(event)),
+            disconnect,
+        };
+
+        render(
+            <LocaleProvider initialLocale="en">
+                <FacilitatorAudioQuality
+                    room={room as never}
+                    isStaff
+                    isAssignedFacilitator
+                />
+            </LocaleProvider>,
+        );
+        await act(async () => Promise.resolve());
+        await act(async () => {
+            vi.advanceTimersByTime(2_000);
+            await Promise.resolve();
+        });
+
+        expect(screen.getByTestId('facilitator-audio-quality')).toHaveAttribute('data-severity', 'critical');
+        expect(screen.getByText(/Packet loss is above/)).toBeInTheDocument();
+        expect(publishData).toHaveBeenCalled();
+        expect(setMicrophoneEnabled).not.toHaveBeenCalled();
+        expect(unpublishTrack).not.toHaveBeenCalled();
+        expect(disconnect).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/session/__tests__/FacilitatorAudioQuality.test.tsx
+++ b/src/components/session/__tests__/FacilitatorAudioQuality.test.tsx
@@ -76,7 +76,11 @@ describe('FacilitatorAudioQuality', () => {
                 />
             </LocaleProvider>,
         );
-        await act(async () => Promise.resolve());
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+        expect(screen.getByTestId('facilitator-audio-quality')).toHaveAttribute('data-severity', 'healthy');
         await act(async () => {
             vi.advanceTimersByTime(2_000);
             await Promise.resolve();

--- a/src/lib/__tests__/facilitator-audio-quality.test.ts
+++ b/src/lib/__tests__/facilitator-audio-quality.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    assessAudioQuality,
+    encodeFacilitatorTelemetry,
+    measureAudioQuality,
+    parseFacilitatorTelemetry,
+} from '@/lib/facilitator-audio-quality';
+
+function report(...stats: Array<Record<string, unknown>>): RTCStatsReport {
+    const values = new Map(stats.map((stat, index) => [String(stat.id ?? index), stat]));
+    return values as unknown as RTCStatsReport;
+}
+
+describe('facilitator audio quality measurements', () => {
+    it('derives uplink bitrate, loss, jitter and RTT from counter deltas', () => {
+        const first = measureAudioQuality(report(
+            { id: 'out', type: 'outbound-rtp', kind: 'audio', timestamp: 1_000, bytesSent: 10_000, packetsSent: 100, codecId: 'opus' },
+            { id: 'remote', type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 98, packetsLost: 2, jitter: 0.012, roundTripTime: 0.08 },
+            { id: 'opus', type: 'codec', mimeType: 'audio/opus', clockRate: 48_000 },
+        ), 'uplink', undefined, { sampledAt: 1_000 });
+        expect(first).not.toBeNull();
+
+        const second = measureAudioQuality(report(
+            { id: 'out', type: 'outbound-rtp', kind: 'audio', timestamp: 3_000, bytesSent: 34_000, packetsSent: 300, codecId: 'opus' },
+            { id: 'remote', type: 'remote-inbound-rtp', kind: 'audio', packetsReceived: 294, packetsLost: 6, jitter: 0.012, roundTripTime: 0.08 },
+            { id: 'opus', type: 'codec', mimeType: 'audio/opus', clockRate: 48_000 },
+        ), 'uplink', first!.baseline, { sampledAt: 3_000 });
+
+        expect(second?.measurement).toMatchObject({
+            bitrateKbps: 96,
+            packetLossPct: 2,
+            jitterMs: 12,
+            roundTripTimeMs: 80,
+            codec: 'audio/opus',
+        });
+    });
+
+    it('derives receiver concealment without treating cumulative counters as a percentage', () => {
+        const first = measureAudioQuality(report({
+            type: 'inbound-rtp', kind: 'audio', timestamp: 1_000, bytesReceived: 10_000,
+            packetsReceived: 100, packetsLost: 0, concealedSamples: 0, totalSamplesReceived: 48_000,
+        }), 'downlink', undefined, { sampledAt: 1_000 });
+        const second = measureAudioQuality(report({
+            type: 'inbound-rtp', kind: 'audio', timestamp: 3_000, bytesReceived: 34_000,
+            packetsReceived: 200, packetsLost: 0, concealedSamples: 960, totalSamplesReceived: 144_000,
+        }), 'downlink', first!.baseline, { sampledAt: 3_000 });
+
+        expect(second?.measurement.bitrateKbps).toBe(96);
+        expect(second?.measurement.concealmentPct).toBe(1);
+    });
+
+    it('reports browser processing and degraded transport but never owns a media action', () => {
+        const measurement = {
+            sampledAt: 10_000,
+            plane: 'uplink' as const,
+            bitrateKbps: 28,
+            packetLossPct: 7,
+            audioLevel: 0.12,
+            capture: { echoCancellation: true, noiseSuppression: true },
+        };
+
+        expect(assessAudioQuality(measurement, 10_100)).toEqual({
+            severity: 'critical',
+            reasons: ['packet_loss', 'bitrate'],
+        });
+        // The observer contract is structural: measurements and assessments
+        // contain data only, with no callback capable of muting/unpublishing.
+        expect(Object.values(measurement).every((value) => typeof value !== 'function')).toBe(true);
+    });
+
+    it('round-trips bounded identity-free facilitator telemetry', () => {
+        const measurement = {
+            sampledAt: Date.now(),
+            plane: 'uplink' as const,
+            bitrateKbps: 92,
+            capture: { sampleRateHz: 48_000, echoCancellation: false },
+        };
+        const decoded = parseFacilitatorTelemetry(encodeFacilitatorTelemetry(measurement));
+        expect(decoded?.measurement).toEqual(measurement);
+        expect(new TextDecoder().decode(encodeFacilitatorTelemetry(measurement))).not.toMatch(/identity|email|token|deviceId/i);
+    });
+});

--- a/src/lib/__tests__/livekit-server.test.ts
+++ b/src/lib/__tests__/livekit-server.test.ts
@@ -77,6 +77,18 @@ describe('livekit-server', () => {
         });
     });
 
+    it('allows only the assigned facilitator to send Staff audio telemetry', async () => {
+        const { createSessionToken } = await import('../livekit-server');
+        await createSessionToken('stage', 'identity', 'Julián', true, {
+            role: 'FACILITATOR_OP',
+            isAssignedFacilitator: true,
+        });
+
+        expect(addGrant).toHaveBeenCalledWith(expect.objectContaining({
+            canPublishData: true,
+        }));
+    });
+
     it('makes the bed strictly subscribe-only', async () => {
         const { createBedToken } = await import('../livekit-server');
         await createBedToken('beacon', 'bed-identity');

--- a/src/lib/facilitator-audio-quality.ts
+++ b/src/lib/facilitator-audio-quality.ts
@@ -1,0 +1,300 @@
+export const FACILITATOR_AUDIO_PROFILE = {
+    version: 1,
+    codec: 'audio/opus',
+    maxBitrateKbps: 96,
+    sampleRateHz: 48_000,
+    channelCount: 1,
+    dtx: false,
+    red: true,
+    autoGainControl: false,
+    echoCancellation: false,
+    noiseSuppression: false,
+    voiceIsolation: false,
+} as const;
+
+export const FACILITATOR_AUDIO_TELEMETRY_TOPIC = 'hb.facilitator-audio.v1';
+export const FACILITATOR_AUDIO_SAMPLE_MS = 2_000;
+export const FACILITATOR_AUDIO_STALE_MS = 7_000;
+
+export type AudioQualityPlane = 'uplink' | 'downlink';
+export type AudioQualitySeverity = 'healthy' | 'warning' | 'critical' | 'waiting';
+
+export type SafeCaptureSettings = {
+    sampleRateHz?: number;
+    channelCount?: number;
+    autoGainControl?: boolean;
+    echoCancellation?: boolean;
+    noiseSuppression?: boolean;
+    voiceIsolation?: boolean;
+};
+
+export type AudioQualityMeasurement = {
+    sampledAt: number;
+    plane: AudioQualityPlane;
+    bitrateKbps?: number;
+    packetLossPct?: number;
+    jitterMs?: number;
+    roundTripTimeMs?: number;
+    concealmentPct?: number;
+    availableBitrateKbps?: number;
+    audioLevel?: number;
+    codec?: string;
+    connectionQuality?: string;
+    capture?: SafeCaptureSettings;
+};
+
+export type FacilitatorAudioTelemetry = {
+    version: 1;
+    profileVersion: 1;
+    measurement: AudioQualityMeasurement;
+};
+
+export type AudioStatsBaseline = {
+    timestampMs: number;
+    bytes: number;
+    packets: number;
+    packetsLost: number;
+    concealedSamples: number;
+    totalSamples: number;
+};
+
+export type AudioQualityAssessment = {
+    severity: AudioQualitySeverity;
+    reasons: string[];
+};
+
+type Stat = Record<string, unknown> & { id?: string; type?: string };
+
+function finite(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function boolean(value: unknown): boolean | undefined {
+    return typeof value === 'boolean' ? value : undefined;
+}
+
+function nonNegativeDelta(current: number, previous: number): number | undefined {
+    const delta = current - previous;
+    return delta >= 0 ? delta : undefined;
+}
+
+function rounded(value: number | undefined, digits = 1): number | undefined {
+    if (value === undefined) return undefined;
+    const factor = 10 ** digits;
+    return Math.round(value * factor) / factor;
+}
+
+function statsArray(report: RTCStatsReport | Iterable<unknown>): Stat[] {
+    const values: Stat[] = [];
+    if ('forEach' in report && typeof report.forEach === 'function') {
+        report.forEach((value: unknown) => {
+            if (value && typeof value === 'object') values.push(value as Stat);
+        });
+        return values;
+    }
+    for (const entry of report) {
+        const value = Array.isArray(entry) && entry.length === 2 ? entry[1] : entry;
+        if (value && typeof value === 'object') values.push(value as Stat);
+    }
+    return values;
+}
+
+function isAudioStat(stat: Stat): boolean {
+    return stat.kind === 'audio' || stat.mediaType === 'audio';
+}
+
+function selectedCandidatePair(stats: Stat[]): Stat | undefined {
+    const transport = stats.find((stat) => stat.type === 'transport');
+    const selectedId = typeof transport?.selectedCandidatePairId === 'string'
+        ? transport.selectedCandidatePairId
+        : undefined;
+    return stats.find((stat) => stat.type === 'candidate-pair' && (
+        stat.id === selectedId || (stat.nominated === true && stat.state === 'succeeded')
+    ));
+}
+
+function codecFor(stats: Stat[], rtp: Stat | undefined): string | undefined {
+    const codecId = typeof rtp?.codecId === 'string' ? rtp.codecId : undefined;
+    const codec = stats.find((stat) => stat.type === 'codec' && stat.id === codecId);
+    return typeof codec?.mimeType === 'string' ? codec.mimeType.toLowerCase() : undefined;
+}
+
+function safeCaptureSettings(settings: MediaTrackSettings | undefined): SafeCaptureSettings | undefined {
+    if (!settings) return undefined;
+    const capture: SafeCaptureSettings = {
+        sampleRateHz: finite(settings.sampleRate),
+        channelCount: finite(settings.channelCount),
+        autoGainControl: boolean(settings.autoGainControl),
+        echoCancellation: boolean(settings.echoCancellation),
+        noiseSuppression: boolean(settings.noiseSuppression),
+        voiceIsolation: boolean((settings as MediaTrackSettings & { voiceIsolation?: boolean }).voiceIsolation),
+    };
+    return Object.values(capture).some((value) => value !== undefined) ? capture : undefined;
+}
+
+/**
+ * Converts browser WebRTC counters into a bounded, identity-free measurement.
+ * The function observes stats only; it has no reference to media controls.
+ */
+export function measureAudioQuality(
+    report: RTCStatsReport | Iterable<unknown>,
+    plane: AudioQualityPlane,
+    previous?: AudioStatsBaseline,
+    options: {
+        sampledAt?: number;
+        connectionQuality?: string;
+        captureSettings?: MediaTrackSettings;
+    } = {},
+): { measurement: AudioQualityMeasurement; baseline: AudioStatsBaseline } | null {
+    const stats = statsArray(report);
+    const rtp = stats.find((stat) => (
+        stat.type === (plane === 'uplink' ? 'outbound-rtp' : 'inbound-rtp') && isAudioStat(stat)
+    ));
+    if (!rtp) return null;
+
+    const remoteInbound = plane === 'uplink'
+        ? stats.find((stat) => stat.type === 'remote-inbound-rtp' && isAudioStat(stat))
+        : undefined;
+    const networkStat = remoteInbound ?? rtp;
+    const candidatePair = selectedCandidatePair(stats);
+    const timestampMs = finite(rtp.timestamp) ?? options.sampledAt ?? Date.now();
+    const bytes = finite(plane === 'uplink' ? rtp.bytesSent : rtp.bytesReceived) ?? 0;
+    const packets = finite(plane === 'uplink' ? networkStat?.packetsReceived : rtp.packetsReceived)
+        ?? finite(rtp.packetsSent)
+        ?? 0;
+    const packetsLost = finite(networkStat?.packetsLost) ?? 0;
+    const concealedSamples = finite(rtp.concealedSamples) ?? 0;
+    const totalSamplesReceived = finite(rtp.totalSamplesReceived);
+    const totalSamplesDuration = finite(rtp.totalSamplesDuration);
+    const codecClockRate = finite(stats.find((stat) => stat.id === rtp.codecId)?.clockRate) ?? 48_000;
+    const totalSamples = totalSamplesReceived ?? ((totalSamplesDuration ?? 0) * codecClockRate);
+    const baseline: AudioStatsBaseline = {
+        timestampMs,
+        bytes,
+        packets,
+        packetsLost,
+        concealedSamples,
+        totalSamples,
+    };
+
+    let bitrateKbps: number | undefined;
+    let packetLossPct: number | undefined;
+    let concealmentPct: number | undefined;
+    if (previous) {
+        const elapsedMs = nonNegativeDelta(timestampMs, previous.timestampMs);
+        const byteDelta = nonNegativeDelta(bytes, previous.bytes);
+        if (elapsedMs && byteDelta !== undefined) {
+            bitrateKbps = (byteDelta * 8) / elapsedMs;
+        }
+
+        const packetDelta = nonNegativeDelta(packets, previous.packets);
+        const lostDelta = nonNegativeDelta(packetsLost, previous.packetsLost);
+        if (packetDelta !== undefined && lostDelta !== undefined && packetDelta + lostDelta > 0) {
+            packetLossPct = (lostDelta / (packetDelta + lostDelta)) * 100;
+        } else {
+            const fractionLost = finite(networkStat?.fractionLost);
+            if (fractionLost !== undefined) packetLossPct = fractionLost * 100;
+        }
+
+        if (plane === 'downlink') {
+            const concealedDelta = nonNegativeDelta(concealedSamples, previous.concealedSamples);
+            const sampleDelta = nonNegativeDelta(totalSamples, previous.totalSamples);
+            if (concealedDelta !== undefined && sampleDelta && sampleDelta > 0) {
+                concealmentPct = (concealedDelta / sampleDelta) * 100;
+            }
+        }
+    }
+
+    const roundTripTimeSeconds = finite(remoteInbound?.roundTripTime)
+        ?? finite(candidatePair?.currentRoundTripTime);
+    const availableBitrate = finite(
+        plane === 'uplink'
+            ? candidatePair?.availableOutgoingBitrate
+            : candidatePair?.availableIncomingBitrate,
+    );
+
+    return {
+        baseline,
+        measurement: {
+            sampledAt: options.sampledAt ?? Date.now(),
+            plane,
+            bitrateKbps: rounded(bitrateKbps),
+            packetLossPct: rounded(packetLossPct, 2),
+            jitterMs: rounded(finite(networkStat?.jitter) === undefined
+                ? undefined
+                : finite(networkStat?.jitter)! * 1_000),
+            roundTripTimeMs: rounded(roundTripTimeSeconds === undefined ? undefined : roundTripTimeSeconds * 1_000),
+            concealmentPct: rounded(concealmentPct, 2),
+            availableBitrateKbps: rounded(availableBitrate === undefined ? undefined : availableBitrate / 1_000),
+            audioLevel: rounded(finite(rtp.audioLevel)
+                ?? finite(stats.find((stat) => stat.type === 'media-source' && isAudioStat(stat))?.audioLevel), 3),
+            codec: codecFor(stats, rtp),
+            connectionQuality: options.connectionQuality,
+            capture: plane === 'uplink' ? safeCaptureSettings(options.captureSettings) : undefined,
+        },
+    };
+}
+
+export function assessAudioQuality(
+    measurement: AudioQualityMeasurement | null,
+    now = Date.now(),
+): AudioQualityAssessment {
+    if (!measurement) return { severity: 'waiting', reasons: ['no_measurement'] };
+    if (now - measurement.sampledAt > FACILITATOR_AUDIO_STALE_MS) {
+        return { severity: 'critical', reasons: ['stale'] };
+    }
+
+    const critical: string[] = [];
+    const warning: string[] = [];
+    const quality = measurement.connectionQuality?.toLowerCase();
+    if (quality === 'lost') critical.push('connection_lost');
+    else if (quality === 'poor') warning.push('connection_poor');
+    if ((measurement.packetLossPct ?? 0) >= 5) critical.push('packet_loss');
+    else if ((measurement.packetLossPct ?? 0) >= 2) warning.push('packet_loss');
+    if ((measurement.jitterMs ?? 0) >= 50) critical.push('jitter');
+    else if ((measurement.jitterMs ?? 0) >= 25) warning.push('jitter');
+    if ((measurement.roundTripTimeMs ?? 0) >= 400) critical.push('rtt');
+    else if ((measurement.roundTripTimeMs ?? 0) >= 200) warning.push('rtt');
+    if ((measurement.concealmentPct ?? 0) >= 5) critical.push('concealment');
+    else if ((measurement.concealmentPct ?? 0) >= 1) warning.push('concealment');
+    // Opus legitimately spends fewer bits during silence even with DTX off.
+    // Only call bitrate degraded while the browser reports active speech.
+    const hasActiveAudio = (measurement.audioLevel ?? 0) >= 0.01;
+    if (hasActiveAudio && measurement.bitrateKbps !== undefined && measurement.bitrateKbps < 32) critical.push('bitrate');
+    else if (hasActiveAudio && measurement.bitrateKbps !== undefined && measurement.bitrateKbps < 48) warning.push('bitrate');
+
+    if (measurement.plane === 'uplink' && measurement.capture) {
+        const capture = measurement.capture;
+        if ((capture.sampleRateHz ?? FACILITATOR_AUDIO_PROFILE.sampleRateHz) < 44_100) warning.push('sample_rate');
+        if (capture.autoGainControl === true) warning.push('auto_gain_control');
+        if (capture.echoCancellation === true) warning.push('echo_cancellation');
+        if (capture.noiseSuppression === true) warning.push('noise_suppression');
+        if (capture.voiceIsolation === true) warning.push('voice_isolation');
+    }
+
+    if (critical.length) return { severity: 'critical', reasons: [...new Set(critical)] };
+    if (warning.length) return { severity: 'warning', reasons: [...new Set(warning)] };
+    return { severity: 'healthy', reasons: [] };
+}
+
+export function encodeFacilitatorTelemetry(measurement: AudioQualityMeasurement): Uint8Array {
+    const telemetry: FacilitatorAudioTelemetry = {
+        version: 1,
+        profileVersion: FACILITATOR_AUDIO_PROFILE.version,
+        measurement,
+    };
+    return new TextEncoder().encode(JSON.stringify(telemetry));
+}
+
+export function parseFacilitatorTelemetry(payload: Uint8Array): FacilitatorAudioTelemetry | null {
+    if (payload.byteLength > 4_096) return null;
+    try {
+        const parsed = JSON.parse(new TextDecoder().decode(payload)) as Partial<FacilitatorAudioTelemetry>;
+        if (parsed.version !== 1 || parsed.profileVersion !== 1 || !parsed.measurement) return null;
+        const measurement = parsed.measurement;
+        if (measurement.plane !== 'uplink' || !Number.isFinite(measurement.sampledAt)) return null;
+        return parsed as FacilitatorAudioTelemetry;
+    } catch {
+        return null;
+    }
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -117,6 +117,28 @@ export type Messages = {
         assignedFacilitatorCapability: string;
         operationalStaffCapability: string;
         staffConsole: string;
+        audioQuality: {
+            heading: string;
+            healthy: string;
+            warning: string;
+            critical: string;
+            waiting: string;
+            facilitatorUplink: string;
+            thisDeviceDownlink: string;
+            measuredAgo: string;
+            noAutomaticAction: string;
+            profile: string;
+            bitrate: string;
+            packetLoss: string;
+            jitter: string;
+            roundTripTime: string;
+            concealment: string;
+            availableBitrate: string;
+            codec: string;
+            capture: string;
+            unavailable: string;
+            reasons: Record<string, string>;
+        };
         audioActivationLabel: string;
         audioPrompt: string;
         startAudio: string;
@@ -617,6 +639,43 @@ export const messages: Record<UiLocale, Messages> = {
             assignedFacilitatorCapability: 'Facilitación asignada · podés conducir y publicar en este evento; tu cámara y micrófono siguen bajo tu control.',
             operationalStaffCapability: 'Acceso operativo · podés acompañar este evento, pero no publicar como facilitación asignada.',
             staffConsole: 'Escena y manos',
+            audioQuality: {
+                heading: 'Calidad de voz de facilitación',
+                healthy: 'Dentro de parámetros',
+                warning: 'Revisar calidad',
+                critical: 'Calidad degradada',
+                waiting: 'Esperando mediciones',
+                facilitatorUplink: 'Salida del facilitador',
+                thisDeviceDownlink: 'Recepción en este dispositivo',
+                measuredAgo: 'medido hace {seconds} s',
+                noAutomaticAction: 'Este monitor sólo advierte: nunca silencia, corta ni modifica la transmisión.',
+                profile: 'Perfil objetivo: Opus mono · 96 kbps máx. · 48 kHz · RED activo · DTX y filtros del navegador apagados.',
+                bitrate: 'Bitrate',
+                packetLoss: 'Pérdida',
+                jitter: 'Jitter',
+                roundTripTime: 'RTT',
+                concealment: 'Audio reconstruido',
+                availableBitrate: 'Ancho de banda disponible',
+                codec: 'Codec',
+                capture: 'Captura real',
+                unavailable: 'sin dato',
+                reasons: {
+                    no_measurement: 'Todavía no hay una medición utilizable.',
+                    stale: 'La telemetría dejó de actualizarse.',
+                    connection_lost: 'LiveKit informa que se perdió la conexión.',
+                    connection_poor: 'LiveKit informa una conexión débil.',
+                    packet_loss: 'La pérdida de paquetes supera el rango razonable.',
+                    jitter: 'La variación de llegada del audio es alta.',
+                    rtt: 'La latencia de ida y vuelta es alta.',
+                    concealment: 'El navegador está reconstruyendo demasiado audio perdido.',
+                    bitrate: 'El bitrate efectivo está por debajo del rango de alta fidelidad.',
+                    sample_rate: 'La captura real está por debajo de 44,1 kHz.',
+                    auto_gain_control: 'El navegador mantuvo activo el control automático de ganancia.',
+                    echo_cancellation: 'El navegador mantuvo activa la cancelación de eco.',
+                    noise_suppression: 'El navegador mantuvo activa la supresión de ruido.',
+                    voice_isolation: 'El navegador mantuvo activo el aislamiento de voz.',
+                },
+            },
             audioActivationLabel: 'Activación de audio',
             audioPrompt: 'Presioná una vez para escuchar la sesión y el Beacon.',
             startAudio: 'Iniciar audio',
@@ -1172,6 +1231,43 @@ export const messages: Record<UiLocale, Messages> = {
             assignedFacilitatorCapability: 'Assigned facilitator · you can conduct and publish in this event; your camera and microphone remain under your control.',
             operationalStaffCapability: 'Operational access · you can support this event, but you do not publish as its assigned facilitator.',
             staffConsole: 'Stage and hands',
+            audioQuality: {
+                heading: 'Facilitator voice quality',
+                healthy: 'Within parameters',
+                warning: 'Check quality',
+                critical: 'Quality degraded',
+                waiting: 'Waiting for measurements',
+                facilitatorUplink: 'Facilitator uplink',
+                thisDeviceDownlink: 'Reception on this device',
+                measuredAgo: 'measured {seconds} s ago',
+                noAutomaticAction: 'This monitor only warns: it never mutes, stops, or changes the transmission.',
+                profile: 'Target profile: mono Opus · 96 kbps max · 48 kHz · RED on · DTX and browser processing off.',
+                bitrate: 'Bitrate',
+                packetLoss: 'Loss',
+                jitter: 'Jitter',
+                roundTripTime: 'RTT',
+                concealment: 'Concealed audio',
+                availableBitrate: 'Available bandwidth',
+                codec: 'Codec',
+                capture: 'Actual capture',
+                unavailable: 'unavailable',
+                reasons: {
+                    no_measurement: 'No usable measurement is available yet.',
+                    stale: 'Telemetry has stopped updating.',
+                    connection_lost: 'LiveKit reports a lost connection.',
+                    connection_poor: 'LiveKit reports a weak connection.',
+                    packet_loss: 'Packet loss is above the reasonable range.',
+                    jitter: 'Audio arrival variation is high.',
+                    rtt: 'Round-trip latency is high.',
+                    concealment: 'The browser is reconstructing too much lost audio.',
+                    bitrate: 'Effective bitrate is below the high-fidelity range.',
+                    sample_rate: 'Actual capture is below 44.1 kHz.',
+                    auto_gain_control: 'The browser kept automatic gain control enabled.',
+                    echo_cancellation: 'The browser kept echo cancellation enabled.',
+                    noise_suppression: 'The browser kept noise suppression enabled.',
+                    voice_isolation: 'The browser kept voice isolation enabled.',
+                },
+            },
             audioActivationLabel: 'Audio activation',
             audioPrompt: 'Press once to hear the session and Beacon.',
             startAudio: 'Start audio',

--- a/src/lib/livekit-server.ts
+++ b/src/lib/livekit-server.ts
@@ -100,7 +100,10 @@ export async function createSessionToken(
         canPublishSources: canPublish
             ? [TrackSource.MICROPHONE, TrackSource.CAMERA]
             : [],
-        canPublishData: false,
+        // Only the assigned facilitator may emit the small, bounded and
+        // identity-free audio-quality snapshot consumed by Staff monitors.
+        // Attendees and operational Staff remain unable to publish data.
+        canPublishData: metadata?.isAssignedFacilitator === true,
         canSubscribe: true,
     });
 


### PR DESCRIPTION
Implements #459; physical microphone acceptance remains open on the issue.

## Contract
- scopes the high-fidelity profile to the assigned facilitator: Opus mono, 96 kbps max, high priority, 48 kHz preferred, RED on, DTX and browser voice processing off
- shows all Staff roles separate facilitator-uplink and local-downlink measurements with real bitrate, packet loss, jitter, RTT, concealment, codec and sanitized capture settings
- emits bounded, lossy, identity-free facilitator telemetry only to connected Staff
- never mutes, unpublishes, disconnects, reloads or changes media in response to quality
- documents primary-source research, limitations and initial warning ranges

## Evidence
- 1,079 unit/component/API tests passed; 23 environment-gated integration tests skipped as designed
- production build passed, including TypeScript and page generation
- focused degraded-quality test proves warnings do not call mic, unpublish or disconnect controls
- real-LiveKit browser continuity gate now requires facilitator measurements while preserving existing continuity invariants

## Deployment
No migration and no Docker image build were needed locally. This changes the app image only; LiveKit and the playlist bot remain untouched.