### PR TITLE
Fix attendee room deep-link Account handoff

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { SESSION_COOKIE_NAME } from './src/lib/session-auth';
@@ -31,6 +31,10 @@ function location(response: NextResponse): URL {
 }
 
 describe('middleware', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
     it('recognizes exactly the cookie the session contract issues', () => {
         // Drift guard for the literal in `middleware.ts`, which cannot import
         // `@/lib/session-auth` because the edge runtime has no `node:crypto`.
@@ -40,6 +44,18 @@ describe('middleware', () => {
     });
 
     describe('without a session cookie', () => {
+        it('starts the attendee Account handoff directly when Account is enabled', () => {
+            vi.stubEnv('BEACON_ACCOUNT_ENABLED', 'true');
+
+            const response = middleware(request('/session/session-saturday'));
+
+            expect(response.status).toBe(307);
+            const target = location(response);
+            expect(target.pathname).toBe('/api/account/login');
+            expect(target.searchParams.get('flow')).toBe('attendee');
+            expect(target.searchParams.get('next')).toBe('/session/session-saturday');
+        });
+
         it('sends a room visitor to the landing page with the room remembered', () => {
             const response = middleware(request('/session/session-saturday'));
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,7 +24,7 @@ import type { NextRequest } from 'next/server';
  */
 const SESSION_COOKIE = 'hb_session';
 
-/** Attendee surfaces: the paid room. Login is the code + email form on `/`. */
+/** Attendee surfaces: the protected room. */
 const ATTENDEE_PREFIXES = ['/session'];
 
 /** Staff surfaces: the operator console. */
@@ -46,9 +46,17 @@ export default function middleware(request: NextRequest): NextResponse {
     }
 
     if (matches(pathname, ATTENDEE_PREFIXES)) {
-        // Carry the destination so a reconnecting attendee lands back in their
-        // room after re-entering the code. `next` is re-validated where it is
-        // consumed; nothing trusts it as given.
+        // A room deep link must not strand an Account user on the public event
+        // list. When central Account is enabled, begin the bounded OIDC handoff
+        // immediately and carry the local room path through its validated
+        // `next` contract. Deployments without Account keep the legacy ticket
+        // login surface.
+        if (process.env.BEACON_ACCOUNT_ENABLED === 'true') {
+            const target = new URL('/api/account/login', request.url);
+            target.searchParams.set('flow', 'attendee');
+            target.searchParams.set('next', pathname);
+            return NextResponse.redirect(target);
+        }
         const target = new URL('/', request.url);
         target.searchParams.set('next', pathname);
         return NextResponse.redirect(target);


### PR DESCRIPTION
## What\n- send unauthenticated room deep links straight through the bounded Beacon Account attendee handoff when Account is enabled\n- preserve the validated local room destination\n- retain the legacy landing fallback for deployments without Account\n\n## Why\nA hidden TEST room redirected a signed-in Account user to the public event list, where no attendee CTA was rendered. This made the room appear inaccessible even though it was LIVE and eligible for code-free Account access.\n\n## Verification\n- middleware contract: 12/12\n- ESLint (changed files)\n- TypeScript after Prisma generation\n- diff check