### PR TITLE
HOTFIX: preserve crossfader after audio unlock

### DIFF
--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -1027,6 +1027,41 @@ describe('SessionRoomPage - two-room crossfader', () => {
 });
 
 describe('SessionRoomPage - audio activation', () => {
+    it('reapplies an exclusive Beacon mix after LiveKit unmutes remote audio', async () => {
+        await renderConnected();
+        const stageAudio = document.createElement('audio');
+        const stageTrack = {
+            kind: 'audio',
+            attach: () => stageAudio,
+            detach: () => [stageAudio],
+        };
+        act(() => {
+            currentRoom().emit(
+                'trackSubscribed',
+                stageTrack,
+                {},
+                { identity: 'facilitator' },
+            );
+        });
+
+        const balance = screen.getAllByRole('slider')[1];
+        fireEvent.change(balance, { target: { value: '0' } });
+        await waitFor(() => {
+            expect(stageAudio.volume).toBe(0);
+            expect(stageAudio.muted).toBe(true);
+        });
+
+        currentRoom().startAudio.mockImplementationOnce(async () => {
+            // Mirrors LiveKit Room.startAudio(): unlock every remote element.
+            stageAudio.muted = false;
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Start audio' }));
+
+        await waitFor(() => expect(currentRoom().startAudio).toHaveBeenCalledOnce());
+        expect(stageAudio.volume).toBe(0);
+        expect(stageAudio.muted).toBe(true);
+    });
+
     it('starts both LiveKit rooms before awaiting either one', async () => {
         await renderConnected();
         const stageAudio = document.createElement('audio');

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -256,6 +256,16 @@ function SessionRoom() {
     participantFallbackRef.current = copy.session.participantFallback;
     stageInvitationAcceptedRef.current = stageInvitationAccepted;
 
+    const applyStageGain = useCallback((gain: number) => {
+        stageVolumeRef.current = gain;
+        audioElementsRef.current.forEach((element) => {
+            element.volume = gain;
+            // LiveKit's audio unlock may unmute every attached remote element.
+            // Keep the Beacon endpoint exclusive even after that SDK side effect.
+            element.muted = gain === 0;
+        });
+    }, []);
+
     const slotFor = useCallback((identity: string): number => {
         const existing = slotOrderRef.current.get(identity);
         if (existing !== undefined) return existing;
@@ -419,6 +429,10 @@ function SessionRoom() {
                 beaconStart,
                 stageStart,
             ]);
+            // room.startAudio() deliberately unlocks/unmutes remote elements.
+            // Reapply the current personal mix after the unlock so Session does
+            // not leak when the crossfader is fully at Beacon.
+            applyStageGain(stageVolumeRef.current);
             if (!beaconStarted) {
                 setAudioActivationError(
                     copy.session.beaconAudioError,
@@ -430,7 +444,7 @@ function SessionRoom() {
                 copy.session.audioError,
             );
         }
-    }, [startBeaconAudio, copy.session.beaconAudioError, copy.session.audioError]);
+    }, [applyStageGain, startBeaconAudio, copy.session.beaconAudioError, copy.session.audioError]);
 
     const acceptStageInvitation = useCallback(async () => {
         const room = roomRef.current;
@@ -742,15 +756,9 @@ function SessionRoom() {
 
     useEffect(() => {
         const gains = roomMixGains(volume, mix);
-        stageVolumeRef.current = gains.session;
-        audioElementsRef.current.forEach((el) => {
-            el.volume = gains.session;
-            // Volume zero should be enough, but an explicit mute guarantees
-            // the Beacon endpoint never leaks stage voice across engines.
-            el.muted = gains.session === 0;
-        });
+        applyStageGain(gains.session);
         setBeaconVolume(gains.beacon);
-    }, [volume, mix, setBeaconVolume]);
+    }, [volume, mix, applyStageGain, setBeaconVolume]);
 
     const toggleMic = useCallback(async () => {
         const room = roomRef.current;

--- a/src/components/session/FacilitatorAudioQuality.tsx
+++ b/src/components/session/FacilitatorAudioQuality.tsx
@@ -268,7 +268,6 @@ export default function FacilitatorAudioQuality({ room, isStaff, isAssignedFacil
                         />
                     ) : null}
                 </div>
-                <p className="mt-3 text-xs text-[var(--text-muted)]">{labels.noAutomaticAction}</p>
             </details>
         </aside>
     );

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -126,7 +126,6 @@ export type Messages = {
             facilitatorUplink: string;
             thisDeviceDownlink: string;
             measuredAgo: string;
-            noAutomaticAction: string;
             profile: string;
             bitrate: string;
             packetLoss: string;
@@ -648,7 +647,6 @@ export const messages: Record<UiLocale, Messages> = {
                 facilitatorUplink: 'Salida del facilitador',
                 thisDeviceDownlink: 'Recepción en este dispositivo',
                 measuredAgo: 'medido hace {seconds} s',
-                noAutomaticAction: 'Este monitor sólo advierte: nunca silencia, corta ni modifica la transmisión.',
                 profile: 'Perfil objetivo: Opus mono · 96 kbps máx. · 48 kHz · RED activo · DTX y filtros del navegador apagados.',
                 bitrate: 'Bitrate',
                 packetLoss: 'Pérdida',
@@ -1240,7 +1238,6 @@ export const messages: Record<UiLocale, Messages> = {
                 facilitatorUplink: 'Facilitator uplink',
                 thisDeviceDownlink: 'Reception on this device',
                 measuredAgo: 'measured {seconds} s ago',
-                noAutomaticAction: 'This monitor only warns: it never mutes, stops, or changes the transmission.',
                 profile: 'Target profile: mono Opus · 96 kbps max · 48 kHz · RED on · DTX and browser processing off.',
                 bitrate: 'Bitrate',
                 packetLoss: 'Loss',


### PR DESCRIPTION
## Root cause

`Room.startAudio()` unlocks and unmutes attached remote audio elements. The Beacon room restored its post-unlock policy, but the event-room path did not reapply the current Session gain. A crossfader already at the Beacon endpoint could therefore leak facilitator audio after Start audio.

## Fix

- centralize application of the stage gain/mute
- reapply the current Session gain immediately after both LiveKit rooms finish audio unlock
- preserve the existing contract: full Beacon means Session 0; full Session retains the 5% Beacon floor

## Verification

- regression test explicitly simulates LiveKit unmuting the stage element during `startAudio()`
- pre-commit suite: 1100 passed, 25 skipped integration tests
- directed session room + mix contract: 38/38
- changed-file ESLint and diff check

User approval: Nico reported the production behavior during the TEST rehearsal and explicitly requested the critical mix contract be restored. No source, codec, payments, role, event lifecycle or DNS change.
