### PR TITLE
fix(ui): remove internal audio-monitor disclaimer

### DIFF
--- a/src/components/session/FacilitatorAudioQuality.tsx
+++ b/src/components/session/FacilitatorAudioQuality.tsx
@@ -268,7 +268,6 @@ export default function FacilitatorAudioQuality({ room, isStaff, isAssignedFacil
                         />
                     ) : null}
                 </div>
-                <p className="mt-3 text-xs text-[var(--text-muted)]">{labels.noAutomaticAction}</p>
             </details>
         </aside>
     );

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -126,7 +126,6 @@ export type Messages = {
             facilitatorUplink: string;
             thisDeviceDownlink: string;
             measuredAgo: string;
-            noAutomaticAction: string;
             profile: string;
             bitrate: string;
             packetLoss: string;
@@ -648,7 +647,6 @@ export const messages: Record<UiLocale, Messages> = {
                 facilitatorUplink: 'Salida del facilitador',
                 thisDeviceDownlink: 'Recepción en este dispositivo',
                 measuredAgo: 'medido hace {seconds} s',
-                noAutomaticAction: 'Este monitor sólo advierte: nunca silencia, corta ni modifica la transmisión.',
                 profile: 'Perfil objetivo: Opus mono · 96 kbps máx. · 48 kHz · RED activo · DTX y filtros del navegador apagados.',
                 bitrate: 'Bitrate',
                 packetLoss: 'Pérdida',
@@ -1240,7 +1238,6 @@ export const messages: Record<UiLocale, Messages> = {
                 facilitatorUplink: 'Facilitator uplink',
                 thisDeviceDownlink: 'Reception on this device',
                 measuredAgo: 'measured {seconds} s ago',
-                noAutomaticAction: 'This monitor only warns: it never mutes, stops, or changes the transmission.',
                 profile: 'Target profile: mono Opus · 96 kbps max · 48 kHz · RED on · DTX and browser processing off.',
                 bitrate: 'Bitrate',
                 packetLoss: 'Loss',


### PR DESCRIPTION
Backport of #471 to the canonical development branch so the removed implementation disclaimer cannot return in the next release.

No audio behavior, thresholds, monitoring, or transmission settings change.

Verification on the release-equivalent patch:
- 1100 unit/component/API tests passed
- Chromium/Android, Firefox/accessibility, and WebKit gates passed
- audio-boundary and build checks passed

UX rule recorded in #469.