### PR TITLE
fix(analytics): validate backups with pinned PostgreSQL tools

### DIFF
--- a/ops/analytics/backup-analytics.sh
+++ b/ops/analytics/backup-analytics.sh
@@ -9,6 +9,7 @@ mount_root="${ANALYTICS_BACKUP_REQUIRED_MOUNT:-/mnt/beacon-data}"
 output_root="${ANALYTICS_BACKUP_OUTPUT:-/mnt/beacon-data/backups/analytics/postgres}"
 recipients_file="${ANALYTICS_BACKUP_RECIPIENTS_FILE:-/etc/harmonic-beacon/analytics-backup-recipients.txt}"
 retention_days="${ANALYTICS_BACKUP_RETENTION_DAYS:-14}"
+postgres_image="postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777"
 
 mountpoint -q -- "$mount_root" || { echo "Analytics backup mount is absent: $mount_root" >&2; exit 72; }
 [[ "$(stat -c %d -- "$mount_root")" != "$(stat -c %d -- /)" ]] || {
@@ -29,7 +30,7 @@ trap '[[ -n "${stage:-}" && "$stage" == /mnt/beacon-data/backups/analytics/.stag
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 plain="${stage}/hb-analytics-${stamp}.dump"
 docker exec hb-analytics-postgres pg_dump -U analytics_owner -d analytics --format=custom --no-owner --no-privileges > "$plain"
-pg_restore --list "$plain" >/dev/null
+docker run --rm -i "$postgres_image" pg_restore --list < "$plain" >/dev/null
 output="${output_root}/hb-analytics-${stamp}.dump.age"
 age -r "${recipients[0]}" -r "${recipients[1]}" -o "$output" "$plain"
 chmod 600 "$output"

--- a/ops/analytics/restore-verify-analytics.sh
+++ b/ops/analytics/restore-verify-analytics.sh
@@ -4,6 +4,7 @@ umask 077
 
 backup="${1:-}"
 identity="${ANALYTICS_BACKUP_IDENTITY_FILE:-/etc/harmonic-beacon/analytics-backup-identity.txt}"
+postgres_image="postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777"
 [[ -s "$backup" && -s "${backup}.sha256" && -s "$identity" ]] || {
     echo "Usage: $0 /mnt/beacon-data/backups/analytics/postgres/hb-analytics-*.dump.age" >&2
     exit 64
@@ -19,7 +20,7 @@ cleanup() {
 }
 trap cleanup EXIT
 age -d -i "$identity" -o "$stage/database.dump" "$backup"
-pg_restore --list "$stage/database.dump" >/dev/null
+docker run --rm -i "$postgres_image" pg_restore --list < "$stage/database.dump" >/dev/null
 docker exec hb-analytics-postgres createdb -U analytics_owner -O analytics_owner "$restore_db"
 docker cp "$stage/database.dump" "hb-analytics-postgres:/tmp/${restore_db}.dump"
 docker exec hb-analytics-postgres pg_restore -U analytics_owner -d "$restore_db" --no-owner --no-privileges "/tmp/${restore_db}.dump"

--- a/services/analytics/test/static-contract.test.mjs
+++ b/services/analytics/test/static-contract.test.mjs
@@ -49,3 +49,14 @@ test('browser retention preserves daily acquisition aggregates beyond raw-event 
     assert.match(worker, /insert into mart\.acquisition_daily/);
     assert.match(worker, /delete from ingest\.raw_events where received_at < now\(\)-interval '180 days'/);
 });
+
+test('backup verification uses the pinned PostgreSQL toolchain and mounted data disk', async () => {
+    const backup = await readFile(new URL('../../ops/analytics/backup-analytics.sh', root), 'utf8');
+    const restore = await readFile(new URL('../../ops/analytics/restore-verify-analytics.sh', root), 'utf8');
+    for (const script of [backup, restore]) {
+        assert.match(script, /mountpoint -q/);
+        assert.match(script, /postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777/);
+        assert.match(script, /docker run --rm -i "\$postgres_image" pg_restore --list/);
+        assert.doesNotMatch(script, /^pg_restore /m);
+    }
+});


### PR DESCRIPTION
Removes the undeclared host pg_restore dependency from analytics backup and restore verification. Both paths now use the same pinned PostgreSQL 16 image already used by Account backup verification, while preserving the real-mount checks.\n\nVerification: bash -n; analytics suite 31/31 (8 PostgreSQL cases skipped without a test URL); new static regression contract.