### PR TITLE
fix(analytics): start worker process from compose

### DIFF
--- a/ops/analytics/compose.yml
+++ b/ops/analytics/compose.yml
@@ -73,6 +73,7 @@ services:
     image: harmonic-beacon/analytics:${ANALYTICS_IMAGE_TAG:?required}
     container_name: hb-analytics-worker
     restart: unless-stopped
+    command: ["node", "src/worker.mjs"]
     env_file: ${ANALYTICS_ENV_FILE:-/etc/harmonic-beacon/analytics.env}
     environment:
       ANALYTICS_DATABASE_ADMIN_URL: postgresql://analytics_owner:${ANALYTICS_POSTGRES_PASSWORD:?required}@hb-analytics-postgres:5432/analytics

--- a/services/analytics/src/sources.mjs
+++ b/services/analytics/src/sources.mjs
@@ -96,7 +96,7 @@ export class SourceIngestor {
                 const subject = this.subject('account', row.id);
                 await db.query(`insert into mart.account_facts
                     (source_system,source_key_digest,account_subject,created_at,verified_at,auth_method,last_active_at,traffic_class,environment)
-                    values('listener',$1,$2,$3,case when $4 then $5::timestamptz else null::timestamptz end,$6,$5::timestamptz,$7,'production')
+                    values('listener',$1,$2,$3,case when $4::boolean then $5::timestamptz else null::timestamptz end,$6,$5::timestamptz,$7,'production')
                     on conflict(source_system,source_key_digest) do update set verified_at=excluded.verified_at,
                       auth_method=excluded.auth_method,last_active_at=greatest(mart.account_facts.last_active_at,excluded.last_active_at),
                       traffic_class=excluded.traffic_class,ingested_at=now()`, [

--- a/services/analytics/src/sources.mjs
+++ b/services/analytics/src/sources.mjs
@@ -96,7 +96,7 @@ export class SourceIngestor {
                 const subject = this.subject('account', row.id);
                 await db.query(`insert into mart.account_facts
                     (source_system,source_key_digest,account_subject,created_at,verified_at,auth_method,last_active_at,traffic_class,environment)
-                    values('listener',$1,$2,$3,case when $4 then $5 else null end,$6,$5,$7,'production')
+                    values('listener',$1,$2,$3,case when $4 then $5::timestamptz else null::timestamptz end,$6,$5::timestamptz,$7,'production')
                     on conflict(source_system,source_key_digest) do update set verified_at=excluded.verified_at,
                       auth_method=excluded.auth_method,last_active_at=greatest(mart.account_facts.last_active_at,excluded.last_active_at),
                       traffic_class=excluded.traffic_class,ingested_at=now()`, [
@@ -191,7 +191,8 @@ export class SourceIngestor {
         let written = 0;
         for (const row of result.rows) {
             const endedAt = row.left_at ?? row.event_ended_at ?? (['ENDED','CANCELLED'].includes(row.status) ? row.updated_at : null);
-            if (!endedAt || new Date(endedAt) < new Date(row.joined_at)) continue;
+            const durationMs = endedAt ? new Date(endedAt).getTime() - new Date(row.joined_at).getTime() : -1;
+            if (!endedAt || durationMs < 0 || durationMs > 12 * 60 * 60 * 1000) continue;
             const isStaff = Boolean(row.staff_user_id);
             // Legacy Live identities are event-scoped pseudonyms, not Account subjects.
             // Future presence leases carry an authenticated Account subject separately.
@@ -209,7 +210,8 @@ export class SourceIngestor {
             written += 1;
         }
         for (const row of durable.rows) {
-            if (!row.ended_at || new Date(row.ended_at) < new Date(row.started_at)) continue;
+            const durationMs = row.ended_at ? new Date(row.ended_at).getTime() - new Date(row.started_at).getTime() : -1;
+            if (!row.ended_at || durationMs < 0 || durationMs > 12 * 60 * 60 * 1000) continue;
             const isStaff = Boolean(row.staff_user_id);
             const person = this.subject(isStaff ? 'staff-person' : 'live-person', row.staff_user_id ?? row.participant_identity);
             let accountSubject = null;

--- a/services/analytics/src/sources.mjs
+++ b/services/analytics/src/sources.mjs
@@ -152,8 +152,8 @@ export class SourceIngestor {
                 const classification = row.synthetic ? 'synthetic' : this.traffic(subject);
                 await db.query(`insert into mart.membership_snapshots
                     (source_system,source_key,account_subject,revision,state,provider,offer_code,currency,amount_minor,effective_at,paid_through,terminal_at,traffic_class,environment)
-                    values('listener-projection',$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,
-                      case when $4 in ('EXPIRED','REFUNDED','CANCELLED') then $11 else null end,$12,'production')
+                    values('listener-projection',$1,$2,$3,$4::varchar,$5,$6,$7,$8,$9,$10,
+                      case when $4::varchar in ('EXPIRED','REFUNDED','CANCELLED') then $11 else null end,$12,'production')
                     on conflict(source_system,source_key,revision) do update set state=excluded.state,paid_through=excluded.paid_through,
                       terminal_at=excluded.terminal_at,traffic_class=excluded.traffic_class,ingested_at=now()`, [
                     row.id, subject, row.revision, row.state, row.provider ?? row.source, row.offer_code,

--- a/services/analytics/src/sources.mjs
+++ b/services/analytics/src/sources.mjs
@@ -153,7 +153,7 @@ export class SourceIngestor {
                 await db.query(`insert into mart.membership_snapshots
                     (source_system,source_key,account_subject,revision,state,provider,offer_code,currency,amount_minor,effective_at,paid_through,terminal_at,traffic_class,environment)
                     values('listener-projection',$1,$2,$3,$4::varchar,$5,$6,$7,$8,$9,$10,
-                      case when $4::varchar in ('EXPIRED','REFUNDED','CANCELLED') then $11 else null end,$12,'production')
+                      case when $4::varchar in ('EXPIRED','REFUNDED','CANCELLED') then $11::timestamptz else null::timestamptz end,$12,'production')
                     on conflict(source_system,source_key,revision) do update set state=excluded.state,paid_through=excluded.paid_through,
                       terminal_at=excluded.terminal_at,traffic_class=excluded.traffic_class,ingested_at=now()`, [
                     row.id, subject, row.revision, row.state, row.provider ?? row.source, row.offer_code,

--- a/services/analytics/test/static-contract.test.mjs
+++ b/services/analytics/test/static-contract.test.mjs
@@ -38,7 +38,7 @@ test('source backfills exclude unverifiable legacy lease time from real metrics'
     assert.match(source, /\.\.\.payments\.rows/);
     assert.match(source, /PAYMENT_REFUNDED','DISPUTED/);
     assert.match(source, /'confirmed'.*'refunded'.*'reversed'/s);
-    assert.match(source, /\$5::timestamptz/);
+    assert.match(source, /\$4::boolean.*\$5::timestamptz/);
     assert.match(source, /durationMs > 12 \* 60 \* 60 \* 1000/);
     assert.match(source, /recordFailure/);
     assert.match(source, /resolveFailures/);

--- a/services/analytics/test/static-contract.test.mjs
+++ b/services/analytics/test/static-contract.test.mjs
@@ -40,6 +40,7 @@ test('source backfills exclude unverifiable legacy lease time from real metrics'
     assert.match(source, /'confirmed'.*'refunded'.*'reversed'/s);
     assert.match(source, /\$4::boolean.*\$5::timestamptz/);
     assert.match(source, /\$4::varchar in \('EXPIRED','REFUNDED','CANCELLED'\)/);
+    assert.match(source, /then \$11::timestamptz else null::timestamptz/);
     assert.match(source, /durationMs > 12 \* 60 \* 60 \* 1000/);
     assert.match(source, /recordFailure/);
     assert.match(source, /resolveFailures/);

--- a/services/analytics/test/static-contract.test.mjs
+++ b/services/analytics/test/static-contract.test.mjs
@@ -50,6 +50,11 @@ test('browser retention preserves daily acquisition aggregates beyond raw-event 
     assert.match(worker, /delete from ingest\.raw_events where received_at < now\(\)-interval '180 days'/);
 });
 
+test('Compose starts the analytics worker entrypoint rather than the collector server', async () => {
+    const compose = await readFile(new URL('../../ops/analytics/compose.yml', root), 'utf8');
+    assert.match(compose, /worker:[\s\S]*command: \["node", "src\/worker\.mjs"\]/);
+});
+
 test('backup verification uses the pinned PostgreSQL toolchain and mounted data disk', async () => {
     const backup = await readFile(new URL('../../ops/analytics/backup-analytics.sh', root), 'utf8');
     const restore = await readFile(new URL('../../ops/analytics/restore-verify-analytics.sh', root), 'utf8');

--- a/services/analytics/test/static-contract.test.mjs
+++ b/services/analytics/test/static-contract.test.mjs
@@ -38,6 +38,8 @@ test('source backfills exclude unverifiable legacy lease time from real metrics'
     assert.match(source, /\.\.\.payments\.rows/);
     assert.match(source, /PAYMENT_REFUNDED','DISPUTED/);
     assert.match(source, /'confirmed'.*'refunded'.*'reversed'/s);
+    assert.match(source, /\$5::timestamptz/);
+    assert.match(source, /durationMs > 12 \* 60 \* 60 \* 1000/);
     assert.match(source, /recordFailure/);
     assert.match(source, /resolveFailures/);
 });

--- a/services/analytics/test/static-contract.test.mjs
+++ b/services/analytics/test/static-contract.test.mjs
@@ -39,6 +39,7 @@ test('source backfills exclude unverifiable legacy lease time from real metrics'
     assert.match(source, /PAYMENT_REFUNDED','DISPUTED/);
     assert.match(source, /'confirmed'.*'refunded'.*'reversed'/s);
     assert.match(source, /\$4::boolean.*\$5::timestamptz/);
+    assert.match(source, /\$4::varchar in \('EXPIRED','REFUNDED','CANCELLED'\)/);
     assert.match(source, /durationMs > 12 \* 60 \* 60 \* 1000/);
     assert.match(source, /recordFailure/);
     assert.match(source, /resolveFailures/);


### PR DESCRIPTION
Production rollout evidence showed the `worker` service inheriting the analytics image default (`server.mjs`), so it restarted without `ANALYTICS_DATABASE_URL` instead of running the backfill loop.

- pin `node src/worker.mjs` as the worker command
- add a static regression contract
- focused analytics suite: 32 total, 24 passed / 8 PostgreSQL skips without test URL

Collector and product apps remained healthy; the failed worker was stopped and monitoring stayed disabled pending this fix.