### PR TITLE
feat(analytics): allow every staff role to view dashboard

### DIFF
--- a/docs/analytics/ARCHITECTURE.md
+++ b/docs/analytics/ARCHITECTURE.md
@@ -17,9 +17,10 @@ would create two browser pipelines and competing session definitions. The collec
 single strict contract, stores raw facts append-only and remains smaller than the Umami tracker.
 
 Metabase OSS cannot reuse the existing Account/Staff authorization or provide the required
-per-person access/export audit without a second identity system or paid SSO. The Admin surface in
-Live queries only the analytics mart through a read-only role, reuses Staff `ADMIN` plus explicit
-`ANALYTICS_VIEWER` / `ANALYTICS_EXPORTER` grants, and records every detail view and export. It therefore has a narrower
+per-person access/export audit without a second identity system or paid SSO. The Staff surface in
+Live queries only the analytics mart through a read-only role, grants view access to every authenticated
+Staff role, restricts exports to `ADMIN` or an explicit `ANALYTICS_EXPORTER` grant, and records every
+detail view and export. It therefore has a narrower
 attack surface and clearer ownership than an embedded BI instance.
 
 ## Topology

--- a/docs/analytics/DATA_GOVERNANCE.md
+++ b/docs/analytics/DATA_GOVERNANCE.md
@@ -47,7 +47,7 @@ browser analytics in a consent-required territory.
 
 ## Access and data-subject operations
 
-- Live `ADMIN` and explicit `ANALYTICS_VIEWER` roles may view the dashboard.
+- Every authenticated Live staff role may view the dashboard.
 - `ADMIN` and `ANALYTICS_EXPORTER` may export. Every view/export records actor, role, filter digest
   and exported row count; the audit never stores the result set.
 - A correction or access request resolves the person in Account, derives the privileged HMAC

--- a/docs/analytics/RUNBOOK.md
+++ b/docs/analytics/RUNBOOK.md
@@ -21,7 +21,8 @@ The authoritative data-class, purpose, jurisdiction and owner matrix is
 - Network digests: 30 days; advertising click IDs: 90 days; raw browser events: 180 days.
 - Canonical account, listening, attendance, membership and payment facts: retained while needed
   for operations, financial/legal obligations and longitudinal product analysis.
-- Dashboard: Live `ADMIN` or an explicit `AnalyticsRoleGrant`; CSV requires EXPORTER or ADMIN.
+- Dashboard: every authenticated Live staff role has view access; CSV requires an active
+  `EXPORTER` grant or `ADMIN`.
 - Every view/export appends an opaque actor, role, filters digest and row count to `audit`.
 - Passwords, auth tokens, secrets, signed URLs, payment numbers, chat/media content and form values
   are prohibited by the contract and rejected before storage.

--- a/src/lib/__tests__/analytics-access.test.ts
+++ b/src/lib/__tests__/analytics-access.test.ts
@@ -1,0 +1,57 @@
+import type { StaffRole } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    findUnique: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+    prisma: {
+        analyticsRoleGrant: {
+            findUnique: mocks.findUnique,
+        },
+    },
+}));
+
+import { effectiveAnalyticsRole } from '@/lib/analytics-access';
+import type { StaffPrincipal } from '@/lib/ops-auth';
+
+function staff(role: StaffRole): StaffPrincipal {
+    return {
+        id: `staff-${role.toLowerCase()}`,
+        email: `${role.toLowerCase()}@harmonicbeacon.com`,
+        name: role,
+        role,
+    };
+}
+
+describe('effectiveAnalyticsRole', () => {
+    beforeEach(() => {
+        mocks.findUnique.mockReset();
+        mocks.findUnique.mockResolvedValue(null);
+    });
+
+    it.each(['FACILITATOR', 'FACILITATOR_OP', 'OPERATOR'] as const)(
+        'allows %s staff to view analytics without an explicit grant',
+        async role => {
+            await expect(effectiveAnalyticsRole(staff(role))).resolves.toBe('ANALYTICS_VIEWER');
+        },
+    );
+
+    it('keeps ADMIN access and export authority without querying grants', async () => {
+        await expect(effectiveAnalyticsRole(staff('ADMIN'))).resolves.toBe('ADMIN');
+        expect(mocks.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('upgrades staff with an active EXPORTER grant', async () => {
+        mocks.findUnique.mockResolvedValue({ role: 'EXPORTER', revokedAt: null });
+
+        await expect(effectiveAnalyticsRole(staff('OPERATOR'))).resolves.toBe('ANALYTICS_EXPORTER');
+    });
+
+    it('keeps staff view-only when an EXPORTER grant is revoked', async () => {
+        mocks.findUnique.mockResolvedValue({ role: 'EXPORTER', revokedAt: new Date() });
+
+        await expect(effectiveAnalyticsRole(staff('FACILITATOR'))).resolves.toBe('ANALYTICS_VIEWER');
+    });
+});

--- a/src/lib/analytics-access.ts
+++ b/src/lib/analytics-access.ts
@@ -10,10 +10,13 @@ export async function effectiveAnalyticsRole(staff: StaffPrincipal): Promise<Eff
     const delegate = (prisma as unknown as { analyticsRoleGrant?: {
         findUnique(args: unknown): Promise<{ role: 'VIEWER' | 'EXPORTER'; revokedAt: Date | null } | null>;
     } }).analyticsRoleGrant;
-    if (!delegate) return null;
-    const grant = await delegate.findUnique({ where: { staffUserId: staff.id } });
-    if (!grant || grant.revokedAt) return null;
-    return grant.role === 'EXPORTER' ? 'ANALYTICS_EXPORTER' : 'ANALYTICS_VIEWER';
+    const grant = delegate
+        ? await delegate.findUnique({ where: { staffUserId: staff.id } })
+        : null;
+    if (grant && !grant.revokedAt && grant.role === 'EXPORTER') {
+        return 'ANALYTICS_EXPORTER';
+    }
+    return 'ANALYTICS_VIEWER';
 }
 
 function required(name: string): string {


### PR DESCRIPTION
1|## Summary
2|
3|- make Analytics view-only access the default for every authenticated Live staff role
4|- preserve export access for Admin and active `EXPORTER` grants only
5|- keep revoked exporter grants at the baseline view-only permission
6|- update analytics architecture, governance, and operations documentation
7|
8|## Verification
9|
10|- `npx vitest run src/lib/__tests__/analytics-access.test.ts --reporter=verbose`
11|  - RED before implementation: 4 expected authorization failures
12|  - GREEN after implementation: 6/6 passed
13|- `npm test`: 1116 passed, 25 skipped
14|- `npx tsc --noEmit`: passed
15|- `npm run lint`: passed
16|- `npm run build`: passed
17|- independent security/logic review: passed with no findings on `dde9031e6859d7453206c5cdb757ca74596e662d`
18|
19|## Security boundary
20|
21|This does not expand CSV export privileges. `ANALYTICS_VIEWER` continues to receive `403 export_forbidden` for CSV requests; only `ADMIN` and an active `EXPORTER` grant can export.
22|
23|## Deployment note
24|
25|Current production staff received explicit `VIEWER` grants as the supported immediate path. No merge or deploy should proceed while repository gates are red.
26|
27|The exact PR head currently reproduces two pre-existing `release` blockers unrelated to this five-file diff:
28|
29|1. `lint-and-build`: the production dependency audit rejects `fast-uri` and `mysql2` advisories. The same dependency baseline is present on `release`; this PR changes no dependency files.
30|2. `analytics`: `services/analytics/test/postgres.test.mjs:229` fails in `quality run records canonical integrity and storage samples` (`false !== true`). The identical test and assertion failed in PR #493 before this branch existed. A single rerun reproduced it.
31|
32|Passing GitHub checks on this head: `test`, `e2e`, and `frozen-audio-paths`.
33|