### PR TITLE
fix(analytics): restore release gates

### DIFF
--- a/docs/operations/DEPENDENCY_SECURITY.md
+++ b/docs/operations/DEPENDENCY_SECURITY.md
@@ -34,6 +34,17 @@ patched dependency.
 The prior production `tsx` chain now resolves to `tsx@4.23.12` and patched
 `esbuild@0.28.2` within the already-declared compatible range.
 
+Prisma 7.9.1 also pins `mysql2@3.15.3` directly and reaches `fast-uri` through
+its bundled development tooling. New advisories published after the original
+review made both resolved versions fail the production gate. The root lockfile
+therefore overrides them to the first patched compatible releases reviewed on
+2026-09-03: `mysql2@3.24.3` and `fast-uri@3.1.6`. Harmonic Beacon uses
+PostgreSQL rather than MySQL, but the bundled package remains part of the
+installed production tree and is not exempted. Prisma generation, the full
+production build and the complete test suites remain required while these
+upstream pins are overridden. Remove each override once Prisma declares a
+patched version itself.
+
 Every independently deployed Node package is audited, not only the repository
 root. The tapestry service is pinned to Sharp 0.35.3 after its prior 0.34 line
 reported a high-severity inherited libvips advisory. CI and release now run

--- a/package-lock.json
+++ b/package-lock.json
@@ -5322,15 +5322,6 @@
         "robust-predicates": "^3.0.2"
       }
     },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6299,9 +6290,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -6865,9 +6856,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8271,23 +8262,24 @@
       "license": "MIT"
     },
     "node_modules/mysql2": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
-      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "license": "MIT",
       "dependencies": {
-        "aws-ssl-profiles": "^1.1.1",
-        "denque": "^2.1.0",
+        "aws-ssl-profiles": "^1.1.2",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.7.0",
-        "long": "^5.2.1",
-        "lru.min": "^1.0.0",
-        "named-placeholders": "^1.1.3",
-        "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.2"
+        "iconv-lite": "^0.7.3",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
       }
     },
     "node_modules/named-placeholders": {
@@ -9623,11 +9615,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/seq-queue": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -9914,13 +9901,19 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/sqlstring": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+    "node_modules/sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
     "node_modules/stable-hash": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
   "overrides": {
     "deepmerge-ts": "8.0.1",
     "esbuild": "0.28.2",
+    "fast-uri": "3.1.6",
+    "mysql2": "3.24.3",
     "playwright-core": "1.61.0",
     "next": {
       "postcss": "8.5.25",

--- a/services/analytics/test/postgres.test.mjs
+++ b/services/analytics/test/postgres.test.mjs
@@ -32,6 +32,7 @@ postgresTest('PostgreSQL ingestion deduplicates retries by event id', async () =
     const touches = await store.pool.query('select first_attribution,last_attribution from ingest.raw_events where event_id=$1', [event.event_id]);
     assert.equal(touches.rows[0].first_attribution.utm_source, 'newsletter');
     assert.equal(touches.rows[0].last_attribution.utm_source, 'meta');
+    await store.pool.query('delete from ingest.raw_events where event_id=$1', [event.event_id]);
     await store.close();
 });
 
@@ -101,6 +102,8 @@ postgresTest('canonical account links reclassify matching browser traffic by tim
     assert.equal(updated.rowCount >= 1, true);
     const result = await pool.query('select traffic_class from ingest.raw_events where event_id=$1', [eventId]);
     assert.equal(result.rows[0].traffic_class, 'internal');
+    await pool.query('delete from ingest.raw_events where event_id=$1', [eventId]);
+    await pool.query('delete from identity_map.account_links where visitor_id=$1', [visitorId]);
     await pool.end();
 });
 


### PR DESCRIPTION
## Summary

- pin the remediated `fast-uri` and `mysql2` transitive versions required by Prisma
- remove time-dependent residue from PostgreSQL analytics fixtures
- preserve production code and analytics access semantics unchanged

## Root cause

The PostgreSQL suite left two synthetic rows dated 2026-08-29. Once they aged beyond the quality windows, the real clock-skew and orphan-link checks correctly reported them. The release lockfile also resolved Prisma transitive dependencies to newly-advised versions.

## Verification

- production audits: zero high/critical advisories
- analytics PostgreSQL 16.14 suite: 36/36
- main Vitest coverage suite: 1110 passed, 25 skipped
- lint: pass
- Next production build: pass
- analytics shell/Compose validation: pass

No Meta Pixel, DNS, runtime configuration, event, role, audio, payment, or membership behavior changes.