### PR TITLE
fix(analytics): honor inclusive zoned date ranges

### DIFF
--- a/docs/analytics/METRICS.md
+++ b/docs/analytics/METRICS.md
@@ -25,8 +25,20 @@ the durable #308 interval table.
 Refunds and provider-confirmed disputes/reversals subtract their canonical amount from net revenue;
 an abandoned or pending checkout contributes nothing. `0` means the query ran and found no qualifying facts. `unknown` means a fact is absent. `stale`
 means its source watermark exceeded the freshness contract. `error` means the latest sync failed.
-Daily acquisition buckets remain after the 180-day raw-browser retention window, without retaining visitor IDs or advertising click IDs.
+Daily acquisition and series buckets are materialized on UTC calendar days. They remain after the
+180-day raw-browser retention window without retaining visitor IDs or advertising click IDs; they
+are therefore retained daily aggregates, not a claim of distinct people across an arbitrary
+multi-day range. Instant-backed headline, duration and funnel metrics use the selected IANA zone
+exactly.
 Clicks, return URLs, `APPROVAL_PENDING`, and abandoned provider pages never count as payments.
+
+Dashboard date inputs are inclusive calendar dates in the selected IANA timezone. The service
+converts `From` to that zone's first instant and `Through` to the first instant of the following
+calendar day, then applies a half-open `[start, end)` predicate. This preserves every instant of
+the selected final day without double-counting a boundary and respects 23/25-hour daylight-saving
+days. Previous-period comparisons use the same number of calendar days and never overlap the
+current period. Invalid, reversed or greater-than-two-year selections fail before querying the
+mart.
 
 First touch is the visitor's earliest stored campaign/referrer/landing. Last touch changes on a
 later explicit UTM/click ID or external referrer. A signed 15-minute handoff carries only opaque

--- a/services/analytics/src/dashboard.mjs
+++ b/services/analytics/src/dashboard.mjs
@@ -1,18 +1,85 @@
 const environments = new Set(['production', 'staging', 'development', 'test']);
 const trafficClasses = new Set(['real', 'internal', 'synthetic', 'test', 'unknown']);
+const calendarDayPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+const dayMs = 86400000;
 
-export function dashboardFilters(input = {}) {
-    const end = input.end ? new Date(input.end) : new Date();
-    const start = input.start ? new Date(input.start) : new Date(end.getTime() - 30 * 86400000);
-    if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || start >= end || end - start > 2 * 366 * 86400000) {
+function calendarDayParts(value) {
+    const match = calendarDayPattern.exec(value ?? '');
+    if (!match) throw new Error('invalid_date_range');
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const check = new Date(Date.UTC(year, month - 1, day));
+    if (check.getUTCFullYear() !== year || check.getUTCMonth() !== month - 1 || check.getUTCDate() !== day) {
         throw new Error('invalid_date_range');
     }
+    return { year, month, day };
+}
+
+function calendarDayAt(instant, formatter) {
+    const values = Object.fromEntries(formatter.formatToParts(instant)
+        .filter(part => part.type !== 'literal')
+        .map(part => [part.type, part.value]));
+    return `${values.year}-${values.month}-${values.day}`;
+}
+
+function shiftCalendarDay(value, amount) {
+    const { year, month, day } = calendarDayParts(value);
+    const shifted = new Date(Date.UTC(year, month - 1, day + amount));
+    return shifted.toISOString().slice(0, 10);
+}
+
+/**
+ * Return the first real instant belonging to an IANA-zone calendar day. A
+ * binary search avoids assuming a fixed UTC offset and therefore handles
+ * 23/25-hour DST days as well as zones whose offset changes at midnight.
+ */
+function zonedDayStart(value, timezone, formatter) {
+    const { year, month, day } = calendarDayParts(value);
+    const nominal = Date.UTC(year, month - 1, day);
+    let low = nominal - 36 * 60 * 60 * 1000;
+    let high = nominal + 36 * 60 * 60 * 1000;
+    while (low < high) {
+        const middle = Math.floor((low + high) / 2);
+        if (calendarDayAt(new Date(middle), formatter) < value) low = middle + 1;
+        else high = middle;
+    }
+    if (calendarDayAt(new Date(low), formatter) !== value) throw new Error('invalid_date_range');
+    return new Date(low);
+}
+
+export function dashboardFilters(input = {}) {
     const environment = environments.has(input.environment) ? input.environment : 'production';
     const traffic = Array.isArray(input.traffic) ? input.traffic.filter(value => trafficClasses.has(value)) : ['real'];
     if (traffic.length === 0) throw new Error('invalid_traffic_filter');
-    const timezone = typeof input.timezone === 'string' && input.timezone.length <= 64 ? input.timezone : 'UTC';
-    try { new Intl.DateTimeFormat('en', { timeZone: timezone }); } catch { throw new Error('invalid_timezone'); }
-    return { start, end, environment, traffic: [...new Set(traffic)], timezone };
+    let timezone = 'UTC';
+    if (input.timezone != null) {
+        if (typeof input.timezone !== 'string' || input.timezone.length === 0 || input.timezone.length > 64) {
+            throw new Error('invalid_timezone');
+        }
+        timezone = input.timezone;
+    }
+    let formatter;
+    try {
+        formatter = new Intl.DateTimeFormat('en-CA', {
+            timeZone: timezone, year: 'numeric', month: '2-digit', day: '2-digit',
+        });
+    } catch { throw new Error('invalid_timezone'); }
+    const today = calendarDayAt(new Date(), formatter);
+    const startDay = input.start ?? shiftCalendarDay(today, -29);
+    const endDay = input.end ?? today;
+    const startParts = calendarDayParts(startDay);
+    const endParts = calendarDayParts(endDay);
+    const startOrdinal = Date.UTC(startParts.year, startParts.month - 1, startParts.day);
+    const endOrdinal = Date.UTC(endParts.year, endParts.month - 1, endParts.day);
+    const selectedDays = Math.round((endOrdinal - startOrdinal) / dayMs) + 1;
+    if (selectedDays < 1 || selectedDays > 2 * 366) throw new Error('invalid_date_range');
+    const start = zonedDayStart(startDay, timezone, formatter);
+    const end = zonedDayStart(shiftCalendarDay(endDay, 1), timezone, formatter);
+    return {
+        start, end, startDay, endDay, environment,
+        traffic: [...new Set(traffic)], timezone,
+    };
 }
 
 export const metricDefinitions = {
@@ -30,6 +97,7 @@ export const metricDefinitions = {
 export async function queryDashboard(pool, rawFilters = {}) {
     const filters = dashboardFilters(rawFilters);
     const params = [filters.start, filters.end, filters.environment, filters.traffic];
+    const dayParams = [filters.environment, filters.traffic, filters.startDay, filters.endDay];
     const scope = `occurred_at >= $1 and occurred_at < $2 and environment=$3 and traffic_class=any($4::text[])`;
     const [web, accounts, listen, live, commerce, acquisition, geography, devices, events, memberships, campaigns, health, quality, storage, series, cohorts, pages, listenerActivity, funnel, lifecycle] = await Promise.all([
         pool.query(`select count(distinct visitor_id)::bigint visitors,count(distinct session_id)::bigint sessions,
@@ -57,8 +125,8 @@ export async function queryDashboard(pool, rawFilters = {}) {
         pool.query(`select source,medium,campaign,first_source,first_medium,first_campaign,
             first_referrer,last_referrer,first_landing,last_landing,
             sum(visitors)::bigint visitors,sum(sessions)::bigint sessions,sum(pageviews)::bigint pageviews
-            from mart.acquisition where metric_date >= ($1 at time zone $5)::date and metric_date <= ($2 at time zone $5)::date
-              and environment=$3 and traffic_class=any($4::text[]) group by 1,2,3,4,5,6,7,8,9,10 order by visitors desc limit 100`, [...params, filters.timezone]),
+            from mart.acquisition where metric_date >= $3::date and metric_date <= $4::date
+              and environment=$1 and traffic_class=any($2::text[]) group by 1,2,3,4,5,6,7,8,9,10 order by visitors desc limit 100`, dayParams),
         pool.query(`select coalesce(country_code,'unknown') country,coalesce(region_code,'unknown') region,
             count(distinct visitor_id)::bigint visitors from ingest.raw_events where ${scope} group by 1,2 order by visitors desc limit 100`, params),
         pool.query(`select coalesce(device->>'class','unknown') class,coalesce(device->>'browser','unknown') browser,
@@ -81,8 +149,9 @@ export async function queryDashboard(pool, rawFilters = {}) {
             group by 1,2,3 order by memberships desc`, [filters.environment, filters.traffic]),
         pool.query(`select entity_type,entity_id,name,configured_status,effective_status,delivering,date_start,date_stop,
             account_currency,spend_minor,impressions,reach,frequency,clicks,ctr,cpc_minor,cpm_minor,actions
-            from mart.campaign_delivery where date_start is null or (date_start <= $2::date and date_stop >= $1::date)
-            order by delivering desc,impressions desc nulls last,name limit 500`, [filters.start, filters.end]),
+            from mart.campaign_delivery where date_start is null or
+              (date_start <= $2::date and date_stop >= $1::date)
+            order by delivering desc,impressions desc nulls last,name limit 500`, [filters.startDay, filters.endDay]),
         pool.query('select * from mart.source_health order by source'),
         pool.query(`select check_name,source,status,observed_value,expected_value,details,checked_at
             from mart.latest_quality_results order by status desc,source,check_name`),
@@ -96,15 +165,16 @@ export async function queryDashboard(pool, rawFilters = {}) {
             sum(listening_seconds)::bigint listening_seconds,sum(attendees)::bigint attendees,
             sum(attendee_seconds)::bigint attendee_seconds,sum(payments_confirmed)::bigint payments_confirmed,
             sum(revenue_minor)::bigint revenue_minor,currency from mart.daily_metrics
-            where metric_date >= ($1 at time zone $5)::date and metric_date <= ($2 at time zone $5)::date
-              and environment=$3 and traffic_class=any($4::text[]) group by metric_date,surface,currency order by metric_date,surface`, [...params, filters.timezone]),
-        pool.query(`with firsts as (select account_subject,min(started_at)::date cohort_date from mart.listening_intervals_unioned
+            where metric_date >= $3::date and metric_date <= $4::date
+              and environment=$1 and traffic_class=any($2::text[]) group by metric_date,surface,currency order by metric_date,surface`, dayParams),
+        pool.query(`with firsts as (select account_subject,min(started_at at time zone $5)::date cohort_date from mart.listening_intervals_unioned
               where environment=$3 and traffic_class=any($4::text[]) group by account_subject), activity as (
-              select distinct account_subject,started_at::date activity_date from mart.listening_intervals_unioned
+              select distinct account_subject,(started_at at time zone $5)::date activity_date from mart.listening_intervals_unioned
               where started_at < $2 and ended_at > $1 and environment=$3 and traffic_class=any($4::text[]))
             select cohort_date,(activity_date-cohort_date) day_number,count(distinct activity.account_subject)::bigint listeners
-            from firsts join activity using(account_subject) where cohort_date >= $1::date and cohort_date < $2::date
-            group by 1,2 order by 1,2`, params),
+            from firsts join activity using(account_subject)
+            where cohort_date >= ($1 at time zone $5)::date and cohort_date < ($2 at time zone $5)::date
+            group by 1,2 order by 1,2`, [...params, filters.timezone]),
         pool.query(`select surface,page->>'path' path,coalesce(page->>'landing','unknown') landing,
             coalesce(page->>'referrer','direct') referrer,count(*) filter(where event_name='page.viewed')::bigint pageviews,
             count(distinct visitor_id)::bigint visitors,count(distinct session_id)::bigint sessions

--- a/services/analytics/test/dashboard.test.mjs
+++ b/services/analytics/test/dashboard.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { dashboardFilters, queryDashboard } from '../src/dashboard.mjs';
+
+test('calendar ranges include the selected final day in the chosen timezone', () => {
+    const filters = dashboardFilters({
+        start: '2026-09-03', end: '2026-09-03',
+        timezone: 'America/Argentina/Cordoba', traffic: ['real'],
+    });
+    assert.equal(filters.start.toISOString(), '2026-09-03T03:00:00.000Z');
+    assert.equal(filters.end.toISOString(), '2026-09-04T03:00:00.000Z');
+    assert.equal(filters.startDay, '2026-09-03');
+    assert.equal(filters.endDay, '2026-09-03');
+});
+
+test('calendar boundaries honor 23-hour and 25-hour DST days', () => {
+    const spring = dashboardFilters({
+        start: '2026-03-08', end: '2026-03-08', timezone: 'America/New_York', traffic: ['real'],
+    });
+    assert.equal(spring.start.toISOString(), '2026-03-08T05:00:00.000Z');
+    assert.equal(spring.end.toISOString(), '2026-03-09T04:00:00.000Z');
+    assert.equal(spring.end - spring.start, 23 * 60 * 60 * 1000);
+
+    const fall = dashboardFilters({
+        start: '2026-11-01', end: '2026-11-01', timezone: 'America/New_York', traffic: ['real'],
+    });
+    assert.equal(fall.start.toISOString(), '2026-11-01T04:00:00.000Z');
+    assert.equal(fall.end.toISOString(), '2026-11-02T05:00:00.000Z');
+    assert.equal(fall.end - fall.start, 25 * 60 * 60 * 1000);
+});
+
+test('calendar range validation rejects impossible, reversed and oversized selections', () => {
+    assert.throws(() => dashboardFilters({ start: '2026-02-30', end: '2026-03-01', timezone: 'UTC', traffic: ['real'] }), /invalid_date_range/);
+    assert.throws(() => dashboardFilters({ start: '2026-09-04', end: '2026-09-03', timezone: 'UTC', traffic: ['real'] }), /invalid_date_range/);
+    assert.throws(() => dashboardFilters({ start: '2024-01-01', end: '2026-01-02', timezone: 'UTC', traffic: ['real'] }), /invalid_date_range/);
+    assert.throws(() => dashboardFilters({ start: '2026-09-03', end: '2026-09-03', timezone: 'Mars/Olympus', traffic: ['real'] }), /invalid_timezone/);
+    assert.throws(() => dashboardFilters({ start: '2026-09-03', end: '2026-09-03', timezone: 'x'.repeat(65), traffic: ['real'] }), /invalid_timezone/);
+});
+
+test('dashboard SQL receives zoned boundaries and explicit retained UTC day labels', async () => {
+    const calls = [];
+    const pool = {
+        query: async (sql, params = []) => {
+            calls.push({ sql, params });
+            return { rows: [] };
+        },
+    };
+    const result = await queryDashboard(pool, {
+        start: '2026-03-08', end: '2026-03-08',
+        timezone: 'America/New_York', environment: 'production', traffic: ['real'],
+    });
+    assert.equal(result.filters.start, '2026-03-08T05:00:00.000Z');
+    assert.equal(result.filters.end, '2026-03-09T04:00:00.000Z');
+    assert.equal(result.filters.startDay, '2026-03-08');
+    assert.equal(result.filters.endDay, '2026-03-08');
+    assert.ok(calls.some(call => call.sql.includes('mart.campaign_delivery') && call.sql.includes('date_start <= $2::date')));
+    assert.ok(calls.some(call => call.sql.includes('cohort_date') && call.sql.includes('started_at at time zone $5')));
+    assert.ok(calls.some(call => call.sql.includes('mart.daily_metrics') && call.sql.includes('metric_date <= $4::date')));
+    assert.ok(calls.some(call => call.sql.includes('mart.acquisition') && call.sql.includes('metric_date <= $4::date')));
+});

--- a/services/analytics/test/postgres.test.mjs
+++ b/services/analytics/test/postgres.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import pg from 'pg';
 
+import { queryDashboard } from '../src/dashboard.mjs';
 import { syncMetaSource } from '../src/meta-sync.mjs';
 import { runQualityAndRetention } from '../src/quality.mjs';
 import { RECLASSIFY_BROWSER_TRAFFIC_SQL } from '../src/queries.mjs';
@@ -11,6 +12,35 @@ import { createStore } from '../src/store.mjs';
 
 const connectionString = process.env.ANALYTICS_TEST_DATABASE_URL;
 const postgresTest = connectionString ? test : test.skip;
+
+postgresTest('dashboard calendar boundaries include exactly the selected zoned day', async () => {
+    const pool = new pg.Pool({ connectionString });
+    const rows = [
+        ['20000000-0000-4000-8000-000000000101', '20000000-0000-4000-8000-000000000111', '2026-03-08T04:59:59.999Z'],
+        ['20000000-0000-4000-8000-000000000102', '20000000-0000-4000-8000-000000000112', '2026-03-08T05:00:00.000Z'],
+        ['20000000-0000-4000-8000-000000000103', '20000000-0000-4000-8000-000000000113', '2026-03-09T03:59:59.999Z'],
+        ['20000000-0000-4000-8000-000000000104', '20000000-0000-4000-8000-000000000114', '2026-03-09T04:00:00.000Z'],
+    ];
+    await pool.query('delete from ingest.raw_events where event_id=any($1::uuid[])', [rows.map(row => row[0])]);
+    for (const [eventId, visitorId, occurredAt] of rows) {
+        await pool.query(`insert into ingest.raw_events
+            (event_id,schema_version,event_name,occurred_at,received_at,source,surface,environment,visitor_id,traffic_class)
+            values($1,'hb.analytics.event.v1','page.viewed',$2,$2,'browser','home','test',$3,'test')`,
+        [eventId, occurredAt, visitorId]);
+    }
+    try {
+        const dashboard = await queryDashboard(pool, {
+            start: '2026-03-08', end: '2026-03-08', timezone: 'America/New_York',
+            environment: 'test', traffic: ['test'],
+        });
+        assert.equal(Number(dashboard.summary.visitors), 2);
+        assert.equal(dashboard.filters.start, '2026-03-08T05:00:00.000Z');
+        assert.equal(dashboard.filters.end, '2026-03-09T04:00:00.000Z');
+    } finally {
+        await pool.query('delete from ingest.raw_events where event_id=any($1::uuid[])', [rows.map(row => row[0])]);
+        await pool.end();
+    }
+});
 
 postgresTest('PostgreSQL ingestion deduplicates retries by event id', async () => {
     const store = createStore(connectionString);

--- a/src/app/api/ops/analytics/__tests__/route.test.ts
+++ b/src/app/api/ops/analytics/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    effectiveAnalyticsRole: vi.fn(),
+    fetchAnalyticsDashboard: vi.fn(),
+    resolveStaffSession: vi.fn(),
+}));
+
+vi.mock('@/lib/analytics-access', () => ({
+    effectiveAnalyticsRole: mocks.effectiveAnalyticsRole,
+    fetchAnalyticsDashboard: mocks.fetchAnalyticsDashboard,
+}));
+vi.mock('@/lib/ops-auth', () => ({ resolveStaffSession: mocks.resolveStaffSession }));
+
+import { GET } from '../route';
+
+describe('analytics API calendar filters', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.resolveStaffSession.mockResolvedValue({ id: 'admin-1', role: 'ADMIN' });
+        mocks.effectiveAnalyticsRole.mockResolvedValue('ADMIN');
+        mocks.fetchAnalyticsDashboard.mockResolvedValue({ summary: {} });
+    });
+
+    it('uses equal inclusive calendar spans for current and previous comparisons', async () => {
+        const request = new NextRequest('https://live.harmonicbeacon.com/api/ops/analytics?start=2026-08-05&end=2026-09-03&timezone=America%2FArgentina%2FCordoba&traffic=real&compare=previous');
+        const response = await GET(request);
+
+        expect(response.status).toBe(200);
+        expect(mocks.fetchAnalyticsDashboard).toHaveBeenCalledTimes(2);
+        expect(mocks.fetchAnalyticsDashboard.mock.calls[0][0].filters).toMatchObject({
+            start: '2026-08-05', end: '2026-09-03', timezone: 'America/Argentina/Cordoba',
+        });
+        expect(mocks.fetchAnalyticsDashboard.mock.calls[1][0].filters).toMatchObject({
+            start: '2026-07-06', end: '2026-08-04', timezone: 'America/Argentina/Cordoba',
+        });
+    });
+
+    it.each([
+        'start=2026-09-04&end=2026-09-03&timezone=UTC',
+        'start=2026-02-30&end=2026-03-01&timezone=UTC',
+        'start=2026-09-03&end=2026-09-03&timezone=Mars%2FOlympus',
+        'start=2026-09-03&timezone=UTC',
+        'timezone=Mars%2FOlympus',
+    ])('rejects an invalid calendar selection before querying analytics: %s', async query => {
+        const response = await GET(new NextRequest(`https://live.harmonicbeacon.com/api/ops/analytics?${query}`));
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toEqual({ error: 'invalid_date_range' });
+        expect(mocks.fetchAnalyticsDashboard).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/ops/analytics/route.ts
+++ b/src/app/api/ops/analytics/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { effectiveAnalyticsRole, fetchAnalyticsDashboard } from '@/lib/analytics-access';
+import {
+    previousCalendarRange, validateAnalyticsCalendarSelection, validateAnalyticsTimezone,
+} from '@/lib/analytics-calendar-range';
 import { analyticsCsv } from '@/lib/analytics-csv';
 import { resolveStaffSession } from '@/lib/ops-auth';
 
@@ -27,6 +30,23 @@ export async function GET(request: NextRequest) {
     if (exporting && role === 'ANALYTICS_VIEWER') return NextResponse.json({ error: 'export_forbidden' }, { status: 403 });
     try {
         const currentFilters = filters(request);
+        let comparison: { start: string; end: string } | null = null;
+        try {
+            validateAnalyticsTimezone(currentFilters.timezone);
+        } catch {
+            return NextResponse.json({ error: 'invalid_date_range' }, { status: 400 });
+        }
+        if (currentFilters.start || currentFilters.end) {
+            if (!currentFilters.start || !currentFilters.end) {
+                return NextResponse.json({ error: 'invalid_date_range' }, { status: 400 });
+            }
+            try {
+                validateAnalyticsCalendarSelection(currentFilters.start, currentFilters.end, currentFilters.timezone);
+                comparison = previousCalendarRange(currentFilters.start, currentFilters.end);
+            } catch {
+                return NextResponse.json({ error: 'invalid_date_range' }, { status: 400 });
+            }
+        }
         const current = await fetchAnalyticsDashboard({ staff, role, filters: currentFilters, export: exporting });
         if (dataset) {
             const rows = current[dataset];
@@ -40,12 +60,9 @@ export async function GET(request: NextRequest) {
             });
         }
         let previous: Record<string, unknown> | null = null;
-        if (request.nextUrl.searchParams.get('compare') === 'previous' && currentFilters.start && currentFilters.end) {
-            const start = new Date(currentFilters.start);
-            const end = new Date(currentFilters.end);
-            const duration = end.getTime() - start.getTime();
+        if (request.nextUrl.searchParams.get('compare') === 'previous' && comparison) {
             previous = await fetchAnalyticsDashboard({
-                staff, role, filters: { ...currentFilters, start: new Date(start.getTime() - duration), end: start },
+                staff, role, filters: { ...currentFilters, ...comparison },
             });
         }
         return NextResponse.json({ current, previous }, { headers: { 'cache-control': 'private, no-store' } });

--- a/src/app/ops/analytics/AnalyticsDashboard.tsx
+++ b/src/app/ops/analytics/AnalyticsDashboard.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { calendarDayInTimeZone, shiftCalendarDay } from '@/lib/analytics-calendar-range';
+
 type Row = Record<string, unknown>;
 type Dashboard = {
     generated_at: string;
@@ -12,7 +14,6 @@ type Dashboard = {
     listener_activity: Row[]; funnel: Row[]; lifecycle: Row[];
 };
 
-const isoDay = (date: Date) => date.toISOString().slice(0, 10);
 const display = (value: unknown) => value == null ? 'Unknown' : String(value);
 const number = (value: unknown) => Number(value ?? 0).toLocaleString();
 
@@ -23,24 +24,44 @@ function Table({ rows }: { rows: Row[] }) {
 }
 
 export default function AnalyticsDashboard({ canExport }: { canExport: boolean }) {
-    const [start, setStart] = useState(isoDay(new Date(Date.now() - 30 * 86400000)));
-    const [end, setEnd] = useState(isoDay(new Date(Date.now() + 86400000)));
+    const initialDay = new Date().toISOString().slice(0, 10);
+    const [start, setStart] = useState(shiftCalendarDay(initialDay, -29));
+    const [end, setEnd] = useState(initialDay);
     const [traffic, setTraffic] = useState('real');
+    const [timezone, setTimezone] = useState('UTC');
+    const [applied, setApplied] = useState({ start, end, traffic, timezone });
+    const [browserReady, setBrowserReady] = useState(false);
     const [data, setData] = useState<Dashboard | null>(null);
     const [previous, setPrevious] = useState<Dashboard | null>(null);
-    const [state, setState] = useState<'loading' | 'ok' | 'error'>('loading');
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-    const query = useMemo(() => new URLSearchParams({ start, end, traffic, timezone, environment: 'production', compare: 'previous' }), [start, end, traffic, timezone]);
+    const [state, setState] = useState<'loading' | 'ok' | 'invalid' | 'error'>('loading');
+    const timezones = useMemo(() => {
+        const intl = Intl as typeof Intl & { supportedValuesOf?: (key: 'timeZone') => string[] };
+        const values = intl.supportedValuesOf?.('timeZone') ?? [];
+        return [...new Set(['UTC', timezone, ...values])];
+    }, [timezone]);
+    const query = useMemo(() => new URLSearchParams({ ...applied, environment: 'production', compare: 'previous' }), [applied]);
     const load = useCallback(async () => {
         setState('loading');
         try {
             const response = await fetch(`/api/ops/analytics?${query}`, { cache: 'no-store' });
+            if (response.status === 400) {
+                setData(null); setPrevious(null); setState('invalid'); return;
+            }
             if (!response.ok) throw new Error('unavailable');
             const body = await response.json();
             setData(body.current); setPrevious(body.previous); setState('ok');
         } catch { setState('error'); }
     }, [query]);
-    useEffect(() => { void load(); }, [load]);
+    useEffect(() => {
+        const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+        const today = calendarDayInTimeZone(new Date(), localTimezone);
+        setTimezone(localTimezone);
+        setStart(shiftCalendarDay(today, -29));
+        setEnd(today);
+        setApplied({ start: shiftCalendarDay(today, -29), end: today, traffic: 'real', timezone: localTimezone });
+        setBrowserReady(true);
+    }, []);
+    useEffect(() => { if (browserReady) void load(); }, [browserReady, load]);
 
     const cards = data ? [
         ['Visitors', data.summary.visitors, 'visitors'], ['Sessions', data.summary.sessions, 'sessions'],
@@ -52,13 +73,15 @@ export default function AnalyticsDashboard({ canExport }: { canExport: boolean }
 
     return <div className="space-y-6">
         <header><p className="text-xs uppercase tracking-[.2em] text-[var(--lime)]">Internal · production</p><h1 className="text-3xl font-semibold text-[var(--paper)]">Analytics</h1><p className="mt-1 text-sm text-[var(--text-secondary)]">Acquisition, product, events, memberships and confirmed commerce.</p></header>
-        <form className="grid gap-3 rounded-xl border border-white/10 bg-white/5 p-4 sm:grid-cols-4" onSubmit={event => { event.preventDefault(); void load(); }}>
+        <form className="grid gap-3 rounded-xl border border-white/10 bg-white/5 p-4 sm:grid-cols-2 lg:grid-cols-5" onSubmit={event => { event.preventDefault(); if (browserReady) setApplied({ start, end, traffic, timezone }); }}>
             <label className="text-sm">From<input className="mt-1 block w-full rounded bg-black/20 p-2" type="date" value={start} onChange={event => setStart(event.target.value)} /></label>
             <label className="text-sm">Through<input className="mt-1 block w-full rounded bg-black/20 p-2" type="date" value={end} onChange={event => setEnd(event.target.value)} /></label>
+            <label className="text-sm">Timezone<input className="mt-1 block w-full rounded bg-black/20 p-2" list="analytics-timezones" value={timezone} onChange={event => setTimezone(event.target.value)} /><datalist id="analytics-timezones">{timezones.map(value => <option key={value} value={value} />)}</datalist></label>
             <label className="text-sm">Traffic<select className="mt-1 block w-full rounded bg-black/20 p-2" value={traffic} onChange={event => setTraffic(event.target.value)}><option value="real">Real only</option><option value="real,internal">Real + internal</option><option value="real,internal,test,synthetic,unknown">All classes</option></select></label>
-            <button className="self-end rounded bg-[var(--lime)] px-4 py-2 font-semibold text-black" type="submit">Apply</button>
+            <button className="self-end rounded bg-[var(--lime)] px-4 py-2 font-semibold text-black disabled:opacity-50" disabled={!browserReady} type="submit">Apply</button>
         </form>
         {state === 'loading' ? <p>Loading current data…</p> : null}
+        {state === 'invalid' ? <div role="alert" className="rounded border border-amber-400/40 bg-amber-950/20 p-4">Check the date range and IANA timezone, then apply again.</div> : null}
         {state === 'error' ? <div role="alert" className="rounded border border-red-400/40 bg-red-950/30 p-4">Analytics is unavailable; product surfaces are unaffected. Retry shortly.</div> : null}
         {data ? <>
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">{cards.map(([label, value, definition]) => {

--- a/src/app/ops/analytics/__tests__/AnalyticsDashboard.test.tsx
+++ b/src/app/ops/analytics/__tests__/AnalyticsDashboard.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AnalyticsDashboard from '../AnalyticsDashboard';
+
+const emptyDashboard = {
+    generated_at: '2026-09-03T12:00:00Z',
+    summary: {}, definitions: {},
+    commerce: [], acquisition: [], geography: [], devices: [], pages: [], events: [],
+    memberships: [], campaigns: [], health: [], quality: [], storage: [], series: [], cohorts: [],
+    listener_activity: [], funnel: [], lifecycle: [],
+};
+
+describe('analytics dashboard calendar filters', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date('2026-09-03T12:00:00Z'));
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ current: emptyDashboard, previous: emptyDashboard }),
+        }));
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it('selects 30 inclusive local calendar days and exposes the timezone filter', async () => {
+        render(<AnalyticsDashboard canExport={false} />);
+
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+        expect(screen.getByLabelText('Timezone')).toHaveValue(timezone);
+        expect(screen.getByLabelText('From')).toHaveValue('2026-08-05');
+        expect(screen.getByLabelText('Through')).toHaveValue('2026-09-03');
+
+        await waitFor(() => expect(fetch).toHaveBeenCalled());
+        const requestUrl = String(vi.mocked(fetch).mock.calls.at(-1)?.[0]);
+        const params = new URL(requestUrl, 'https://live.harmonicbeacon.com').searchParams;
+        expect(params.get('start')).toBe('2026-08-05');
+        expect(params.get('end')).toBe('2026-09-03');
+        expect(params.get('timezone')).toBe(timezone);
+        expect(params.get('compare')).toBe('previous');
+
+        const callsBeforeEditing = vi.mocked(fetch).mock.calls.length;
+        fireEvent.change(screen.getByLabelText('Timezone'), { target: { value: 'America/New_York' } });
+        expect(vi.mocked(fetch).mock.calls).toHaveLength(callsBeforeEditing);
+        fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        await waitFor(() => expect(vi.mocked(fetch).mock.calls.length).toBeGreaterThan(callsBeforeEditing));
+        const updated = new URL(String(vi.mocked(fetch).mock.calls.at(-1)?.[0]), 'https://live.harmonicbeacon.com');
+        expect(updated.searchParams.get('timezone')).toBe('America/New_York');
+
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 400 } as Response);
+        fireEvent.change(screen.getByLabelText('Timezone'), { target: { value: 'Mars/Olympus' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        expect(await screen.findByRole('alert')).toHaveTextContent('Check the date range and IANA timezone');
+    });
+});

--- a/src/lib/__tests__/analytics-calendar-range.test.ts
+++ b/src/lib/__tests__/analytics-calendar-range.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    calendarDayInTimeZone, previousCalendarRange, shiftCalendarDay, validateAnalyticsCalendarSelection,
+} from '@/lib/analytics-calendar-range';
+
+describe('analytics calendar ranges', () => {
+    it('shifts calendar dates without inheriting the machine timezone', () => {
+        expect(shiftCalendarDay('2026-03-01', -1)).toBe('2026-02-28');
+        expect(shiftCalendarDay('2024-03-01', -1)).toBe('2024-02-29');
+    });
+
+    it('derives the visible calendar day in the selected IANA timezone', () => {
+        const instant = new Date('2026-09-03T01:00:00Z');
+        expect(calendarDayInTimeZone(instant, 'UTC')).toBe('2026-09-03');
+        expect(calendarDayInTimeZone(instant, 'America/Argentina/Cordoba')).toBe('2026-09-02');
+    });
+
+    it('builds an equally sized, non-overlapping previous inclusive range', () => {
+        expect(previousCalendarRange('2026-08-05', '2026-09-03')).toEqual({
+            start: '2026-07-06', end: '2026-08-04',
+        });
+        expect(previousCalendarRange('2026-09-03', '2026-09-03')).toEqual({
+            start: '2026-09-02', end: '2026-09-02',
+        });
+    });
+
+    it('rejects impossible, reversed and oversized calendar ranges', () => {
+        expect(() => previousCalendarRange('2026-02-30', '2026-03-01')).toThrow('invalid_calendar_day');
+        expect(() => previousCalendarRange('2026-09-04', '2026-09-03')).toThrow('invalid_calendar_range');
+        expect(() => previousCalendarRange('2024-01-01', '2026-01-02')).toThrow('invalid_calendar_range');
+        expect(() => validateAnalyticsCalendarSelection('2026-09-03', '2026-09-03', 'Mars/Olympus')).toThrow('invalid_timezone');
+    });
+});

--- a/src/lib/analytics-calendar-range.ts
+++ b/src/lib/analytics-calendar-range.ts
@@ -1,0 +1,52 @@
+const CALENDAR_DAY = /^(\d{4})-(\d{2})-(\d{2})$/;
+const DAY_MS = 86_400_000;
+
+function calendarOrdinal(value: string): number {
+    const match = CALENDAR_DAY.exec(value);
+    if (!match) throw new Error('invalid_calendar_day');
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const ordinal = Date.UTC(year, month - 1, day);
+    const parsed = new Date(ordinal);
+    if (parsed.getUTCFullYear() !== year || parsed.getUTCMonth() !== month - 1 || parsed.getUTCDate() !== day) {
+        throw new Error('invalid_calendar_day');
+    }
+    return ordinal;
+}
+
+export function shiftCalendarDay(value: string, amount: number): string {
+    return new Date(calendarOrdinal(value) + amount * DAY_MS).toISOString().slice(0, 10);
+}
+
+export function calendarDayInTimeZone(instant: Date, timezone: string): string {
+    const parts = Object.fromEntries(new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone, year: 'numeric', month: '2-digit', day: '2-digit',
+    }).formatToParts(instant).filter(part => part.type !== 'literal').map(part => [part.type, part.value]));
+    return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+export function previousCalendarRange(start: string, end: string): { start: string; end: string } {
+    const startOrdinal = calendarOrdinal(start);
+    const endOrdinal = calendarOrdinal(end);
+    const selectedDays = Math.round((endOrdinal - startOrdinal) / DAY_MS) + 1;
+    if (selectedDays < 1 || selectedDays > 2 * 366) throw new Error('invalid_calendar_range');
+    return {
+        start: shiftCalendarDay(start, -selectedDays),
+        end: shiftCalendarDay(start, -1),
+    };
+}
+
+export function validateAnalyticsTimezone(timezone: string): void {
+    if (!timezone || timezone.length > 64) throw new Error('invalid_timezone');
+    try {
+        new Intl.DateTimeFormat('en', { timeZone: timezone }).format(new Date(0));
+    } catch {
+        throw new Error('invalid_timezone');
+    }
+}
+
+export function validateAnalyticsCalendarSelection(start: string, end: string, timezone: string): void {
+    previousCalendarRange(start, end);
+    validateAnalyticsTimezone(timezone);
+}


### PR DESCRIPTION
## Outcome

Fixes the production dashboard date contract discovered during the authenticated browser audit:

- treats From/Through as inclusive calendar dates in the selected IANA timezone;
- defaults to the current local day plus the previous 29 days (30 inclusive), instead of ending tomorrow;
- exposes a timezone selector and applies draft filters only on Apply;
- compares against an equal, non-overlapping previous calendar range;
- rejects impossible, reversed, oversized, partial, or invalid-zone ranges before querying;
- preserves retained UTC daily-bucket semantics explicitly while instant-backed metrics use exact zoned half-open boundaries;
- aligns cohorts and Meta calendar overlap with the selected dates.

## Evidence

- full application suite: 128 files passed / 1,121 tests passed (25 integration tests intentionally skipped without external databases);
- analytics suite: 41/41 passed against disposable PostgreSQL 16.14 after all migrations;
- DST boundary coverage: 23-hour spring day and 25-hour fall day;
- real PostgreSQL boundary proof excludes the instant immediately before and after the selected New York day;
- TypeScript, ESLint, production build, root production dependency audit, and analytics production dependency audit passed.

No migrations. No Meta Pixel, DNS, payment, membership, identity, event, or role changes.