### PR TITLE
feat(api): expose amplification credit entry feed

### DIFF
--- a/contracts/amplification-credit-entries/v1/README.md
+++ b/contracts/amplification-credit-entries/v1/README.md
@@ -1,0 +1,24 @@
+# amplification-credit-entries.v1 shared contract
+
+Copy this directory byte-for-byte into the Myth Bot repository. `SHA256SUMS`
+covers the schema, both synthetic fixtures, and this README; consumers should
+refuse integration when any hash differs.
+
+`GET /api/internal/v1/amplification-credit-entries` authenticates with
+`Authorization: Bearer <token>` plus `X-HB-Service-Key-Id`, using Beacon's
+current/previous commerce service key rotation. It returns at most 100 entries
+in ascending `(entered_at, entry_id)` order. Each `entry_id` is the stable
+Beacon `SessionParticipant.id`; reconnect intervals collapse into the
+participant's earliest server-observed `LivePresenceInterval.startedAt`.
+
+`next_cursor` is an opaque durable resume position, not a decoded client data
+structure. Every non-empty page advances it to the last returned entry. An
+empty poll echoes the validated supplied cursor (or returns `null` only when no
+cursor was supplied), so the consumer can persist its position and later poll
+without replaying the feed. Consumers must commit the entries and cursor in one
+database transaction and must not advance the cursor when that transaction
+fails.
+
+The full fixture includes one commerce-backed paid ticket and one free ticket.
+The free entry deliberately has nullable registration, email, and display name.
+All values are synthetic and carry no production identity.

--- a/contracts/amplification-credit-entries/v1/SHA256SUMS
+++ b/contracts/amplification-credit-entries/v1/SHA256SUMS
@@ -1,0 +1,4 @@
+32df500db25f916abf0a3bb8c9b444c4134dd23db936d2a5f1e6abf71c09ee75  README.md
+c6cf421634be2845c379c19e653ce148f8b6378560b9d96c4956fd18f059dda0  empty-page.fixture.json
+ba55674faa787daa4f0d68f2aae3c4781f8f205eb719ec7427769c4ad46f5085  page.fixture.json
+8d56ab6ba93e69fb16c9c9c357a442d40af84dd640b53a3a3bce208c0e0832f1  response.schema.json

--- a/contracts/amplification-credit-entries/v1/empty-page.fixture.json
+++ b/contracts/amplification-credit-entries/v1/empty-page.fixture.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "amplification-credit-entries.v1",
+  "entries": [],
+  "next_cursor": "eyJ2IjoxLCJlbnRlcmVkX2F0IjoiMjAyNi0wOC0wOVQyMDoxNTozMC4wMDBaIiwiZW50cnlfaWQiOiI3MDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDIifQ"
+}

--- a/contracts/amplification-credit-entries/v1/page.fixture.json
+++ b/contracts/amplification-credit-entries/v1/page.fixture.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "amplification-credit-entries.v1",
+  "entries": [
+    {
+      "entry_id": "70000000-0000-4000-8000-000000000001",
+      "scheduled_session_id": "10000000-0000-4000-8000-000000000001",
+      "ticket_entitlement_id": "50000000-0000-4000-8000-000000000001",
+      "registration_id": "20000000-0000-4000-8000-000000000001",
+      "email": "ana@example.com",
+      "display_name": "Ana",
+      "entered_at": "2026-08-09T20:00:00.000Z"
+    },
+    {
+      "entry_id": "70000000-0000-4000-8000-000000000002",
+      "scheduled_session_id": "10000000-0000-4000-8000-000000000001",
+      "ticket_entitlement_id": "50000000-0000-4000-8000-000000000002",
+      "registration_id": null,
+      "email": null,
+      "display_name": null,
+      "entered_at": "2026-08-09T20:15:30.000Z"
+    }
+  ],
+  "next_cursor": "eyJ2IjoxLCJlbnRlcmVkX2F0IjoiMjAyNi0wOC0wOVQyMDoxNTozMC4wMDBaIiwiZW50cnlfaWQiOiI3MDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDIifQ"
+}

--- a/contracts/amplification-credit-entries/v1/response.schema.json
+++ b/contracts/amplification-credit-entries/v1/response.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harmonicbeacon.com/contracts/amplification-credit-entries/v1/response.schema.json",
+  "title": "Amplification credit entries response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "entries", "next_cursor"],
+  "properties": {
+    "schema_version": { "const": "amplification-credit-entries.v1" },
+    "entries": {
+      "type": "array",
+      "maxItems": 100,
+      "items": { "$ref": "#/$defs/entry" }
+    },
+    "next_cursor": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^[A-Za-z0-9_-]+$"
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entry_id", "scheduled_session_id", "ticket_entitlement_id",
+        "registration_id", "email", "display_name", "entered_at"
+      ],
+      "properties": {
+        "entry_id": { "type": "string", "format": "uuid" },
+        "scheduled_session_id": { "type": "string", "format": "uuid" },
+        "ticket_entitlement_id": { "type": "string", "format": "uuid" },
+        "registration_id": { "type": ["string", "null"], "format": "uuid" },
+        "email": { "type": ["string", "null"], "format": "email", "maxLength": 254 },
+        "display_name": { "type": ["string", "null"] },
+        "entered_at": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$"
+        }
+      }
+    }
+  }
+}

--- a/src/app/api/internal/v1/amplification-credit-entries/__tests__/route.test.ts
+++ b/src/app/api/internal/v1/amplification-credit-entries/__tests__/route.test.ts
@@ -1,0 +1,95 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    authorize: vi.fn(),
+    queryRaw: vi.fn(),
+}));
+
+vi.mock('@/lib/commerce-service-auth', () => ({
+    authorizeCommerceService: mocks.authorize,
+}));
+vi.mock('@/lib/db', () => ({
+    prisma: { $queryRaw: mocks.queryRaw },
+}));
+
+import { GET } from '../route';
+
+const URL = 'http://beacon-app:3000/api/internal/v1/amplification-credit-entries';
+
+function request(query = '', headers: Record<string, string> = {}): NextRequest {
+    return new NextRequest(`${URL}${query}`, {
+        headers: {
+            authorization: 'Bearer secret-not-logged',
+            'x-hb-service-key-id': 'current',
+            ...headers,
+        },
+    });
+}
+
+describe('private amplification credit entry feed', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.authorize.mockReturnValue(true);
+        mocks.queryRaw.mockResolvedValue([]);
+    });
+
+    it('reuses commerce service authentication and fails closed before querying', async () => {
+        mocks.authorize.mockReturnValue(false);
+        const response = await GET(request());
+        expect(response.status).toBe(401);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(mocks.authorize).toHaveBeenCalledWith('Bearer secret-not-logged', 'current');
+        expect(mocks.queryRaw).not.toHaveBeenCalled();
+        expect(await response.json()).toEqual({
+            error: 'unauthorized',
+            message: 'Service authentication failed',
+        });
+    });
+
+    it('returns the v1 envelope with nullable identity fields and private no-store', async () => {
+        mocks.queryRaw.mockResolvedValue([{
+            entry_id: '70000000-0000-4000-8000-000000000002',
+            scheduled_session_id: '10000000-0000-4000-8000-000000000001',
+            ticket_entitlement_id: '50000000-0000-4000-8000-000000000002',
+            registration_id: null,
+            email: null,
+            display_name: null,
+            entered_at: new Date('2026-08-09T20:15:30.000Z'),
+        }]);
+
+        const response = await GET(request('?limit=1'));
+        expect(response.status).toBe(200);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(await response.json()).toEqual({
+            schema_version: 'amplification-credit-entries.v1',
+            entries: [{
+                entry_id: '70000000-0000-4000-8000-000000000002',
+                scheduled_session_id: '10000000-0000-4000-8000-000000000001',
+                ticket_entitlement_id: '50000000-0000-4000-8000-000000000002',
+                registration_id: null,
+                email: null,
+                display_name: null,
+                entered_at: '2026-08-09T20:15:30.000Z',
+            }],
+            next_cursor: expect.any(String),
+        });
+    });
+
+    it('rejects malformed cursors and out-of-range limits without querying', async () => {
+        for (const query of ['?cursor=not+base64url', '?limit=101', '?limit=01']) {
+            const response = await GET(request(query));
+            expect(response.status).toBe(400);
+            expect(response.headers.get('cache-control')).toBe('private, no-store');
+        }
+        expect(mocks.queryRaw).not.toHaveBeenCalled();
+    });
+
+    it('keeps private no-store on unexpected database failures', async () => {
+        mocks.queryRaw.mockRejectedValue(new Error('sensitive database detail'));
+        const response = await GET(request());
+        expect(response.status).toBe(500);
+        expect(response.headers.get('cache-control')).toBe('private, no-store');
+        expect(await response.json()).toMatchObject({ error: 'amplification_credit_feed_unavailable' });
+    });
+});

--- a/src/app/api/internal/v1/amplification-credit-entries/route.ts
+++ b/src/app/api/internal/v1/amplification-credit-entries/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+    AmplificationCreditFeedError,
+    listAmplificationCreditEntries,
+    parseAmplificationCreditFeedQuery,
+} from '@/lib/amplification-credit-feed';
+import { authorizeCommerceService } from '@/lib/commerce-service-auth';
+
+export const dynamic = 'force-dynamic';
+
+const PRIVATE_NO_STORE = { 'Cache-Control': 'private, no-store' };
+
+function response(body: unknown, status = 200): NextResponse {
+    return NextResponse.json(body, { status, headers: PRIVATE_NO_STORE });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+    if (!authorizeCommerceService(
+        request.headers.get('authorization'),
+        request.headers.get('x-hb-service-key-id'),
+    )) {
+        return response({
+            error: 'unauthorized',
+            message: 'Service authentication failed',
+        }, 401);
+    }
+
+    try {
+        return response(await listAmplificationCreditEntries(
+            parseAmplificationCreditFeedQuery(request.nextUrl.searchParams),
+        ));
+    } catch (error) {
+        if (error instanceof AmplificationCreditFeedError) {
+            return response({ error: error.code, message: error.message }, error.status);
+        }
+        console.error('[amplification-credit-feed] feed read failed');
+        return response({
+            error: 'amplification_credit_feed_unavailable',
+            message: 'Beacon could not read amplification credit entries',
+        }, 500);
+    }
+}

--- a/src/lib/__tests__/amplification-credit-contract.test.ts
+++ b/src/lib/__tests__/amplification-credit-contract.test.ts
@@ -1,0 +1,37 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const CONTRACT = path.resolve('contracts/amplification-credit-entries/v1');
+
+describe('amplification credit shared contract bytes', () => {
+    it('keeps every copyable contract artifact covered by SHA256SUMS', () => {
+        const manifest = readFileSync(path.join(CONTRACT, 'SHA256SUMS'), 'utf8').trim().split('\n');
+        expect(manifest).toHaveLength(4);
+        for (const line of manifest) {
+            const [expected, filename] = line.split('  ', 2);
+            const bytes = readFileSync(path.join(CONTRACT, filename));
+            expect(createHash('sha256').update(bytes).digest('hex'), filename).toBe(expected);
+        }
+    });
+
+    it('ships paid, free-nullable and durable empty-poll synthetic fixtures', () => {
+        const page = JSON.parse(readFileSync(path.join(CONTRACT, 'page.fixture.json'), 'utf8'));
+        const empty = JSON.parse(readFileSync(path.join(CONTRACT, 'empty-page.fixture.json'), 'utf8'));
+        expect(page.schema_version).toBe('amplification-credit-entries.v1');
+        expect(page.entries).toHaveLength(2);
+        expect(page.entries[0].registration_id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(page.entries[1]).toMatchObject({
+            registration_id: null,
+            email: null,
+            display_name: null,
+        });
+        expect(empty).toEqual({
+            schema_version: 'amplification-credit-entries.v1',
+            entries: [],
+            next_cursor: page.next_cursor,
+        });
+    });
+});

--- a/src/lib/__tests__/amplification-credit-feed.integration.test.ts
+++ b/src/lib/__tests__/amplification-credit-feed.integration.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+    decodeAmplificationCreditCursor,
+    listAmplificationCreditEntries,
+} from '@/lib/amplification-credit-feed';
+import { prisma } from '@/lib/db';
+
+const integration = process.env.AMPLIFICATION_CREDIT_FEED_INTEGRATION_TEST === '1'
+    ? describe
+    : describe.skip;
+
+const FACILITATOR_ID = 'a0000000-0000-4000-8000-000000000001';
+const PAID_SESSION_ID = 'a1000000-0000-4000-8000-000000000001';
+const FREE_SESSION_ID = 'a2000000-0000-4000-8000-000000000001';
+const TEST_SESSION_ID = 'a3000000-0000-4000-8000-000000000001';
+const SESSION_IDS = [PAID_SESSION_ID, FREE_SESSION_ID, TEST_SESSION_ID];
+
+const PAID_TICKET_ID = 'b1000000-0000-4000-8000-000000000001';
+const FREE_TICKET_ID = 'b2000000-0000-4000-8000-000000000001';
+const TEST_TICKET_ID = 'b3000000-0000-4000-8000-000000000001';
+const NO_PRESENCE_TICKET_ID = 'b1000000-0000-4000-8000-000000000003';
+
+const PAID_PARTICIPANT_ID = 'c1000000-0000-4000-8000-000000000001';
+const FREE_PARTICIPANT_ID = 'c2000000-0000-4000-8000-000000000001';
+const STAFF_PARTICIPANT_ID = 'c1000000-0000-4000-8000-000000000002';
+const TEST_PARTICIPANT_ID = 'c3000000-0000-4000-8000-000000000001';
+const NO_PRESENCE_PARTICIPANT_ID = 'c1000000-0000-4000-8000-000000000004';
+const REGISTRATION_ID = 'd1000000-0000-4000-8000-000000000001';
+
+async function cleanup(): Promise<void> {
+    await prisma.commerceEntitlement.deleteMany({ where: { scheduledSessionId: { in: SESSION_IDS } } });
+    await prisma.scheduledSession.deleteMany({ where: { id: { in: SESSION_IDS } } });
+    await prisma.user.deleteMany({ where: { id: FACILITATOR_ID } });
+}
+
+integration('amplification credit feed PostgreSQL eligibility contract', () => {
+    beforeAll(async () => {
+        const configured = process.env.DATABASE_URL;
+        if (!configured) throw new Error('amplification credit integration DATABASE_URL is required');
+        const expectedDatabase = new URL(configured).pathname.replace(/^\//, '');
+        const [{ database }] = await prisma.$queryRaw<Array<{ database: string }>>`
+            SELECT current_database() AS "database"
+        `;
+        if (!expectedDatabase.endsWith('_test') || database !== expectedDatabase) {
+            throw new Error(
+                'amplification credit integration cleanup is restricted to the exact configured *_test database',
+            );
+        }
+
+        await cleanup();
+        await prisma.user.create({
+            data: {
+                id: FACILITATOR_ID,
+                email: 'amplification-feed@integration.invalid',
+                name: 'Integration facilitator',
+                role: 'FACILITATOR',
+                passwordDigest: 'not-used',
+            },
+        });
+        await prisma.scheduledSession.createMany({
+            data: [
+                {
+                    id: PAID_SESSION_ID,
+                    title: 'Paid eligible session',
+                    roomName: 'amplification-feed-paid',
+                    language: 'SPANISH',
+                    scheduledAt: new Date('2026-08-09T19:00:00.000Z'),
+                    status: 'ENDED',
+                    paidMode: true,
+                    facilitatorId: FACILITATOR_ID,
+                },
+                {
+                    id: FREE_SESSION_ID,
+                    title: 'Free eligible session',
+                    roomName: 'amplification-feed-free',
+                    language: 'ENGLISH',
+                    scheduledAt: new Date('2026-08-09T19:30:00.000Z'),
+                    status: 'ENDED',
+                    paidMode: true,
+                    publicAccess: true,
+                    facilitatorId: FACILITATOR_ID,
+                },
+                {
+                    id: TEST_SESSION_ID,
+                    title: 'Excluded test session',
+                    roomName: 'amplification-feed-test',
+                    language: 'SPANISH',
+                    scheduledAt: new Date('2026-08-09T20:00:00.000Z'),
+                    status: 'ENDED',
+                    isTest: true,
+                    facilitatorId: FACILITATOR_ID,
+                },
+            ],
+        });
+        const expiresAt = new Date('2026-08-10T19:00:00.000Z');
+        await prisma.ticketEntitlement.createMany({
+            data: [
+                { id: PAID_TICKET_ID, scheduledSessionId: PAID_SESSION_ID, codeDigest: 'feed-paid', codeLastFour: 'PAID', tier: 'GLOBAL_NORTH', state: 'BOUND', boundEmail: 'paid@example.com', boundAt: new Date('2026-08-09T19:00:00.000Z'), expiresAt },
+                { id: FREE_TICKET_ID, scheduledSessionId: FREE_SESSION_ID, codeDigest: 'feed-free', codeLastFour: 'FREE', tier: 'COMP', state: 'BOUND', boundEmail: null, accountId: 'synthetic-free-account', accountIssuer: 'https://accounts.integration.invalid', boundAt: new Date('2026-08-09T19:00:00.000Z'), expiresAt },
+                { id: TEST_TICKET_ID, scheduledSessionId: TEST_SESSION_ID, codeDigest: 'feed-test', codeLastFour: 'TEST', tier: 'COMP', state: 'BOUND', boundEmail: 'test@example.com', boundAt: new Date('2026-08-09T19:00:00.000Z'), expiresAt },
+                { id: NO_PRESENCE_TICKET_ID, scheduledSessionId: PAID_SESSION_ID, codeDigest: 'feed-none', codeLastFour: 'NONE', tier: 'GLOBAL_SOUTH', state: 'BOUND', boundEmail: 'absent@example.com', boundAt: new Date('2026-08-09T19:00:00.000Z'), expiresAt },
+            ],
+        });
+        await prisma.sessionParticipant.createMany({
+            data: [
+                { id: PAID_PARTICIPANT_ID, scheduledSessionId: PAID_SESSION_ID, participantIdentity: 'paid-person', displayName: 'Paid person', ticketEntitlementId: PAID_TICKET_ID },
+                { id: FREE_PARTICIPANT_ID, scheduledSessionId: FREE_SESSION_ID, participantIdentity: 'free-person', displayName: null, ticketEntitlementId: FREE_TICKET_ID },
+                { id: STAFF_PARTICIPANT_ID, scheduledSessionId: PAID_SESSION_ID, participantIdentity: 'staff-person', displayName: 'Staff person', staffUserId: FACILITATOR_ID },
+                { id: TEST_PARTICIPANT_ID, scheduledSessionId: TEST_SESSION_ID, participantIdentity: 'test-person', displayName: 'Test person', ticketEntitlementId: TEST_TICKET_ID },
+                { id: NO_PRESENCE_PARTICIPANT_ID, scheduledSessionId: PAID_SESSION_ID, participantIdentity: 'absent-person', displayName: 'Absent person', ticketEntitlementId: NO_PRESENCE_TICKET_ID },
+            ],
+        });
+        await prisma.livePresenceInterval.createMany({
+            data: [
+                { scheduledSessionId: PAID_SESSION_ID, participantId: PAID_PARTICIPANT_ID, generation: 1, startedAt: new Date('2026-08-09T20:00:00.000Z'), lastHeartbeatAt: new Date('2026-08-09T20:01:00.000Z'), endedAt: new Date('2026-08-09T20:01:00.000Z') },
+                { scheduledSessionId: PAID_SESSION_ID, participantId: PAID_PARTICIPANT_ID, generation: 2, startedAt: new Date('2026-08-09T20:05:00.000Z'), lastHeartbeatAt: new Date('2026-08-09T20:06:00.000Z'), endedAt: new Date('2026-08-09T20:06:00.000Z'), reconnectCount: 1 },
+                { scheduledSessionId: FREE_SESSION_ID, participantId: FREE_PARTICIPANT_ID, generation: 1, startedAt: new Date('2026-08-09T20:15:30.000Z'), lastHeartbeatAt: new Date('2026-08-09T20:16:00.000Z'), endedAt: new Date('2026-08-09T20:16:00.000Z') },
+                { scheduledSessionId: PAID_SESSION_ID, participantId: STAFF_PARTICIPANT_ID, generation: 1, startedAt: new Date('2026-08-09T19:50:00.000Z'), lastHeartbeatAt: new Date('2026-08-09T19:51:00.000Z'), endedAt: new Date('2026-08-09T19:51:00.000Z') },
+                { scheduledSessionId: TEST_SESSION_ID, participantId: TEST_PARTICIPANT_ID, generation: 1, startedAt: new Date('2026-08-09T19:45:00.000Z'), lastHeartbeatAt: new Date('2026-08-09T19:46:00.000Z'), endedAt: new Date('2026-08-09T19:46:00.000Z') },
+            ],
+        });
+        await prisma.commerceEntitlement.create({
+            data: {
+                provider: 'TICKET_TAILOR',
+                externalTicketId: 'amplification-feed-paid-ticket',
+                externalOrderId: 'amplification-feed-paid-order',
+                registrationId: REGISTRATION_ID,
+                scheduledSessionId: PAID_SESSION_ID,
+                ticketEntitlementId: PAID_TICKET_ID,
+                providerState: 'ACTIVE',
+                reasonCode: 'PAYMENT_VERIFIED',
+                provisionRevision: 1,
+                commandHash: 'a'.repeat(64),
+                boundEmail: 'paid@example.com',
+                tier: 'GLOBAL_NORTH',
+                grantId: 'e1000000-0000-4000-8000-000000000001',
+                grantGeneration: 1,
+                derivationKeyVersion: 1,
+                codeDigestVersion: 1,
+                providerObservedAt: new Date('2026-08-09T19:00:00.000Z'),
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await cleanup();
+        await prisma.$disconnect();
+    });
+
+    it('filters ineligible rows, includes paid/free, deduplicates reconnects and paginates durably', async () => {
+        const first = await listAmplificationCreditEntries({ cursor: null, limit: 1 });
+        expect(first.entries).toEqual([{
+            entry_id: PAID_PARTICIPANT_ID,
+            scheduled_session_id: PAID_SESSION_ID,
+            ticket_entitlement_id: PAID_TICKET_ID,
+            registration_id: REGISTRATION_ID,
+            email: 'paid@example.com',
+            display_name: 'Paid person',
+            entered_at: '2026-08-09T20:00:00.000Z',
+        }]);
+
+        const second = await listAmplificationCreditEntries({
+            cursor: decodeAmplificationCreditCursor(first.next_cursor),
+            limit: 1,
+        });
+        expect(second.entries).toEqual([{
+            entry_id: FREE_PARTICIPANT_ID,
+            scheduled_session_id: FREE_SESSION_ID,
+            ticket_entitlement_id: FREE_TICKET_ID,
+            registration_id: null,
+            email: null,
+            display_name: null,
+            entered_at: '2026-08-09T20:15:30.000Z',
+        }]);
+
+        const cursor = decodeAmplificationCreditCursor(second.next_cursor);
+        const empty = await listAmplificationCreditEntries({ cursor, limit: 100 });
+        expect(empty.entries).toEqual([]);
+        expect(empty.next_cursor).toBe(second.next_cursor);
+    });
+});

--- a/src/lib/__tests__/amplification-credit-feed.test.ts
+++ b/src/lib/__tests__/amplification-credit-feed.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ queryRaw: vi.fn() }));
+
+vi.mock('@/lib/db', () => ({
+    prisma: { $queryRaw: mocks.queryRaw },
+}));
+
+import {
+    AmplificationCreditFeedError,
+    decodeAmplificationCreditCursor,
+    encodeAmplificationCreditCursor,
+    listAmplificationCreditEntries,
+    parseAmplificationCreditFeedLimit,
+    parseAmplificationCreditFeedQuery,
+} from '@/lib/amplification-credit-feed';
+
+const FIRST_ID = '70000000-0000-4000-8000-000000000001';
+const SECOND_ID = '70000000-0000-4000-8000-000000000002';
+
+function row(overrides: Record<string, unknown> = {}) {
+    return {
+        entry_id: FIRST_ID,
+        scheduled_session_id: '10000000-0000-4000-8000-000000000001',
+        ticket_entitlement_id: '50000000-0000-4000-8000-000000000001',
+        registration_id: '20000000-0000-4000-8000-000000000001',
+        email: 'ana@example.com',
+        display_name: 'Ana',
+        entered_at: new Date('2026-08-09T20:00:00.000Z'),
+        ...overrides,
+    };
+}
+
+function queryText(): string {
+    const query = mocks.queryRaw.mock.calls.at(-1)?.[0] as { strings: readonly string[] };
+    return query.strings.join('?').replace(/\s+/g, ' ');
+}
+
+describe('amplification credit cursor and limit', () => {
+    it('round-trips the exact entered_at + entry_id position', () => {
+        const cursor = {
+            v: 1 as const,
+            entered_at: '2026-08-09T20:00:00.000Z',
+            entry_id: FIRST_ID,
+        };
+        expect(decodeAmplificationCreditCursor(encodeAmplificationCreditCursor(cursor))).toEqual(cursor);
+        expect(decodeAmplificationCreditCursor(null)).toBeNull();
+    });
+
+    it('strictly rejects malformed, non-canonical, unknown-field and repeated cursors', () => {
+        const invalid = [
+            '',
+            'not+base64url',
+            Buffer.from('{"v":1,"entered_at":"not-a-date","entry_id":"bad"}').toString('base64url'),
+            Buffer.from(JSON.stringify({
+                v: 1,
+                entered_at: '2026-08-09T20:00:00.000Z',
+                entry_id: FIRST_ID,
+                extra: true,
+            })).toString('base64url'),
+            Buffer.from(JSON.stringify({
+                v: 2,
+                entered_at: '2026-08-09T20:00:00.000Z',
+                entry_id: FIRST_ID,
+            })).toString('base64url'),
+        ];
+        for (const value of invalid) {
+            expect(() => decodeAmplificationCreditCursor(value)).toThrowError(
+                expect.objectContaining({ code: 'invalid_cursor', status: 400 }) as Error,
+            );
+        }
+        expect(() => parseAmplificationCreditFeedQuery(
+            new URLSearchParams('cursor=a&cursor=b'),
+        )).toThrowError(expect.objectContaining({ code: 'invalid_request' }) as Error);
+    });
+
+    it('defaults to 50, accepts 1-100 and strictly rejects other limit spellings', () => {
+        expect(parseAmplificationCreditFeedLimit(null)).toBe(50);
+        expect(parseAmplificationCreditFeedLimit('1')).toBe(1);
+        expect(parseAmplificationCreditFeedLimit('100')).toBe(100);
+        for (const value of ['', '0', '01', '1.0', '-1', '101', 'abc']) {
+            expect(() => parseAmplificationCreditFeedLimit(value)).toThrowError(
+                expect.objectContaining({ code: 'invalid_limit', status: 400 }) as Error,
+            );
+        }
+    });
+});
+
+describe('amplification credit feed query', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('filters staff, no-ticket and test sessions while retaining paid and free tickets', async () => {
+        mocks.queryRaw.mockResolvedValue([
+            row(),
+            row({
+                entry_id: SECOND_ID,
+                registration_id: null,
+                email: null,
+                display_name: null,
+                entered_at: new Date('2026-08-09T20:15:30.000Z'),
+            }),
+        ]);
+
+        const page = await listAmplificationCreditEntries({ cursor: null, limit: 100 });
+
+        const sql = queryText();
+        expect(sql).toContain('"session"."is_test" = FALSE');
+        expect(sql).toContain('"participant"."staff_user_id" IS NULL');
+        expect(sql).toContain('"participant"."ticket_entitlement_id" IS NOT NULL');
+        expect(sql).toContain('LEFT JOIN "commerce_entitlements" AS "commerce"');
+        expect(page.entries).toHaveLength(2);
+        expect(page.entries[1]).toMatchObject({
+            registration_id: null,
+            email: null,
+            display_name: null,
+        });
+    });
+
+    it('deduplicates reconnect intervals with MIN(started_at) per SessionParticipant', async () => {
+        mocks.queryRaw.mockResolvedValue([row()]);
+
+        const page = await listAmplificationCreditEntries({ cursor: null, limit: 50 });
+
+        const sql = queryText();
+        expect(sql).toContain('MIN("presence"."started_at") AS "entered_at"');
+        expect(sql).toContain('GROUP BY "participant"."id"');
+        expect(page.entries).toEqual([expect.objectContaining({
+            entry_id: FIRST_ID,
+            entered_at: '2026-08-09T20:00:00.000Z',
+        })]);
+    });
+
+    it('orders and resumes strictly by entered_at then entry_id', async () => {
+        mocks.queryRaw.mockResolvedValueOnce([
+            row(),
+            row({ entry_id: SECOND_ID }),
+        ]);
+        const first = await listAmplificationCreditEntries({ cursor: null, limit: 2 });
+        const cursor = decodeAmplificationCreditCursor(first.next_cursor);
+        expect(cursor).toEqual({
+            v: 1,
+            entered_at: '2026-08-09T20:00:00.000Z',
+            entry_id: SECOND_ID,
+        });
+        expect(queryText()).toContain('ORDER BY "entered_at" ASC, "entry_id" ASC');
+
+        mocks.queryRaw.mockResolvedValueOnce([]);
+        const empty = await listAmplificationCreditEntries({ cursor, limit: 2 });
+        expect(empty.entries).toEqual([]);
+        expect(empty.next_cursor).toBe(first.next_cursor);
+        expect(queryText()).toContain('"entered_at" > ? OR ("entered_at" = ? AND "entry_id" > ?::uuid)');
+    });
+
+    it('returns a durable cursor even when a non-empty page is the current tail', async () => {
+        mocks.queryRaw.mockResolvedValue([row()]);
+        const page = await listAmplificationCreditEntries({ cursor: null, limit: 100 });
+        expect(page.next_cursor).not.toBeNull();
+        expect(decodeAmplificationCreditCursor(page.next_cursor)).toMatchObject({ entry_id: FIRST_ID });
+    });
+
+    it('defends the database boundary against an unbounded internal caller', async () => {
+        await expect(listAmplificationCreditEntries({ cursor: null, limit: 101 })).rejects.toMatchObject({
+            code: 'invalid_limit',
+            status: 400,
+        });
+        expect(mocks.queryRaw).not.toHaveBeenCalled();
+    });
+
+    it('surfaces only the expected feed error class for invalid input', () => {
+        expect(() => parseAmplificationCreditFeedQuery(new URLSearchParams('unexpected=1')))
+            .toThrowError(AmplificationCreditFeedError);
+    });
+});

--- a/src/lib/amplification-credit-feed.ts
+++ b/src/lib/amplification-credit-feed.ts
@@ -1,0 +1,238 @@
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/db';
+
+export const AMPLIFICATION_CREDIT_FEED_SCHEMA = 'amplification-credit-entries.v1' as const;
+export const AMPLIFICATION_CREDIT_FEED_DEFAULT_LIMIT = 50;
+export const AMPLIFICATION_CREDIT_FEED_MAX_LIMIT = 100;
+
+const CURSOR_MAX_CHARS = 512;
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export class AmplificationCreditFeedError extends Error {
+    constructor(
+        public readonly code: 'invalid_cursor' | 'invalid_limit' | 'invalid_request',
+        public readonly status: 400,
+        message: string,
+    ) {
+        super(message);
+        this.name = 'AmplificationCreditFeedError';
+    }
+}
+
+export type AmplificationCreditEntry = {
+    entry_id: string;
+    scheduled_session_id: string;
+    ticket_entitlement_id: string;
+    registration_id: string | null;
+    email: string | null;
+    display_name: string | null;
+    entered_at: string;
+};
+
+export type AmplificationCreditFeedPage = {
+    schema_version: typeof AMPLIFICATION_CREDIT_FEED_SCHEMA;
+    entries: AmplificationCreditEntry[];
+    next_cursor: string | null;
+};
+
+export type AmplificationCreditCursor = {
+    v: 1;
+    entered_at: string;
+    entry_id: string;
+};
+
+type AmplificationCreditDatabaseRow = {
+    entry_id: string;
+    scheduled_session_id: string;
+    ticket_entitlement_id: string;
+    registration_id: string | null;
+    email: string | null;
+    display_name: string | null;
+    entered_at: Date;
+};
+
+function invalidCursor(): never {
+    throw new AmplificationCreditFeedError('invalid_cursor', 400, 'Cursor is not valid');
+}
+
+export function encodeAmplificationCreditCursor(cursor: AmplificationCreditCursor): string {
+    return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeAmplificationCreditCursor(raw: string | null): AmplificationCreditCursor | null {
+    if (raw === null) return null;
+    if (raw.length === 0 || raw.length > CURSOR_MAX_CHARS || !BASE64URL.test(raw)) {
+        return invalidCursor();
+    }
+
+    try {
+        const decoded = Buffer.from(raw, 'base64url');
+        if (decoded.toString('base64url') !== raw) return invalidCursor();
+        const parsed = JSON.parse(decoded.toString('utf8')) as unknown;
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            return invalidCursor();
+        }
+        const record = parsed as Record<string, unknown>;
+        const keys = Object.keys(record).sort();
+        if (
+            keys.length !== 3 ||
+            keys[0] !== 'entered_at' ||
+            keys[1] !== 'entry_id' ||
+            keys[2] !== 'v' ||
+            record.v !== 1 ||
+            typeof record.entered_at !== 'string' ||
+            typeof record.entry_id !== 'string' ||
+            !UUID.test(record.entry_id)
+        ) {
+            return invalidCursor();
+        }
+        const instant = new Date(record.entered_at);
+        if (Number.isNaN(instant.getTime()) || instant.toISOString() !== record.entered_at) {
+            return invalidCursor();
+        }
+        return {
+            v: 1,
+            entered_at: record.entered_at,
+            entry_id: record.entry_id,
+        };
+    } catch (error) {
+        if (error instanceof AmplificationCreditFeedError) throw error;
+        return invalidCursor();
+    }
+}
+
+export function parseAmplificationCreditFeedLimit(raw: string | null): number {
+    if (raw === null) return AMPLIFICATION_CREDIT_FEED_DEFAULT_LIMIT;
+    if (!/^[1-9][0-9]{0,2}$/.test(raw)) {
+        throw new AmplificationCreditFeedError(
+            'invalid_limit',
+            400,
+            `Limit must be an integer between 1 and ${AMPLIFICATION_CREDIT_FEED_MAX_LIMIT}`,
+        );
+    }
+    const limit = Number(raw);
+    if (limit > AMPLIFICATION_CREDIT_FEED_MAX_LIMIT) {
+        throw new AmplificationCreditFeedError(
+            'invalid_limit',
+            400,
+            `Limit must be an integer between 1 and ${AMPLIFICATION_CREDIT_FEED_MAX_LIMIT}`,
+        );
+    }
+    return limit;
+}
+
+export function parseAmplificationCreditFeedQuery(searchParams: URLSearchParams): {
+    cursor: AmplificationCreditCursor | null;
+    limit: number;
+} {
+    for (const key of searchParams.keys()) {
+        if (key !== 'cursor' && key !== 'limit') {
+            throw new AmplificationCreditFeedError('invalid_request', 400, 'Unknown query parameter');
+        }
+    }
+    if (searchParams.getAll('cursor').length > 1 || searchParams.getAll('limit').length > 1) {
+        throw new AmplificationCreditFeedError('invalid_request', 400, 'Query parameters must not repeat');
+    }
+    return {
+        cursor: decodeAmplificationCreditCursor(searchParams.get('cursor')),
+        limit: parseAmplificationCreditFeedLimit(searchParams.get('limit')),
+    };
+}
+
+function mapRow(row: AmplificationCreditDatabaseRow): AmplificationCreditEntry {
+    return {
+        entry_id: row.entry_id,
+        scheduled_session_id: row.scheduled_session_id,
+        ticket_entitlement_id: row.ticket_entitlement_id,
+        registration_id: row.registration_id,
+        email: row.email,
+        display_name: row.display_name,
+        entered_at: row.entered_at.toISOString(),
+    };
+}
+
+export async function listAmplificationCreditEntries(input: {
+    cursor: AmplificationCreditCursor | null;
+    limit: number;
+}): Promise<AmplificationCreditFeedPage> {
+    if (
+        !Number.isSafeInteger(input.limit) ||
+        input.limit < 1 ||
+        input.limit > AMPLIFICATION_CREDIT_FEED_MAX_LIMIT
+    ) {
+        throw new AmplificationCreditFeedError(
+            'invalid_limit',
+            400,
+            `Limit must be an integer between 1 and ${AMPLIFICATION_CREDIT_FEED_MAX_LIMIT}`,
+        );
+    }
+    const cursorPredicate = input.cursor
+        ? Prisma.sql`
+            WHERE (
+                "entered_at" > ${new Date(input.cursor.entered_at)}
+                OR ("entered_at" = ${new Date(input.cursor.entered_at)} AND "entry_id" > ${input.cursor.entry_id}::uuid)
+            )
+        `
+        : Prisma.empty;
+
+    const rows = await prisma.$queryRaw<AmplificationCreditDatabaseRow[]>(Prisma.sql`
+        WITH "eligible_entries" AS (
+            SELECT
+                "participant"."id" AS "entry_id",
+                "participant"."scheduled_session_id" AS "scheduled_session_id",
+                "participant"."ticket_entitlement_id" AS "ticket_entitlement_id",
+                "commerce"."registration_id" AS "registration_id",
+                "ticket"."bound_email" AS "email",
+                "participant"."display_name" AS "display_name",
+                MIN("presence"."started_at") AS "entered_at"
+            FROM "session_participants" AS "participant"
+            INNER JOIN "scheduled_sessions" AS "session"
+                ON "session"."id" = "participant"."scheduled_session_id"
+            INNER JOIN "ticket_entitlements" AS "ticket"
+                ON "ticket"."id" = "participant"."ticket_entitlement_id"
+            INNER JOIN "live_presence_intervals" AS "presence"
+                ON "presence"."participant_id" = "participant"."id"
+                AND "presence"."scheduled_session_id" = "participant"."scheduled_session_id"
+            LEFT JOIN "commerce_entitlements" AS "commerce"
+                ON "commerce"."ticket_entitlement_id" = "participant"."ticket_entitlement_id"
+                AND "commerce"."scheduled_session_id" = "participant"."scheduled_session_id"
+            WHERE "session"."is_test" = FALSE
+                AND "participant"."staff_user_id" IS NULL
+                AND "participant"."ticket_entitlement_id" IS NOT NULL
+            GROUP BY
+                "participant"."id",
+                "participant"."scheduled_session_id",
+                "participant"."ticket_entitlement_id",
+                "commerce"."registration_id",
+                "ticket"."bound_email",
+                "participant"."display_name"
+        )
+        SELECT
+            "entry_id",
+            "scheduled_session_id",
+            "ticket_entitlement_id",
+            "registration_id",
+            "email",
+            "display_name",
+            "entered_at"
+        FROM "eligible_entries"
+        ${cursorPredicate}
+        ORDER BY "entered_at" ASC, "entry_id" ASC
+        LIMIT ${input.limit}
+    `);
+
+    const last = rows.at(-1);
+    return {
+        schema_version: AMPLIFICATION_CREDIT_FEED_SCHEMA,
+        entries: rows.map(mapRow),
+        next_cursor: last
+            ? encodeAmplificationCreditCursor({
+                v: 1,
+                entered_at: last.entered_at.toISOString(),
+                entry_id: last.entry_id,
+            })
+            : input.cursor ? encodeAmplificationCreditCursor(input.cursor) : null,
+    };
+}


### PR DESCRIPTION
## Summary

- add the private authenticated `GET /api/internal/v1/amplification-credit-entries` route using the existing commerce service key rotation
- derive one eligible entry per `SessionParticipant` from `MIN(LivePresenceInterval.startedAt)`, excluding staff, no-ticket participants, test sessions, and participants without observed presence while retaining paid and free tickets
- add strict bounded pagination with a durable opaque `(entered_at, entry_id)` resume cursor, including cursor preservation on empty polls
- ship a byte-verifiable JSON Schema plus paid/free and empty-poll synthetic fixtures for copying into PMP Myth Bot

## Validation

- `npm test` — 1,108 passed, 24 skipped
- focused feed/route/contract tests — 15 passed
- PostgreSQL integration test on a disposable Postgres 16 database — 1 passed
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

No frontend or Prisma schema changes.

Closes #501.
Coordinates with https://github.com/Mar-IA-no/PMP-myth-bot/issues/22.