### PR TITLE
fix(live): show remaining Umbral sessions at 14:00 ART

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -43,6 +43,7 @@ const SESSION_2 = {
 };
 const NOW = new Date('2026-08-05T12:00:00.000Z');
 const PUBLIC_ID = '50000000-0000-4000-8000-202608220001';
+const REMAINING_PUBLIC_ID = '50000000-0000-4000-8000-202609050001';
 
 function mountDb(findMany: ReturnType<typeof vi.fn>) {
     const prisma = { scheduledSession: { findMany } };
@@ -230,6 +231,24 @@ describe('landing page', () => {
         );
         expect(screen.queryByRole('link', { name: /Comprar entrada/ })).toBeNull();
         expect(screen.queryByTestId('ticket-login-form')).toBeNull();
+    });
+
+    it('shows the remaining public cycle at 14:00 Argentina without changing its stored schedule', async () => {
+        const scheduledAt = new Date('2026-09-05T16:00:00.000Z');
+        mountDb(vi.fn().mockResolvedValue([{
+            ...SATURDAY,
+            id: REMAINING_PUBLIC_ID,
+            scheduledAt,
+            publicAccess: true,
+        }]));
+
+        await renderPage();
+
+        expect(document.querySelector('.event-local-time__primary')).toHaveTextContent(
+            /Argentina: sábado, 5 de septiembre, 14:00 (ART|GMT-3)/,
+        );
+        expect(screen.getByText(/Referencia universal:/)).toHaveTextContent('17:00 UTC');
+        expect(scheduledAt.toISOString()).toBe('2026-09-05T16:00:00.000Z');
     });
 
     it('makes upcoming gatherings the primary landing promise and links the wider experience below', async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,11 +31,25 @@ type WeekendEvent = {
 };
 
 const INTERNAL_NEXT = /^\/session(\/[A-Za-z0-9_-]+)*$/;
+// Editorial override for the public landing only. The stored schedule still
+// controls room access, lifecycle automation and every non-landing surface.
+const LANDING_ONLY_1400_ART_SESSION_IDS = new Set([
+    '50000000-0000-4000-8000-202609050001',
+    '50000000-0000-4000-8000-202609120001',
+]);
+const ONE_HOUR_MS = 60 * 60 * 1000;
 // A missed lifecycle transition must not leave an old LIVE row advertising the
 // current checkout indefinitely. Weekend sessions last hours, not days; 24
 // hours keeps a delayed/extended live room discoverable while failing closed
 // before a stale row can be presented as the next paid event.
 const PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function landingDisplayTime(event: Pick<WeekendEvent, 'id' | 'scheduledAt'>): string {
+    const displayTime = LANDING_ONLY_1400_ART_SESSION_IDS.has(event.id)
+        ? new Date(event.scheduledAt.getTime() + ONE_HOUR_MS)
+        : event.scheduledAt;
+    return displayTime.toISOString();
+}
 
 function publicScheduleNow(): Date {
     const pinned = process.env.E2E_DASHBOARD_ENABLED === '1'
@@ -165,7 +179,7 @@ export default async function LandingPage({
                                                     )}
                                                 </>
                                             )}
-                                            <EventLocalTime at={event.scheduledAt.toISOString()} />
+                                            <EventLocalTime at={landingDisplayTime(event)} />
                                         </div>
                                         <div className="text-right">
                                             <p className="text-xs font-mono text-[var(--text-secondary)]">


### PR DESCRIPTION
## Qué cambia\n- muestra los encuentros restantes del ciclo a las 14:00 de Argentina en la landing pública\n- mantiene conversiones visuales coherentes para el selector de país\n\n## Fuera de alcance\n- no modifica scheduledAt en base de datos\n- no cambia acceso, salas, Ticket Tailor ni automatizaciones del evento\n\n## Verificación\n- test específico de landing\n- suite completa\n- TypeScript\n- lint\n- build de producción