### PR TITLE
fix(landing): make 14:00 schedule rollout-safe

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -44,6 +44,7 @@ const SESSION_2 = {
 const NOW = new Date('2026-08-05T12:00:00.000Z');
 const PUBLIC_ID = '50000000-0000-4000-8000-202608220001';
 const REMAINING_PUBLIC_ID = '50000000-0000-4000-8000-202609050001';
+const FINAL_PUBLIC_ID = '50000000-0000-4000-8000-202609120001';
 
 function mountDb(findMany: ReturnType<typeof vi.fn>) {
     const prisma = { scheduledSession: { findMany } };
@@ -233,11 +234,16 @@ describe('landing page', () => {
         expect(screen.queryByTestId('ticket-login-form')).toBeNull();
     });
 
-    it('shows the remaining public cycle at 14:00 Argentina without changing its stored schedule', async () => {
-        const scheduledAt = new Date('2026-09-05T16:00:00.000Z');
+    it.each([
+        ['third legacy', REMAINING_PUBLIC_ID, '2026-09-05T16:00:00.000Z'],
+        ['third canonical', REMAINING_PUBLIC_ID, '2026-09-05T17:00:00.000Z'],
+        ['fourth legacy', FINAL_PUBLIC_ID, '2026-09-12T16:00:00.000Z'],
+        ['fourth canonical', FINAL_PUBLIC_ID, '2026-09-12T17:00:00.000Z'],
+    ])('shows the remaining public cycle at 14:00 Argentina with the %s stored schedule', async (_state, id, storedAt) => {
+        const scheduledAt = new Date(storedAt);
         mountDb(vi.fn().mockResolvedValue([{
             ...SATURDAY,
-            id: REMAINING_PUBLIC_ID,
+            id,
             scheduledAt,
             publicAccess: true,
         }]));
@@ -245,10 +251,10 @@ describe('landing page', () => {
         await renderPage();
 
         expect(document.querySelector('.event-local-time__primary')).toHaveTextContent(
-            /Argentina: sábado, 5 de septiembre, 14:00 (ART|GMT-3)/,
+            /Argentina: sábado, (5|12) de septiembre, 14:00 (ART|GMT-3)/,
         );
         expect(screen.getByText(/Referencia universal:/)).toHaveTextContent('17:00 UTC');
-        expect(scheduledAt.toISOString()).toBe('2026-09-05T16:00:00.000Z');
+        expect(scheduledAt.toISOString()).toBe(storedAt);
     });
 
     it('makes upcoming gatherings the primary landing promise and links the wider experience below', async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,13 +31,19 @@ type WeekendEvent = {
 };
 
 const INTERNAL_NEXT = /^\/session(\/[A-Za-z0-9_-]+)*$/;
-// Editorial override for the public landing only. The stored schedule still
-// controls room access, lifecycle automation and every non-landing surface.
-const LANDING_ONLY_1400_ART_SESSION_IDS = new Set([
-    '50000000-0000-4000-8000-202609050001',
-    '50000000-0000-4000-8000-202609120001',
+// Rollout-safe editorial override: normalize only the legacy stored times.
+// Once scheduled_at is migrated to the canonical value, this becomes a no-op
+// so the app cannot show 15:00 while old and new revisions overlap.
+const LANDING_1400_ART_SCHEDULES = new Map([
+    ['50000000-0000-4000-8000-202609050001', {
+        legacy: '2026-09-05T16:00:00.000Z',
+        canonical: '2026-09-05T17:00:00.000Z',
+    }],
+    ['50000000-0000-4000-8000-202609120001', {
+        legacy: '2026-09-12T16:00:00.000Z',
+        canonical: '2026-09-12T17:00:00.000Z',
+    }],
 ]);
-const ONE_HOUR_MS = 60 * 60 * 1000;
 // A missed lifecycle transition must not leave an old LIVE row advertising the
 // current checkout indefinitely. Weekend sessions last hours, not days; 24
 // hours keeps a delayed/extended live room discoverable while failing closed
@@ -45,10 +51,9 @@ const ONE_HOUR_MS = 60 * 60 * 1000;
 const PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function landingDisplayTime(event: Pick<WeekendEvent, 'id' | 'scheduledAt'>): string {
-    const displayTime = LANDING_ONLY_1400_ART_SESSION_IDS.has(event.id)
-        ? new Date(event.scheduledAt.getTime() + ONE_HOUR_MS)
-        : event.scheduledAt;
-    return displayTime.toISOString();
+    const stored = event.scheduledAt.toISOString();
+    const schedule = LANDING_1400_ART_SCHEDULES.get(event.id);
+    return schedule?.legacy === stored ? schedule.canonical : stored;
 }
 
 function publicScheduleNow(): Date {


### PR DESCRIPTION
## Cambio

Primera fase del cambio de horario de los dos encuentros restantes del ciclo:

- mantiene 14:00 Argentina / 17:00 UTC en la landing mientras la base aún guarda 16:00 UTC
- también muestra 14:00 correctamente cuando `scheduled_at` ya sea 17:00 UTC
- cubre ambos IDs estables, 5 y 12 de septiembre
- no modifica otras sesiones ni horarios inesperados

## Por qué se despliega antes de la migración

`deploy.yml` aplica migraciones antes de reemplazar la app. El override anterior sumaba una hora incondicionalmente; con la base migrada habría mostrado 15:00 durante el rollout o un rollback. Esta fase hace el código compatible con DB vieja y nueva antes de cambiar la fuente canónica.

## Verificación

- regresión roja sobre `release`: el estado canónico de 17:00 UTC aparecía como 15:00 ART
- regresión verde: legacy y canonical para los dos encuentros muestran 14:00 ART
- suite completa: 1140 passed, 26 skipped
- TypeScript, ESLint y build de producción: verdes
- auditorías productivas root/Tapestry/Playlist: sin vulnerabilidades high/critical
- revisión independiente pre-commit: aprobada, sin errores de seguridad ni lógica

## Siguiente fase

Después de desplegar este PR, un segundo PR atómico migrará sólo las dos sesiones a 17:00 UTC y retirará el override temporal.

Related: #493.
