### PR TITLE
fix(session): converge attendee identity and safe stage exit

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,6 +106,10 @@ jobs:
           npm run db:fixture:load
           DATABASE_URL="$E2E_DATABASE_URL" npx prisma migrate deploy
           DATABASE_URL="$E2E_DATABASE_URL" npm run stage-grants:forward-drain
+        env:
+          LIVEKIT_INTERNAL_URL: http://localhost:7880
+          LIVEKIT_API_KEY: ${{ env.E2E_LIVEKIT_API_KEY }}
+          LIVEKIT_API_SECRET: ${{ env.E2E_LIVEKIT_API_SECRET }}
 
       - name: Verify session contributions contract in PostgreSQL
         # Real-database proof of the CHAT-01 guarantees: idempotency unique

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -17,9 +17,10 @@ export async function loginViaDashboard(
     role: DashboardRole,
     name: string,
     landing: string,
+    options: { nameConfirmed?: boolean } = {},
 ): Promise<void> {
     const response = await page.request.post('/api/test-login', {
-        data: { name, role, landing },
+        data: { name, role, landing, ...options },
     });
     expect(
         response.ok(),

--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -131,6 +131,39 @@ export async function withoutContributions<T>(
     }
 }
 
+/**
+ * Clear a fixture session's raised hands before and after `run`.
+ *
+ * Hand-flow specs exercise the real persistent queue. Keeping this cleanup
+ * close to those specs prevents their state from leaking into later cockpit
+ * screenshots while still allowing the product endpoints to own every
+ * transition under test.
+ */
+export async function withoutRaisedHands<T>(
+    databaseUrl: string,
+    sessionId: string,
+    run: () => Promise<T>,
+): Promise<T> {
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+        await client.query(
+            'update session_participants set raised_at = null where scheduled_session_id = $1',
+            [sessionId],
+        );
+        try {
+            return await run();
+        } finally {
+            await client.query(
+                'update session_participants set raised_at = null where scheduled_session_id = $1',
+                [sessionId],
+            );
+        }
+    } finally {
+        await client.end();
+    }
+}
+
 /** Replace fixture event titles for a layout test, then restore them exactly. */
 export async function withSessionTitles<T>(
     databaseUrl: string,

--- a/e2e/tests/accessibility.spec.ts
+++ b/e2e/tests/accessibility.spec.ts
@@ -76,6 +76,21 @@ test.describe('public surfaces', () => {
 });
 
 stackTest.describe('role surfaces', () => {
+    stackTest('attendee name confirmation is accessible before LiveKit mounts', async ({ page }, testInfo) => {
+        await loginViaDashboard(
+            page,
+            'ATTENDEE',
+            'Participante',
+            ROUTES.session(SESSION_ES.id),
+            { nameConfirmed: false },
+        );
+        await expect(page.getByRole('textbox', {
+            name: /Tu nombre visible|Your visible name/i,
+        })).toBeVisible();
+        await expect(page.getByTestId('connection-state')).toHaveCount(0);
+        await assertAccessible(page, 'attendee-name-confirmation', testInfo);
+    });
+
     stackTest('attendee session shell is accessible', async ({ page }, testInfo) => {
         // Doors open so the attendee reaches the real shell; without LiveKit
         // the deterministic connection-error card is checked instead.

--- a/e2e/tests/attendee-identity.spec.ts
+++ b/e2e/tests/attendee-identity.spec.ts
@@ -1,0 +1,103 @@
+import { expect, stackTest } from '../fixtures/stack';
+import { loginAttendeeWithTicket, loginViaDashboard } from '../fixtures/auth';
+import { requireDirectDb, withSessionStatus } from '../fixtures/db';
+import { ROUTES, SESSION_ES, TICKETS } from '../fixtures/test-data';
+
+stackTest('an unconfirmed attendee alias blocks LiveKit until it is corrected, then survives refresh', async ({
+    browser,
+}, testInfo) => {
+    const db = requireDirectDb(testInfo);
+    await withSessionStatus(db, SESSION_ES.id, 'LIVE', async () => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        try {
+            await loginViaDashboard(
+                page,
+                'ATTENDEE',
+                'Participante',
+                ROUTES.session(SESSION_ES.id),
+                { nameConfirmed: false },
+            );
+
+            const input = page.getByRole('textbox', { name: /Tu nombre visible|Your visible name/i });
+            await expect(input).toBeVisible();
+            await expect(page.getByTestId('connection-state')).toHaveCount(0);
+            await input.fill('Anahí 李');
+            await page.getByRole('button', { name: /Confirmar y continuar|Confirm and continue/i }).click();
+
+            await expect(page.getByTestId('connection-state')).toHaveAttribute(
+                'data-state',
+                'connected',
+                { timeout: 20_000 },
+            );
+            await expect(page.getByTestId('viewer-identity')).toContainText('Anahí 李');
+
+            await page.reload();
+            await expect(page.getByTestId('connection-state')).toHaveAttribute(
+                'data-state',
+                'connected',
+                { timeout: 20_000 },
+            );
+            await expect(input).toHaveCount(0);
+            await expect(page.getByTestId('viewer-identity')).toContainText('Anahí 李');
+        } finally {
+            await context.close();
+        }
+    });
+});
+
+stackTest('a second device can correct the stable event alias used by the hand queue', async ({
+    browser,
+}, testInfo) => {
+    stackTest.slow();
+    const db = requireDirectDb(testInfo);
+    await withSessionStatus(db, SESSION_ES.id, 'LIVE', async () => {
+        const firstContext = await browser.newContext();
+        const secondContext = await browser.newContext();
+        const staffContext = await browser.newContext();
+        const first = await firstContext.newPage();
+        const second = await secondContext.newPage();
+        const staff = await staffContext.newPage();
+        try {
+            await loginAttendeeWithTicket(first, {
+                name: 'Primer nombre',
+                email: TICKETS.esBound.email,
+                code: TICKETS.esBound.code,
+            });
+            await expect(first.getByTestId('viewer-identity')).toContainText('Primer nombre', {
+                timeout: 20_000,
+            });
+
+            await loginAttendeeWithTicket(second, {
+                name: 'Anahí 李',
+                email: TICKETS.esBound.email,
+                code: TICKETS.esBound.code,
+            });
+            await expect(second.getByTestId('viewer-identity')).toContainText('Anahí 李', {
+                timeout: 20_000,
+            });
+
+            await loginViaDashboard(
+                staff,
+                'OPERATOR',
+                'Identity Operator',
+                ROUTES.opsSession(SESSION_ES.id),
+            );
+            await staff.locator('[data-signal="hands"]').click();
+            await second.getByRole('button', { name: /Levantar la mano|Raise hand/i }).click();
+
+            const queue = staff
+                .getByRole('heading', { name: /Fila de manos|Hand queue/i })
+                .locator('..');
+            const correctedHand = queue.locator('li').filter({ hasText: 'Anahí 李' });
+            await expect(correctedHand).toHaveCount(1, {
+                timeout: 10_000,
+            });
+            await expect(queue.locator('li').filter({ hasText: 'Primer nombre' })).toHaveCount(0);
+        } finally {
+            await firstContext.close();
+            await secondContext.close();
+            await staffContext.close();
+        }
+    });
+});

--- a/e2e/tests/attendee-identity.spec.ts
+++ b/e2e/tests/attendee-identity.spec.ts
@@ -1,6 +1,6 @@
 import { expect, stackTest } from '../fixtures/stack';
 import { loginAttendeeWithTicket, loginViaDashboard } from '../fixtures/auth';
-import { requireDirectDb, withSessionStatus } from '../fixtures/db';
+import { requireDirectDb, withoutRaisedHands, withSessionStatus } from '../fixtures/db';
 import { ROUTES, SESSION_ES, TICKETS } from '../fixtures/test-data';
 
 stackTest('an unconfirmed attendee alias blocks LiveKit until it is corrected, then survives refresh', async ({
@@ -52,52 +52,54 @@ stackTest('a second device can correct the stable event alias used by the hand q
     stackTest.slow();
     const db = requireDirectDb(testInfo);
     await withSessionStatus(db, SESSION_ES.id, 'LIVE', async () => {
-        const firstContext = await browser.newContext();
-        const secondContext = await browser.newContext();
-        const staffContext = await browser.newContext();
-        const first = await firstContext.newPage();
-        const second = await secondContext.newPage();
-        const staff = await staffContext.newPage();
-        try {
-            await loginAttendeeWithTicket(first, {
-                name: 'Primer nombre',
-                email: TICKETS.esBound.email,
-                code: TICKETS.esBound.code,
-            });
-            await expect(first.getByTestId('viewer-identity')).toContainText('Primer nombre', {
-                timeout: 20_000,
-            });
+        await withoutRaisedHands(db, SESSION_ES.id, async () => {
+            const firstContext = await browser.newContext();
+            const secondContext = await browser.newContext();
+            const staffContext = await browser.newContext();
+            const first = await firstContext.newPage();
+            const second = await secondContext.newPage();
+            const staff = await staffContext.newPage();
+            try {
+                await loginAttendeeWithTicket(first, {
+                    name: 'Primer nombre',
+                    email: TICKETS.esBound.email,
+                    code: TICKETS.esBound.code,
+                });
+                await expect(first.getByTestId('viewer-identity')).toContainText('Primer nombre', {
+                    timeout: 20_000,
+                });
 
-            await loginAttendeeWithTicket(second, {
-                name: 'Anahí 李',
-                email: TICKETS.esBound.email,
-                code: TICKETS.esBound.code,
-            });
-            await expect(second.getByTestId('viewer-identity')).toContainText('Anahí 李', {
-                timeout: 20_000,
-            });
+                await loginAttendeeWithTicket(second, {
+                    name: 'Anahí 李',
+                    email: TICKETS.esBound.email,
+                    code: TICKETS.esBound.code,
+                });
+                await expect(second.getByTestId('viewer-identity')).toContainText('Anahí 李', {
+                    timeout: 20_000,
+                });
 
-            await loginViaDashboard(
-                staff,
-                'OPERATOR',
-                'Identity Operator',
-                ROUTES.opsSession(SESSION_ES.id),
-            );
-            await staff.locator('[data-signal="hands"]').click();
-            await second.getByRole('button', { name: /Levantar la mano|Raise hand/i }).click();
+                await loginViaDashboard(
+                    staff,
+                    'OPERATOR',
+                    'Identity Operator',
+                    ROUTES.opsSession(SESSION_ES.id),
+                );
+                await staff.locator('[data-signal="hands"]').click();
+                await second.getByRole('button', { name: /Levantar la mano|Raise hand/i }).click();
 
-            const queue = staff
-                .getByRole('heading', { name: /Fila de manos|Hand queue/i })
-                .locator('..');
-            const correctedHand = queue.locator('li').filter({ hasText: 'Anahí 李' });
-            await expect(correctedHand).toHaveCount(1, {
-                timeout: 10_000,
-            });
-            await expect(queue.locator('li').filter({ hasText: 'Primer nombre' })).toHaveCount(0);
-        } finally {
-            await firstContext.close();
-            await secondContext.close();
-            await staffContext.close();
-        }
+                const queue = staff
+                    .getByRole('heading', { name: /Fila de manos|Hand queue/i })
+                    .locator('..');
+                const correctedHand = queue.locator('li').filter({ hasText: 'Anahí 李' });
+                await expect(correctedHand).toHaveCount(1, {
+                    timeout: 10_000,
+                });
+                await expect(queue.locator('li').filter({ hasText: 'Primer nombre' })).toHaveCount(0);
+            } finally {
+                await firstContext.close();
+                await secondContext.close();
+                await staffContext.close();
+            }
+        });
     });
 });

--- a/e2e/tests/media-continuity.spec.ts
+++ b/e2e/tests/media-continuity.spec.ts
@@ -68,6 +68,12 @@ async function leaveConnectedRoom(
     const leave = surface.getByRole('button', { name: /Leave session|Salir de la sesión/i });
     if (await leave.isVisible()) {
         await leave.click();
+        const confirmation = surface.getByRole('alertdialog', {
+            name: /Leave session|Salir de la sesión/i,
+        });
+        await confirmation.getByRole('button', {
+            name: /Yes, leave the session|Sí, salir de la sesión/i,
+        }).click();
         await expect(surface.getByTestId('connection-state')).toHaveCount(0);
     }
 }

--- a/e2e/tests/stage-invitation.spec.ts
+++ b/e2e/tests/stage-invitation.spec.ts
@@ -116,10 +116,32 @@ stackTest('a fresh connection stays invited until the attendee accepts the stage
             await expect(stageRow.getByRole('button', { name: /Take floor|Quitar la palabra/i })).toBeVisible({
                 timeout: 10_000,
             });
-            await stageRow.getByRole('button', { name: /Take floor|Quitar la palabra/i }).click();
+
+            // The attendee owns the return transition. It revokes publishing
+            // without leaving either receiving room or requiring a new audio
+            // activation, and is deliberately distinct from session exit.
+            await attendee.getByRole('button', { name: /Leave the scene|Dejar la escena/i }).click();
+            const leaveConfirmation = attendee.getByRole('alertdialog', {
+                name: /Return to the audience|volver al público/i,
+            });
+            await expect(leaveConfirmation).toContainText(/without reconnecting|sin reconectarte/i);
+            await leaveConfirmation.getByRole('button', {
+                name: /Yes, leave the scene|Sí, dejar la escena/i,
+            }).click();
+
             await expect(
                 attendee.getByRole('button', { name: /Turn camera off|Apagar (?:la )?cámara/i }),
             ).toHaveCount(0, { timeout: 10_000 });
+            await expect(attendee.getByTestId('connection-state')).toHaveAttribute(
+                'data-state',
+                'connected',
+            );
+            await expect(attendee.getByRole('button', { name: /Raise hand|Levantar la mano/i })).toBeVisible({
+                timeout: 10_000,
+            });
+            await expect(stageRow.getByRole('button', { name: /Take floor|Quitar la palabra/i })).toHaveCount(0, {
+                timeout: 10_000,
+            });
         } finally {
             await attendeeContext.close();
             await staffContext.close();

--- a/prisma/migrations/20260903150000_confirm_attendee_display_name/migration.sql
+++ b/prisma/migrations/20260903150000_confirm_attendee_display_name/migration.sql
@@ -1,0 +1,5 @@
+-- A room alias is explicitly confirmed before an attendee mounts LiveKit.
+-- Existing sessions remain unconfirmed so their next entry repairs any
+-- historical generic alias instead of silently carrying it forward.
+ALTER TABLE "web_sessions"
+ADD COLUMN "display_name_confirmed_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -339,25 +339,26 @@ model CommerceMediaOutbox {
 }
 
 model WebSession {
-  id                  String             @id @default(uuid()) @db.Uuid
-  tokenDigest         String             @unique @map("token_digest")
-  displayName         String?            @map("display_name")
-  accountIssuer       String?            @map("account_issuer")
-  accountSubject      String?            @map("account_subject")
-  accountSessionId    String?            @map("account_session_id")
-  accountDisplayName  String?            @map("account_display_name")
-  accountValidatedAt  DateTime?          @map("account_validated_at")
-  staffUserId         String?            @map("staff_user_id") @db.Uuid
-  staffUser           User?              @relation("StaffWebSessions", fields: [staffUserId], references: [id], onDelete: Cascade)
-  ticketEntitlementId String?            @map("ticket_entitlement_id") @db.Uuid
-  ticketEntitlement   TicketEntitlement? @relation(fields: [ticketEntitlementId], references: [id], onDelete: Cascade)
-  expiresAt           DateTime           @map("expires_at")
-  lastSeenAt          DateTime?          @map("last_seen_at")
-  revokedAt           DateTime?          @map("revoked_at")
-  revokedByUserId     String?            @map("revoked_by_user_id") @db.Uuid
-  revokedBy           User?              @relation("WebSessionRevoker", fields: [revokedByUserId], references: [id], onDelete: SetNull)
-  revocationReason    String?            @map("revocation_reason")
-  createdAt           DateTime           @default(now()) @map("created_at")
+  id                     String             @id @default(uuid()) @db.Uuid
+  tokenDigest            String             @unique @map("token_digest")
+  displayName            String?            @map("display_name")
+  displayNameConfirmedAt DateTime?          @map("display_name_confirmed_at")
+  accountIssuer          String?            @map("account_issuer")
+  accountSubject         String?            @map("account_subject")
+  accountSessionId       String?            @map("account_session_id")
+  accountDisplayName     String?            @map("account_display_name")
+  accountValidatedAt     DateTime?          @map("account_validated_at")
+  staffUserId            String?            @map("staff_user_id") @db.Uuid
+  staffUser              User?              @relation("StaffWebSessions", fields: [staffUserId], references: [id], onDelete: Cascade)
+  ticketEntitlementId    String?            @map("ticket_entitlement_id") @db.Uuid
+  ticketEntitlement      TicketEntitlement? @relation(fields: [ticketEntitlementId], references: [id], onDelete: Cascade)
+  expiresAt              DateTime           @map("expires_at")
+  lastSeenAt             DateTime?          @map("last_seen_at")
+  revokedAt              DateTime?          @map("revoked_at")
+  revokedByUserId        String?            @map("revoked_by_user_id") @db.Uuid
+  revokedBy              User?              @relation("WebSessionRevoker", fields: [revokedByUserId], references: [id], onDelete: SetNull)
+  revocationReason       String?            @map("revocation_reason")
+  createdAt              DateTime           @default(now()) @map("created_at")
 
   @@index([staffUserId])
   @@index([ticketEntitlementId])

--- a/src/app/api/auth/ticket/route.ts
+++ b/src/app/api/auth/ticket/route.ts
@@ -366,6 +366,7 @@ async function redeem(
             data: {
                 tokenDigest: issued.database.tokenDigest,
                 displayName,
+                displayNameConfirmedAt: now,
                 ticketEntitlementId: entitlement.id,
                 ...(account ? {
                     accountIssuer: account.issuer,

--- a/src/app/api/ops/sessions/[id]/participants/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/participants/__tests__/route.test.ts
@@ -40,7 +40,7 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
         listParticipants.mockResolvedValue([
             {
                 identity: 'opaque-publisher',
-                name: 'Ana',
+                name: 'Participant',
                 tracks: [
                     {
                         sid: 'TR_audio',
@@ -59,6 +59,7 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
                 {
                     id: 'publisher',
                     participantIdentity: 'opaque-publisher',
+                    displayName: 'Ana',
                     joinedAt: new Date('2026-08-01T15:00:00Z'),
                     leftAt: null,
                     raisedAt: null,
@@ -71,6 +72,7 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
                 {
                     id: 'waiting',
                     participantIdentity: 'opaque-waiting',
+                    displayName: 'Beto',
                     joinedAt: new Date('2026-08-01T15:01:00Z'),
                     leftAt: null,
                     raisedAt: new Date('2026-08-01T15:11:00Z'),
@@ -222,8 +224,8 @@ describe('GET /api/ops/sessions/[id]/participants', () => {
         expect(body).toMatchObject({
             liveStateAvailable: false,
             participants: [
-                { id: 'publisher', connected: null, media: [], stageState: 'UNKNOWN' },
-                { id: 'waiting', connected: null, media: [] },
+                { id: 'publisher', displayName: 'Ana', connected: null, media: [], stageState: 'UNKNOWN' },
+                { id: 'waiting', displayName: 'Beto', connected: null, media: [] },
             ],
         });
     });

--- a/src/app/api/ops/sessions/[id]/participants/route.ts
+++ b/src/app/api/ops/sessions/[id]/participants/route.ts
@@ -96,6 +96,7 @@ export async function GET(
                 select: {
                     id: true,
                     participantIdentity: true,
+                    displayName: true,
                     joinedAt: true,
                     leftAt: true,
                     raisedAt: true,
@@ -196,7 +197,11 @@ export async function GET(
         return {
             id: participant.id,
             identity: participant.participantIdentity,
-            displayName: participant.staffUser?.name ?? (live?.name?.trim() || 'Attendee'),
+            // The confirmed database alias is authoritative. LiveKit carries
+            // a neutral audience name until publication and may be offline.
+            displayName: participant.staffUser?.name ??
+                participant.displayName?.trim() ??
+                'Attendee',
             principalType: participant.staffUser ? 'staff' : 'attendee',
             staffRole: participant.staffUser?.role ?? null,
             isAssignedFacilitator,

--- a/src/app/api/ops/sessions/[id]/tapestry/manifest/__tests__/route.test.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/manifest/__tests__/route.test.ts
@@ -43,6 +43,7 @@ function sessionOk() {
         participants: [
             {
                 participantIdentity: 'lk-ana',
+                displayName: 'Ana',
                 leftAt: null,
                 raisedAt: RAISED_AT,
                 publishGrantedAt: null,
@@ -51,6 +52,7 @@ function sessionOk() {
             },
             {
                 participantIdentity: 'lk-beto',
+                displayName: 'Beto',
                 leftAt: null,
                 raisedAt: null,
                 publishGrantedAt: null,
@@ -88,12 +90,12 @@ beforeEach(() => {
     mocks.listParticipants.mockResolvedValue([
         {
             identity: 'lk-ana',
-            name: 'Ana',
+            name: 'Participant',
             tracks: [{ sid: 'TR_cam', source: 1, muted: false }],
         },
         {
             identity: 'lk-beto',
-            name: 'Beto',
+            name: 'Participant',
             tracks: [{ sid: 'TR_cam', source: 1, muted: true }],
         },
     ]);
@@ -220,6 +222,6 @@ describe('GET /api/ops/sessions/[id]/tapestry/manifest', () => {
         expect(body.entries[0]).toMatchObject({ presence: 'unknown', camera: 'unknown' });
         // Names, hands and tiles survive the outage.
         expect(body.entries[0].handRaised).toBe(true);
-        expect(body.entries[0].displayName).toBe('Attendee');
+        expect(body.entries[0].displayName).toBe('Ana');
     });
 });

--- a/src/app/api/ops/sessions/[id]/tapestry/manifest/route.ts
+++ b/src/app/api/ops/sessions/[id]/tapestry/manifest/route.ts
@@ -91,6 +91,7 @@ export async function GET(
             participants: {
                 select: {
                     participantIdentity: true,
+                    displayName: true,
                     leftAt: true,
                     raisedAt: true,
                     publishGrantedAt: true,
@@ -143,6 +144,7 @@ export async function GET(
     const participants: ManifestParticipant[] = scheduledSession.participants.map(
         (participant) => ({
             identity: participant.participantIdentity,
+            displayName: participant.displayName,
             leftAt: participant.leftAt,
             raisedAt: participant.raisedAt,
             publishGrantedAt: participant.publishGrantedAt,

--- a/src/app/api/scheduled-sessions/[id]/contributions/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/contributions/__tests__/route.test.ts
@@ -54,6 +54,7 @@ function request(method: string, body?: unknown, searchParams?: Record<string, s
 function mockAttendee(sessionId = SESSION_ID) {
     mocks.webSessionFindUnique.mockResolvedValue({
         displayName: 'Ana',
+        displayNameConfirmedAt: new Date('2026-08-01T12:00:00Z'),
         expiresAt: FUTURE,
         revokedAt: null,
         staffUser: null,
@@ -72,6 +73,7 @@ function mockAttendee(sessionId = SESSION_ID) {
 function mockStaff() {
     mocks.webSessionFindUnique.mockResolvedValue({
         displayName: null,
+        displayNameConfirmedAt: null,
         expiresAt: FUTURE,
         revokedAt: null,
         staffUser: {

--- a/src/app/api/scheduled-sessions/[id]/entry/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/entry/__tests__/route.test.ts
@@ -2,15 +2,32 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createRequest, mockParams, parseResponse } from '@/__tests__/helpers';
 
-const { principalFromToken, accountIdentityFromToken, attachPublicSessionAccess, findUnique } = vi.hoisted(() => ({
+const {
+    principalFromToken,
+    accountIdentityFromToken,
+    attachPublicSessionAccess,
+    findUnique,
+    readAttendeeDisplayName,
+    confirmAttendeeDisplayName,
+} = vi.hoisted(() => ({
     principalFromToken: vi.fn(),
     accountIdentityFromToken: vi.fn(),
     attachPublicSessionAccess: vi.fn(),
     findUnique: vi.fn(),
+    readAttendeeDisplayName: vi.fn(),
+    confirmAttendeeDisplayName: vi.fn(),
 }));
 
 vi.mock('@/lib/principal', () => ({ principalFromToken, accountIdentityFromToken }));
 vi.mock('@/lib/public-session-access', () => ({ attachPublicSessionAccess }));
+vi.mock('@/lib/attendee-display-name', async (importOriginal) => {
+    const original = await importOriginal<typeof import('@/lib/attendee-display-name')>();
+    return {
+        ...original,
+        readAttendeeDisplayName,
+        confirmAttendeeDisplayName,
+    };
+});
 vi.mock('@/lib/db', () => ({
     prisma: { scheduledSession: { findUnique } },
 }));
@@ -44,6 +61,21 @@ async function getEntry() {
     ));
 }
 
+async function patchEntry(body: unknown) {
+    const { PATCH } = await import('../route');
+    return parseResponse(await PATCH(
+        createRequest('/api/scheduled-sessions/event-1/entry', {
+            method: 'PATCH',
+            headers: {
+                cookie: 'hb_session=opaque',
+                'content-type': 'application/json',
+            },
+            body,
+        }),
+        mockParams({ id: 'event-1' }),
+    ));
+}
+
 describe('GET /api/scheduled-sessions/[id]/entry', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -51,6 +83,14 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
         accountIdentityFromToken.mockResolvedValue(null);
         attachPublicSessionAccess.mockResolvedValue(false);
         findUnique.mockResolvedValue(session);
+        readAttendeeDisplayName.mockResolvedValue({
+            displayName: 'Annie',
+            confirmed: false,
+        });
+        confirmAttendeeDisplayName.mockResolvedValue({
+            displayName: 'Annie ✿',
+            confirmed: true,
+        });
     });
 
     it('confirms a valid ticket and returns WAITING before doors open', async () => {
@@ -58,6 +98,11 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
         expect(status).toBe(200);
         expect(body).toEqual({
             state: 'WAITING',
+            identity: {
+                kind: 'attendee',
+                displayName: 'Annie',
+                confirmed: false,
+            },
             session: {
                 id: 'event-1',
                 title: 'The Return',
@@ -67,6 +112,7 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
             },
         });
         expect(JSON.stringify(body)).not.toMatch(/token|email|1234/i);
+        expect(readAttendeeDisplayName).toHaveBeenCalledWith('web-1', 'event-1', 'ticket-1');
     });
 
     it.each([
@@ -113,7 +159,11 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
             userId: 'facilitator-1',
             role: 'FACILITATOR',
         });
-        expect((await getEntry()).body).toMatchObject({ state: 'READY' });
+        expect((await getEntry()).body).toMatchObject({
+            state: 'READY',
+            identity: { kind: 'staff' },
+        });
+        expect(readAttendeeDisplayName).not.toHaveBeenCalled();
     });
 
     it('rejects an unassigned facilitator', async () => {
@@ -141,5 +191,32 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
         accountIdentityFromToken.mockResolvedValue(null);
         expect((await getEntry()).status).toBe(401);
         expect(findUnique).not.toHaveBeenCalled();
+    });
+
+    it('confirms a normalized international display name for the current attendee only', async () => {
+        const result = await patchEntry({ displayName: '  Anahí   李  ' });
+
+        expect(result).toEqual({
+            status: 200,
+            body: { displayName: 'Annie ✿', confirmed: true },
+        });
+        expect(confirmAttendeeDisplayName).toHaveBeenCalledWith({
+            webSessionId: 'web-1',
+            scheduledSessionId: 'event-1',
+            ticketEntitlementId: 'ticket-1',
+            displayName: '  Anahí   李  ',
+        });
+    });
+
+    it('does not let staff mutate an attendee alias', async () => {
+        principalFromToken.mockResolvedValue({
+            kind: 'staff',
+            webSessionId: 'web-staff',
+            userId: 'facilitator-1',
+            role: 'FACILITATOR',
+        });
+
+        expect((await patchEntry({ displayName: 'Someone else' })).status).toBe(403);
+        expect(confirmAttendeeDisplayName).not.toHaveBeenCalled();
     });
 });

--- a/src/app/api/scheduled-sessions/[id]/entry/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/entry/__tests__/route.test.ts
@@ -208,6 +208,16 @@ describe('GET /api/scheduled-sessions/[id]/entry', () => {
         });
     });
 
+    it.each(['ENDED', 'CANCELLED'])('does not accept an alias mutation after a session is %s', async (status) => {
+        findUnique.mockResolvedValue({ ...session, status });
+
+        expect((await patchEntry({ displayName: 'Late alias' }))).toMatchObject({
+            status: 409,
+            body: { error: 'session_terminal' },
+        });
+        expect(confirmAttendeeDisplayName).not.toHaveBeenCalled();
+    });
+
     it('does not let staff mutate an attendee alias', async () => {
         principalFromToken.mockResolvedValue({
             kind: 'staff',

--- a/src/app/api/scheduled-sessions/[id]/entry/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/entry/route.ts
@@ -132,6 +132,9 @@ export async function PATCH(
     if (resolved.principal.kind !== 'attendee') {
         return response({ error: 'Not authorized' }, 403);
     }
+    if (resolved.session.status === 'ENDED' || resolved.session.status === 'CANCELLED') {
+        return response({ error: 'session_terminal' }, 409);
+    }
 
     let displayName = '';
     try {

--- a/src/app/api/scheduled-sessions/[id]/entry/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/entry/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import {
+    AttendeeDisplayNameError,
+    confirmAttendeeDisplayName,
+    readAttendeeDisplayName,
+} from '@/lib/attendee-display-name';
 import { prisma } from '@/lib/db';
 import { accountIdentityFromToken, principalFromToken } from '@/lib/principal';
 import { attachPublicSessionAccess } from '@/lib/public-session-access';
@@ -8,26 +13,20 @@ import { eventStaffPolicy } from '@/lib/staff-capabilities';
 
 export const dynamic = 'force-dynamic';
 
-/**
- * Lightweight, non-token entry state. The room page polls this before mounting
- * either LiveKit connection, so a valid ticket can wait truthfully without
- * receiving stage or bed credentials.
- */
-export async function GET(
-    request: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
-) {
+const PRIVATE_NO_STORE = { 'Cache-Control': 'private, no-store' };
+
+function response(body: unknown, status = 200) {
+    return NextResponse.json(body, { status, headers: PRIVATE_NO_STORE });
+}
+
+async function resolveEntry(request: NextRequest, id: string) {
     const cookieValue = request.cookies.get(SESSION_COOKIE_NAME)?.value;
     let principal = await principalFromToken(cookieValue);
     const account = principal ? null : await accountIdentityFromToken(cookieValue);
     if (!principal && !account) {
-        return NextResponse.json(
-            { error: 'Authentication required' },
-            { status: 401 },
-        );
+        return { ok: false as const, error: response({ error: 'Authentication required' }, 401) };
     }
 
-    const { id } = await params;
     const session = await prisma.scheduledSession.findUnique({
         where: { id },
         select: {
@@ -41,7 +40,7 @@ export async function GET(
         },
     });
     if (!session) {
-        return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+        return { ok: false as const, error: response({ error: 'Session not found' }, 404) };
     }
 
     if (!principal && account && cookieValue && session.publicAccess) {
@@ -49,11 +48,11 @@ export async function GET(
         if (attached) principal = await principalFromToken(cookieValue);
     }
     if (!principal) {
-        return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+        return { ok: false as const, error: response({ error: 'Not authorized' }, 403) };
     }
 
     if (principal.kind === 'attendee' && principal.scheduledSessionId !== session.id) {
-        return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+        return { ok: false as const, error: response({ error: 'Not authorized' }, 403) };
     }
     if (principal.kind === 'staff') {
         const policy = eventStaffPolicy(
@@ -61,9 +60,26 @@ export async function GET(
             session.facilitatorId === principal.userId,
         );
         if (!policy.canOperateEvent) {
-            return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+            return { ok: false as const, error: response({ error: 'Not authorized' }, 403) };
         }
     }
+
+    return { ok: true as const, principal, session };
+}
+
+/**
+ * Lightweight, non-token entry state. The room page polls this before mounting
+ * either LiveKit connection, so a valid ticket can wait truthfully without
+ * receiving stage or bed credentials.
+ */
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    const resolved = await resolveEntry(request, id);
+    if (!resolved.ok) return resolved.error;
+    const { principal, session } = resolved;
 
     const state = session.status === 'SCHEDULED'
         ? (principal.kind === 'attendee' ? 'WAITING' : 'READY')
@@ -71,8 +87,30 @@ export async function GET(
             ? 'READY'
             : session.status;
 
-    return NextResponse.json({
+    let identity: { kind: 'staff' } | {
+        kind: 'attendee';
+        displayName: string;
+        confirmed: boolean;
+    } = { kind: 'staff' };
+    if (principal.kind === 'attendee') {
+        try {
+            const name = await readAttendeeDisplayName(
+                principal.webSessionId,
+                id,
+                principal.entitlementId,
+            );
+            identity = { kind: 'attendee', ...name };
+        } catch (failure) {
+            if (failure instanceof AttendeeDisplayNameError) {
+                return response({ error: failure.code }, failure.status);
+            }
+            throw failure;
+        }
+    }
+
+    return response({
         state,
+        identity,
         session: {
             id: session.id,
             title: session.title,
@@ -81,4 +119,43 @@ export async function GET(
             status: session.status,
         },
     });
+}
+
+/** Confirm or correct the caller's own room alias before LiveKit is mounted. */
+export async function PATCH(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    const resolved = await resolveEntry(request, id);
+    if (!resolved.ok) return resolved.error;
+    if (resolved.principal.kind !== 'attendee') {
+        return response({ error: 'Not authorized' }, 403);
+    }
+
+    let displayName = '';
+    try {
+        const body = await request.json() as { displayName?: unknown };
+        displayName = typeof body.displayName === 'string' ? body.displayName : '';
+    } catch {
+        // The shared validator below returns the same bounded client error.
+    }
+
+    try {
+        return response(await confirmAttendeeDisplayName({
+            webSessionId: resolved.principal.webSessionId,
+            scheduledSessionId: id,
+            ticketEntitlementId: resolved.principal.entitlementId,
+            displayName,
+        }));
+    } catch (failure) {
+        if (failure instanceof AttendeeDisplayNameError) {
+            return response(
+                { error: failure.code, message: failure.message },
+                failure.status,
+            );
+        }
+        console.error('[entry] unexpected display-name confirmation failure');
+        return response({ error: 'entry_unavailable' }, 500);
+    }
 }

--- a/src/app/api/scheduled-sessions/[id]/hand/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/hand/__tests__/route.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
     lowerHand: vi.fn(),
     getHandState: vi.fn(),
     declineStageInvitation: vi.fn(),
+    leaveStage: vi.fn(),
 }));
 
 vi.mock('@/lib/room-entitlement', () => ({
@@ -27,6 +28,7 @@ vi.mock('@/lib/stage-control', async (importOriginal) => {
     return {
         ...original,
         declineStageInvitation: mocks.declineStageInvitation,
+        leaveStage: mocks.leaveStage,
     };
 });
 
@@ -76,6 +78,13 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
             canPublish: false,
             reconcileNeeded: false,
             grantVersion: 2,
+        });
+        mocks.leaveStage.mockResolvedValue({
+            participantId: 'participant-1',
+            participantIdentity: 'opaque-attendee-1',
+            canPublish: false,
+            reconcileNeeded: false,
+            grantVersion: 3,
         });
     });
 
@@ -185,6 +194,32 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
         });
     });
 
+    it('lets the caller leave their own stage grant and returns the converged hand state', async () => {
+        mocks.getHandState.mockResolvedValue(handState({
+            raised: false,
+            raisedAt: null,
+            queuePosition: null,
+            canPublish: false,
+        }));
+        const { PATCH } = await import('../route');
+
+        const { status, body } = await parseResponse(await PATCH(
+            createRequest('/api/scheduled-sessions/event-1/hand', {
+                method: 'PATCH',
+                body: { action: 'leave_stage' },
+            }),
+            mockParams({ id: 'event-1' }),
+        ));
+
+        expect(status).toBe(200);
+        expect(body).toMatchObject({ raised: false, canPublish: false });
+        expect(mocks.leaveStage).toHaveBeenCalledWith({
+            scheduledSessionId: 'event-1',
+            participantIdentity: 'opaque-attendee-1',
+        });
+        expect(mocks.declineStageInvitation).not.toHaveBeenCalled();
+    });
+
     it('rejects an unknown invitation action without changing a grant', async () => {
         const { PATCH } = await import('../route');
 
@@ -198,6 +233,7 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
 
         expect(response.status).toBe(400);
         expect(mocks.declineStageInvitation).not.toHaveBeenCalled();
+        expect(mocks.leaveStage).not.toHaveBeenCalled();
     });
 
     it('returns the caller\u2019s own state for the polling loop, without PII', async () => {

--- a/src/app/api/scheduled-sessions/[id]/hand/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/hand/__tests__/route.test.ts
@@ -54,6 +54,7 @@ function handState(overrides: Record<string, unknown> = {}) {
         raisedAt: new Date('2026-08-01T15:10:00Z'),
         queuePosition: 2,
         canPublish: false,
+        grantVersion: 1,
         ...overrides,
     };
 }
@@ -141,6 +142,7 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
             raisedAt: '2026-08-01T15:10:00.000Z',
             queuePosition: 2,
             canPublish: false,
+            grantVersion: 1,
         });
         expect(mocks.raiseHand).toHaveBeenCalledWith({
             scheduledSessionId: 'event-1',
@@ -177,7 +179,7 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
         const { status, body } = await parseResponse(await PATCH(
             createRequest('/api/scheduled-sessions/event-1/hand', {
                 method: 'PATCH',
-                body: { action: 'decline_invitation' },
+                body: { action: 'decline_invitation', expectedGrantVersion: 1 },
             }),
             mockParams({ id: 'event-1' }),
         ));
@@ -187,6 +189,7 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
         expect(mocks.declineStageInvitation).toHaveBeenCalledWith({
             scheduledSessionId: 'event-1',
             participantIdentity: 'opaque-attendee-1',
+            expectedGrantVersion: 1,
         });
         expect(mocks.getHandState).toHaveBeenCalledWith({
             scheduledSessionId: 'event-1',
@@ -206,7 +209,7 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
         const { status, body } = await parseResponse(await PATCH(
             createRequest('/api/scheduled-sessions/event-1/hand', {
                 method: 'PATCH',
-                body: { action: 'leave_stage' },
+                body: { action: 'leave_stage', expectedGrantVersion: 1 },
             }),
             mockParams({ id: 'event-1' }),
         ));
@@ -216,6 +219,7 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
         expect(mocks.leaveStage).toHaveBeenCalledWith({
             scheduledSessionId: 'event-1',
             participantIdentity: 'opaque-attendee-1',
+            expectedGrantVersion: 1,
         });
         expect(mocks.declineStageInvitation).not.toHaveBeenCalled();
     });
@@ -234,6 +238,21 @@ describe('/api/scheduled-sessions/[id]/hand', () => {
         expect(response.status).toBe(400);
         expect(mocks.declineStageInvitation).not.toHaveBeenCalled();
         expect(mocks.leaveStage).not.toHaveBeenCalled();
+    });
+
+    it('requires the grant version for every attendee stage exit', async () => {
+        const { PATCH } = await import('../route');
+        const response = await PATCH(
+            createRequest('/api/scheduled-sessions/event-1/hand', {
+                method: 'PATCH',
+                body: { action: 'leave_stage' },
+            }),
+            mockParams({ id: 'event-1' }),
+        );
+
+        expect(response.status).toBe(400);
+        expect(mocks.leaveStage).not.toHaveBeenCalled();
+        expect(mocks.declineStageInvitation).not.toHaveBeenCalled();
     });
 
     it('returns the caller\u2019s own state for the polling loop, without PII', async () => {

--- a/src/app/api/scheduled-sessions/[id]/hand/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/hand/route.ts
@@ -182,7 +182,7 @@ export async function PATCH(
             { status: 400 },
         );
     }
-    if (!Number.isInteger(body.expectedGrantVersion) ||
+    if (!Number.isSafeInteger(body.expectedGrantVersion) ||
         (body.expectedGrantVersion as number) < 0) {
         return NextResponse.json(
             { error: 'invalid_request', message: 'A current grant version is required' },

--- a/src/app/api/scheduled-sessions/[id]/hand/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/hand/route.ts
@@ -10,6 +10,7 @@ import {
 import { resolveRoomPrincipal } from '@/lib/room-entitlement';
 import {
     declineStageInvitation,
+    leaveStage,
     StageControlError,
 } from '@/lib/stage-control';
 
@@ -170,21 +171,24 @@ export async function PATCH(
             { status: 400 },
         );
     }
-    if (body.action !== 'decline_invitation') {
+    if (body.action !== 'decline_invitation' && body.action !== 'leave_stage') {
         return NextResponse.json(
-            { error: 'invalid_request', message: 'Action must be decline_invitation' },
+            { error: 'invalid_request', message: 'Action must be decline_invitation or leave_stage' },
             { status: 400 },
         );
     }
 
     try {
-        const declined = await declineStageInvitation({
+        const changeStage = body.action === 'leave_stage'
+            ? leaveStage
+            : declineStageInvitation;
+        const changed = await changeStage({
             scheduledSessionId: id,
             participantIdentity: principal.identity,
         });
         return NextResponse.json(serialize(await getHandState({
             scheduledSessionId: id,
-            participantIdentity: declined.participantIdentity,
+            participantIdentity: changed.participantIdentity,
         })));
     } catch (failure) {
         return handErrorResponse(failure);

--- a/src/app/api/scheduled-sessions/[id]/hand/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/hand/route.ts
@@ -29,6 +29,7 @@ type HandResponse = {
     raisedAt: string | null;
     queuePosition: number | null;
     canPublish: boolean;
+    grantVersion: number;
 };
 
 function serialize(state: HandState): HandResponse {
@@ -38,6 +39,7 @@ function serialize(state: HandState): HandResponse {
         raisedAt: state.raisedAt?.toISOString() ?? null,
         queuePosition: state.queuePosition,
         canPublish: state.canPublish,
+        grantVersion: state.grantVersion,
     };
 }
 
@@ -162,9 +164,12 @@ export async function PATCH(
         return error;
     }
 
-    let body: { action?: unknown };
+    let body: { action?: unknown; expectedGrantVersion?: unknown };
     try {
-        body = await request.json() as { action?: unknown };
+        body = await request.json() as {
+            action?: unknown;
+            expectedGrantVersion?: unknown;
+        };
     } catch {
         return NextResponse.json(
             { error: 'invalid_request', message: 'A JSON request body is required' },
@@ -177,6 +182,13 @@ export async function PATCH(
             { status: 400 },
         );
     }
+    if (!Number.isInteger(body.expectedGrantVersion) ||
+        (body.expectedGrantVersion as number) < 0) {
+        return NextResponse.json(
+            { error: 'invalid_request', message: 'A current grant version is required' },
+            { status: 400 },
+        );
+    }
 
     try {
         const changeStage = body.action === 'leave_stage'
@@ -185,6 +197,7 @@ export async function PATCH(
         const changed = await changeStage({
             scheduledSessionId: id,
             participantIdentity: principal.identity,
+            expectedGrantVersion: body.expectedGrantVersion as number,
         });
         return NextResponse.json(serialize(await getHandState({
             scheduledSessionId: id,

--- a/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.readonly.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/tapestry/hands/__tests__/route.readonly.test.ts
@@ -65,6 +65,7 @@ beforeEach(() => {
     process.env.TAPESTRY_INTERNAL_SECRET = 'test-secret';
     mocks.webSessionFindUnique.mockResolvedValue({
         displayName: 'Ana',
+        displayNameConfirmedAt: new Date('2026-08-01T12:00:00Z'),
         expiresAt: FUTURE,
         revokedAt: null,
         staffUser: null,

--- a/src/app/api/scheduled-sessions/[id]/token/__tests__/route.test.ts
+++ b/src/app/api/scheduled-sessions/[id]/token/__tests__/route.test.ts
@@ -82,7 +82,7 @@ describe('GET /api/scheduled-sessions/[id]/token', () => {
         expect(createSessionJoinToken).toHaveBeenCalledWith(
             'weekend-stage',
             'event-stable-opaque',
-            'Attendee',
+            'Participant',
             { role: 'ATTENDEE', isAssignedFacilitator: false },
             '300s',
         );
@@ -177,7 +177,7 @@ describe('GET /api/scheduled-sessions/[id]/token', () => {
         expect(createSessionJoinToken).toHaveBeenCalledWith(
             'weekend-stage',
             'event-stable-opaque',
-            'Attendee',
+            'Participant',
             { role: 'ATTENDEE', isAssignedFacilitator: false },
             '300s',
         );

--- a/src/app/api/scheduled-sessions/[id]/token/route.ts
+++ b/src/app/api/scheduled-sessions/[id]/token/route.ts
@@ -45,13 +45,19 @@ export async function GET(
             role: principal.role,
             isAssignedFacilitator: principal.isAssignedFacilitator,
         };
+        // Ticket-holder aliases remain server-side until publication is
+        // explicitly activated. A subscribe-only audience JWT therefore
+        // carries a neutral name even if it is inspected or replayed.
+        const livekitName = principal.ticketEntitlementId
+            ? 'Participant'
+            : principal.displayName;
         // Every credential is subscribe-only. The connected browser requests
         // publication activation separately; that server-side step rechecks
         // the current identity and grant while holding the authority locks.
         const token = await createSessionJoinToken(
             principal.session.roomName,
             principal.identity,
-            principal.displayName,
+            livekitName,
             tokenMetadata,
             tokenTtl,
         );

--- a/src/app/api/test-login/route.ts
+++ b/src/app/api/test-login/route.ts
@@ -76,6 +76,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     let name: string;
     let role: DashboardRole;
     let landing: string | null;
+    let nameConfirmed: boolean;
     try {
         const body = (await request.json()) as unknown;
         const fields = (body ?? {}) as Record<string, unknown>;
@@ -84,6 +85,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             ? (fields.role as DashboardRole)
             : 'ATTENDEE';
         landing = sanitizeLanding(fields.landing);
+        // E2E-only hook for exercising the pre-room confirmation gate. The
+        // default mirrors a tester explicitly choosing the dashboard name.
+        nameConfirmed = fields.nameConfirmed !== false;
     } catch {
         return NextResponse.json({ error: 'Malformed request.' }, { status: 400 });
     }
@@ -150,6 +154,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             data: {
                 tokenDigest: issued.database.tokenDigest,
                 displayName: name,
+                displayNameConfirmedAt: nameConfirmed ? now : null,
                 staffUserId,
                 ticketEntitlementId,
                 expiresAt: webSessionExpiry(now),

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -81,7 +81,11 @@ export default function LoginClient({
                     maxLength={60}
                     autoComplete="name"
                     className="event-field"
+                    aria-describedby="display-name-hint"
                 />
+                <p id="display-name-hint" className="text-xs leading-5 text-[var(--text-muted)]">
+                    {messages.displayNameHint}
+                </p>
             </div>
 
             <div className="space-y-1.5">
@@ -120,12 +124,8 @@ export default function LoginClient({
                     required
                     autoComplete="email"
                     spellCheck={false}
-                    aria-describedby="display-name-hint"
                     className="event-field"
                 />
-                <p id="display-name-hint" className="text-xs leading-5 text-[var(--text-muted)]">
-                    {messages.displayNameHint}
-                </p>
             </div>}
 
             {error && (

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -120,8 +120,12 @@ export default function LoginClient({
                     required
                     autoComplete="email"
                     spellCheck={false}
+                    aria-describedby="display-name-hint"
                     className="event-field"
                 />
+                <p id="display-name-hint" className="text-xs leading-5 text-[var(--text-muted)]">
+                    {messages.displayNameHint}
+                </p>
             </div>}
 
             {error && (

--- a/src/app/login/__tests__/LoginClient.test.tsx
+++ b/src/app/login/__tests__/LoginClient.test.tsx
@@ -174,6 +174,15 @@ describe('LoginClient', () => {
         expect(screen.getByLabelText('Ticket code')).toHaveAttribute('maxlength', '80');
     });
 
+    it('associates the name privacy explanation with the alias instead of the email', () => {
+        renderLogin('en');
+
+        expect(screen.getByLabelText('Name shown in the room')).toHaveAccessibleDescription(
+            'The team and people on stage will use this name to recognize you. You can confirm it before joining.',
+        );
+        expect(screen.getByLabelText('Email used to buy the ticket')).not.toHaveAccessibleDescription();
+    });
+
     it('keeps the Account profile name as an editable event alias and never asks for email', async () => {
         const fetchMock = mockFetch({
             status: 200,
@@ -188,6 +197,9 @@ describe('LoginClient', () => {
         const user = userEvent.setup();
         const alias = screen.getByLabelText(/Name shown in the room/);
         expect(alias).toHaveValue('Account profile');
+        expect(alias).toHaveAccessibleDescription(
+            'The team and people on stage will use this name to recognize you. You can confirm it before joining.',
+        );
         await user.clear(alias);
         await user.type(alias, 'Event alias');
         await user.type(screen.getByLabelText(/Ticket code/), CODE);

--- a/src/app/session/[id]/__tests__/media-continuity.test.tsx
+++ b/src/app/session/[id]/__tests__/media-continuity.test.tsx
@@ -113,7 +113,14 @@ beforeEach(() => {
             if (init?.method === 'DELETE') handRaised = false;
             return Promise.resolve({
                 ok: true,
-                json: async () => ({ raised: handRaised, canPublish: false }),
+                json: async () => ({
+                    participantId: 'participant-1',
+                    raised: handRaised,
+                    raisedAt: handRaised ? '2026-08-01T15:10:00.000Z' : null,
+                    queuePosition: handRaised ? 1 : null,
+                    canPublish: false,
+                    grantVersion: 0,
+                }),
             });
         }
         return Promise.resolve({ ok: true, json: async () => ({}) });

--- a/src/app/session/[id]/__tests__/media-continuity.test.tsx
+++ b/src/app/session/[id]/__tests__/media-continuity.test.tsx
@@ -73,6 +73,7 @@ const TOKEN_RESPONSE = {
 
 const ENTRY_RESPONSE = {
     state: 'READY',
+    identity: { kind: 'attendee', displayName: 'Nico', confirmed: true },
     session: {
         id: 'session-1',
         title: 'Test Session',

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -446,6 +446,63 @@ describe('SessionRoomPage - event entry', () => {
         ).toHaveLength(roomsBefore + 1));
         expect(await screen.findByTestId('viewer-identity')).toHaveTextContent('Anahí 李');
     });
+
+    it('ignores an entry poll that started before the attendee confirmed their name', async () => {
+        const roomsBefore = (Room as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+        const unconfirmed = {
+            ...ENTRY_RESPONSE,
+            identity: { kind: 'attendee', displayName: 'Participante', confirmed: false },
+        };
+        let entryGets = 0;
+        let releaseStalePoll: (value: typeof unconfirmed) => void = () => {};
+        const stalePoll = new Promise<typeof unconfirmed>((resolve) => {
+            releaseStalePoll = resolve;
+        });
+        vi.mocked(global.fetch).mockImplementation((url: string | URL | Request, init?: RequestInit) => {
+            if (String(url).includes('/entry') && init?.method === 'PATCH') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ displayName: 'Anahí 李', confirmed: true }),
+                } as Response);
+            }
+            if (String(url).includes('/entry')) {
+                entryGets += 1;
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => entryGets === 1 ? unconfirmed : stalePoll,
+                } as Response);
+            }
+            if (String(url).includes('/token')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ ...TOKEN_RESPONSE, displayName: 'Anahí 李' }),
+                } as Response);
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+        });
+
+        renderPage('es');
+        const input = await screen.findByRole('textbox', { name: /Tu nombre visible|Your visible name/i });
+        fireEvent.focus(window);
+        await waitFor(() => expect(entryGets).toBe(2));
+
+        fireEvent.change(input, { target: { value: 'Anahí 李' } });
+        fireEvent.click(screen.getByRole('button', { name: /Confirmar y continuar|Confirm and continue/i }));
+        await waitFor(() => expect(
+            (Room as unknown as { mock: { calls: unknown[] } }).mock.calls,
+        ).toHaveLength(roomsBefore + 1));
+        const connectedRoom = currentRoom();
+
+        await act(async () => {
+            releaseStalePoll(unconfirmed);
+            await stalePoll;
+        });
+
+        expect(screen.queryByRole('textbox', { name: /Tu nombre visible|Your visible name/i })).toBeNull();
+        expect(await screen.findByTestId('viewer-identity')).toHaveTextContent('Anahí 李');
+        expect(connectedRoom.disconnect).not.toHaveBeenCalled();
+    });
 });
 
 describe('SessionRoomPage - participant identity', () => {

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -731,6 +731,65 @@ describe('SessionRoomPage - stage invitation consent', () => {
         };
     }
 
+    it('waits for the matching durable grant version before showing a live permission', async () => {
+        let releaseHandState: (response: Response) => void = () => {};
+        const handState = new Promise<Response>((resolve) => {
+            releaseHandState = resolve;
+        });
+        vi.mocked(global.fetch).mockImplementation((url: string | URL | Request, init?: RequestInit) => {
+            const target = String(url);
+            if (target.includes('/entry')) {
+                return Promise.resolve({ ok: true, json: async () => ENTRY_RESPONSE } as Response);
+            }
+            if (target.includes('/token')) {
+                return Promise.resolve({ ok: true, json: async () => TOKEN_RESPONSE } as Response);
+            }
+            if (target.includes('/hand') && init?.method === 'PATCH') {
+                currentRoom().localParticipant.permissions.canPublish = false;
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ canPublish: false, grantVersion: 8 }),
+                } as Response);
+            }
+            if (target.includes('/hand')) return handState;
+            return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+        });
+
+        await renderConnected();
+        const room = currentRoom();
+        room.localParticipant.permissions.canPublish = true;
+        act(() => room.emit('participantPermissionsChanged', null, room.localParticipant));
+
+        expect(screen.queryByRole('dialog', { name: 'You’re invited into the scene' }))
+            .not.toBeInTheDocument();
+
+        await act(async () => {
+            releaseHandState({
+                ok: true,
+                json: async () => ({
+                    participantId: 'participant-1',
+                    raised: false,
+                    raisedAt: null,
+                    queuePosition: null,
+                    canPublish: true,
+                    grantVersion: 7,
+                }),
+            } as Response);
+            await handState;
+        });
+
+        const dialog = await screen.findByRole('dialog', { name: 'You’re invited into the scene' });
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Not now' }));
+        await waitFor(() => expect(dialog).not.toBeInTheDocument());
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/api/scheduled-sessions/session-1/hand',
+            expect.objectContaining({
+                method: 'PATCH',
+                body: JSON.stringify({ action: 'decline_invitation', expectedGrantVersion: 7 }),
+            }),
+        );
+    });
+
     it('requests no device and exposes no stage controls before the attendee accepts', async () => {
         const roomCount = (Room as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
         const { room, dialog } = await receiveInvitation();
@@ -1096,7 +1155,14 @@ describe('SessionRoomPage - transport-failure disconnect', () => {
                 if (target.includes('/hand')) {
                     return Promise.resolve({
                         ok: true,
-                        json: async () => ({ canPublish }),
+                        json: async () => ({
+                            participantId: 'participant-1',
+                            raised: false,
+                            raisedAt: null,
+                            queuePosition: null,
+                            canPublish,
+                            grantVersion: 1,
+                        }),
                     } as Response);
                 }
                 return Promise.resolve({ ok: true, json: async () => ({}) } as Response);

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -204,6 +204,7 @@ const TOKEN_RESPONSE = {
 
 const ENTRY_RESPONSE = {
     state: 'READY',
+    identity: { kind: 'attendee', displayName: 'Nico', confirmed: true },
     session: {
         id: 'session-1',
         title: 'Test Session',
@@ -280,6 +281,7 @@ describe('SessionRoomPage - event entry', () => {
                     ok: true,
                     json: async () => ({
                         state: 'WAITING',
+                        identity: ENTRY_RESPONSE.identity,
                         session: {
                             ...ENTRY_RESPONSE.session,
                             language: 'SPANISH',
@@ -307,6 +309,7 @@ describe('SessionRoomPage - event entry', () => {
             ok: true,
             json: async () => ({
                 state: 'WAITING',
+                identity: ENTRY_RESPONSE.identity,
                 session: {
                     ...ENTRY_RESPONSE.session,
                     language: 'SPANISH',
@@ -329,6 +332,7 @@ describe('SessionRoomPage - event entry', () => {
             ok: true,
             json: async () => ({
                 state: 'ENDED',
+                identity: ENTRY_RESPONSE.identity,
                 session: { ...ENTRY_RESPONSE.session, status: 'ENDED' },
             }),
         } as Response);
@@ -350,6 +354,7 @@ describe('SessionRoomPage - event entry', () => {
                     json: async () => entryChecks === 1
                         ? {
                             state: 'WAITING',
+                            identity: ENTRY_RESPONSE.identity,
                             session: { ...ENTRY_RESPONSE.session, status: 'SCHEDULED' },
                         }
                         : ENTRY_RESPONSE,
@@ -381,6 +386,7 @@ describe('SessionRoomPage - event entry', () => {
                         ? ENTRY_RESPONSE
                         : {
                             state: 'ENDED',
+                            identity: ENTRY_RESPONSE.identity,
                             session: { ...ENTRY_RESPONSE.session, status: 'ENDED' },
                         },
                 } as Response);
@@ -399,6 +405,46 @@ describe('SessionRoomPage - event entry', () => {
 
         expect(await screen.findByText('Session ended')).toBeInTheDocument();
         await waitFor(() => expect(connectedRoom.disconnect).toHaveBeenCalledOnce());
+    });
+
+    it('does not mint a LiveKit token until the attendee confirms their visible name', async () => {
+        const roomsBefore = (Room as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+        const unconfirmed = {
+            ...ENTRY_RESPONSE,
+            identity: { kind: 'attendee', displayName: 'Participante', confirmed: false },
+        };
+        vi.mocked(global.fetch).mockImplementation((url: string | URL | Request, init?: RequestInit) => {
+            if (String(url).includes('/entry') && init?.method === 'PATCH') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ displayName: 'Anahí 李', confirmed: true }),
+                } as Response);
+            }
+            if (String(url).includes('/entry')) {
+                return Promise.resolve({ ok: true, json: async () => unconfirmed } as Response);
+            }
+            if (String(url).includes('/token')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ ...TOKEN_RESPONSE, displayName: 'Anahí 李' }),
+                } as Response);
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+        });
+
+        renderPage('es');
+
+        const input = await screen.findByRole('textbox', { name: /Tu nombre visible|Your visible name/i });
+        expect((Room as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(roomsBefore);
+        expect(vi.mocked(global.fetch).mock.calls.filter(([url]) => String(url).includes('/token'))).toHaveLength(0);
+        fireEvent.change(input, { target: { value: 'Anahí 李' } });
+        fireEvent.click(screen.getByRole('button', { name: /Confirmar y continuar|Confirm and continue/i }));
+
+        await waitFor(() => expect(
+            (Room as unknown as { mock: { calls: unknown[] } }).mock.calls,
+        ).toHaveLength(roomsBefore + 1));
+        expect(await screen.findByTestId('viewer-identity')).toHaveTextContent('Anahí 李');
     });
 });
 
@@ -744,6 +790,90 @@ describe('SessionRoomPage - stage invitation consent', () => {
         expect(await screen.findByRole('button', { name: 'Raise hand' })).toBeInTheDocument();
         expect(screen.queryByText('Session ended')).not.toBeInTheDocument();
     });
+
+    it('leaves the stage deliberately and keeps both receiving rooms mounted', async () => {
+        const { room } = await receiveInvitation();
+        fireEvent.click(screen.getByRole('button', { name: 'Accept and join' }));
+        await screen.findByRole('button', { name: 'Leave the scene' });
+        const roomCount = (Room as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+        const beaconStarts = audioMocks.startBeaconAudio.mock.calls.length;
+        const stageAudioStarts = room.startAudio.mock.calls.length;
+
+        fireEvent.click(screen.getByRole('button', { name: 'Leave the scene' }));
+        const confirmation = await screen.findByRole('alertdialog', { name: 'Return to the audience?' });
+        expect(confirmation).toHaveTextContent(/keep hearing the session and Beacon without reconnecting/i);
+        expect(screen.getByRole('button', { name: 'Stay on stage' })).toHaveFocus();
+        expect(room.disconnect).not.toHaveBeenCalled();
+
+        const confirm = screen.getByRole('button', { name: 'Yes, leave the scene' });
+        fireEvent.click(confirm);
+        fireEvent.click(confirm);
+
+        await waitFor(() => expect(screen.queryByRole('button', { name: 'Leave the scene' })).not.toBeInTheDocument());
+        const leaveRequests = vi.mocked(global.fetch).mock.calls.filter(([, init]) =>
+            init?.method === 'PATCH' && init.body === JSON.stringify({ action: 'leave_stage' }));
+        expect(leaveRequests).toHaveLength(1);
+        expect((Room as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(roomCount);
+        expect(room.disconnect).not.toHaveBeenCalled();
+        expect(audioMocks.startBeaconAudio).toHaveBeenCalledTimes(beaconStarts);
+        expect(room.startAudio).toHaveBeenCalledTimes(stageAudioStarts);
+        expect(screen.getByTestId('connection-state')).toHaveAttribute('data-state', 'connected');
+    });
+
+    it('stays on stage with retryable feedback when the voluntary exit request fails', async () => {
+        const { room } = await receiveInvitation();
+        fireEvent.click(screen.getByRole('button', { name: 'Accept and join' }));
+        await screen.findByRole('button', { name: 'Leave the scene' });
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const fetchMock = vi.mocked(global.fetch);
+        const fallback = fetchMock.getMockImplementation();
+        fetchMock.mockImplementation((url, init) => {
+            if (
+                String(url).includes('/hand') &&
+                init?.method === 'PATCH' &&
+                init.body === JSON.stringify({ action: 'leave_stage' })
+            ) {
+                return Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    json: async () => ({ error: 'stage_unavailable' }),
+                } as Response);
+            }
+            return fallback!(url, init);
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Leave the scene' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Yes, leave the scene' }));
+
+        expect(await screen.findByText(/could not complete your return/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Yes, leave the scene' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Turn camera off' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Mute microphone' })).toBeInTheDocument();
+        expect(room.disconnect).not.toHaveBeenCalled();
+        expect(screen.getByTestId('connection-state')).toHaveAttribute('data-state', 'connected');
+    });
+});
+
+describe('SessionRoomPage - deliberate session exit', () => {
+    it('separates session exit from everyday controls and disconnects only after confirmation', async () => {
+        await renderConnected();
+        const room = currentRoom();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Leave session' }));
+        const confirmation = screen.getByRole('alertdialog', { name: 'Leave session' });
+        expect(confirmation).toHaveTextContent(/disconnects this page from the session and Beacon/i);
+        expect(room.disconnect).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Stay in the session' })).toHaveFocus();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Stay in the session' }));
+        expect(room.disconnect).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByRole('button', { name: 'Leave session' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Yes, leave the session' }));
+
+        expect(room.disconnect).toHaveBeenCalledOnce();
+        expect(mockPush).toHaveBeenCalledWith('/');
+    });
 });
 
 describe('SessionRoomPage - server-ended disconnect', () => {
@@ -949,6 +1079,7 @@ describe('SessionRoomPage - intentional disconnects are not terminal states', ()
         await renderConnected();
 
         fireEvent.click(screen.getByRole('button', { name: 'Leave session' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Yes, leave the session' }));
         await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/'));
 
         // The real SDK would still fire Disconnected(CLIENT_INITIATED) after

--- a/src/app/session/[id]/__tests__/page.test.tsx
+++ b/src/app/session/[id]/__tests__/page.test.tsx
@@ -344,6 +344,23 @@ describe('SessionRoomPage - event entry', () => {
         expect(Room).not.toHaveBeenCalled();
     });
 
+    it('shows terminal state before asking an unconfirmed attendee for an alias', async () => {
+        vi.mocked(global.fetch).mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                state: 'CANCELLED',
+                identity: { kind: 'attendee', displayName: 'Draft', confirmed: false },
+                session: { ...ENTRY_RESPONSE.session, status: 'CANCELLED' },
+            }),
+        } as Response);
+
+        renderPage();
+
+        expect(await screen.findByText('Session cancelled')).toBeInTheDocument();
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+        expect(Room).not.toHaveBeenCalled();
+    });
+
     it('enters automatically when a status refresh observes open doors', async () => {
         let entryChecks = 0;
         vi.mocked(global.fetch).mockImplementation((url: string | URL | Request) => {
@@ -692,6 +709,7 @@ describe('SessionRoomPage - stage invitation consent', () => {
                         raisedAt: null,
                         queuePosition: null,
                         canPublish,
+                        grantVersion: canPublish ? 1 : 2,
                     }),
                 } as Response);
             }
@@ -827,7 +845,7 @@ describe('SessionRoomPage - stage invitation consent', () => {
             '/api/scheduled-sessions/session-1/hand',
             expect.objectContaining({
                 method: 'PATCH',
-                body: JSON.stringify({ action: 'decline_invitation' }),
+                body: JSON.stringify({ action: 'decline_invitation', expectedGrantVersion: 1 }),
             }),
         );
         expect(room.localParticipant.setCameraEnabled).not.toHaveBeenCalled();
@@ -858,6 +876,7 @@ describe('SessionRoomPage - stage invitation consent', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Leave the scene' }));
         const confirmation = await screen.findByRole('alertdialog', { name: 'Return to the audience?' });
+        expect(confirmation).toHaveAttribute('aria-modal', 'true');
         expect(confirmation).toHaveTextContent(/keep hearing the session and Beacon without reconnecting/i);
         expect(screen.getByRole('button', { name: 'Stay on stage' })).toHaveFocus();
         expect(room.disconnect).not.toHaveBeenCalled();
@@ -868,13 +887,75 @@ describe('SessionRoomPage - stage invitation consent', () => {
 
         await waitFor(() => expect(screen.queryByRole('button', { name: 'Leave the scene' })).not.toBeInTheDocument());
         const leaveRequests = vi.mocked(global.fetch).mock.calls.filter(([, init]) =>
-            init?.method === 'PATCH' && init.body === JSON.stringify({ action: 'leave_stage' }));
+            init?.method === 'PATCH' &&
+            init.body === JSON.stringify({ action: 'leave_stage', expectedGrantVersion: 1 }));
         expect(leaveRequests).toHaveLength(1);
         expect((Room as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(roomCount);
         expect(room.disconnect).not.toHaveBeenCalled();
         expect(audioMocks.startBeaconAudio).toHaveBeenCalledTimes(beaconStarts);
         expect(room.startAudio).toHaveBeenCalledTimes(stageAudioStarts);
         expect(screen.getByTestId('connection-state')).toHaveAttribute('data-state', 'connected');
+    });
+
+    it('keeps an old device completion from restoring stage authority after leaving', async () => {
+        const { room } = await receiveInvitation();
+        fireEvent.click(screen.getByRole('button', { name: 'Accept and join' }));
+        await screen.findByRole('button', { name: 'Turn camera off' });
+
+        let releaseCamera: (() => void) | undefined;
+        room.localParticipant.setCameraEnabled.mockImplementationOnce(async (enabled: boolean) => {
+            await new Promise<void>((resolve) => { releaseCamera = resolve; });
+            room.localParticipant.isCameraEnabled = enabled;
+        });
+        const fetchMock = vi.mocked(global.fetch);
+        const fallback = fetchMock.getMockImplementation();
+        fetchMock.mockImplementation((url, init) => {
+            if (String(url).includes('/hand') && init?.method === 'PATCH') {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        participantId: 'participant-1',
+                        raised: false,
+                        raisedAt: null,
+                        queuePosition: null,
+                        canPublish: false,
+                        grantVersion: 2,
+                    }),
+                } as Response);
+            }
+            return fallback!(url, init);
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Turn camera off' }));
+        await waitFor(() => expect(releaseCamera).toBeTypeOf('function'));
+        fireEvent.click(screen.getByRole('button', { name: 'Leave the scene' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Yes, leave the scene' }));
+        await waitFor(() => expect(screen.queryByRole('button', { name: 'Leave the scene' })).not.toBeInTheDocument());
+
+        releaseCamera?.();
+        await act(async () => {});
+
+        expect(screen.queryByRole('button', { name: 'Leave the scene' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Unmute microphone' })).not.toBeInTheDocument();
+        expect(room.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('traps focus in the stage exit confirmation and restores it on Escape', async () => {
+        await receiveInvitation();
+        fireEvent.click(screen.getByRole('button', { name: 'Accept and join' }));
+        const trigger = await screen.findByRole('button', { name: 'Leave the scene' });
+        fireEvent.click(trigger);
+        const confirmation = await screen.findByRole('alertdialog', { name: 'Return to the audience?' });
+        const cancel = screen.getByRole('button', { name: 'Stay on stage' });
+        const confirm = screen.getByRole('button', { name: 'Yes, leave the scene' });
+
+        expect(cancel).toHaveFocus();
+        fireEvent.keyDown(confirmation, { key: 'Tab' });
+        expect(confirm).toHaveFocus();
+        fireEvent.keyDown(confirmation, { key: 'Escape' });
+
+        expect(screen.queryByRole('alertdialog', { name: 'Return to the audience?' })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Leave the scene' })).toHaveFocus();
     });
 
     it('stays on stage with retryable feedback when the voluntary exit request fails', async () => {
@@ -889,7 +970,7 @@ describe('SessionRoomPage - stage invitation consent', () => {
             if (
                 String(url).includes('/hand') &&
                 init?.method === 'PATCH' &&
-                init.body === JSON.stringify({ action: 'leave_stage' })
+                init.body === JSON.stringify({ action: 'leave_stage', expectedGrantVersion: 1 })
             ) {
                 return Promise.resolve({
                     ok: false,
@@ -919,12 +1000,14 @@ describe('SessionRoomPage - deliberate session exit', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Leave session' }));
         const confirmation = screen.getByRole('alertdialog', { name: 'Leave session' });
+        expect(confirmation).toHaveAttribute('aria-modal', 'true');
         expect(confirmation).toHaveTextContent(/disconnects this page from the session and Beacon/i);
         expect(room.disconnect).not.toHaveBeenCalled();
         expect(screen.getByRole('button', { name: 'Stay in the session' })).toHaveFocus();
 
         fireEvent.click(screen.getByRole('button', { name: 'Stay in the session' }));
         expect(room.disconnect).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Leave session' })).toHaveFocus();
         fireEvent.click(screen.getByRole('button', { name: 'Leave session' }));
         fireEvent.click(screen.getByRole('button', { name: 'Yes, leave the session' }));
 

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -1510,11 +1510,14 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
     const [entry, setEntry] = useState<EntryResponse | null>(null);
     const [entryError, setEntryError] = useState<string | null>(null);
     const [retryEntry, setRetryEntry] = useState(0);
+    const entryRequestGenerationRef = useRef(0);
+    const entryAbortRef = useRef<AbortController | null>(null);
 
     useEffect(() => {
         let cancelled = false;
         let timer: ReturnType<typeof setTimeout> | null = null;
         let inFlight = false;
+        const effectGeneration = ++entryRequestGenerationRef.current;
 
         const checkEntry = async () => {
             if (cancelled || inFlight) return;
@@ -1523,25 +1526,30 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
                 timer = null;
             }
             inFlight = true;
+            const requestGeneration = entryRequestGenerationRef.current;
+            const controller = new AbortController();
+            entryAbortRef.current = controller;
             try {
                 const response = await fetch(`/api/scheduled-sessions/${sessionId}/entry`, {
                     cache: 'no-store',
+                    signal: controller.signal,
                 });
                 const data = await response.json().catch(() => ({})) as Partial<EntryResponse> & { error?: string };
                 if (!response.ok || !data.state || !data.session) {
                     throw new Error(data.error || `Entry status unavailable (HTTP ${response.status})`);
                 }
-                if (!cancelled) {
+                if (!cancelled && requestGeneration === entryRequestGenerationRef.current) {
                     seedLocale(localeForEventLanguage(data.session.language));
                     setEntry(data as EntryResponse);
                     setEntryError(null);
                 }
             } catch (failure) {
-                if (!cancelled) {
+                if (!cancelled && requestGeneration === entryRequestGenerationRef.current) {
                     console.error('Failed to confirm event entry:', redactErrorDetail(failure));
                     setEntryError(copy.session.entryUnavailable);
                 }
             } finally {
+                if (entryAbortRef.current === controller) entryAbortRef.current = null;
                 inFlight = false;
                 if (!cancelled) timer = setTimeout(checkEntry, ENTRY_POLL_MS);
             }
@@ -1556,6 +1564,11 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
         document.addEventListener('visibilitychange', checkWhenVisible);
         return () => {
             cancelled = true;
+            if (entryRequestGenerationRef.current === effectGeneration) {
+                entryRequestGenerationRef.current += 1;
+            }
+            entryAbortRef.current?.abort();
+            entryAbortRef.current = null;
             if (timer) clearTimeout(timer);
             window.removeEventListener('focus', checkWhenVisible);
             window.removeEventListener('online', checkWhenVisible);
@@ -1594,10 +1607,15 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
                 sessionId={sessionId}
                 sessionTitle={entry.session.title}
                 initialDisplayName={entry.identity.displayName}
-                onConfirmed={(displayName) => setEntry((current) => current ? {
-                    ...current,
-                    identity: { kind: 'attendee', displayName, confirmed: true },
-                } : current)}
+                onConfirmed={(displayName) => {
+                    entryRequestGenerationRef.current += 1;
+                    entryAbortRef.current?.abort();
+                    entryAbortRef.current = null;
+                    setEntry((current) => current ? {
+                        ...current,
+                        identity: { kind: 'attendee', displayName, confirmed: true },
+                    } : current);
+                }}
             />
         );
     }

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -20,6 +20,7 @@ import HandRaiseButton from "@/components/session/HandRaiseButton";
 import FacilitatorAudioQuality from "@/components/session/FacilitatorAudioQuality";
 import SessionContributions from "@/components/session/SessionContributions";
 import SessionGuidance from "@/components/session/SessionGuidance";
+import SessionIdentityGate from "@/components/session/SessionIdentityGate";
 import StageLayout, { type StagePublisherView } from "@/components/session/StageLayout";
 import ThumbnailSender from "@/components/session/ThumbnailSender";
 import ThumbnailTapestry from "@/components/session/ThumbnailTapestry";
@@ -245,6 +246,10 @@ function SessionRoom() {
     const [stageInvitationAccepted, setStageInvitationAccepted] = useState(false);
     const [stageInvitationBusy, setStageInvitationBusy] = useState<'accept' | 'decline' | null>(null);
     const [stageInvitationError, setStageInvitationError] = useState<string | null>(null);
+    const [stageExitConfirming, setStageExitConfirming] = useState(false);
+    const [stageExitBusy, setStageExitBusy] = useState(false);
+    const [stageExitError, setStageExitError] = useState<string | null>(null);
+    const [sessionExitConfirming, setSessionExitConfirming] = useState(false);
 
     const roomRef = useRef<Room | null>(null);
     // Keep ownership by track so an unsubscribe can remove the exact DOM node
@@ -264,6 +269,7 @@ function SessionRoom() {
     const desiredCameraRef = useRef(false);
     const deviceOperationRef = useRef<Promise<void> | null>(null);
     const stageInvitationAcceptedRef = useRef(false);
+    const stageExitInFlightRef = useRef(false);
     const terminalViewRef = useRef<HTMLDivElement>(null);
     const stageInvitationRef = useRef<HTMLDivElement>(null);
     const participantFallbackRef = useRef(copy.session.participantFallback);
@@ -508,6 +514,45 @@ function SessionRoom() {
             setStageInvitationBusy(null);
         }
     }, [canPublish, copy.session.invitationDeclineError, id, principalKind, stageInvitationBusy]);
+
+    const leaveStage = useCallback(async () => {
+        if (
+            principalKind !== 'ticket' ||
+            !canPublish ||
+            stageExitBusy ||
+            stageExitInFlightRef.current
+        ) return;
+
+        stageExitInFlightRef.current = true;
+        setStageExitBusy(true);
+        setStageExitError(null);
+        try {
+            const response = await fetch(`/api/scheduled-sessions/${id}/hand`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'leave_stage' }),
+            });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+            // LiveKit's permission event releases the local devices. These
+            // state updates make the attendee UI converge immediately while
+            // both receiving rooms and their audio activation stay mounted.
+            desiredCameraRef.current = false;
+            desiredMicRef.current = false;
+            setStageInvitationAccepted(false);
+            setCanPublish(false);
+            setIsCameraOn(false);
+            setIsMicOn(false);
+            setStageExitConfirming(false);
+            readStage();
+        } catch (failure) {
+            console.error('Failed to leave the stage:', redactErrorDetail(failure));
+            setStageExitError(copy.session.leaveStageFailed);
+        } finally {
+            stageExitInFlightRef.current = false;
+            setStageExitBusy(false);
+        }
+    }, [canPublish, copy.session.leaveStageFailed, id, principalKind, readStage, stageExitBusy]);
 
     // Connect to LiveKit room
     useEffect(() => {
@@ -1235,6 +1280,62 @@ function SessionRoom() {
                             />
                         </div>
                     )}
+                    {canControlStageDevices && principalKind === 'ticket' ? (
+                        <div className="mx-auto mb-4 w-full max-w-md">
+                            {!stageExitConfirming ? (
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setStageExitError(null);
+                                        setStageExitConfirming(true);
+                                    }}
+                                    className="event-button event-button--secondary w-full"
+                                >
+                                    {copy.session.leaveStage}
+                                </button>
+                            ) : (
+                                <section
+                                    role="alertdialog"
+                                    aria-labelledby="leave-stage-heading"
+                                    aria-describedby="leave-stage-body"
+                                    className="rounded border border-[var(--gold)]/40 bg-[var(--surface-alt)] p-4 text-center"
+                                >
+                                    <h2 id="leave-stage-heading" className="font-serif text-xl text-[var(--paper)]">
+                                        {copy.session.leaveStageHeading}
+                                    </h2>
+                                    <p id="leave-stage-body" className="mt-2 text-sm leading-6 text-[var(--text-secondary)]">
+                                        {copy.session.leaveStageBody}
+                                    </p>
+                                    <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => void leaveStage()}
+                                            disabled={stageExitBusy}
+                                            className="event-button event-button--primary w-full"
+                                        >
+                                            {stageExitBusy
+                                                ? copy.session.leavingStage
+                                                : copy.session.leaveStageConfirm}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => setStageExitConfirming(false)}
+                                            disabled={stageExitBusy}
+                                            autoFocus
+                                            className="event-button event-button--secondary w-full"
+                                        >
+                                            {copy.session.leaveStageCancel}
+                                        </button>
+                                    </div>
+                                </section>
+                            )}
+                            {stageExitError ? (
+                                <p role="alert" className="mt-3 text-center text-sm text-[var(--danger)]">
+                                    {stageExitError}
+                                </p>
+                            ) : null}
+                        </div>
+                    ) : null}
                     <div className="flex flex-wrap items-start justify-center gap-x-4 gap-y-3">
                         {canControlStageDevices && (
                             <div className="flex flex-col items-center gap-1">
@@ -1327,24 +1428,48 @@ function SessionRoom() {
                             <span className="text-xs text-[var(--text-secondary)]">{copy.session.audioOnly}</span>
                         </div>
 
-                        <div className="flex flex-col items-center gap-1">
-                            <button
-                                onClick={leaveSession}
-                                className="flex h-14 w-14 items-center justify-center rounded-full bg-white/10 text-[var(--text-muted)] transition-all hover:bg-white/20"
-                                aria-label={copy.session.leaveSession}
-                            >
-                                <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-                                </svg>
-                            </button>
-                            <span className="text-xs text-[var(--text-secondary)]">{copy.session.leave}</span>
-                        </div>
                     </div>
                     {cameraSwitchError && (
                         <p className="mx-auto mt-3 max-w-md text-center text-sm text-[var(--danger)]" role="alert">
                             {cameraSwitchError}
                         </p>
                     )}
+                    <div className="mx-auto mt-5 max-w-md border-t border-[var(--border-subtle)] pt-4 text-center">
+                        {!sessionExitConfirming ? (
+                            <button
+                                type="button"
+                                onClick={() => setSessionExitConfirming(true)}
+                                className="min-h-11 px-3 text-sm text-[var(--text-muted)] underline decoration-white/20 underline-offset-4 hover:text-[var(--cream)]"
+                            >
+                                {copy.session.leaveSession}
+                            </button>
+                        ) : (
+                            <div
+                                role="alertdialog"
+                                aria-label={copy.session.leaveSession}
+                                className="rounded border border-[var(--danger)]/40 bg-[var(--surface-alt)] p-3"
+                            >
+                                <p className="text-sm leading-6 text-[var(--text-secondary)]">{copy.session.leaveSessionBody}</p>
+                                <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:justify-center">
+                                    <button
+                                        type="button"
+                                        onClick={leaveSession}
+                                        className="event-button event-button--secondary"
+                                    >
+                                        {copy.session.leaveSessionConfirm}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => setSessionExitConfirming(false)}
+                                        autoFocus
+                                        className="event-button event-button--secondary"
+                                    >
+                                        {copy.session.leaveSessionCancel}
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </div>
                 </div>
             </div>
         </main>
@@ -1369,6 +1494,11 @@ type EntrySession = {
 
 type EntryResponse = {
     state: EntryState;
+    identity: { kind: 'staff' } | {
+        kind: 'attendee';
+        displayName: string;
+        confirmed: boolean;
+    };
     session: EntrySession;
 };
 
@@ -1455,6 +1585,20 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
                     </div>
                 </div>
             </main>
+        );
+    }
+
+    if (entry.identity.kind === 'attendee' && !entry.identity.confirmed) {
+        return (
+            <SessionIdentityGate
+                sessionId={sessionId}
+                sessionTitle={entry.session.title}
+                initialDisplayName={entry.identity.displayName}
+                onConfirmed={(displayName) => setEntry((current) => current ? {
+                    ...current,
+                    identity: { kind: 'attendee', displayName, confirmed: true },
+                } : current)}
+            />
         );
     }
 

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import {
     AudioPresets,
@@ -67,6 +68,39 @@ function stageRoomOptions(isAssignedFacilitator: boolean): RoomOptions {
 
 const STAGE_REFRESH_MS = 100;
 const STAGE_HANDOFF_MAX_AGE_MS = 30_000;
+
+function keepFocusInsideDialog(
+    event: ReactKeyboardEvent<HTMLElement>,
+    onEscape: () => void,
+    escapeDisabled = false,
+): void {
+    if (event.key === 'Escape') {
+        if (!escapeDisabled) {
+            event.preventDefault();
+            event.stopPropagation();
+            onEscape();
+        }
+        return;
+    }
+    if (event.key !== 'Tab') return;
+
+    const controls = Array.from(event.currentTarget.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    )).filter((element) => !element.hasAttribute('hidden'));
+    if (controls.length === 0) {
+        event.preventDefault();
+        return;
+    }
+    const first = controls[0];
+    const last = controls[controls.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+    }
+}
 
 type StageHandoff = {
     microphone: boolean;
@@ -222,6 +256,7 @@ function SessionRoom() {
     const [isConnecting, setIsConnecting] = useState(true);
     const [connectionError, setConnectionError] = useState(false);
     const [canPublish, setCanPublish] = useState(false);
+    const [grantVersion, setGrantVersion] = useState<number | null>(null);
     const [principalKind, setPrincipalKind] = useState<"ticket" | "staff">("ticket");
     const [isMicOn, setIsMicOn] = useState(false);
     const [isCameraOn, setIsCameraOn] = useState(false);
@@ -270,8 +305,14 @@ function SessionRoom() {
     const deviceOperationRef = useRef<Promise<void> | null>(null);
     const stageInvitationAcceptedRef = useRef(false);
     const stageExitInFlightRef = useRef(false);
+    const stageAuthoritySuppressedRef = useRef(false);
+    const grantVersionRef = useRef<number | null>(null);
     const terminalViewRef = useRef<HTMLDivElement>(null);
     const stageInvitationRef = useRef<HTMLDivElement>(null);
+    const stageExitCancelRef = useRef<HTMLButtonElement>(null);
+    const stageExitTriggerRef = useRef<HTMLButtonElement>(null);
+    const sessionExitCancelRef = useRef<HTMLButtonElement>(null);
+    const sessionExitTriggerRef = useRef<HTMLButtonElement>(null);
     const participantFallbackRef = useRef(copy.session.participantFallback);
     participantFallbackRef.current = copy.session.participantFallback;
     stageInvitationAcceptedRef.current = stageInvitationAccepted;
@@ -292,7 +333,9 @@ function SessionRoom() {
         const everyone: Participant[] = [local, ...room.remoteParticipants.values()];
 
         const publishers: StagePublisherView[] = everyone
-            .filter(isStagePublisher)
+            .filter((participant) =>
+                !(participant === local && stageAuthoritySuppressedRef.current) &&
+                isStagePublisher(participant))
             .map((participant) => {
                 const label = participant.name?.trim() || participantFallbackRef.current;
                 return {
@@ -312,9 +355,11 @@ function SessionRoom() {
         setStagePublishers(publishers);
         setParticipantCount(room.remoteParticipants.size + 1);
         setConnectionState(room.state);
-        setCanPublish(Boolean(local.permissions?.canPublish));
-        setIsMicOn(local.isMicrophoneEnabled);
-        setIsCameraOn(local.isCameraEnabled);
+        const localCanPublish = !stageAuthoritySuppressedRef.current &&
+            Boolean(local.permissions?.canPublish);
+        setCanPublish(localCanPublish);
+        setIsMicOn(localCanPublish && local.isMicrophoneEnabled);
+        setIsCameraOn(localCanPublish && local.isCameraEnabled);
 
         const newestSlot = publishers.reduce((max, p) => Math.max(max, p.grantOrder), -1);
         if (newestSlot > highestSlotRef.current) {
@@ -494,7 +539,7 @@ function SessionRoom() {
     ]);
 
     const declineStageInvitation = useCallback(async () => {
-        if (principalKind !== 'ticket' || !canPublish || stageInvitationBusy) return;
+        if (principalKind !== 'ticket' || !canPublish || stageInvitationBusy || grantVersion === null) return;
 
         setStageInvitationBusy('decline');
         setStageInvitationError(null);
@@ -502,9 +547,18 @@ function SessionRoom() {
             const response = await fetch(`/api/scheduled-sessions/${id}/hand`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ action: 'decline_invitation' }),
+                body: JSON.stringify({
+                    action: 'decline_invitation',
+                    expectedGrantVersion: grantVersion,
+                }),
             });
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            const next = await response.json() as { grantVersion?: unknown };
+            if (Number.isInteger(next.grantVersion) && (next.grantVersion as number) >= 0) {
+                grantVersionRef.current = next.grantVersion as number;
+                setGrantVersion(next.grantVersion as number);
+            }
+            stageAuthoritySuppressedRef.current = true;
             setStageInvitationAccepted(false);
             setCanPublish(false);
         } catch (failure) {
@@ -513,14 +567,15 @@ function SessionRoom() {
         } finally {
             setStageInvitationBusy(null);
         }
-    }, [canPublish, copy.session.invitationDeclineError, id, principalKind, stageInvitationBusy]);
+    }, [canPublish, copy.session.invitationDeclineError, grantVersion, id, principalKind, stageInvitationBusy]);
 
     const leaveStage = useCallback(async () => {
         if (
             principalKind !== 'ticket' ||
             !canPublish ||
             stageExitBusy ||
-            stageExitInFlightRef.current
+            stageExitInFlightRef.current ||
+            grantVersion === null
         ) return;
 
         stageExitInFlightRef.current = true;
@@ -530,21 +585,29 @@ function SessionRoom() {
             const response = await fetch(`/api/scheduled-sessions/${id}/hand`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ action: 'leave_stage' }),
+                body: JSON.stringify({
+                    action: 'leave_stage',
+                    expectedGrantVersion: grantVersion,
+                }),
             });
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            const next = await response.json() as { grantVersion?: unknown };
+            if (Number.isInteger(next.grantVersion) && (next.grantVersion as number) >= 0) {
+                grantVersionRef.current = next.grantVersion as number;
+                setGrantVersion(next.grantVersion as number);
+            }
 
             // LiveKit's permission event releases the local devices. These
             // state updates make the attendee UI converge immediately while
             // both receiving rooms and their audio activation stay mounted.
             desiredCameraRef.current = false;
             desiredMicRef.current = false;
+            stageAuthoritySuppressedRef.current = true;
             setStageInvitationAccepted(false);
             setCanPublish(false);
             setIsCameraOn(false);
             setIsMicOn(false);
             setStageExitConfirming(false);
-            readStage();
         } catch (failure) {
             console.error('Failed to leave the stage:', redactErrorDetail(failure));
             setStageExitError(copy.session.leaveStageFailed);
@@ -552,7 +615,28 @@ function SessionRoom() {
             stageExitInFlightRef.current = false;
             setStageExitBusy(false);
         }
-    }, [canPublish, copy.session.leaveStageFailed, id, principalKind, readStage, stageExitBusy]);
+    }, [canPublish, copy.session.leaveStageFailed, grantVersion, id, principalKind, stageExitBusy]);
+
+    const applyGrantState = useCallback((nextCanPublish: boolean, nextGrantVersion: number) => {
+        const currentGrantVersion = grantVersionRef.current;
+        if (
+            !Number.isInteger(nextGrantVersion) ||
+            nextGrantVersion < 0 ||
+            (currentGrantVersion !== null && nextGrantVersion < currentGrantVersion) ||
+            (stageAuthoritySuppressedRef.current &&
+                nextCanPublish &&
+                currentGrantVersion !== null &&
+                nextGrantVersion <= currentGrantVersion)
+        ) return;
+
+        grantVersionRef.current = nextGrantVersion;
+        setGrantVersion(nextGrantVersion);
+        if (
+            nextCanPublish &&
+            (currentGrantVersion === null || nextGrantVersion > currentGrantVersion)
+        ) stageAuthoritySuppressedRef.current = false;
+        setCanPublish(nextCanPublish);
+    }, []);
 
     // Connect to LiveKit room
     useEffect(() => {
@@ -586,7 +670,9 @@ function SessionRoom() {
                 if (cancelled) return;
 
                 setSessionInfo(data.session);
-                setCanPublish(data.canPublish);
+                setCanPublish(
+                    !stageAuthoritySuppressedRef.current && data.canPublish === true,
+                );
                 setPrincipalKind(data.principalKind === "staff" ? "staff" : "ticket");
                 setViewerInfo({
                     name: typeof data.displayName === "string" ? data.displayName : participantFallbackRef.current,
@@ -705,7 +791,7 @@ function SessionRoom() {
                     return;
                 }
 
-                if (data.canPublish) {
+                if (data.canPublish && !stageAuthoritySuppressedRef.current) {
                     const publicationResponse = await fetch(
                         `/api/scheduled-sessions/${id}/publication`,
                         { method: "POST" },
@@ -833,6 +919,22 @@ function SessionRoom() {
             setStageInvitationError(null);
         }
     }, [canPublish, principalKind, stageInvitationAccepted]);
+
+    useEffect(() => {
+        if (stageExitConfirming) {
+            stageExitCancelRef.current?.focus();
+        } else {
+            stageExitTriggerRef.current?.focus();
+        }
+    }, [stageExitConfirming]);
+
+    useEffect(() => {
+        if (sessionExitConfirming) {
+            sessionExitCancelRef.current?.focus();
+        } else {
+            sessionExitTriggerRef.current?.focus();
+        }
+    }, [sessionExitConfirming]);
 
     useEffect(() => {
         const sessionVol = volume * mix;
@@ -1170,7 +1272,7 @@ function SessionRoom() {
                                     type="button"
                                     className="event-button event-button--secondary w-full"
                                     onClick={() => void declineStageInvitation()}
-                                    disabled={stageInvitationBusy !== null}
+                                    disabled={stageInvitationBusy !== null || grantVersion === null}
                                 >
                                     {stageInvitationBusy === 'decline'
                                         ? copy.session.decliningInvitation
@@ -1275,7 +1377,7 @@ function SessionRoom() {
                         <div className="mb-4 flex justify-center">
                             <HandRaiseButton
                                 sessionId={id}
-                                onPublishGrantChange={setCanPublish}
+                                onPublishGrantChange={applyGrantState}
                                 stageInvitationAccepted={stageInvitationAccepted}
                             />
                         </div>
@@ -1285,6 +1387,7 @@ function SessionRoom() {
                             {!stageExitConfirming ? (
                                 <button
                                     type="button"
+                                    ref={stageExitTriggerRef}
                                     onClick={() => {
                                         setStageExitError(null);
                                         setStageExitConfirming(true);
@@ -1296,8 +1399,14 @@ function SessionRoom() {
                             ) : (
                                 <section
                                     role="alertdialog"
+                                    aria-modal="true"
                                     aria-labelledby="leave-stage-heading"
                                     aria-describedby="leave-stage-body"
+                                    onKeyDown={(event) => keepFocusInsideDialog(
+                                        event,
+                                        () => setStageExitConfirming(false),
+                                        stageExitBusy,
+                                    )}
                                     className="rounded border border-[var(--gold)]/40 bg-[var(--surface-alt)] p-4 text-center"
                                 >
                                     <h2 id="leave-stage-heading" className="font-serif text-xl text-[var(--paper)]">
@@ -1310,7 +1419,7 @@ function SessionRoom() {
                                         <button
                                             type="button"
                                             onClick={() => void leaveStage()}
-                                            disabled={stageExitBusy}
+                                            disabled={stageExitBusy || grantVersion === null}
                                             className="event-button event-button--primary w-full"
                                         >
                                             {stageExitBusy
@@ -1319,9 +1428,9 @@ function SessionRoom() {
                                         </button>
                                         <button
                                             type="button"
+                                            ref={stageExitCancelRef}
                                             onClick={() => setStageExitConfirming(false)}
                                             disabled={stageExitBusy}
-                                            autoFocus
                                             className="event-button event-button--secondary w-full"
                                         >
                                             {copy.session.leaveStageCancel}
@@ -1438,6 +1547,7 @@ function SessionRoom() {
                         {!sessionExitConfirming ? (
                             <button
                                 type="button"
+                                ref={sessionExitTriggerRef}
                                 onClick={() => setSessionExitConfirming(true)}
                                 className="min-h-11 px-3 text-sm text-[var(--text-muted)] underline decoration-white/20 underline-offset-4 hover:text-[var(--cream)]"
                             >
@@ -1446,7 +1556,12 @@ function SessionRoom() {
                         ) : (
                             <div
                                 role="alertdialog"
+                                aria-modal="true"
                                 aria-label={copy.session.leaveSession}
+                                onKeyDown={(event) => keepFocusInsideDialog(
+                                    event,
+                                    () => setSessionExitConfirming(false),
+                                )}
                                 className="rounded border border-[var(--danger)]/40 bg-[var(--surface-alt)] p-3"
                             >
                                 <p className="text-sm leading-6 text-[var(--text-secondary)]">{copy.session.leaveSessionBody}</p>
@@ -1460,8 +1575,8 @@ function SessionRoom() {
                                     </button>
                                     <button
                                         type="button"
+                                        ref={sessionExitCancelRef}
                                         onClick={() => setSessionExitConfirming(false)}
-                                        autoFocus
                                         className="event-button event-button--secondary"
                                     >
                                         {copy.session.leaveSessionCancel}
@@ -1601,6 +1716,32 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
         );
     }
 
+    if (entry.state === 'ENDED' || entry.state === 'CANCELLED') {
+        const cancelled = entry.state === 'CANCELLED';
+        return (
+            <main className="event-shell">
+                <div className="relative z-10 flex min-h-screen items-center justify-center px-4">
+                    <section role="status" aria-live="polite" className="event-card w-full max-w-sm text-center">
+                        <div className="terminal-state__icon">&#10022;</div>
+                        <h1 className="terminal-state__title">
+                            {cancelled ? copy.session.cancelledHeading : copy.session.endedHeading}
+                        </h1>
+                        <p className="terminal-state__body">
+                            {cancelled ? copy.session.cancelledBody : copy.session.closingBody}
+                        </p>
+                        <button
+                            type="button"
+                            onClick={() => router.push('/')}
+                            className="event-button event-button--secondary mt-4 w-full"
+                        >
+                            {copy.session.backToSessions}
+                        </button>
+                    </section>
+                </div>
+            </main>
+        );
+    }
+
     if (entry.identity.kind === 'attendee' && !entry.identity.confirmed) {
         return (
             <SessionIdentityGate
@@ -1651,32 +1792,6 @@ function SessionEntryGate({ sessionId }: { sessionId: string }) {
                     {/* Guidance waits outside the live region: the disclosure
                         toggling must not be announced as a door-state change. */}
                     <SessionGuidance copy={copy.session.guidance} className="w-full max-w-md" />
-                </div>
-            </main>
-        );
-    }
-
-    if (entry.state === 'ENDED' || entry.state === 'CANCELLED') {
-        const cancelled = entry.state === 'CANCELLED';
-        return (
-            <main className="event-shell">
-                <div className="relative z-10 flex min-h-screen items-center justify-center px-4">
-                    <section role="status" aria-live="polite" className="event-card w-full max-w-sm text-center">
-                        <div className="terminal-state__icon">&#10022;</div>
-                        <h1 className="terminal-state__title">
-                            {cancelled ? copy.session.cancelledHeading : copy.session.endedHeading}
-                        </h1>
-                        <p className="terminal-state__body">
-                            {cancelled ? copy.session.cancelledBody : copy.session.closingBody}
-                        </p>
-                        <button
-                            type="button"
-                            onClick={() => router.push('/')}
-                            className="event-button event-button--secondary mt-4 w-full"
-                        >
-                            {copy.session.backToSessions}
-                        </button>
-                    </section>
                 </div>
             </main>
         );

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -554,7 +554,7 @@ function SessionRoom() {
             });
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             const next = await response.json() as { grantVersion?: unknown };
-            if (Number.isInteger(next.grantVersion) && (next.grantVersion as number) >= 0) {
+            if (Number.isSafeInteger(next.grantVersion) && (next.grantVersion as number) >= 0) {
                 grantVersionRef.current = next.grantVersion as number;
                 setGrantVersion(next.grantVersion as number);
             }
@@ -592,7 +592,7 @@ function SessionRoom() {
             });
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             const next = await response.json() as { grantVersion?: unknown };
-            if (Number.isInteger(next.grantVersion) && (next.grantVersion as number) >= 0) {
+            if (Number.isSafeInteger(next.grantVersion) && (next.grantVersion as number) >= 0) {
                 grantVersionRef.current = next.grantVersion as number;
                 setGrantVersion(next.grantVersion as number);
             }
@@ -620,7 +620,7 @@ function SessionRoom() {
     const applyGrantState = useCallback((nextCanPublish: boolean, nextGrantVersion: number) => {
         const currentGrantVersion = grantVersionRef.current;
         if (
-            !Number.isInteger(nextGrantVersion) ||
+            !Number.isSafeInteger(nextGrantVersion) ||
             nextGrantVersion < 0 ||
             (currentGrantVersion !== null && nextGrantVersion < currentGrantVersion) ||
             (stageAuthoritySuppressedRef.current &&

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -307,6 +307,7 @@ function SessionRoom() {
     const stageExitInFlightRef = useRef(false);
     const stageAuthoritySuppressedRef = useRef(false);
     const grantVersionRef = useRef<number | null>(null);
+    const principalKindRef = useRef<"ticket" | "staff">("ticket");
     const terminalViewRef = useRef<HTMLDivElement>(null);
     const stageInvitationRef = useRef<HTMLDivElement>(null);
     const stageExitCancelRef = useRef<HTMLButtonElement>(null);
@@ -316,6 +317,7 @@ function SessionRoom() {
     const participantFallbackRef = useRef(copy.session.participantFallback);
     participantFallbackRef.current = copy.session.participantFallback;
     stageInvitationAcceptedRef.current = stageInvitationAccepted;
+    principalKindRef.current = principalKind;
 
     const slotFor = useCallback((identity: string): number => {
         const existing = slotOrderRef.current.get(identity);
@@ -357,7 +359,14 @@ function SessionRoom() {
         setConnectionState(room.state);
         const localCanPublish = !stageAuthoritySuppressedRef.current &&
             Boolean(local.permissions?.canPublish);
-        setCanPublish(localCanPublish);
+        // A ticket holder's LiveKit permission can arrive before the next
+        // authoritative hand-state poll. Do not expose an invitation backed
+        // by the previous grantVersion: declining it would correctly fail the
+        // server CAS with a stale revision. Staff have no attendee hand poll,
+        // so their event-scoped permission remains LiveKit-driven.
+        if (principalKindRef.current === 'staff' || !localCanPublish) {
+            setCanPublish(localCanPublish);
+        }
         setIsMicOn(localCanPublish && local.isMicrophoneEnabled);
         setIsCameraOn(localCanPublish && local.isCameraEnabled);
 
@@ -670,10 +679,22 @@ function SessionRoom() {
                 if (cancelled) return;
 
                 setSessionInfo(data.session);
-                setCanPublish(
-                    !stageAuthoritySuppressedRef.current && data.canPublish === true,
-                );
-                setPrincipalKind(data.principalKind === "staff" ? "staff" : "ticket");
+                const resolvedPrincipalKind = data.principalKind === "staff" ? "staff" : "ticket";
+                principalKindRef.current = resolvedPrincipalKind;
+                setPrincipalKind(resolvedPrincipalKind);
+                // On a fresh attendee page, wait for HandRaiseButton to pair
+                // canPublish with its exact grantVersion. During an accepted
+                // transport reconnect the existing authority is already
+                // paired, so preserve it without UI flicker.
+                if (
+                    resolvedPrincipalKind === "staff" ||
+                    data.canPublish !== true ||
+                    stageInvitationAcceptedRef.current
+                ) {
+                    setCanPublish(
+                        !stageAuthoritySuppressedRef.current && data.canPublish === true,
+                    );
+                }
                 setViewerInfo({
                     name: typeof data.displayName === "string" ? data.displayName : participantFallbackRef.current,
                     role: typeof data.role === "string" ? data.role : "PARTICIPANT",

--- a/src/components/session/HandRaiseButton.tsx
+++ b/src/components/session/HandRaiseButton.tsx
@@ -47,7 +47,7 @@ async function handStateFrom(response: Response): Promise<OwnHandState> {
     }
     if (
         typeof body.canPublish !== 'boolean' ||
-        !Number.isInteger(body.grantVersion) ||
+        !Number.isSafeInteger(body.grantVersion) ||
         (body.grantVersion as number) < 0
     ) {
         throw new HandRequestError(502, 'invalid_hand_state');

--- a/src/components/session/HandRaiseButton.tsx
+++ b/src/components/session/HandRaiseButton.tsx
@@ -16,11 +16,12 @@ type OwnHandState = {
     raisedAt: string | null;
     queuePosition: number | null;
     canPublish: boolean;
+    grantVersion: number;
 };
 
 type Props = {
     sessionId: string;
-    onPublishGrantChange?: (canPublish: boolean) => void;
+    onPublishGrantChange?: (canPublish: boolean, grantVersion: number) => void;
     stageInvitationAccepted?: boolean;
 };
 
@@ -43,6 +44,13 @@ async function handStateFrom(response: Response): Promise<OwnHandState> {
             response.status,
             typeof body.error === 'string' ? body.error : null,
         );
+    }
+    if (
+        typeof body.canPublish !== 'boolean' ||
+        !Number.isInteger(body.grantVersion) ||
+        (body.grantVersion as number) < 0
+    ) {
+        throw new HandRequestError(502, 'invalid_hand_state');
     }
     return body as OwnHandState;
 }
@@ -75,13 +83,21 @@ export default function HandRaiseButton({
     const [authorizationBlocked, setAuthorizationBlocked] = useState(false);
     const mounted = useRef(true);
     const authorizationBlockedRef = useRef(false);
-    const lastGrant = useRef<boolean | null>(null);
+    const lastAuthority = useRef<{ canPublish: boolean; grantVersion: number } | null>(null);
 
     const applyState = useCallback((next: OwnHandState) => {
         setState(next);
-        if (lastGrant.current !== next.canPublish) {
-            lastGrant.current = next.canPublish;
-            onPublishGrantChange?.(next.canPublish);
+        const previous = lastAuthority.current;
+        if (
+            !previous ||
+            previous.canPublish !== next.canPublish ||
+            previous.grantVersion !== next.grantVersion
+        ) {
+            lastAuthority.current = {
+                canPublish: next.canPublish,
+                grantVersion: next.grantVersion,
+            };
+            onPublishGrantChange?.(next.canPublish, next.grantVersion);
         }
     }, [onPublishGrantChange]);
 

--- a/src/components/session/SessionIdentityGate.tsx
+++ b/src/components/session/SessionIdentityGate.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { useLocale } from '@/context/LocaleContext';
+
+type Props = {
+    sessionId: string;
+    sessionTitle: string;
+    initialDisplayName: string;
+    onConfirmed: (displayName: string) => void;
+};
+
+export default function SessionIdentityGate({
+    sessionId,
+    sessionTitle,
+    initialDisplayName,
+    onConfirmed,
+}: Props) {
+    const { copy } = useLocale();
+    const [displayName, setDisplayName] = useState(initialDisplayName);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        setDisplayName(initialDisplayName);
+        setError(null);
+    }, [initialDisplayName, sessionId]);
+
+    async function submit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (busy) return;
+        if (!displayName.trim()) {
+            setError(copy.session.nameConfirmationRequired);
+            inputRef.current?.focus();
+            return;
+        }
+
+        setBusy(true);
+        setError(null);
+        try {
+            const response = await fetch(`/api/scheduled-sessions/${sessionId}/entry`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ displayName }),
+            });
+            const body = await response.json().catch(() => ({})) as {
+                displayName?: unknown;
+                error?: unknown;
+            };
+            if (!response.ok || typeof body.displayName !== 'string') {
+                if (response.status === 400) {
+                    setError(copy.session.nameConfirmationRequired);
+                    inputRef.current?.focus();
+                } else {
+                    setError(copy.session.nameConfirmationFailed);
+                }
+                return;
+            }
+            onConfirmed(body.displayName);
+        } catch {
+            setError(copy.session.nameConfirmationFailed);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    return (
+        <main className="event-shell">
+            <div className="relative z-10 flex min-h-screen items-center justify-center px-4 py-8">
+                <form
+                    className="event-card w-full max-w-md space-y-5"
+                    onSubmit={(event) => void submit(event)}
+                    noValidate
+                >
+                    <header className="space-y-2">
+                        <p className="hb-section-label">{copy.session.nameConfirmationEyebrow}</p>
+                        <h1 className="font-serif text-3xl font-normal text-[var(--paper)]">
+                            {copy.session.nameConfirmationHeading}
+                        </h1>
+                        <p className="text-sm leading-6 text-[var(--text-secondary)]">
+                            {copy.session.nameConfirmationBody}
+                        </p>
+                        <p className="text-xs text-[var(--gold)]">{sessionTitle}</p>
+                    </header>
+
+                    <div className="space-y-1.5">
+                        <label htmlFor="session-display-name" className="block text-sm font-medium text-[var(--paper)]">
+                            {copy.session.nameConfirmationLabel}
+                        </label>
+                        <input
+                            ref={inputRef}
+                            id="session-display-name"
+                            name="displayName"
+                            value={displayName}
+                            onChange={(event) => setDisplayName(event.target.value)}
+                            required
+                            maxLength={60}
+                            autoComplete="name"
+                            autoFocus
+                            aria-describedby="session-display-name-hint"
+                            className="event-field"
+                        />
+                        <p id="session-display-name-hint" className="text-xs leading-5 text-[var(--text-muted)]">
+                            {copy.session.nameConfirmationHint}
+                        </p>
+                    </div>
+
+                    {error ? (
+                        <p role="alert" className="event-alert event-alert--danger">{error}</p>
+                    ) : null}
+
+                    <button
+                        type="submit"
+                        disabled={busy}
+                        aria-busy={busy}
+                        className="event-button event-button--primary w-full"
+                    >
+                        {busy
+                            ? copy.session.nameConfirmationSaving
+                            : copy.session.nameConfirmationAction}
+                    </button>
+                    <p className="text-xs leading-5 text-[var(--text-muted)]">
+                        {copy.session.nameConfirmationPrivacy}
+                    </p>
+                </form>
+            </div>
+        </main>
+    );
+}

--- a/src/components/session/__tests__/HandRaiseButton.test.tsx
+++ b/src/components/session/__tests__/HandRaiseButton.test.tsx
@@ -20,6 +20,7 @@ function state(overrides: Partial<HandState> = {}): HandState {
         raisedAt: null,
         queuePosition: null,
         canPublish: false,
+        grantVersion: 0,
         ...overrides,
     };
 }
@@ -107,17 +108,17 @@ describe('HandRaiseButton', () => {
     it('notifies the room page when polling observes a promotion, without a reconnect', async () => {
         const { fetchMock } = mockFetchSequence([
             state({ raised: true, queuePosition: 1 }),
-            state({ canPublish: true }),
+            state({ canPublish: true, grantVersion: 1 }),
         ]);
         vi.stubGlobal('fetch', fetchMock);
         const onGrant = vi.fn();
         const view = render(<HandRaiseButton sessionId="event-1" onPublishGrantChange={onGrant} />);
 
         // First poll: no grant, callback fires once with false.
-        await waitFor(() => expect(onGrant).toHaveBeenCalledWith(false));
+        await waitFor(() => expect(onGrant).toHaveBeenCalledWith(false, 0));
         // Second poll (2s interval): the durable grant flipped — the room page
         // can now offer mic/camera. No token refetch, no reconnect.
-        await waitFor(() => expect(onGrant).toHaveBeenCalledWith(true), { timeout: 4000 });
+        await waitFor(() => expect(onGrant).toHaveBeenCalledWith(true, 1), { timeout: 4000 });
         expect(screen.queryByText(/You are on stage — enable microphone and camera/)).not.toBeInTheDocument();
         expect(screen.queryByRole('button', { name: /hand/i })).not.toBeInTheDocument();
 

--- a/src/components/session/__tests__/SessionIdentityGate.test.tsx
+++ b/src/components/session/__tests__/SessionIdentityGate.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { LocaleProvider } from '@/context/LocaleContext';
+import SessionIdentityGate from '@/components/session/SessionIdentityGate';
+
+describe('SessionIdentityGate', () => {
+    beforeEach(() => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ displayName: 'Anahí 李', confirmed: true }),
+        }) as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.restoreAllMocks();
+    });
+
+    it('explains why the name is needed and confirms international characters', async () => {
+        const onConfirmed = vi.fn();
+        render(
+            <LocaleProvider initialLocale="es">
+                <SessionIdentityGate
+                    sessionId="session-1"
+                    sessionTitle="El Umbral"
+                    initialDisplayName="Participante"
+                    onConfirmed={onConfirmed}
+                />
+            </LocaleProvider>,
+        );
+
+        expect(screen.getByText('El Umbral')).toBeInTheDocument();
+        expect(screen.getByText(/reconocerte cuando levantes la mano/i)).toBeInTheDocument();
+        const input = screen.getByRole('textbox', { name: 'Tu nombre visible' });
+        fireEvent.change(input, { target: { value: '  Anahí   李  ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Confirmar y continuar' }));
+
+        await waitFor(() => expect(onConfirmed).toHaveBeenCalledWith('Anahí 李'));
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/api/scheduled-sessions/session-1/entry',
+            expect.objectContaining({
+                method: 'PATCH',
+                body: JSON.stringify({ displayName: '  Anahí   李  ' }),
+            }),
+        );
+    });
+
+    it('keeps the attendee outside LiveKit and focuses an empty required name', () => {
+        render(
+            <LocaleProvider initialLocale="en">
+                <SessionIdentityGate
+                    sessionId="session-1"
+                    sessionTitle="The Threshold"
+                    initialDisplayName=""
+                    onConfirmed={vi.fn()}
+                />
+            </LocaleProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Confirm and continue' }));
+        const input = screen.getByRole('textbox', { name: 'Your visible name' });
+        expect(input).toHaveFocus();
+        expect(screen.getByRole('alert')).toHaveTextContent(/Enter a visible name/i);
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('announces a server failure and allows retry without losing the draft', async () => {
+        vi.mocked(global.fetch).mockResolvedValue({
+            ok: false,
+            status: 503,
+            json: async () => ({ error: 'entry_unavailable' }),
+        } as Response);
+        render(
+            <LocaleProvider initialLocale="en">
+                <SessionIdentityGate
+                    sessionId="session-1"
+                    sessionTitle="The Threshold"
+                    initialDisplayName="Annie"
+                    onConfirmed={vi.fn()}
+                />
+            </LocaleProvider>,
+        );
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Annie ✿' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Confirm and continue' }));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(/could not save your name/i);
+        expect(screen.getByRole('textbox')).toHaveValue('Annie ✿');
+        expect(screen.getByRole('button', { name: 'Confirm and continue' })).toBeEnabled();
+    });
+});

--- a/src/lib/__tests__/attendee-display-name.test.ts
+++ b/src/lib/__tests__/attendee-display-name.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+    const transaction = {
+        $queryRaw: vi.fn(),
+        webSession: {
+            findFirst: vi.fn(),
+            updateMany: vi.fn(),
+            update: vi.fn(),
+        },
+        sessionParticipant: { updateMany: vi.fn() },
+    };
+    return {
+        transaction,
+        $transaction: vi.fn(async (operation: (tx: typeof transaction) => unknown) =>
+            operation(transaction)),
+        readWebSession: vi.fn(),
+        readParticipant: vi.fn(),
+    };
+});
+
+vi.mock('@/lib/db', () => ({
+    prisma: {
+        $transaction: mocks.$transaction,
+        webSession: { findFirst: mocks.readWebSession },
+        sessionParticipant: { findFirst: mocks.readParticipant },
+    },
+}));
+
+import {
+    AttendeeDisplayNameError,
+    confirmAttendeeDisplayName,
+    readAttendeeDisplayName,
+} from '@/lib/attendee-display-name';
+
+describe('attendee display name', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.readWebSession.mockResolvedValue({
+            displayName: 'Web alias',
+            displayNameConfirmedAt: null,
+        });
+        mocks.readParticipant.mockResolvedValue(null);
+        mocks.transaction.webSession.findFirst.mockResolvedValue({ id: 'web-1' });
+        mocks.transaction.webSession.updateMany.mockResolvedValue({ count: 2 });
+        mocks.transaction.webSession.update.mockResolvedValue({ id: 'web-1' });
+        mocks.transaction.sessionParticipant.updateMany.mockResolvedValue({ count: 1 });
+    });
+
+    it('reads the durable participant alias first and requires explicit confirmation', async () => {
+        mocks.readParticipant.mockResolvedValue({ displayName: '  Anahí 李  ' });
+
+        await expect(readAttendeeDisplayName('web-1', 'session-1', 'ticket-1'))
+            .resolves.toEqual({ displayName: 'Anahí 李', confirmed: false });
+    });
+
+    it('does not silently invent a generic alias when no name exists', async () => {
+        mocks.readWebSession.mockResolvedValue({
+            displayName: null,
+            displayNameConfirmedAt: null,
+        });
+
+        await expect(readAttendeeDisplayName('web-1', 'session-1', 'ticket-1'))
+            .resolves.toEqual({ displayName: '', confirmed: false });
+    });
+
+    it('normalizes and converges active devices plus the durable participant atomically', async () => {
+        const now = new Date('2026-09-03T15:00:00Z');
+        const result = await confirmAttendeeDisplayName({
+            webSessionId: 'web-1',
+            scheduledSessionId: 'session-1',
+            ticketEntitlementId: 'ticket-1',
+            displayName: '  Anahí   李  ',
+            now,
+        });
+
+        expect(result).toEqual({ displayName: 'Anahí 李', confirmed: true });
+        expect(mocks.transaction.$queryRaw).toHaveBeenCalledOnce();
+        expect(mocks.transaction.webSession.updateMany).toHaveBeenCalledWith({
+            where: {
+                ticketEntitlementId: 'ticket-1',
+                revokedAt: null,
+                expiresAt: { gt: now },
+            },
+            data: { displayName: 'Anahí 李' },
+        });
+        expect(mocks.transaction.webSession.update).toHaveBeenCalledWith({
+            where: { id: 'web-1' },
+            data: { displayNameConfirmedAt: now },
+        });
+        expect(mocks.transaction.sessionParticipant.updateMany).toHaveBeenCalledWith({
+            where: {
+                scheduledSessionId: 'session-1',
+                ticketEntitlementId: 'ticket-1',
+            },
+            data: { displayName: 'Anahí 李' },
+        });
+    });
+
+    it.each(['', '   ', 'A\u0000B', 'x'.repeat(61)])('rejects an invalid or overlong name without opening a transaction', async (displayName) => {
+        await expect(confirmAttendeeDisplayName({
+            webSessionId: 'web-1',
+            scheduledSessionId: 'session-1',
+            ticketEntitlementId: 'ticket-1',
+            displayName,
+        })).rejects.toMatchObject({
+            code: 'invalid_name',
+            status: 400,
+        } satisfies Partial<AttendeeDisplayNameError>);
+        expect(mocks.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects a revoked, expired, or mismatched web session before changing an alias', async () => {
+        mocks.transaction.webSession.findFirst.mockResolvedValue(null);
+
+        await expect(confirmAttendeeDisplayName({
+            webSessionId: 'web-other',
+            scheduledSessionId: 'session-1',
+            ticketEntitlementId: 'ticket-1',
+            displayName: 'Annie',
+        })).rejects.toMatchObject({ code: 'not_authorized', status: 403 });
+        expect(mocks.transaction.webSession.updateMany).not.toHaveBeenCalled();
+        expect(mocks.transaction.sessionParticipant.updateMany).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/__tests__/public-session-access.test.ts
+++ b/src/lib/__tests__/public-session-access.test.ts
@@ -78,6 +78,7 @@ describe('attachPublicSessionAccess', () => {
             data: {
                 ticketEntitlementId: 'free-entitlement-1',
                 displayName: 'Sai',
+                displayNameConfirmedAt: null,
                 lastSeenAt: now,
             },
         });

--- a/src/lib/__tests__/room-entitlement.integration.test.ts
+++ b/src/lib/__tests__/room-entitlement.integration.test.ts
@@ -91,6 +91,7 @@ integration('room entitlement PostgreSQL concurrency', () => {
                 {
                     tokenDigest: digestSessionToken(TICKET_COOKIE),
                     displayName: 'Race attendee',
+                    displayNameConfirmedAt: NOW,
                     ticketEntitlementId: TICKET_ID,
                     expiresAt: new Date('2026-08-06T12:00:00.000Z'),
                 },

--- a/src/lib/__tests__/room-entitlement.test.ts
+++ b/src/lib/__tests__/room-entitlement.test.ts
@@ -227,6 +227,35 @@ describe('resolveRoomPrincipal', () => {
         });
     });
 
+    it('lets a newly confirmed device correct the durable alias without changing identity', async () => {
+        findWebSession.mockResolvedValue({
+            ...activeTicketSession,
+            displayName: 'Anahí 李',
+            displayNameConfirmedAt: now,
+        });
+        findParticipant.mockResolvedValue({
+            id: 'participant-1',
+            displayName: 'Nombre anterior',
+            publishGrantedAt: null,
+            publishRevokedAt: null,
+        });
+
+        const { resolveRoomPrincipal } = await import('../room-entitlement');
+        const result = await resolveRoomPrincipal(request(), 'event-1', now);
+
+        expect(result).toMatchObject({
+            ok: true,
+            principal: {
+                identity: 'opaque:event-1:ticket:ticket-1',
+                displayName: 'Anahí 李',
+            },
+        });
+        expect(updateParticipant).toHaveBeenCalledWith(expect.objectContaining({
+            where: { id: 'participant-1' },
+            data: expect.objectContaining({ displayName: 'Anahí 李' }),
+        }));
+    });
+
     it('recovers a concurrent ticket insert only from the exact canonical winner', async () => {
         findParticipant
             .mockResolvedValueOnce(null)
@@ -257,7 +286,7 @@ describe('resolveRoomPrincipal', () => {
         });
         expect(updateParticipant).toHaveBeenCalledWith({
             where: { id: 'ticket-race-winner' },
-            data: { leftAt: null },
+            data: { leftAt: null, displayName: 'Ana' },
             select: {
                 grantReconcileNeeded: true,
                 publishGrantedAt: true,
@@ -385,6 +414,7 @@ describe('resolveRoomPrincipal', () => {
         expect(updateParticipant).toHaveBeenCalledWith({
             where: { id: 'seeded-facilitator-row' },
             data: {
+                displayName: 'Julián',
                 leftAt: null,
             },
             select: {

--- a/src/lib/__tests__/room-entitlement.test.ts
+++ b/src/lib/__tests__/room-entitlement.test.ts
@@ -39,6 +39,7 @@ const activeEvent = {
 };
 const activeTicketSession = {
     displayName: 'Ana',
+    displayNameConfirmedAt: now,
     expiresAt: new Date('2026-08-03T00:00:00Z'),
     revokedAt: null,
     staffUser: null,
@@ -139,6 +140,23 @@ describe('resolveRoomPrincipal', () => {
             error: 'Authentication required',
         });
         expect(findWebSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects a direct room or hand request until the attendee confirms the event alias', async () => {
+        findWebSession.mockResolvedValue({
+            ...activeTicketSession,
+            displayNameConfirmedAt: null,
+        });
+
+        const { resolveRoomPrincipal } = await import('../room-entitlement');
+        await expect(resolveRoomPrincipal(request(), 'event-1', now)).resolves.toEqual({
+            ok: false,
+            status: 403,
+            error: 'Not authorized',
+        });
+        expect(findParticipant).not.toHaveBeenCalled();
+        expect(upsertParticipant).not.toHaveBeenCalled();
+        expect(updateParticipant).not.toHaveBeenCalled();
     });
 
     it.each([

--- a/src/lib/__tests__/room-token-issue.test.ts
+++ b/src/lib/__tests__/room-token-issue.test.ts
@@ -84,6 +84,7 @@ describe('finalizeRoomTokenIssue', () => {
         });
         mocks.participantFindFirst.mockResolvedValue({
             id: 'participant-1',
+            displayName: 'Ana',
             publishGrantedAt: new Date('2026-09-05T12:00:00Z'),
             publishRevokedAt: null,
             grantReconcileNeeded: false,
@@ -106,6 +107,7 @@ describe('finalizeRoomTokenIssue', () => {
             'stage',
             'identity-current',
             {
+                name: 'Ana',
                 permission: {
                     canPublish: true,
                     canPublishData: false,

--- a/src/lib/__tests__/stage-control.test.ts
+++ b/src/lib/__tests__/stage-control.test.ts
@@ -540,6 +540,83 @@ describe('stage control', () => {
         );
     });
 
+    it('lets a ticket-backed attendee leave the stage, clears their hand, and audits the voluntary action', async () => {
+        participants = [attendee('target', true, new Date('2026-08-01T15:10:00Z'))];
+        const { leaveStage } = await import('../stage-control');
+
+        const result = await leaveStage({
+            scheduledSessionId: event.id,
+            participantIdentity: 'opaque-target',
+        });
+
+        expect(result).toMatchObject({ canPublish: false, reconcileNeeded: false });
+        expect(participants[0]).toMatchObject({
+            raisedAt: null,
+            grantVersion: 2,
+        });
+        expect(participants[0].publishRevokedAt).not.toBeNull();
+        expect(mocks.auditCreate).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                actorUserId: null,
+                action: 'stage.attendee.leave',
+                targetId: 'target',
+            }),
+        });
+    });
+
+    it('makes repeated voluntary exits idempotent, including a double click race', async () => {
+        participants = [attendee('target', true, new Date('2026-08-01T15:10:00Z'))];
+        const { leaveStage } = await import('../stage-control');
+
+        const [first, second] = await Promise.all([
+            leaveStage({
+                scheduledSessionId: event.id,
+                participantIdentity: 'opaque-target',
+            }),
+            leaveStage({
+                scheduledSessionId: event.id,
+                participantIdentity: 'opaque-target',
+            }),
+        ]);
+
+        expect(first.grantVersion).toBe(2);
+        expect(second.grantVersion).toBe(2);
+        expect(participants[0]).toMatchObject({
+            raisedAt: null,
+            grantVersion: 2,
+        });
+        expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+        expect(mocks.updateParticipant).toHaveBeenCalledTimes(2);
+    });
+
+    it('converges a simultaneous voluntary exit and staff demotion on one revoked grant', async () => {
+        participants = [attendee('target', true, new Date('2026-08-01T15:10:00Z'))];
+        const { demoteParticipant, leaveStage } = await import('../stage-control');
+
+        const results = await Promise.all([
+            leaveStage({
+                scheduledSessionId: event.id,
+                participantIdentity: 'opaque-target',
+            }),
+            demoteParticipant({
+                scheduledSessionId: event.id,
+                participantId: 'target',
+                actorUserId: 'operator-1',
+                clearHand: true,
+            }),
+        ]);
+
+        expect(results).toEqual([
+            expect.objectContaining({ canPublish: false, grantVersion: 2 }),
+            expect.objectContaining({ canPublish: false, grantVersion: 2 }),
+        ]);
+        expect(participants[0]).toMatchObject({
+            raisedAt: null,
+            grantVersion: 2,
+        });
+        expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+    });
+
     it('refuses to demote the assigned facilitator reserved by the weekend contract', async () => {
         participants = [{
             ...attendee('facilitator', true),

--- a/src/lib/__tests__/stage-control.test.ts
+++ b/src/lib/__tests__/stage-control.test.ts
@@ -519,6 +519,7 @@ describe('stage control', () => {
         const result = await declineStageInvitation({
             scheduledSessionId: event.id,
             participantIdentity: 'opaque-target',
+            expectedGrantVersion: 1,
         });
 
         expect(result).toMatchObject({ canPublish: false, reconcileNeeded: false });
@@ -547,6 +548,7 @@ describe('stage control', () => {
         const result = await leaveStage({
             scheduledSessionId: event.id,
             participantIdentity: 'opaque-target',
+            expectedGrantVersion: 1,
         });
 
         expect(result).toMatchObject({ canPublish: false, reconcileNeeded: false });
@@ -572,10 +574,12 @@ describe('stage control', () => {
             leaveStage({
                 scheduledSessionId: event.id,
                 participantIdentity: 'opaque-target',
+                expectedGrantVersion: 1,
             }),
             leaveStage({
                 scheduledSessionId: event.id,
                 participantIdentity: 'opaque-target',
+                expectedGrantVersion: 1,
             }),
         ]);
 
@@ -597,6 +601,7 @@ describe('stage control', () => {
             leaveStage({
                 scheduledSessionId: event.id,
                 participantIdentity: 'opaque-target',
+                expectedGrantVersion: 1,
             }),
             demoteParticipant({
                 scheduledSessionId: event.id,
@@ -615,6 +620,24 @@ describe('stage control', () => {
             grantVersion: 2,
         });
         expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an old exit after the attendee has been promoted again', async () => {
+        participants = [attendee('target', true, new Date('2026-08-01T15:10:00Z'))];
+        participants[0].grantVersion = 3;
+        const before = { ...participants[0] };
+        const { leaveStage } = await import('../stage-control');
+
+        await expect(leaveStage({
+            scheduledSessionId: event.id,
+            participantIdentity: 'opaque-target',
+            expectedGrantVersion: 1,
+        })).rejects.toMatchObject({ code: 'stale_grant_version', status: 409 });
+
+        expect(participants[0]).toEqual(before);
+        expect(mocks.transitionGrant).not.toHaveBeenCalled();
+        expect(mocks.auditCreate).not.toHaveBeenCalled();
+        expect(mocks.processGrant).not.toHaveBeenCalled();
     });
 
     it('refuses to demote the assigned facilitator reserved by the weekend contract', async () => {

--- a/src/lib/__tests__/tapestry-manifest.test.ts
+++ b/src/lib/__tests__/tapestry-manifest.test.ts
@@ -12,6 +12,7 @@ const SESSION_ID = 'session-1';
 function participant(overrides: Partial<ManifestParticipant> = {}): ManifestParticipant {
     return {
         identity: 'lk-ana',
+        displayName: null,
         leftAt: null,
         raisedAt: null,
         publishGrantedAt: null,
@@ -106,6 +107,21 @@ describe('buildTapestryManifest', () => {
             participants: [participant({ staffName: 'Julián' })],
         });
         expect(manifest.entries[0].displayName).toBe('Julián');
+    });
+
+    it('keeps the confirmed database alias when LiveKit is neutral or unavailable', () => {
+        const neutral = build({
+            participants: [participant({ displayName: 'Ana DB' })],
+            live: new Map([['lk-ana', live('Participant')]]),
+        });
+        expect(neutral.entries[0].displayName).toBe('Ana DB');
+
+        const unavailable = build({
+            participants: [participant({ displayName: 'Ana DB' })],
+            live: new Map(),
+            liveStateAvailable: false,
+        });
+        expect(unavailable.entries[0].displayName).toBe('Ana DB');
     });
 
     it('reports presence states truthfully', () => {

--- a/src/lib/attendee-display-name.ts
+++ b/src/lib/attendee-display-name.ts
@@ -1,0 +1,139 @@
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/db';
+import { isValidDisplayName, normalizeDisplayName } from '@/lib/principal';
+
+export type AttendeeDisplayNameState = {
+    displayName: string;
+    confirmed: boolean;
+};
+
+export class AttendeeDisplayNameError extends Error {
+    constructor(
+        public readonly code: 'invalid_name' | 'not_authorized',
+        public readonly status: 400 | 403,
+        message: string,
+    ) {
+        super(message);
+        this.name = 'AttendeeDisplayNameError';
+    }
+}
+
+/** Read the alias the room will actually use, without materializing presence. */
+export async function readAttendeeDisplayName(
+    webSessionId: string,
+    scheduledSessionId: string,
+    ticketEntitlementId: string,
+): Promise<AttendeeDisplayNameState> {
+    const [webSession, participant] = await Promise.all([
+        prisma.webSession.findFirst({
+            where: {
+                id: webSessionId,
+                ticketEntitlementId,
+                revokedAt: null,
+            },
+            select: {
+                displayName: true,
+                displayNameConfirmedAt: true,
+            },
+        }),
+        prisma.sessionParticipant.findFirst({
+            where: { scheduledSessionId, ticketEntitlementId },
+            select: { displayName: true },
+        }),
+    ]);
+    if (!webSession) {
+        throw new AttendeeDisplayNameError(
+            'not_authorized',
+            403,
+            'The attendee session is not authorized',
+        );
+    }
+
+    const confirmedWebName = webSession.displayNameConfirmedAt !== null
+        ? webSession.displayName?.trim()
+        : null;
+    const displayName = normalizeDisplayName(
+        confirmedWebName || participant?.displayName?.trim() || webSession.displayName?.trim() || '',
+    );
+    return {
+        displayName,
+        confirmed: webSession.displayNameConfirmedAt !== null && isValidDisplayName(displayName),
+    };
+}
+
+/**
+ * Confirm one browser session and converge every active session plus the
+ * durable room participant on the same event alias. The entitlement row is
+ * the mutex, so simultaneous corrections from two devices have one winner.
+ */
+export async function confirmAttendeeDisplayName(input: {
+    webSessionId: string;
+    scheduledSessionId: string;
+    ticketEntitlementId: string;
+    displayName: string;
+    now?: Date;
+}): Promise<AttendeeDisplayNameState> {
+    const normalizedCandidate = input.displayName.trim().replace(/\s+/g, ' ');
+    const displayName = normalizeDisplayName(input.displayName);
+    if (normalizedCandidate.length > 60 || !isValidDisplayName(displayName)) {
+        throw new AttendeeDisplayNameError(
+            'invalid_name',
+            400,
+            'A visible name between 1 and 60 characters is required',
+        );
+    }
+    const now = input.now ?? new Date();
+
+    await prisma.$transaction(async (transaction) => {
+        await transaction.$queryRaw(
+            Prisma.sql`
+                SELECT "id"
+                FROM "ticket_entitlements"
+                WHERE "id"::text = ${input.ticketEntitlementId}
+                FOR UPDATE
+            `,
+        );
+
+        const current = await transaction.webSession.findFirst({
+            where: {
+                id: input.webSessionId,
+                ticketEntitlementId: input.ticketEntitlementId,
+                revokedAt: null,
+                expiresAt: { gt: now },
+            },
+            select: { id: true },
+        });
+        if (!current) {
+            throw new AttendeeDisplayNameError(
+                'not_authorized',
+                403,
+                'The attendee session is not authorized',
+            );
+        }
+
+        // Other active devices inherit the corrected alias, but each device
+        // still confirms deliberately before its own first room connection.
+        await transaction.webSession.updateMany({
+            where: {
+                ticketEntitlementId: input.ticketEntitlementId,
+                revokedAt: null,
+                expiresAt: { gt: now },
+            },
+            data: { displayName },
+        });
+        await transaction.webSession.update({
+            where: { id: input.webSessionId },
+            data: { displayNameConfirmedAt: now },
+        });
+        await transaction.sessionParticipant.updateMany({
+            where: {
+                scheduledSessionId: input.scheduledSessionId,
+                ticketEntitlementId: input.ticketEntitlementId,
+            },
+            data: { displayName },
+        });
+    });
+
+    return { displayName, confirmed: true };
+}

--- a/src/lib/hand-queue.ts
+++ b/src/lib/hand-queue.ts
@@ -30,6 +30,7 @@ export type HandState = {
     raisedAt: Date | null;
     queuePosition: number | null;
     canPublish: boolean;
+    grantVersion: number;
 };
 
 type HandTargetInput = {
@@ -67,6 +68,7 @@ async function computeQueuePosition(
         raisedAt: Date | null;
         publishGrantedAt: Date | null;
         publishRevokedAt: Date | null;
+        grantVersion: number;
     },
 ): Promise<number | null> {
     if (participant.raisedAt === null || hasActiveGrant(participant)) {
@@ -102,6 +104,7 @@ function toHandState(
         raisedAt: Date | null;
         publishGrantedAt: Date | null;
         publishRevokedAt: Date | null;
+        grantVersion: number;
     },
     queuePosition: number | null,
 ): HandState {
@@ -111,6 +114,7 @@ function toHandState(
         raisedAt: participant.raisedAt,
         queuePosition,
         canPublish: hasActiveGrant(participant),
+        grantVersion: participant.grantVersion,
     };
 }
 
@@ -144,6 +148,7 @@ export async function raiseHand(input: RaiseInput): Promise<HandState> {
             raisedAt: true,
             publishGrantedAt: true,
             publishRevokedAt: true,
+            grantVersion: true,
         },
     });
     // The upsert above matches on identity, so an existing row that has not
@@ -183,6 +188,7 @@ export async function lowerHand(input: LowerInput): Promise<HandState> {
             raisedAt: true,
             publishGrantedAt: true,
             publishRevokedAt: true,
+            grantVersion: true,
         },
     });
     if (!participant) {
@@ -203,6 +209,7 @@ export async function lowerHand(input: LowerInput): Promise<HandState> {
                 raisedAt: true,
                 publishGrantedAt: true,
                 publishRevokedAt: true,
+                grantVersion: true,
             },
         });
 
@@ -268,6 +275,7 @@ export async function getHandState(
             raisedAt: true,
             publishGrantedAt: true,
             publishRevokedAt: true,
+            grantVersion: true,
         },
     });
     if (!participant) {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -61,6 +61,7 @@ export type Messages = {
         accountError: string;
         accountReconnectHint: string;
         displayName: string;
+        displayNameHint: string;
         ticketCode: string;
         ticketCodeHint: string;
         email: string;
@@ -189,9 +190,29 @@ export type Messages = {
         switchToAudioOnly: string;
         leave: string;
         leaveSession: string;
+        leaveSessionBody: string;
+        leaveSessionConfirm: string;
+        leaveSessionCancel: string;
+        leaveStage: string;
+        leaveStageHeading: string;
+        leaveStageBody: string;
+        leaveStageConfirm: string;
+        leaveStageCancel: string;
+        leavingStage: string;
+        leaveStageFailed: string;
         preparingRoom: string;
         confirmingEntry: string;
         entryUnavailable: string;
+        nameConfirmationEyebrow: string;
+        nameConfirmationHeading: string;
+        nameConfirmationBody: string;
+        nameConfirmationLabel: string;
+        nameConfirmationHint: string;
+        nameConfirmationAction: string;
+        nameConfirmationSaving: string;
+        nameConfirmationRequired: string;
+        nameConfirmationFailed: string;
+        nameConfirmationPrivacy: string;
         ticketConfirmed: string;
         doorsClosed: string;
         doorsReconnecting: string;
@@ -582,6 +603,7 @@ export const messages: Record<UiLocale, Messages> = {
             accountError: 'No pudimos confirmar tu cuenta. Intentá de nuevo.',
             accountReconnectHint: 'Tu entrada admite a una persona. El mismo código funciona de nuevo si recargás o se corta la conexión.',
             displayName: 'Nombre visible en la sala',
+            displayNameHint: 'El equipo y las personas en escena usarán este nombre para reconocerte. Vas a poder confirmarlo antes de entrar.',
             ticketCode: 'Código de entrada',
             ticketCodeHint: 'Exactamente como aparece en tu entrada o invitación',
             email: 'Correo con el que compraste la entrada',
@@ -725,9 +747,29 @@ export const messages: Record<UiLocale, Messages> = {
             switchToAudioOnly: 'Cambiar a solo audio',
             leave: 'Salir',
             leaveSession: 'Salir de la sesión',
+            leaveSessionBody: 'Esto desconecta esta página de la sesión y del Beacon. Para volver, vas a tener que ingresar otra vez.',
+            leaveSessionConfirm: 'Sí, salir de la sesión',
+            leaveSessionCancel: 'Seguir en la sesión',
+            leaveStage: 'Dejar la escena',
+            leaveStageHeading: '¿Querés volver al público?',
+            leaveStageBody: 'Tu cámara y micrófono dejarán de publicarse. Vas a seguir escuchando la sesión y el Beacon sin reconectarte.',
+            leaveStageConfirm: 'Sí, dejar la escena',
+            leaveStageCancel: 'Seguir en escena',
+            leavingStage: 'Volviendo al público…',
+            leaveStageFailed: 'No pudimos completar la vuelta al público. Tu permiso se está reconciliando; intentá de nuevo.',
             preparingRoom: 'Preparando tu sala',
             confirmingEntry: 'Confirmando tu entrada y el estado del evento…',
             entryUnavailable: 'No se pudo comprobar el ingreso',
+            nameConfirmationEyebrow: 'Antes de entrar',
+            nameConfirmationHeading: '¿Cómo querés que te nombremos?',
+            nameConfirmationBody: 'Confirmá o corregí el nombre que verá el equipo para reconocerte cuando levantes la mano o entres en escena.',
+            nameConfirmationLabel: 'Tu nombre visible',
+            nameConfirmationHint: 'Hasta 60 caracteres. Puede ser tu nombre, apodo o el nombre con el que querés participar.',
+            nameConfirmationAction: 'Confirmar y continuar',
+            nameConfirmationSaving: 'Guardando nombre…',
+            nameConfirmationRequired: 'Escribí un nombre visible de hasta 60 caracteres.',
+            nameConfirmationFailed: 'No pudimos guardar tu nombre. Tu acceso sigue vigente; intentá de nuevo.',
+            nameConfirmationPrivacy: 'No convierte el tapiz en un directorio público. Tu nombre se muestra solo en las superficies autorizadas y, públicamente, cuando levantás la mano.',
             ticketConfirmed: 'Entrada confirmada',
             doorsClosed: 'Las puertas todavía están cerradas. Esta página te hará entrar automáticamente cuando el equipo las abra.',
             doorsReconnecting: 'Estamos recuperando la conexión para comprobar las puertas. Tu entrada sigue confirmada.',
@@ -1174,6 +1216,7 @@ export const messages: Record<UiLocale, Messages> = {
             accountError: 'We could not confirm your account. Try again.',
             accountReconnectHint: 'Your ticket admits one person. The same code works again after a refresh or a dropped connection.',
             displayName: 'Name shown in the room',
+            displayNameHint: 'The team and people on stage will use this name to recognize you. You can confirm it before joining.',
             ticketCode: 'Ticket code',
             ticketCodeHint: 'Exactly as it appears on your ticket or invitation',
             email: 'Email used to buy the ticket',
@@ -1317,9 +1360,29 @@ export const messages: Record<UiLocale, Messages> = {
             switchToAudioOnly: 'Switch to audio only',
             leave: 'Leave',
             leaveSession: 'Leave session',
+            leaveSessionBody: 'This disconnects this page from the session and Beacon. To return, you will need to join again.',
+            leaveSessionConfirm: 'Yes, leave the session',
+            leaveSessionCancel: 'Stay in the session',
+            leaveStage: 'Leave the scene',
+            leaveStageHeading: 'Return to the audience?',
+            leaveStageBody: 'Your camera and microphone will stop publishing. You will keep hearing the session and Beacon without reconnecting.',
+            leaveStageConfirm: 'Yes, leave the scene',
+            leaveStageCancel: 'Stay on stage',
+            leavingStage: 'Returning to the audience…',
+            leaveStageFailed: 'We could not complete your return to the audience. Your permission is being reconciled; try again.',
             preparingRoom: 'Preparing your room',
             confirmingEntry: 'Confirming your ticket and event status…',
             entryUnavailable: 'Entry status unavailable',
+            nameConfirmationEyebrow: 'Before joining',
+            nameConfirmationHeading: 'What should we call you?',
+            nameConfirmationBody: 'Confirm or correct the name the team will use to recognize you when you raise your hand or join the stage.',
+            nameConfirmationLabel: 'Your visible name',
+            nameConfirmationHint: 'Up to 60 characters. Use your name, nickname, or the name you want to participate with.',
+            nameConfirmationAction: 'Confirm and continue',
+            nameConfirmationSaving: 'Saving name…',
+            nameConfirmationRequired: 'Enter a visible name of up to 60 characters.',
+            nameConfirmationFailed: 'We could not save your name. Your access is still valid; try again.',
+            nameConfirmationPrivacy: 'This does not turn the tapestry into a public directory. Your name appears only on authorized surfaces and, publicly, when you raise your hand.',
             ticketConfirmed: 'Ticket confirmed',
             doorsClosed: 'The doors are not open yet. This page will bring you in automatically when the team opens them.',
             doorsReconnecting: 'We are reconnecting to check the doors. Your ticket remains confirmed.',

--- a/src/lib/promo-invitation.ts
+++ b/src/lib/promo-invitation.ts
@@ -227,6 +227,7 @@ export async function redeemPromoInvitationByDigest(
             data: {
                 tokenDigest: issued.database.tokenDigest,
                 displayName,
+                displayNameConfirmedAt: now,
                 ticketEntitlementId: entitlement.id,
                 ...(account ? {
                     accountIssuer: account.issuer,

--- a/src/lib/public-session-access.ts
+++ b/src/lib/public-session-access.ts
@@ -65,6 +65,7 @@ export async function attachPublicSessionAccess(
             data: {
                 ticketEntitlementId: entitlement.id,
                 displayName: account.displayName?.trim() || 'Participante',
+                displayNameConfirmedAt: null,
                 lastSeenAt: now,
             },
         });

--- a/src/lib/room-entitlement.ts
+++ b/src/lib/room-entitlement.ts
@@ -241,6 +241,12 @@ async function resolveRoomAccess(
         ) {
             return { ok: false, status: 403, error: 'Not authorized' };
         }
+        // The entry gate is the sole place where an attendee authorizes the
+        // event alias. Direct token/hand URLs must not materialize a room
+        // participant or expose that alias before the explicit confirmation.
+        if (!webSession.displayNameConfirmedAt) {
+            return { ok: false, status: 403, error: 'Not authorized' };
+        }
 
         principalId = ticket.commerceEntitlement
             ? `${ticket.id}:v${ticket.commerceEntitlement.livekitIdentityVersion}`

--- a/src/lib/room-entitlement.ts
+++ b/src/lib/room-entitlement.ts
@@ -103,7 +103,7 @@ async function recoverConcurrentParticipant(
 
     return prisma.sessionParticipant.update({
         where: { id: winner.id },
-        data: { leftAt: null },
+        data: { leftAt: null, displayName: access.displayName },
         select: {
             publishGrantedAt: true,
             publishRevokedAt: true,
@@ -134,6 +134,7 @@ async function resolveRoomAccess(
         select: {
             id: true,
             displayName: true,
+            displayNameConfirmedAt: true,
             accountIssuer: true,
             accountSubject: true,
             accountSessionId: true,
@@ -327,7 +328,9 @@ async function resolveRoomAccess(
             // Revocations rotate this identity so stale JWTs and late RPCs are
             // fenced away from the current connection.
             identity: existingParticipant?.participantIdentity ?? baselineIdentity,
-            displayName: existingParticipant?.displayName?.trim() || displayName,
+            displayName: ticketEntitlementId && webSession.displayNameConfirmedAt
+                ? webSession.displayName?.trim() || existingParticipant?.displayName?.trim() || displayName
+                : existingParticipant?.displayName?.trim() || displayName,
             role,
             isAssignedFacilitator,
             canPublishInitially,
@@ -407,7 +410,9 @@ export async function resolveRoomPrincipal(
                 where: { id: existingParticipant.id },
                 data: {
                     // Joining again resumes presence without rewriting identity
-                    // or the alias already captured for this participation.
+                    // after a grant fence. A newly confirmed alias from another
+                    // device becomes the durable event name.
+                    displayName: access.displayName,
                     leftAt: null,
                 },
                 select: {

--- a/src/lib/room-token-issue.ts
+++ b/src/lib/room-token-issue.ts
@@ -22,6 +22,7 @@ type CurrentPrincipalInput = {
 type LockedCurrentPrincipal = {
     participantId: string;
     roomName: string;
+    displayName: string;
     effectiveCanPublish: boolean;
     isAssignedFacilitator: boolean;
     commerceEntitlementId: string | null;
@@ -157,6 +158,7 @@ async function lockCurrentPrincipal(
         },
         select: {
             id: true,
+            displayName: true,
             publishGrantedAt: true,
             publishRevokedAt: true,
             grantReconcileNeeded: true,
@@ -167,6 +169,7 @@ async function lockCurrentPrincipal(
     return {
         participantId: participant.id,
         roomName: session.room_name,
+        displayName: participant.displayName?.trim() || 'Participant',
         effectiveCanPublish: participant.publishGrantedAt !== null &&
             participant.publishRevokedAt === null &&
             !participant.grantReconcileNeeded,
@@ -240,7 +243,10 @@ export async function activateRoomPublication(
         await getRoomService(LIVEKIT_PERMISSION_TIMEOUT_SECONDS).updateParticipant(
             current.roomName,
             input.expectedIdentity,
-            { permission: stagePublisherPermission(current.isAssignedFacilitator) },
+            {
+                name: current.displayName,
+                permission: stagePublisherPermission(current.isAssignedFacilitator),
+            },
         );
         return true;
     }, TRANSACTION_OPTIONS);

--- a/src/lib/stage-control.ts
+++ b/src/lib/stage-control.ts
@@ -37,6 +37,7 @@ export class StageControlError extends Error {
             | 'entitlement_inactive'
             | 'not_publisher'
             | 'facilitator_required'
+            | 'stale_grant_version'
             | 'invalid_request'
             | 'livekit_failed',
         public readonly status: 400 | 404 | 409 | 502,
@@ -82,11 +83,13 @@ type DemoteInput = Omit<GrantInput, 'actorUserId'> & {
     actorUserId: string | null;
     auditAction?: 'stage.demote' | 'stage.invitation.decline' | 'stage.attendee.leave';
     clearHand?: boolean;
+    expectedGrantVersion?: number;
 };
 
 type DeclineInvitationInput = {
     scheduledSessionId: string;
     participantIdentity: string;
+    expectedGrantVersion: number;
     now?: Date;
 };
 
@@ -272,7 +275,6 @@ export async function promoteParticipant(
                 'Participant not found',
             );
         }
-
         const ticket = target.ticketEntitlement;
         const hasActiveEntitlement = target.ticketEntitlementId !== null &&
             target.ticketEntitlementId !== undefined &&
@@ -398,6 +400,29 @@ export async function demoteParticipant(
                 'Participant not found',
             );
         }
+        const activeGrant = target.publishGrantedAt !== null &&
+            target.publishRevokedAt === null;
+        if (input.expectedGrantVersion !== undefined &&
+            target.grantVersion !== input.expectedGrantVersion) {
+            const isCompletedDuplicate =
+                target.grantVersion === input.expectedGrantVersion + 1 &&
+                !activeGrant &&
+                (!input.clearHand || target.raisedAt === null);
+            if (!isCompletedDuplicate) {
+                throw new StageControlError(
+                    'stale_grant_version',
+                    409,
+                    'The stage grant changed; refresh before trying again',
+                );
+            }
+            return {
+                participantId: target.id,
+                participantIdentity: target.participantIdentity,
+                canPublish: false,
+                grantVersion: target.grantVersion,
+                reconcileNeeded: target.grantReconcileNeeded,
+            };
+        }
         if (
             target.staffUserId === scheduledSession.facilitatorId &&
             target.staffUser?.disabledAt === null
@@ -409,8 +434,6 @@ export async function demoteParticipant(
             );
         }
 
-        const activeGrant = target.publishGrantedAt !== null &&
-            target.publishRevokedAt === null;
         if (!activeGrant) {
             const clearsRaisedHand = input.clearHand === true && target.raisedAt !== null;
             if (clearsRaisedHand) {
@@ -500,6 +523,7 @@ export async function declineStageInvitation(
         reason: 'Attendee declined stage invitation',
         auditAction: 'stage.invitation.decline',
         clearHand: true,
+        expectedGrantVersion: input.expectedGrantVersion,
         now: input.now,
     });
 }
@@ -535,6 +559,7 @@ export async function leaveStage(
         reason: 'Attendee voluntarily left the stage',
         auditAction: 'stage.attendee.leave',
         clearHand: true,
+        expectedGrantVersion: input.expectedGrantVersion,
         now: input.now,
     });
 }

--- a/src/lib/stage-control.ts
+++ b/src/lib/stage-control.ts
@@ -80,7 +80,7 @@ type GrantInput = {
 
 type DemoteInput = Omit<GrantInput, 'actorUserId'> & {
     actorUserId: string | null;
-    auditAction?: 'stage.demote' | 'stage.invitation.decline';
+    auditAction?: 'stage.demote' | 'stage.invitation.decline' | 'stage.attendee.leave';
     clearHand?: boolean;
 };
 
@@ -89,6 +89,8 @@ type DeclineInvitationInput = {
     participantIdentity: string;
     now?: Date;
 };
+
+type LeaveStageInput = DeclineInvitationInput;
 
 type MuteInput = {
     scheduledSessionId: string;
@@ -360,6 +362,7 @@ export async function demoteParticipant(
     const now = input.now ?? new Date();
     const revocation = await prisma.$transaction(async (transaction) => {
         await lockGrantSession(transaction, input.scheduledSessionId);
+        await lockGrantParticipants(transaction, [input.participantId]);
         const scheduledSession = await transaction.scheduledSession.findUnique({
             where: { id: input.scheduledSessionId },
             select: { roomName: true, facilitatorId: true },
@@ -380,6 +383,11 @@ export async function demoteParticipant(
                 id: true,
                 participantIdentity: true,
                 staffUserId: true,
+                raisedAt: true,
+                publishGrantedAt: true,
+                publishRevokedAt: true,
+                grantVersion: true,
+                grantReconcileNeeded: true,
                 staffUser: { select: { disabledAt: true } },
             },
         });
@@ -400,6 +408,34 @@ export async function demoteParticipant(
                 'The assigned facilitator holds the reserved stage slot and cannot be demoted',
             );
         }
+
+        const activeGrant = target.publishGrantedAt !== null &&
+            target.publishRevokedAt === null;
+        if (!activeGrant) {
+            const clearsRaisedHand = input.clearHand === true && target.raisedAt !== null;
+            if (clearsRaisedHand) {
+                await transaction.sessionParticipant.update({
+                    where: { id: target.id },
+                    data: { raisedAt: null },
+                });
+                await audit(
+                    transaction,
+                    input.actorUserId,
+                    input.auditAction ?? 'stage.demote',
+                    target.id,
+                    input.reason,
+                    { grantVersion: target.grantVersion },
+                );
+            }
+            return {
+                participantId: target.id,
+                participantIdentity: target.participantIdentity,
+                canPublish: false,
+                grantVersion: target.grantVersion,
+                reconcileNeeded: target.grantReconcileNeeded,
+            };
+        }
+
         const participant = await transitionParticipantGrant(transaction, {
             scheduledSessionId: input.scheduledSessionId,
             participantId: target.id,
@@ -463,6 +499,41 @@ export async function declineStageInvitation(
         actorUserId: null,
         reason: 'Attendee declined stage invitation',
         auditAction: 'stage.invitation.decline',
+        clearHand: true,
+        now: input.now,
+    });
+}
+
+/**
+ * Return an attendee from the stage to the audience using only their resolved
+ * opaque room identity. Repeated requests and a simultaneous staff demotion
+ * converge on the same revoked grant without allocating a new version.
+ */
+export async function leaveStage(
+    input: LeaveStageInput,
+): Promise<StageGrantResult> {
+    const participant = await prisma.sessionParticipant.findFirst({
+        where: {
+            scheduledSessionId: input.scheduledSessionId,
+            participantIdentity: input.participantIdentity,
+            ticketEntitlementId: { not: null },
+        },
+        select: { id: true },
+    });
+    if (!participant) {
+        throw new StageControlError(
+            'participant_not_found',
+            404,
+            'Participant not found',
+        );
+    }
+
+    return demoteParticipant({
+        scheduledSessionId: input.scheduledSessionId,
+        participantId: participant.id,
+        actorUserId: null,
+        reason: 'Attendee voluntarily left the stage',
+        auditAction: 'stage.attendee.leave',
         clearHand: true,
         now: input.now,
     });

--- a/src/lib/tapestry-manifest.ts
+++ b/src/lib/tapestry-manifest.ts
@@ -14,8 +14,9 @@ import type { CompositeLayout } from '@/lib/tapestry-layout';
  *
  * Privacy contract: entries are keyed by the opaque tapestry tile id (HMAC),
  * never by LiveKit identity or any internal id. Names come from the
- * already-authorized room name / staff account name — the same source the
- * room itself shows. Nothing here exposes emails, ticket ids, LiveKit
+ * confirmed event alias / staff account name stored in PostgreSQL. LiveKit's
+ * audience name is intentionally neutral and is never the authority for a
+ * known participant. Nothing here exposes emails, ticket ids, LiveKit
  * identities or join history.
  *
  * Truthfulness contract: the manifest never invents state. Tiles come from
@@ -80,6 +81,7 @@ export type TapestryManifest = {
 
 export type ManifestParticipant = {
     identity: string;
+    displayName: string | null;
     leftAt: Date | null;
     raisedAt: Date | null;
     publishGrantedAt: Date | null;
@@ -119,6 +121,7 @@ function displayNameFor(
 ): string {
     return (
         participant?.staffName ??
+        participant?.displayName?.trim() ??
         (identity ? live.get(identity)?.name.trim() : '') ??
         'Attendee'
     ) || 'Attendee';


### PR DESCRIPTION
Reemplaza y completa #504 sobre la base durable de #513.

Conserva los commits y la autoría de Ani/Olivia que sí aplican, y cierra los bloqueantes de la revisión independiente:

- CAS explícito con expectedGrantVersion y rechazo de replay obsoleto.
- Salida y decline idempotentes sin revisiones/outbox espurios.
- Supresión local inmediata de media y estado de escenario tras salir.
- Identidad visible confirmada antes de emitir acceso a sala; el JWT no filtra nombres sin confirmar.
- PostgreSQL como autoridad del alias para staff y tapiz, incluso si LiveKit no responde.
- Sesiones terminales visibles sin gate de identidad y mutaciones rechazadas.
- Diálogos accesibles con foco atrapado, Escape y restauración.
- Grant versions acotadas a enteros seguros.

Validación local del head previo al merge de main:

- 1177 tests pasaron; sólo suites gated/skipped esperadas.
- 37/37 contratos PostgreSQL reales pasaron, incluidas concurrencia y migraciones.
- TypeScript, Prisma, ESLint, diff-check y build productivo verdes.
- Auditoría de dependencias productivas: cero high/critical.
- Las rutas de audio congeladas no fueron modificadas.

El merge de main incorpora #513 ya validado por CI completo y no introdujo conflictos.