### PR TITLE
fix(ops): prevent grant reconciler rollout OOM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,10 @@ services:
       resources:
         limits:
           cpus: '0.25'
-          memory: 256M
+          # The durable stage-grant migration briefly pushes the tsx worker
+          # above 256 MiB while its module graph and first backlog are warm.
+          # Keep enough cgroup headroom to avoid an OOM/restart during rollout.
+          memory: 512M
     logging:
       driver: "json-file"
       options:

--- a/src/lib/__tests__/production-runtime-contract.test.ts
+++ b/src/lib/__tests__/production-runtime-contract.test.ts
@@ -19,6 +19,17 @@ describe('production operational entrypoints', () => {
         expect(worker).toContain('runtime imports loaded');
     });
 
+    it('keeps enough memory headroom for the durable grant worker to warm up', () => {
+        const compose = readFileSync('docker-compose.yml', 'utf8');
+        const reconciler = compose.slice(
+            compose.indexOf('  commerce-reconciler:'),
+            compose.indexOf('\n  # ── Playlist bot'),
+        );
+
+        expect(reconciler).toContain('memory: 512M');
+        expect(reconciler).not.toContain('memory: 256M');
+    });
+
     it('quiesces and preflights before any automatic application rollback', () => {
         const helper = readFileSync('deploy/hb-deploy-root', 'utf8');
         const rollback = helper.slice(helper.indexOf('rollback() {'), helper.indexOf('\nusage() {'));


### PR DESCRIPTION
## What\n- raise only the commerce/stage-grant reconciler cgroup limit from 256 MiB to 512 MiB\n- add a runtime-contract regression test for the production Compose limit\n\n## Why\nThe first production start of release 7d5dc71 was cgroup-OOM-killed at 256 MiB while warming the tsx module graph and draining the migration backlog (kernel OOM evidence, ~252 MiB RSS). Docker recovered it once and it remained healthy, but the old limit leaves insufficient deterministic startup headroom. The live container has already been raised to 512 MiB without restart; this PR makes that reviewed state durable.\n\n## Verification\n- focused runtime-contract test: 5/5\n- TypeScript: green\n- ESLint: green\n- live update preserved worker health; no further restart\n\nNo application logic, audio, room, identity, payment, or data behavior changes.