### PR TITLE
fix(live): schedule Umbral and add September 9 rehearsal

### DIFF
--- a/prisma/migrations/20260908130000_move_final_umbral_to_1000_argentina/migration.sql
+++ b/prisma/migrations/20260908130000_move_final_umbral_to_1000_argentina/migration.sql
@@ -1,0 +1,29 @@
+-- Dirección moved the final public Umbral session to 10:00 Argentina
+-- (America/Argentina/Cordoba, UTC-3), which is 13:00 UTC. Historical
+-- sessions and migrations keep their actual times.
+UPDATE "scheduled_sessions"
+SET
+    "scheduled_at" = '2026-09-12 13:00:00'::timestamp,
+    "updated_at" = CURRENT_TIMESTAMP
+WHERE "id" = '50000000-0000-4000-8000-202609120001'::uuid
+  AND "status" = 'SCHEDULED'::"ScheduledSessionStatus";
+
+DO $$
+DECLARE
+    initialized_count integer;
+    corrected_count integer;
+BEGIN
+    SELECT count(*) INTO initialized_count FROM "users";
+
+    SELECT count(*) INTO corrected_count
+    FROM "scheduled_sessions"
+    WHERE "id" = '50000000-0000-4000-8000-202609120001'::uuid
+      AND "scheduled_at" = '2026-09-12 13:00:00'::timestamp
+      AND "status" = 'SCHEDULED'::"ScheduledSessionStatus";
+
+    IF initialized_count = 0 AND corrected_count <> 0 THEN
+        RAISE EXCEPTION 'Empty installation contains the final Umbral session';
+    ELSIF initialized_count > 0 AND corrected_count <> 1 THEN
+        RAISE EXCEPTION 'Final Umbral session must start at 13:00 UTC';
+    END IF;
+END $$;

--- a/prisma/migrations/20260908233000_create_sep9_internal_rehearsal/migration.sql
+++ b/prisma/migrations/20260908233000_create_sep9_internal_rehearsal/migration.sql
@@ -23,7 +23,7 @@ SELECT
     '2026-09-09 18:00:00'::timestamp,
     'SCHEDULED'::"ScheduledSessionStatus",
     true,
-    false,
+    true,
     false,
     150,
     6,
@@ -55,7 +55,7 @@ BEGIN
       AND "scheduled_at" = '2026-09-09 18:00:00'::timestamp
       AND "status" = 'SCHEDULED'::"ScheduledSessionStatus"
       AND "is_test" = true
-      AND "paid_mode" = false
+      AND "paid_mode" = true
       AND "public_access" = false
       AND "attendee_cap" = 150
       AND "max_publishers" = 6;

--- a/prisma/migrations/20260908233000_create_sep9_internal_rehearsal/migration.sql
+++ b/prisma/migrations/20260908233000_create_sep9_internal_rehearsal/migration.sql
@@ -1,0 +1,79 @@
+-- Dirección requested a private rehearsal session for Wednesday 2026-09-09
+-- at 15:00 Argentina (America/Argentina/Cordoba, UTC-3), which is 18:00 UTC.
+-- The dedicated row inherits only the reviewed Umbral facilitator; it does
+-- not reuse the public room, tickets, participants, grants, or session state.
+WITH facilitator_source AS (
+    SELECT "facilitator_id"
+    FROM "scheduled_sessions"
+    WHERE "id" = '50000000-0000-4000-8000-202609120001'::uuid
+      AND "is_test" = false
+    LIMIT 1
+)
+INSERT INTO "scheduled_sessions" (
+    "id", "title", "description", "room_name", "language", "scheduled_at",
+    "status", "is_test", "paid_mode", "public_access", "attendee_cap",
+    "max_publishers", "facilitator_id", "updated_at"
+)
+SELECT
+    '60000000-0000-4000-8000-202609090001'::uuid,
+    'Prueba interna — Sala Umbral · 09/09 15:00 ART',
+    'Ensayo interno del recorrido de sala. No es un evento público ni habilita entradas reales.',
+    'rehearsal-2026-09-09-1500-art',
+    'SPANISH'::"SessionLanguage",
+    '2026-09-09 18:00:00'::timestamp,
+    'SCHEDULED'::"ScheduledSessionStatus",
+    true,
+    false,
+    false,
+    150,
+    6,
+    facilitator_source."facilitator_id",
+    CURRENT_TIMESTAMP
+FROM facilitator_source
+ON CONFLICT ("id") DO NOTHING;
+
+DO $$
+DECLARE
+    initialized_count integer;
+    source_count integer;
+    rehearsal_count integer;
+    related_count integer;
+BEGIN
+    SELECT count(*) INTO initialized_count FROM "users";
+
+    SELECT count(*) INTO source_count
+    FROM "scheduled_sessions"
+    WHERE "id" = '50000000-0000-4000-8000-202609120001'::uuid
+      AND "is_test" = false;
+
+    SELECT count(*) INTO rehearsal_count
+    FROM "scheduled_sessions"
+    WHERE "id" = '60000000-0000-4000-8000-202609090001'::uuid
+      AND "title" = 'Prueba interna — Sala Umbral · 09/09 15:00 ART'
+      AND "room_name" = 'rehearsal-2026-09-09-1500-art'
+      AND "language" = 'SPANISH'::"SessionLanguage"
+      AND "scheduled_at" = '2026-09-09 18:00:00'::timestamp
+      AND "status" = 'SCHEDULED'::"ScheduledSessionStatus"
+      AND "is_test" = true
+      AND "paid_mode" = false
+      AND "public_access" = false
+      AND "attendee_cap" = 150
+      AND "max_publishers" = 6;
+
+    SELECT
+        (SELECT count(*) FROM "ticket_entitlements"
+         WHERE "scheduled_session_id" = '60000000-0000-4000-8000-202609090001'::uuid)
+      + (SELECT count(*) FROM "session_participants"
+         WHERE "scheduled_session_id" = '60000000-0000-4000-8000-202609090001'::uuid)
+      + (SELECT count(*) FROM "session_contributions"
+         WHERE "scheduled_session_id" = '60000000-0000-4000-8000-202609090001'::uuid)
+    INTO related_count;
+
+    IF initialized_count = 0 AND rehearsal_count <> 0 THEN
+        RAISE EXCEPTION 'Empty installation contains the September 9 rehearsal';
+    ELSIF initialized_count > 0 AND (source_count <> 1 OR rehearsal_count <> 1) THEN
+        RAISE EXCEPTION 'September 9 rehearsal could not be created safely';
+    ELSIF related_count <> 0 THEN
+        RAISE EXCEPTION 'September 9 rehearsal must start without inherited attendee state';
+    END IF;
+END $$;

--- a/src/lib/__tests__/public-cycle.test.ts
+++ b/src/lib/__tests__/public-cycle.test.ts
@@ -48,6 +48,26 @@ describe('public four-Saturday cycle', () => {
         expect(migration).not.toContain("'2026-09-12 17:00:00'::timestamp");
     });
 
+    it('creates an isolated non-public rehearsal for September 9 at 15:00 Argentina', () => {
+        const migration = readFileSync(
+            new URL(
+                '../../../prisma/migrations/20260908233000_create_sep9_internal_rehearsal/migration.sql',
+                import.meta.url,
+            ),
+            'utf8',
+        );
+
+        expect(migration).toContain('60000000-0000-4000-8000-202609090001');
+        expect(migration).toContain('rehearsal-2026-09-09-1500-art');
+        expect(migration).toContain("'2026-09-09 18:00:00'::timestamp");
+        expect(migration).toContain('true,\n    false,\n    false,');
+        expect(migration).toContain('ON CONFLICT ("id") DO NOTHING');
+        expect(migration).toContain('related_count <> 0');
+        expect(migration).toContain('50000000-0000-4000-8000-202609120001');
+        expect(migration).not.toContain('INSERT INTO "ticket_entitlements"');
+        expect(migration).not.toContain('INSERT INTO "session_participants"');
+    });
+
     it('recognizes only an entirely anonymous COMP entitlement for a reviewed public room', () => {
         const candidate = {
             staffUser: null,

--- a/src/lib/__tests__/public-cycle.test.ts
+++ b/src/lib/__tests__/public-cycle.test.ts
@@ -60,7 +60,7 @@ describe('public four-Saturday cycle', () => {
         expect(migration).toContain('60000000-0000-4000-8000-202609090001');
         expect(migration).toContain('rehearsal-2026-09-09-1500-art');
         expect(migration).toContain("'2026-09-09 18:00:00'::timestamp");
-        expect(migration).toContain('true,\n    false,\n    false,');
+        expect(migration).toContain('true,\n    true,\n    false,');
         expect(migration).toContain('ON CONFLICT ("id") DO NOTHING');
         expect(migration).toContain('related_count <> 0');
         expect(migration).toContain('50000000-0000-4000-8000-202609120001');

--- a/src/lib/__tests__/public-cycle.test.ts
+++ b/src/lib/__tests__/public-cycle.test.ts
@@ -31,6 +31,23 @@ describe('public four-Saturday cycle', () => {
         expect(migration).not.toContain('14:00:00');
     });
 
+    it('moves only the final Umbral session to 10:00 Argentina / 13:00 UTC', () => {
+        const migration = readFileSync(
+            new URL(
+                '../../../prisma/migrations/20260908130000_move_final_umbral_to_1000_argentina/migration.sql',
+                import.meta.url,
+            ),
+            'utf8',
+        );
+
+        expect(migration).toContain('50000000-0000-4000-8000-202609120001');
+        expect(migration).toContain("'2026-09-12 13:00:00'::timestamp");
+        expect(migration).toContain('corrected_count <> 1');
+        expect(migration).toContain('initialized_count = 0 AND corrected_count <> 0');
+        expect(migration).not.toContain('202609050001');
+        expect(migration).not.toContain("'2026-09-12 17:00:00'::timestamp");
+    });
+
     it('recognizes only an entirely anonymous COMP entitlement for a reviewed public room', () => {
         const candidate = {
             staffUser: null,


### PR DESCRIPTION
Closes #521
Closes #524

## Summary
- moves only the September 12 Umbral session to 13:00 UTC / 10:00 Argentina
- creates a dedicated internal rehearsal for September 9 at 18:00 UTC / 15:00 Argentina
- marks the rehearsal `isTest=true`, `publicAccess=false`, and starts it without tickets, participants, grants, hands, or contributions
- preserves historical sessions and migrations and fails closed on incompatible initialized databases

## Verification
- `npm test -- --run src/lib/__tests__/public-cycle.test.ts` — 5 tests passed
- `npx prisma validate` — pass
- `git diff --check` — pass

## Editorial boundary
- Public: the September 12 Umbral event displays 10:00 ART.
- Internal: the September 9 rehearsal is visible only in authorized Staff test surfaces and is absent from public discovery.

## Release authorization
Direction explicitly requested on 2026-09-08 that the Saturday event move to 10:00 local Argentina and that the internal rehearsal be available on September 9 at 15:00 local Argentina. Production still requires normal CI, merge, release workflow, health verification, and rollback evidence.