### PR TITLE
test(e2e): target facilitator session heading

### DIFF
--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -113,7 +113,12 @@ stackTest.describe('fixture stack', () => {
     }) => {
         await loginStaffWithPassword(page, STAFF.facilitator);
         await page.waitForURL(`**${ROUTES.opsSession(SESSION_ES.id)}`);
-        await expect(page.getByText(SESSION_ES.title)).toBeVisible();
+        await expect(
+            page.getByRole('heading', {
+                name: `Harmonic Projection — ${SESSION_ES.title}`,
+                exact: true,
+            }),
+        ).toBeVisible();
     });
 
     stackTest('operator dashboard login reaches admission without account switching', async ({


### PR DESCRIPTION
Closes #527.

Uses the semantic page heading for the facilitator own-session assertion, avoiding the duplicate title exposed by the Next.js route announcer in Firefox.

Verification:
- ESLint on `e2e/tests/smoke.spec.ts`
- full Vitest suite: 1181 passed, 41 skipped
- signed-off commit

The required remote E2E gate will exercise the exact Firefox journey.