### PR TITLE
perf: remove duplicate delivery work

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ jobs:
     # ready_for_review event above runs this complete matrix before review;
     # workflow_call (release/deploy) remains unconditional.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:16-alpine
@@ -79,7 +79,15 @@ jobs:
           node-version: '22.22'
           cache: 'npm'
 
+      - name: Restore verified LiveKit load tester cache
+        id: livekit-cli-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/livekit-load-cli/lk
+          key: livekit-load-cli-v1-${{ runner.os }}-${{ runner.arch }}-go-1.25.8-${{ hashFiles('scripts/install-livekit-load-cli.sh', 'scripts/patches/livekit-cli-v2.16.3-vp8-depacketizer.patch') }}
+
       - uses: actions/setup-go@v5
+        if: steps.livekit-cli-cache.outputs.cache-hit != 'true'
         with:
           go-version: '1.25.8'
           cache: false
@@ -109,9 +117,15 @@ jobs:
           exit 1
 
       - name: Build verified LiveKit load tester
+        if: steps.livekit-cli-cache.outputs.cache-hit != 'true'
+        run: scripts/install-livekit-load-cli.sh "$RUNNER_TEMP/livekit-load-cli/lk"
+
+      - name: Verify cached or built LiveKit load tester
         run: |
-          scripts/install-livekit-load-cli.sh "$RUNNER_TEMP/lk"
-          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+          test -x "$RUNNER_TEMP/livekit-load-cli/lk"
+          test "$("$RUNNER_TEMP/livekit-load-cli/lk" --version)" = \
+            'lk version 2.16.3-hb-vp8.1'
+          echo "$RUNNER_TEMP/livekit-load-cli" >> "$GITHUB_PATH"
 
       - name: Run small dual-LiveKit load profile
         run: npm run load:livekit -- --profile ci --run-id "ci-${GITHUB_RUN_ID}"
@@ -210,6 +224,8 @@ jobs:
 
       - name: Run Firefox functional and accessibility gates
         run: npx playwright test --retries=0 --workers=1 --project=firefox
+        env:
+          E2E_REUSE_NEXT_BUILD: '1'
 
       - name: Install WebKit after Chromium screenshot gates
         run: npx playwright install --with-deps webkit
@@ -221,6 +237,8 @@ jobs:
           e2e/tests/audio-activation.spec.ts
           e2e/tests/continuity-navigation.spec.ts
           --project=iphone-webkit
+        env:
+          E2E_REUSE_NEXT_BUILD: '1'
 
       - name: Verify grant, migration, commerce, and invitation durable outbox contracts
         # Real-PostgreSQL proof that grant revisions are serialized across two
@@ -266,7 +284,7 @@ jobs:
   account:
     # Separate runner: no attachment to the legacy Account-disabled database/app.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     permissions:
       contents: read

--- a/.github/workflows/livekit-capacity.yml
+++ b/.github/workflows/livekit-capacity.yml
@@ -63,7 +63,15 @@ jobs:
         with:
           node-version: '22.22'
 
+      - name: Restore verified LiveKit load tester cache
+        id: livekit-cli-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/livekit-load-cli/lk
+          key: livekit-load-cli-v1-${{ runner.os }}-${{ runner.arch }}-go-1.25.8-${{ hashFiles('scripts/install-livekit-load-cli.sh', 'scripts/patches/livekit-cli-v2.16.3-vp8-depacketizer.patch') }}
+
       - uses: actions/setup-go@v5
+        if: steps.livekit-cli-cache.outputs.cache-hit != 'true'
         with:
           go-version: '1.25.8'
           cache: false
@@ -89,7 +97,14 @@ jobs:
             --shard-count "$LOAD_SHARD_COUNT"
 
       - name: Build verified LiveKit load tester once
+        if: steps.livekit-cli-cache.outputs.cache-hit != 'true'
         run: scripts/install-livekit-load-cli.sh "$RUNNER_TEMP/livekit-load-cli/lk"
+
+      - name: Verify cached or built LiveKit load tester
+        run: |
+          test -x "$RUNNER_TEMP/livekit-load-cli/lk"
+          test "$("$RUNNER_TEMP/livekit-load-cli/lk" --version)" = \
+            'lk version 2.16.3-hb-vp8.1'
 
       - name: Share the verified load tester with every shard
         uses: actions/upload-artifact@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
 npx lint-staged
-npx vitest run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,11 @@ npm run lint
 `tsc` was at zero as of July 2026 after a cleanup, which is what makes it usable
 as a signal. A type error introduced now is visible; a hundred are not.
 
-There is a pre-commit hook (husky + lint-staged) that runs eslint on staged files
-and the full test suite. If you need to bypass it for a work-in-progress commit,
-`--no-verify` exists, but the checks above should pass before review.
+The pre-commit hook (husky + lint-staged) runs ESLint only on staged JavaScript
+and TypeScript files. It deliberately does not repeat the full Vitest suite on
+every commit. Run the commands above before review; hosted CI still requires
+the full coverage suite, and release qualification still runs the full suite.
+`--no-verify` exists for work-in-progress commits, but it does not bypass CI.
 
 ## Conventions worth knowing
 

--- a/docs/ops/LIVEKIT_LOAD_HARNESS.md
+++ b/docs/ops/LIVEKIT_LOAD_HARNESS.md
@@ -133,6 +133,15 @@ It runs each shard on a different ephemeral GitHub-hosted runner, builds one
 codec-aware `lk 2.16.3-hb-vp8.1` artifact from the exact source and committed
 patch, schedules all shards against the same future UTC boundary, and
 uploads the redacted source manifests before aggregating them fail-closed.
+
+The prepare job and the reusable E2E job restore the verified load tester from
+an exact GitHub Actions cache key bound to runner OS and architecture, Go
+`1.25.8`, and hashes of both the repository installer and VP8 patch. There are
+no prefix restore keys. A miss builds from the pinned source; every hit and miss
+still verifies executable mode and the exact version
+`lk version 2.16.3-hb-vp8.1`. Cache reuse removes recompilation only: the load
+profile, shard artifact distribution, source manifests, and fail-closed
+aggregation remain unconditional evidence gates.
 Each generator also probes the fixed public production readiness endpoint. Two
 consecutive failures abort its current Stage and Beacon processes, preserve an
 `ABORTED` source manifest and prevent a global PASS. The probe never reads a
@@ -293,6 +302,10 @@ with the correct VP8 depacketizer and also requested a PLI for every count. The
 previous VP8 manifests therefore remain useful topology/cleanup evidence but
 their packet-loss magnitudes are not admissible capacity evidence. H264 controls
 remain runnable and cannot certify the production VP8 browser path.
+
+The exact-input cache is an optimization, not artifact promotion or a weaker
+provenance claim. A key change forces a rebuild, while an unchanged key still
+passes the same executable/version check before any workload can use the binary.
 
 Do not bypass this fail-closed guard. Re-enable VP8 runs only after a pinned CLI
 source selects the depacketizer from the negotiated codec and a focused

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,7 +41,7 @@ they never weaken their assertions to pass.
 
    ```bash
    docker run -d --name hb-e2e-livekit --network host \
-     livekit/livekit-server:latest --dev --node-ip 127.0.0.1
+     livekit/livekit-server:v1.13.4 --dev --node-ip 127.0.0.1
    ```
 
    Dev credentials are LiveKit's public placeholders (`devkey`/`secret`).
@@ -52,8 +52,13 @@ they never weaken their assertions to pass.
    E2E_DATABASE_URL=postgresql://postgres:e2e@localhost:55432/beacon_test npm run test:e2e
    ```
 
-   Playwright builds the app (`npm run build`) and serves the production
-   output itself. First time only, install the pinned browsers used by CI:
+   Local Playwright invocations build the app (`npm run build`) and serve the
+   production output themselves. In the hosted main-browser job, the first
+   Chromium/Android invocation owns that build; the later Firefox and WebKit
+   invocations restart the server against the same candidate `.next` output.
+   The isolated Account job remains a separate environment and performs its
+   own build with its own copied source and configuration. First time only,
+   install the pinned browsers used by CI:
 
    ```bash
    npx playwright install chromium webkit

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,11 @@ const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
 // pinned Playwright browser. CI leaves this unset and keeps its normal binary.
 const CHROME_EXECUTABLE = process.env.PLAYWRIGHT_CHROME_EXECUTABLE?.trim() || undefined;
 
+export function managedServerCommand(port: number, reuseNextBuild: boolean): string {
+    const start = `npx next start --port ${port}`;
+    return reuseNextBuild ? start : `npm run build && ${start}`;
+}
+
 // Resolve the fixture database URL once so both the web server and tests
 // that flip fixture state (e.g. opening doors by setting a session LIVE)
 // talk to the same throwaway database.
@@ -158,7 +163,7 @@ export default defineConfig({
         : {
               // Production build, not dev: no HMR sockets, no dev-tools
               // chrome in screenshots, and the gate exercises what ships.
-              command: `npm run build && npx next start --port ${PORT}`,
+              command: managedServerCommand(PORT, process.env.E2E_REUSE_NEXT_BUILD === '1'),
               // The landing renders (degraded) even without a database, so a
               // 200 here means "server up"; stack-dependent suites probe and
               // skip separately with a precise reason.

--- a/scripts/ops/__tests__/delivery-efficiency.test.mjs
+++ b/scripts/ops/__tests__/delivery-efficiency.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const read = (path) => readFileSync(new URL(`../../../${path}`, import.meta.url), 'utf8');
+
+const hook = read('.husky/pre-commit');
+const packageJson = JSON.parse(read('package.json'));
+const ciWorkflow = read('.github/workflows/ci.yml');
+const deployWorkflow = read('.github/workflows/deploy.yml');
+
+test('pre-commit runs only staged lint and never the full test suite', () => {
+  const commands = hook
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  assert.deepEqual(commands, ['npx lint-staged']);
+  assert.doesNotMatch(hook, /\b(?:vitest|npm\s+(?:run\s+)?test)\b/u);
+});
+
+test('full Vitest remains explicit locally and required in hosted CI', () => {
+  assert.equal(packageJson.scripts.test, 'vitest run');
+  assert.equal(packageJson.scripts['test:coverage'], 'vitest run --coverage');
+  assert.match(ciWorkflow, /^\s*- run: npm run test:coverage$/mu);
+  assert.doesNotMatch(ciWorkflow, /continue-on-error:\s*true[\s\S]{0,200}npm run test:coverage/u);
+});
+
+test('release qualification retains the full Vitest gate', () => {
+  assert.match(deployWorkflow, /^\s+npm test$/mu);
+});

--- a/src/lib/__tests__/live-batch-browser-contract.test.ts
+++ b/src/lib/__tests__/live-batch-browser-contract.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { describe, expect, it } from 'vitest';
-import config from '../../../playwright.config';
+import config, { managedServerCommand } from '../../../playwright.config';
 
 const regressionFiles = [
     'e2e/tests/audio-activation.spec.ts',
@@ -99,6 +99,11 @@ describe('Browser selection contract negative controls', () => {
 });
 
 describe('Live continuity batch browser qualification', () => {
+    it('builds by default and skips only the build when an earlier CI invocation owns it', () => {
+        expect(managedServerCommand(3100, false)).toBe('npm run build && npx next start --port 3100');
+        expect(managedServerCommand(3100, true)).toBe('npx next start --port 3100');
+    });
+
     const desktopCases = [
         { file: 'e2e/tests/continuity-navigation-lifecycle.spec.ts', title: 'lifecycle: attendee native reload cancellation with real pointer activation retains its document' },
         { file: 'e2e/tests/navigation-media-probe.spec.ts', title: 'navigation capture probe retains interception after browser garbage collection' },

--- a/src/lib/__tests__/live-batch-ci-contract.test.ts
+++ b/src/lib/__tests__/live-batch-ci-contract.test.ts
@@ -4,7 +4,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { parse } from 'yaml';
 import { describe, expect, it } from 'vitest';
 
-type Step = { name?: string; run?: string; if?: string; uses?: string; with?: Record<string, unknown> };
+type Step = { name?: string; run?: string; if?: string; uses?: string; env?: Record<string, string>; with?: Record<string, unknown> };
 type Job = { steps: Step[]; env?: Record<string, string>; services?: unknown; if?: string; 'runs-on'?: string };
 const workflow = () => parse(readFileSync('.github/workflows/e2e.yml', 'utf8')) as { jobs: Record<string, Job> };
 const helperConfig = 'e2e/helpers/playwright.config.ts';
@@ -185,7 +185,7 @@ describe('Isolated Account CI gate', () => {
     it('runs the Node protocol/runtime contracts explicitly before the real isolated four-project runner', () => {
         const job = workflow().jobs.account;
         expect(job, 'Account must have its own Docker-capable job').toBeDefined();
-        expect(job['runs-on']).toBe('ubuntu-latest');
+        expect(job['runs-on']).toBe('ubuntu-24.04');
         expect(job.services).toBeUndefined(); // runner creates and verifies its own PG/LiveKit
         const commands = job.steps.map((step) => step.run ?? '').join('\n');
         expect(commands).toContain('node --import tsx --test e2e/account-fixture/protocol.test.ts e2e/account-fixture/runtime-backend.test.ts');
@@ -229,6 +229,25 @@ describe('Isolated Account CI gate', () => {
 });
 
 describe('Main browser CI execution policy', () => {
+    it('builds the main browser candidate once and reuses it only for later engines on a pinned runner', () => {
+        const parsed = workflow();
+        const job = parsed.jobs.e2e;
+        const account = parsed.jobs.account;
+        const chromium = job.steps.find((step) => step.name === 'Run Chromium and Android gates');
+        const firefox = job.steps.find((step) => step.name === 'Run Firefox functional and accessibility gates');
+        const webkit = job.steps.find((step) => step.name === 'Run iPhone/WebKit media gate');
+
+        expect(job['runs-on']).toBe('ubuntu-24.04');
+        expect(account['runs-on']).toBe('ubuntu-24.04');
+        expect(chromium?.env?.E2E_REUSE_NEXT_BUILD).toBeUndefined();
+        expect(firefox?.env?.E2E_REUSE_NEXT_BUILD).toBe('1');
+        expect(webkit?.env?.E2E_REUSE_NEXT_BUILD).toBe('1');
+        expect(chromium?.run).toContain('--project=chromium');
+        expect(chromium?.run).toContain('--project=android-chrome');
+        expect(firefox?.run).toContain('--project=firefox');
+        expect(webkit?.run).toContain('--project=iphone-webkit');
+    });
+
     it('executes discovery contracts and prevents retry masking in every acceptance command', () => {
         const job = workflow().jobs.e2e;
         const steps = job.steps;

--- a/src/lib/__tests__/livekit-load-workflow.test.ts
+++ b/src/lib/__tests__/livekit-load-workflow.test.ts
@@ -103,16 +103,40 @@ describe('distributed LiveKit capacity workflow contract', () => {
         expect(installer).toContain('git -C "$SOURCE_ROOT" apply --check "$PATCH_FILE"');
         expect(livekitPatch).toContain('dpkt = &codecs.VP8Packet{}');
         expect(livekitPatch).toContain('Version = "2.16.3-hb-vp8.1"');
-        expect(workflow.match(/install-livekit-load-cli\.sh/g)).toHaveLength(1);
+        expect(workflow.match(/run: scripts\/install-livekit-load-cli\.sh/g)).toHaveLength(1);
         expect(workflow).toContain('actions/upload-artifact@v4');
         expect(workflow).toContain('actions/download-artifact@v4');
         expect(workflow).toContain('livekit-load-cli-${{ github.run_id }}');
-        expect(e2eWorkflow).toContain('install-livekit-load-cli.sh "$RUNNER_TEMP/lk"');
+        expect(e2eWorkflow).toContain('run: scripts/install-livekit-load-cli.sh "$RUNNER_TEMP/livekit-load-cli/lk"');
         expect(workflow).not.toContain('releases/download/v2.16.3/');
         expect(assertLiveKitCliMeasurementCompatibility({
             stageVideoCodec: 'vp8',
             livekitCliVersion: 'lk version 2.16.3-hb-vp8.1',
         })).toMatchObject({ verified: true });
+    });
+
+    it('caches the verified load tester only by exact platform, toolchain, installer and patch inputs', () => {
+        const exactKey = "livekit-load-cli-v1-${{ runner.os }}-${{ runner.arch }}-go-1.25.8-${{ hashFiles('scripts/install-livekit-load-cli.sh', 'scripts/patches/livekit-cli-v2.16.3-vp8-depacketizer.patch') }}";
+
+        for (const source of [workflow, e2eWorkflow]) {
+            expect(source).toContain('id: livekit-cli-cache');
+            expect(source).toContain('uses: actions/cache@v4');
+            expect(source).toContain('path: ${{ runner.temp }}/livekit-load-cli/lk');
+            expect(source).toContain(`key: ${exactKey}`);
+            expect(source).not.toContain('restore-keys:');
+            expect(source).toMatch(
+                /uses: actions\/setup-go@v5\n\s+if: steps\.livekit-cli-cache\.outputs\.cache-hit != 'true'/,
+            );
+            expect(source).toMatch(
+                /name: Build verified LiveKit load tester(?: once)?\n\s+if: steps\.livekit-cli-cache\.outputs\.cache-hit != 'true'/,
+            );
+            expect(source).toContain('test -x "$RUNNER_TEMP/livekit-load-cli/lk"');
+            expect(source).toContain("'lk version 2.16.3-hb-vp8.1'");
+        }
+
+        expect(e2eWorkflow).toContain('npm run load:livekit -- --profile ci');
+        expect(workflow).toContain('actions/upload-artifact@v4');
+        expect(workflow).toContain('actions/download-artifact@v4');
     });
 
     it('offers a bounded full-topology VP8 diagnostic without weakening rehearsal profiles', () => {


### PR DESCRIPTION
## Outcome

Remove duplicate delivery work without reducing candidate or release coverage.

## Changes

- run only staged-file linting in the local pre-commit hook while retaining full hosted and release Vitest gates;
- build the Next.js candidate once in the browser job, then reuse that exact `.next` output for the subsequent Firefox and WebKit invocations;
- keep Chromium/Android, Firefox, WebKit/iPhone, and the isolated Account matrix unconditional, single-worker, and zero-retry;
- pin browser jobs to `ubuntu-24.04`;
- cache the LiveKit load binary only by OS, architecture, Go version, installer hash, and patch hash, with exact executable/version verification on both hit and miss;
- distribute the verified binary through one run-scoped artifact instead of recompiling in every generator;
- preserve the 80-minute capacity timeout plus aggregate and evidence gates;
- update the contributor, E2E, and load-harness contracts to supersede the repeated-build procedure.

## Safety boundary

- No application, production-audio, SDK, migration, release-promotion, deploy-helper, or production-runtime behavior changes.
- Missing `.next`, a stale/wrong LiveKit binary, a failed browser engine, or a failed required check remains fail-closed.
- Account retains its independent build and four-project qualification.

## Verification

- Delivery-efficiency contracts: 3/3 passed.
- Focused workflow/browser contracts: 59/59 passed.
- TypeScript: passed.
- Scoped ESLint: passed.
- `git diff --check`: passed.
- Candidate was mechanically rebased without conflicts onto merged OPS-A `main` at `1ade548edfb0a3e2a17de165d37245b249d9e745`.

Exact candidate: `da8cdd93875d16de2118fc3b3322dbe1495d1792` (tree `a172542bd68a9a2350ef3ee16077a16f997ac8b0`; 11 paths; binary full-index delta SHA-256 `acf977f3a654ce8da53be702be33428846ccf076c6c820fdc6cdeaab80fdb63c`).

Closes #533
