### PR TITLE
fix(live): keep delayed scheduled sessions visible

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -104,7 +104,7 @@ describe('landing page', () => {
         expect(screen.queryByText('PAGO → PRESENCIA')).toBeNull();
     });
 
-    it('asks only for sessions an attendee could still join', async () => {
+    it('keeps a scheduled session discoverable for the bounded post-start waiting window', async () => {
         const findMany = mountDb(vi.fn().mockResolvedValue([]));
         await renderPage();
 
@@ -114,7 +114,10 @@ describe('landing page', () => {
                     isTest: false,
                     endedAt: null,
                     OR: [
-                        { status: 'SCHEDULED', scheduledAt: { gte: NOW } },
+                        {
+                            status: 'SCHEDULED',
+                            scheduledAt: { gte: new Date('2026-08-04T12:00:00.000Z') },
+                        },
                         {
                             status: 'LIVE',
                             startedAt: { gte: new Date('2026-08-04T12:00:00.000Z') },
@@ -140,7 +143,7 @@ describe('landing page', () => {
 
         expect(findMany.mock.calls[0][0].where.OR[0]).toEqual({
             status: 'SCHEDULED',
-            scheduledAt: { gte: pinned },
+            scheduledAt: { gte: new Date('2026-08-20T12:00:00.000Z') },
         });
     });
 
@@ -153,7 +156,7 @@ describe('landing page', () => {
 
         expect(findMany.mock.calls[0][0].where.OR[0]).toEqual({
             status: 'SCHEDULED',
-            scheduledAt: { gte: NOW },
+            scheduledAt: { gte: new Date('2026-08-04T12:00:00.000Z') },
         });
     });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,11 +31,11 @@ type WeekendEvent = {
 };
 
 const INTERNAL_NEXT = /^\/session(\/[A-Za-z0-9_-]+)*$/;
-// A missed lifecycle transition must not leave an old LIVE row advertising the
-// current checkout indefinitely. Weekend sessions last hours, not days; 24
-// hours keeps a delayed/extended live room discoverable while failing closed
-// before a stale row can be presented as the next paid event.
-const PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+// Keep a delayed session discoverable while it is still waiting for Staff to
+// open the doors. The same bounded window prevents missed lifecycle
+// transitions from advertising either SCHEDULED or LIVE rows indefinitely.
+// Weekend sessions last hours, not days.
+const PUBLIC_SESSION_DISCOVERY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function publicScheduleNow(): Date {
     const pinned = process.env.E2E_DASHBOARD_ENABLED === '1'
@@ -61,15 +61,15 @@ async function weekendEvents(): Promise<WeekendEvent[] | null> {
         // time cannot change the fixture landing halfway through CI. The pin is
         // ignored unless the already test-only dashboard gate is enabled.
         const now = publicScheduleNow();
-        const liveStartedAfter = new Date(now.getTime() - PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS);
+        const discoverableAfter = new Date(now.getTime() - PUBLIC_SESSION_DISCOVERY_MAX_AGE_MS);
 
         return await prisma.scheduledSession.findMany({
             where: {
                 isTest: false,
                 endedAt: null,
                 OR: [
-                    { status: "SCHEDULED", scheduledAt: { gte: now } },
-                    { status: "LIVE", startedAt: { gte: liveStartedAfter } },
+                    { status: "SCHEDULED", scheduledAt: { gte: discoverableAfter } },
+                    { status: "LIVE", startedAt: { gte: discoverableAfter } },
                 ],
             },
             orderBy: { scheduledAt: "asc" },


### PR DESCRIPTION
Closes #546\n\n## Resultado\n\nMantiene una sesión `SCHEDULED` visible en la portada durante la misma ventana acotada de 24 horas que ya protege las sesiones `LIVE`. Así, alcanzar la hora programada no elimina el único CTA público mientras Staff todavía abre las puertas.\n\n## Límites\n\n- no cambia lifecycle, permisos, autenticación ni audio;\n- conserva `endedAt: null`, `isTest: false` y el límite de 24 horas;\n- no crea sesiones ni participantes.\n\n## Verificación\n\n- `npx eslint src/app/page.tsx src/app/__tests__/page.test.tsx`\n- `npm test -- --run src/app/__tests__/page.test.tsx` — 16/16\n- `git diff --check`\n\nEl auditor editorial automatizado indicado por la skill no existe en este repositorio; el cambio no modifica copy ni destinos de CTA.