### PR TITLE
release: keep current event link on the public landing

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -106,7 +106,7 @@ describe('landing page', () => {
         expect(screen.queryByText('PAGO → PRESENCIA')).toBeNull();
     });
 
-    it('asks only for sessions an attendee could still join', async () => {
+    it('keeps a scheduled session discoverable for the bounded post-start waiting window', async () => {
         const findMany = mountDb(vi.fn().mockResolvedValue([]));
         await renderPage();
 
@@ -116,7 +116,10 @@ describe('landing page', () => {
                     isTest: false,
                     endedAt: null,
                     OR: [
-                        { status: 'SCHEDULED', scheduledAt: { gte: NOW } },
+                        {
+                            status: 'SCHEDULED',
+                            scheduledAt: { gte: new Date('2026-08-04T12:00:00.000Z') },
+                        },
                         {
                             status: 'LIVE',
                             startedAt: { gte: new Date('2026-08-04T12:00:00.000Z') },
@@ -142,7 +145,7 @@ describe('landing page', () => {
 
         expect(findMany.mock.calls[0][0].where.OR[0]).toEqual({
             status: 'SCHEDULED',
-            scheduledAt: { gte: pinned },
+            scheduledAt: { gte: new Date('2026-08-20T12:00:00.000Z') },
         });
     });
 
@@ -155,7 +158,7 @@ describe('landing page', () => {
 
         expect(findMany.mock.calls[0][0].where.OR[0]).toEqual({
             status: 'SCHEDULED',
-            scheduledAt: { gte: NOW },
+            scheduledAt: { gte: new Date('2026-08-04T12:00:00.000Z') },
         });
     });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,11 +31,11 @@ type WeekendEvent = {
 };
 
 const INTERNAL_NEXT = /^\/session(\/[A-Za-z0-9_-]+)*$/;
-// A missed lifecycle transition must not leave an old LIVE row advertising the
-// current checkout indefinitely. Weekend sessions last hours, not days; 24
-// hours keeps a delayed/extended live room discoverable while failing closed
-// before a stale row can be presented as the next paid event.
-const PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+// Keep a delayed session discoverable while it is still waiting for Staff to
+// open the doors. The same bounded window prevents missed lifecycle
+// transitions from advertising either SCHEDULED or LIVE rows indefinitely.
+// Weekend sessions last hours, not days.
+const PUBLIC_SESSION_DISCOVERY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function publicScheduleNow(): Date {
     const pinned = process.env.E2E_DASHBOARD_ENABLED === '1'
@@ -61,15 +61,15 @@ async function weekendEvents(): Promise<WeekendEvent[] | null> {
         // time cannot change the fixture landing halfway through CI. The pin is
         // ignored unless the already test-only dashboard gate is enabled.
         const now = publicScheduleNow();
-        const liveStartedAfter = new Date(now.getTime() - PUBLIC_LIVE_DISCOVERY_MAX_AGE_MS);
+        const discoverableAfter = new Date(now.getTime() - PUBLIC_SESSION_DISCOVERY_MAX_AGE_MS);
 
         return await prisma.scheduledSession.findMany({
             where: {
                 isTest: false,
                 endedAt: null,
                 OR: [
-                    { status: "SCHEDULED", scheduledAt: { gte: now } },
-                    { status: "LIVE", startedAt: { gte: liveStartedAfter } },
+                    { status: "SCHEDULED", scheduledAt: { gte: discoverableAfter } },
+                    { status: "LIVE", startedAt: { gte: discoverableAfter } },
                 ],
             },
             orderBy: { scheduledAt: "asc" },


### PR DESCRIPTION
Promotes the reviewed #546 fix from main PR #547 into the Live release lane.\n\nThe public event CTA remains visible for a bounded 24-hour window after its scheduled start while the session is still `SCHEDULED`, and remains visible when `LIVE`. Ended, cancelled, test and stale rows stay excluded.\n\nNo lifecycle, authorization, audio, migration or participant mutation.\n\nMain evidence: #547; focused landing tests 16/16; lint and diff check passed.